### PR TITLE
PUBDEV-7968: Add missing metrics to GLM scoring history

### DIFF
--- a/h2o-algos/src/main/java/hex/gam/GAMModel.java
+++ b/h2o-algos/src/main/java/hex/gam/GAMModel.java
@@ -264,6 +264,8 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
     public Key<Frame> _plug_values = null;
     // internal parameter, handle with care. GLM will stop when there is more than this number of active predictors (after strong rule screening)
     public int _max_active_predictors = -1; // not used in GAM, copied over to GLM params
+    public boolean _generate_scoring_history = false; // if true, will generate GLM scoring history but will slow algo down
+
 
     // the following parameters are for GAM
     public int[] _num_knots; // array storing number of knots per smoother

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -65,11 +65,15 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
   
   public ScoringInfo[] getScoringInfo() { return scoringInfo;}
   
-  public void addScoringInfo(GLMParameters parms, int nclasses, long currTime) {
-    ScoringInfo currInfo = new ScoringInfo();
+  public void addScoringInfo(GLMParameters parms, int nclasses, long currTime, int iter) {
+    if (scoringInfo != null && (((GLMScoringInfo) scoringInfo[scoringInfo.length-1]).iterations() >= iter)) {  // no duplication
+      return;
+    }
+    GLMScoringInfo currInfo = new GLMScoringInfo();
     currInfo.is_classification = nclasses > 1;
     currInfo.validation = parms.valid() != null;
     currInfo.cross_validation = parms._nfolds > 1;
+    currInfo.iterations = iter;
     currInfo.time_stamp_ms = scoringInfo==null?_output._start_time:currTime;
     currInfo.total_training_time_ms = _output._training_time_ms;
     if (_output._training_metrics != null) {
@@ -297,6 +301,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     public boolean _stdOverride; // standardization override by beta constraints
     final static NormalDistribution _dprobit = new NormalDistribution(0,1);  // get the normal distribution
     public GLMType _glmType = GLMType.glm;
+    public boolean _generate_scoring_history = false; // if true, will generate scoring history but will slow algo down
     
     public void validate(GLM glm) {
       if (_solver.equals(Solver.COORDINATE_DESCENT_NAIVE) && _family.equals(Family.multinomial))

--- a/h2o-algos/src/main/java/hex/glm/GLMScoringInfo.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMScoringInfo.java
@@ -1,0 +1,8 @@
+package hex.glm;
+
+import hex.ScoringInfo;
+
+public class GLMScoringInfo extends ScoringInfo implements ScoringInfo.HasIterations {
+  public int iterations;
+  public int iterations() { return iterations; };
+}

--- a/h2o-algos/src/main/java/hex/schemas/GLMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMV3.java
@@ -82,6 +82,7 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
             "max_confusion_matrix_size",
             "max_runtime_secs",
             "custom_metric_func",
+            "generate_scoring_history",
             "auc_type"
     };
 
@@ -250,6 +251,10 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
     @API(help="In case of linearly dependent columns, remove some of the dependent columns", level = Level.secondary, direction = Direction.INPUT)
     public boolean remove_collinear_columns; // _remove_collinear_columns
 
+    @API(help="If set to true, will generate scoring history for GLM.  This may significantly slow down the algo.", 
+            level = Level.secondary, direction = Direction.INPUT)
+    public boolean generate_scoring_history;  // if enabled, will generate scoring history for iterations specified in
+                                              // scoring_iteration_interval and score_every_iteration
     /////////////////////
   }
 }

--- a/h2o-algos/src/test/java/hex/glm/GLMCheckpointTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMCheckpointTest.java
@@ -48,7 +48,7 @@ public class GLMCheckpointTest extends TestUtil {
       GLMModel glm = new GLM(params).trainModel().get();
       Scope.track_generic(glm);
 
-      ScoringHistory manualScoringHistory = new ScoringHistory();
+      ScoringHistory manualScoringHistory = new ScoringHistory(false, false, false);
       TwoDimTable modelScoringHistory = glm._output._scoring_history;
       int[] colHeaderIndex = restoreScoringHistoryFromCheckpoint(modelScoringHistory, params, null,
               manualScoringHistory);

--- a/h2o-core/src/main/java/hex/ScoringInfo.java
+++ b/h2o-core/src/main/java/hex/ScoringInfo.java
@@ -133,7 +133,8 @@ public class ScoringInfo extends Iced<ScoringInfo> {
   public static TwoDimTable createScoringHistoryTable(ScoringInfo[] scoringInfos, boolean hasValidation, boolean hasCrossValidation, ModelCategory modelCategory, boolean isAutoencoder) {
     boolean hasEpochs = (scoringInfos instanceof HasEpochs[]);
     boolean hasSamples = (scoringInfos instanceof HasSamples[]);
-    boolean hasIterations = (scoringInfos instanceof HasIterations[]);
+    boolean hasIterations = (scoringInfos instanceof HasIterations[]) || (scoringInfos != null &&
+            scoringInfos.length > 0 && scoringInfos[0] instanceof HasIterations);
     boolean isClassifier = (modelCategory == ModelCategory.Binomial || modelCategory == ModelCategory.Multinomial
             || modelCategory == ModelCategory.Ordinal);
 

--- a/h2o-py/h2o/estimators/glm.py
+++ b/h2o-py/h2o/estimators/glm.py
@@ -42,7 +42,7 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
                    "max_active_predictors", "interactions", "interaction_pairs", "obj_reg", "stopping_rounds",
                    "stopping_metric", "stopping_tolerance", "balance_classes", "class_sampling_factors",
                    "max_after_balance_size", "max_confusion_matrix_size", "max_runtime_secs", "custom_metric_func",
-                   "auc_type"}
+                   "generate_scoring_history", "auc_type"}
 
     def __init__(self, **kwargs):
         super(H2OGeneralizedLinearEstimator, self).__init__()
@@ -1787,6 +1787,21 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     def custom_metric_func(self, custom_metric_func):
         assert_is_type(custom_metric_func, None, str)
         self._parms["custom_metric_func"] = custom_metric_func
+
+
+    @property
+    def generate_scoring_history(self):
+        """
+        If set to true, will generate scoring history for GLM.  This may significantly slow down the algo.
+
+        Type: ``bool``  (default: ``False``).
+        """
+        return self._parms.get("generate_scoring_history")
+
+    @generate_scoring_history.setter
+    def generate_scoring_history(self, generate_scoring_history):
+        assert_is_type(generate_scoring_history, None, bool)
+        self._parms["generate_scoring_history"] = generate_scoring_history
 
 
     @property

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_alpha_array_gaussian_cv.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_alpha_array_gaussian_cv.py
@@ -13,7 +13,7 @@ def glm_alpha_lambda_arrays_cv():
         path=pyunit_utils.locate("smalldata/glm_test/gaussian_20cols_10000Rows.csv"))
     enum_columns = ["C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"]
     for cname in enum_columns:
-        h2o_data[cname] = h2o_data[cname]
+        h2o_data[cname] = h2o_data[cname].asfactor()
     myY = "C21"
     myX = h2o_data.names.remove(myY)
     data_frames = h2o_data.split_frame(ratios=[0.8])

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_binomial_cv.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_binomial_cv.py
@@ -1,0 +1,54 @@
+from builtins import range
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# Verify scoring history generation for binomial with IRLSM, cross-validation and validation dataset
+def testGLMBinomialScoringHistory():
+    col_list_compare = ["iterations", "objective", "negative_log_likelihood", "training_logloss", "validation_logloss",
+                        "training_classification_error", "validation_classification_error", "training_rmse", 
+                        "validation_rmse", "training_auc", "validation_auc", "training_pr_auc", "validation_pr_auc",
+                        "training_lift", "validation_lift"]
+    h2o_data = h2o.import_file(path=pyunit_utils.locate("smalldata/glm_test/binomial_20_cols_10KRows.csv"))
+    for ind in range(10):
+        h2o_data[ind] = h2o_data[ind].asfactor()
+    h2o_data["C21"] = h2o_data["C21"].asfactor()
+    splits_frames = h2o_data.split_frame(ratios=[.8], seed=1234)
+    train = splits_frames[0]
+    valid = splits_frames[1]
+    Y = "C21"
+    X = list(range(0,20))
+
+    print("Building model with score_interval=1.  Should generate same model as "
+          "score_each_iteration turned on.")
+    h2o_model = glm(family="binomial", score_iteration_interval=1)
+    h2o_model.train(x=X, y=Y, training_frame=train, validation_frame=valid)
+    print("Building model with score_each_iteration turned on.")
+    h2o_model_score_each = glm(family="binomial", score_each_iteration=True)
+    h2o_model_score_each.train(x=X, y=Y, training_frame=train, validation_frame=valid)
+    # scoring history from h2o_model_score_each and h2o_model should be the same
+    pyunit_utils.assert_equal_scoring_history(h2o_model_score_each, h2o_model, col_list_compare)
+
+    print("Building model with score_each_iteration turned on, with  CV.")
+    h2o_model_score_each_cv = glm(family="binomial", score_each_iteration=True, nfolds=3, fold_assignment='modulo', 
+                                  seed=1234)
+    h2o_model_score_each_cv.train(x=X, y=Y, training_frame=train, validation_frame=valid)
+    print("Building model with score_interval=1, and CV.  Should generate same model as score_each_iteration turned "
+          "on, with lambda search and CV.")
+    h2o_model_cv = glm(family="binomial", score_iteration_interval=1, nfolds=3, fold_assignment='modulo', seed=1234)
+    h2o_model_cv.train(x=X, y=Y, training_frame=train, validation_frame=valid)
+    # scoring history from h2o_model_score_each_cv and h2o_model_cv should be the same
+    pyunit_utils.assert_equal_scoring_history(h2o_model_score_each_cv, h2o_model_cv, col_list_compare)
+
+    # check if scoring_interval is set to 4, the output should be the same for every fourth iteration
+    h2o_model_cv_4th = glm(family="binomial", score_iteration_interval=4, nfolds=3, fold_assignment='modulo', seed=1234)
+    h2o_model_cv_4th.train(x=X, y=Y, training_frame=train, validation_frame=valid)
+    pyunit_utils.assertEqualScoringHistoryIteration(h2o_model_cv, h2o_model_cv_4th, col_list_compare)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(testGLMBinomialScoringHistory)
+else:
+    testGLMBinomialScoringHistory()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_binomial_generate_scoring_history_cv.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_binomial_generate_scoring_history_cv.py
@@ -1,0 +1,60 @@
+from builtins import range
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# Verify scoring history generation for binomial with IRLSM, cross-validation and validation dataset when
+# generate_scoring_history = True.  Here, deviance will be added to the scoring history for train/xval/validation.
+# However, this may slow the model training.
+def testGLMBinomialScoringHistory():
+    col_list_compare = ["iterations", "objective", "negative_log_likelihood", "training_logloss", "validation_logloss",
+                        "training_classification_error", "validation_classification_error", "training_rmse", 
+                        "validation_rmse", "training_auc", "validation_auc", "training_pr_auc", "validation_pr_auc",
+                        "training_lift", "validation_lift", "deviance_train", "deviance_test"]
+    h2o_data = h2o.import_file(path=pyunit_utils.locate("smalldata/glm_test/binomial_20_cols_10KRows.csv"))
+    for ind in range(10):
+        h2o_data[ind] = h2o_data[ind].asfactor()
+    h2o_data["C21"] = h2o_data["C21"].asfactor()
+    splits_frames = h2o_data.split_frame(ratios=[.8], seed=1234)
+    train = splits_frames[0]
+    valid = splits_frames[1]
+    Y = "C21"
+    X = list(range(0,20))
+
+    print("Building model with score_interval=1.  Should generate same model as "
+          "score_each_iteration turned on.")
+    h2o_model = glm(family="binomial", score_iteration_interval=1, generate_scoring_history=True)
+    h2o_model.train(x=X, y=Y, training_frame=train, validation_frame=valid)
+    print("Building model with score_each_iteration turned on.")
+    h2o_model_score_each = glm(family="binomial", score_each_iteration=True, generate_scoring_history=True)
+    h2o_model_score_each.train(x=X, y=Y, training_frame=train, validation_frame=valid)
+    # scoring history from h2o_model_score_each and h2o_model should be the same
+    pyunit_utils.assert_equal_scoring_history(h2o_model_score_each, h2o_model, col_list_compare)
+
+    print("Building model with score_each_iteration turned on, with  CV.")
+    h2o_model_score_each_cv = glm(family="binomial", score_each_iteration=True, nfolds=3, fold_assignment='modulo', 
+                                  seed=1234, generate_scoring_history=True)
+    h2o_model_score_each_cv.train(x=X, y=Y, training_frame=train, validation_frame=valid)
+    print("Building model with score_interval=1, and CV.  Should generate same model as score_each_iteration turned "
+          "on, with lambda search and CV.")
+    h2o_model_cv = glm(family="binomial", score_iteration_interval=1, nfolds=3, fold_assignment='modulo', seed=1234,
+                       generate_scoring_history=True)
+    h2o_model_cv.train(x=X, y=Y, training_frame=train, validation_frame=valid)
+    # scoring history from h2o_model_score_each_cv and h2o_model_cv should be the same
+    col_list_compare.append("deviance_xval")
+    col_list_compare.append("deviance_se")
+    pyunit_utils.assert_equal_scoring_history(h2o_model_score_each_cv, h2o_model_cv, col_list_compare)
+
+    # check if scoring_interval is set to 4, the output should be the same for every fourth iteration
+    h2o_model_cv_4th = glm(family="binomial", score_iteration_interval=3, nfolds=3, fold_assignment='modulo', seed=1234,
+                           generate_scoring_history=True)
+    h2o_model_cv_4th.train(x=X, y=Y, training_frame=train, validation_frame=valid)
+    pyunit_utils.assertEqualScoringHistoryIteration(h2o_model_cv, h2o_model_cv_4th, col_list_compare)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(testGLMBinomialScoringHistory)
+else:
+    testGLMBinomialScoringHistory()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_binomial_lambda_search_cv.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_binomial_lambda_search_cv.py
@@ -1,0 +1,60 @@
+from builtins import range
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# Verify scoring history generation for binomial with IRLSM, lambda_search, cross-validation and validation dataset
+def testGLMBinomialScoringHistoryLambdaSearch():
+    col_list_compare = ["iteration", "training_logloss", "validation_logloss",
+                        "training_classification_error", "validation_classification_error", "training_rmse",
+                        "validation_rmse", "training_auc", "validation_auc", "training_pr_auc", "validation_pr_auc",
+                        "training_lift", "validation_lift", "deviance_train", "deviance_test"]
+    h2o_data = h2o.import_file(path=pyunit_utils.locate("smalldata/glm_test/binomial_20_cols_10KRows.csv"))
+    for ind in range(10):
+        h2o_data[ind] = h2o_data[ind].asfactor()
+    h2o_data["C21"] = h2o_data["C21"].asfactor()
+    splits_frames = h2o_data.split_frame(ratios=[.8], seed=1234)
+    train = splits_frames[0]
+    valid = splits_frames[1]
+    Y = "C21"
+    X = list(range(0,20))
+    
+    print("Building model with score_interval=1 and lambda search on.  Should generate same model as "
+          "score_each_iteration turned on.  However, in this case, no scoring history is generated at "
+          "every iteration due to speed constraint.")
+    h2o_model = glm(family="binomial", score_iteration_interval=1, lambda_search=True, nlambdas=10)
+    h2o_model.train(x=X, y=Y, training_frame=train, validation_frame=valid)
+    print("Building model with score_each_iteration turned on, with lambda search.")
+    h2o_model_score_each = glm(family="binomial", score_each_iteration=True, lambda_search=True, nlambdas=10)
+    h2o_model_score_each.train(x=X, y=Y, training_frame=train, validation_frame=valid)
+    # scoring history from h2o_model_score_each and h2o_model should be the same
+    pyunit_utils.assert_equal_scoring_history(h2o_model_score_each, h2o_model, col_list_compare)
+
+    print("Building model with score_each_iteration turned on, with lambda search and CV.")
+    h2o_model_score_each_cv = glm(family="binomial", score_each_iteration=True, lambda_search=True, nlambdas=10,
+                                  nfolds=2, fold_assignment='modulo')
+    h2o_model_score_each_cv.train(x=X, y=Y, training_frame=train, validation_frame=valid)
+    print("Building model with score_interval=1, lambda search on and CV.  Should generate same model as "
+          "score_each_iteration turned on, with lambda search and CV.")
+    h2o_model_cv = glm(family="binomial", score_iteration_interval=1, lambda_search=True, nlambdas=10, nfolds=2,
+                       fold_assignment='modulo')
+    h2o_model_cv.train(x=X, y=Y, training_frame=train, validation_frame=valid)
+    col_list_compare.append("deviance_xval")
+    col_list_compare.append("deviance_se")
+    pyunit_utils.assert_equal_scoring_history(h2o_model_score_each_cv, h2o_model_cv, col_list_compare)
+    
+    # lambda search does not respect user choice for score_iteration_interval.  Scoring history should be the same
+    # no matter what interval you specify.  Since scoring is only done at the end, no regular training metrics are
+    # available.
+    col_list_compare = ["iteration", "deviance_train", "deviance_test", "deviance_xval", "deviance_se"]
+    h2o_model_4th_cv = glm(family="binomial", score_iteration_interval=4, lambda_search=True, nlambdas=10, nfolds=2,
+                       fold_assignment='modulo')
+    h2o_model_4th_cv.train(x=X, y=Y, training_frame=train, validation_frame=valid)
+    pyunit_utils.assert_equal_scoring_history(h2o_model_cv, h2o_model_4th_cv, col_list_compare)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(testGLMBinomialScoringHistoryLambdaSearch)
+else:
+    testGLMBinomialScoringHistoryLambdaSearch()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_binomial_lambda_search_generate_scoring_history_cv.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_binomial_lambda_search_generate_scoring_history_cv.py
@@ -1,0 +1,58 @@
+from builtins import range
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# Verify scoring history generation for binomial with IRLSM, lambda_search, cross-validation, validation dataset and
+# generate_scoring_history
+def testGLMBinomialScoringHistoryLambdaSearch():
+    col_list_compare = ["iterations", "training_logloss", "validation_logloss", "training_classification_error", 
+                        "validation_classification_error", "training_rmse", "validation_rmse", "training_auc", 
+                        "validation_auc", "training_pr_auc", "validation_pr_auc", "training_lift", "validation_lift",
+                        "deviance_train", "deviance_test"]
+    h2o_data = h2o.import_file(path=pyunit_utils.locate("smalldata/glm_test/binomial_20_cols_10KRows.csv"))
+    for ind in range(10):
+        h2o_data[ind] = h2o_data[ind].asfactor()
+    h2o_data["C21"] = h2o_data["C21"].asfactor()
+    splits_frames = h2o_data.split_frame(ratios=[.8], seed=1234)
+    train = splits_frames[0]
+    valid = splits_frames[1]
+    Y = "C21"
+    X = list(range(0,20))
+
+    print("Building model with score_interval=1 and lambda search on.  Should generate same model as "
+          "score_each_iteration turned on.")
+    h2o_model = glm(family="binomial", score_iteration_interval=1, lambda_search=True, nlambdas=10, 
+                    generate_scoring_history=True)
+    h2o_model.train(x=X, y=Y, training_frame=train, validation_frame=valid)
+    print("Building model with score_each_iteration turned on, with lambda search.")
+    h2o_model_score_each = glm(family="binomial", score_each_iteration=True, lambda_search=True, nlambdas=10, 
+                               generate_scoring_history=True)
+    h2o_model_score_each.train(x=X, y=Y, training_frame=train, validation_frame=valid)
+    # scoring history from h2o_model_score_each and h2o_model should be the same
+    pyunit_utils.assert_equal_scoring_history(h2o_model_score_each, h2o_model, col_list_compare)
+
+    print("Building model with score_each_iteration turned on, with lambda search and CV.")
+    h2o_model_score_each_cv = glm(family="binomial", score_each_iteration=True, lambda_search=True, nlambdas=10,
+                                  nfolds=2, fold_assignment='modulo', generate_scoring_history=True)
+    h2o_model_score_each_cv.train(x=X, y=Y, training_frame=train, validation_frame=valid)
+    print("Building model with score_interval=1, lambda search on and CV.  Should generate same model as "
+          "score_each_iteration turned on, with lambda search and CV.")
+    h2o_model_cv = glm(family="binomial", score_iteration_interval=1, lambda_search=True, nlambdas=10, nfolds=2,
+                       fold_assignment='modulo', generate_scoring_history=True)
+    h2o_model_cv.train(x=X, y=Y, training_frame=train, validation_frame=valid)
+    col_list_compare.append("deviance_xval")
+    col_list_compare.append("deviance_se")
+    pyunit_utils.assert_equal_scoring_history(h2o_model_score_each_cv, h2o_model_cv, col_list_compare)
+    
+    h2o_model_4th_cv = glm(family="binomial", score_iteration_interval=4, lambda_search=True, nlambdas=10, nfolds=2,
+                       fold_assignment='modulo', generate_scoring_history=True)
+    h2o_model_4th_cv.train(x=X, y=Y, training_frame=train, validation_frame=valid)
+    pyunit_utils.assertEqualScoringHistoryIteration(h2o_model_cv, h2o_model_4th_cv, col_list_compare)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(testGLMBinomialScoringHistoryLambdaSearch)
+else:
+    testGLMBinomialScoringHistoryLambdaSearch()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_glm_gaussian_cv.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_glm_gaussian_cv.py
@@ -1,0 +1,45 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# test scoring_history for Gaussian family with validation dataset and cv
+def testGLMGaussianScoringHistory():
+    col_list_compare = ["iterations", "objective", "negative_log_likelihood", "training_rmse", "validation_rmse",
+                        "training_mae", "validation_mae", "training_deviance", "validation_deviance"]
+
+    h2o_data = h2o.import_file(
+        path=pyunit_utils.locate("smalldata/glm_test/gaussian_20cols_10000Rows.csv"))
+    enum_columns = ["C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"]
+    for cname in enum_columns:
+        h2o_data[cname] = h2o_data[cname]
+    myY = "C21"
+    myX = h2o_data.names.remove(myY)
+    data_frames = h2o_data.split_frame(ratios=[0.8])
+    training_data = data_frames[0]
+    test_data = data_frames[1]
+    
+    # build gaussian model with score_each_interval to true
+    model = glm(family="gaussian", score_each_iteration=True)
+    model.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
+    # build gaussian model with score_iteration_interval to 1
+    model_score_each = glm(family="gaussian", score_iteration_interval=1)
+    model_score_each.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
+    pyunit_utils.assert_equal_scoring_history(model, model_score_each, col_list_compare)
+
+    # build gaussian model with score_each_interval to true, with CV
+    model_cv = glm(family="gaussian", score_each_iteration=True, nfolds=3, fold_assignment='modulo', seed=1234)
+    model_cv.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
+    # build gaussian model with score_iteration_interval to 1, with CV
+    model_score_each_cv = glm(family="gaussian", score_iteration_interval=1, nfolds=3, fold_assignment='modulo', seed=1234)
+    model_score_each_cv.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
+    pyunit_utils.assert_equal_scoring_history(model_cv, model_score_each_cv, col_list_compare)
+    model_cv_4th = glm(family="gaussian", score_iteration_interval=4, nfolds=3, fold_assignment='modulo', seed=1234)
+    model_cv_4th.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
+    pyunit_utils.assertEqualScoringHistoryIteration(model_cv_4th, model_cv, col_list_compare)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(testGLMGaussianScoringHistory)
+else:
+    testGLMGaussianScoringHistory()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_glm_gaussian_generate_scoring_history_cv.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_glm_gaussian_generate_scoring_history_cv.py
@@ -1,0 +1,49 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# test scoring_history for Gaussian family with validation dataset and cv
+def testGLMGaussianScoringHistory():
+    col_list_compare = ["iterations", "objective", "negative_log_likelihood", "training_rmse", "validation_rmse",
+                        "training_mae", "validation_mae", "training_deviance", "validation_deviance", "deviance_train",
+                        "deviance_test"]
+
+    h2o_data = h2o.import_file(
+        path=pyunit_utils.locate("smalldata/glm_test/gaussian_20cols_10000Rows.csv"))
+    enum_columns = ["C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"]
+    for cname in enum_columns:
+        h2o_data[cname] = h2o_data[cname]
+    myY = "C21"
+    myX = h2o_data.names.remove(myY)
+    data_frames = h2o_data.split_frame(ratios=[0.8])
+    training_data = data_frames[0]
+    test_data = data_frames[1]
+    
+    # build gaussian model with score_each_interval to true
+    model = glm(family="gaussian", score_each_iteration=True, generate_scoring_history=True)
+    model.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
+    # build gaussian model with score_iteration_interval to 1
+    model_score_each = glm(family="gaussian", score_iteration_interval=1, generate_scoring_history=True)
+    model_score_each.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
+    pyunit_utils.assert_equal_scoring_history(model, model_score_each, col_list_compare)
+
+    # build gaussian model with score_each_interval to true, with CV
+    model_cv = glm(family="gaussian", score_each_iteration=True, nfolds=3, fold_assignment='modulo', seed=1234,
+                   generate_scoring_history=True)
+    model_cv.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
+    # build gaussian model with score_iteration_interval to 1, with CV
+    model_score_each_cv = glm(family="gaussian", score_iteration_interval=1, nfolds=3, fold_assignment='modulo', 
+                              seed=1234, generate_scoring_history=True)
+    model_score_each_cv.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
+    pyunit_utils.assert_equal_scoring_history(model_cv, model_score_each_cv, col_list_compare)
+    model_cv_4th = glm(family="gaussian", score_iteration_interval=4, nfolds=3, fold_assignment='modulo', seed=1234,
+                       generate_scoring_history=True)
+    model_cv_4th.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
+    pyunit_utils.assertEqualScoringHistoryIteration(model_cv_4th, model_cv, col_list_compare)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(testGLMGaussianScoringHistory)
+else:
+    testGLMGaussianScoringHistory()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_glm_gaussian_lambda_search_cv.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_glm_gaussian_lambda_search_cv.py
@@ -1,0 +1,52 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# test scoring_history for Gaussian family with validation dataset and cv and lambda_search
+def testGLMGaussianScoringHistory():
+    col_list_compare = ["iterations", "training_rmse", "validation_rmse", "training_mae", "validation_mae", 
+                        "training_deviance", "validation_deviance"]
+    h2o_data = h2o.import_file(
+        path=pyunit_utils.locate("smalldata/glm_test/gaussian_20cols_10000Rows.csv"))
+    enum_columns = ["C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"]
+    for cname in enum_columns:
+        h2o_data[cname] = h2o_data[cname]
+    myY = "C21"
+    myX = h2o_data.names.remove(myY)
+    data_frames = h2o_data.split_frame(ratios=[0.8])
+    training_data = data_frames[0]
+    test_data = data_frames[1]
+    
+    # build gaussian model with score_each_interval to true
+    model = glm(family="gaussian", score_each_iteration=True, lambda_search=True, nlambdas=10)
+    model.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
+    # build gaussian model with score_iteration_interval to 1
+    model_score_each = glm(family="gaussian", score_iteration_interval=1, lambda_search=True, nlambdas=10)
+    model_score_each.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
+    pyunit_utils.assert_equal_scoring_history(model, model_score_each, col_list_compare)
+
+    # build gaussian model with score_each_interval to true, with CV
+    model_cv = glm(family="gaussian", score_each_iteration=True, nfolds=3, fold_assignment='modulo', seed=1234,
+                   lambda_search=True, nlambdas=10)
+    model_cv.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
+    # build gaussian model with score_iteration_interval to 1, with CV
+    model_score_each_cv = glm(family="gaussian", score_iteration_interval=1, nfolds=3, fold_assignment='modulo', 
+                              seed=1234, lambda_search=True, nlambdas=10)
+    model_score_each_cv.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
+    pyunit_utils.assert_equal_scoring_history(model_cv, model_score_each_cv, col_list_compare)
+    
+    # lambda search does not respect user choice for score_iteration_interval.  Scoring history should be the same
+    # no matter what interval you specify.  Since scoring is only done at the end, no regular training metrics are
+    # available.
+    col_list_compare = ["iteration", "deviance_train", "deviance_test", "deviance_xval", "deviance_se"]
+    model_cv_4th = glm(family="gaussian", score_iteration_interval=4, nfolds=3, fold_assignment='modulo', seed=1234, 
+                       lambda_search=True, nlambdas=10)
+    model_cv_4th.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
+    pyunit_utils.assert_equal_scoring_history(model_score_each_cv, model_cv_4th, col_list_compare)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(testGLMGaussianScoringHistory)
+else:
+    testGLMGaussianScoringHistory()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_glm_gaussian_lambda_search_generate_scoring_history_cv.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_glm_gaussian_lambda_search_generate_scoring_history_cv.py
@@ -1,0 +1,50 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# test scoring_history for Gaussian family with validation dataset and cv and lambda_search and generate_scoring_history
+def testGLMGaussianScoringHistory():
+    col_list_compare = ["iterations", "training_rmse", "validation_rmse", "training_mae", "validation_mae", 
+                        "training_deviance", "validation_deviance"]
+    h2o_data = h2o.import_file(
+        path=pyunit_utils.locate("smalldata/glm_test/gaussian_20cols_10000Rows.csv"))
+    enum_columns = ["C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"]
+    for cname in enum_columns:
+        h2o_data[cname] = h2o_data[cname]
+    myY = "C21"
+    myX = h2o_data.names.remove(myY)
+    data_frames = h2o_data.split_frame(ratios=[0.8])
+    training_data = data_frames[0]
+    test_data = data_frames[1]
+    
+    # build gaussian model with score_each_interval to true
+    model = glm(family="gaussian", score_each_iteration=True, lambda_search=True, nlambdas=10, 
+                generate_scoring_history=True)
+    model.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
+    # build gaussian model with score_iteration_interval to 1
+    model_score_each = glm(family="gaussian", score_iteration_interval=1, lambda_search=True, nlambdas=10, 
+                           generate_scoring_history=True)
+    model_score_each.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
+    pyunit_utils.assert_equal_scoring_history(model, model_score_each, col_list_compare)
+
+    # build gaussian model with score_each_interval to true, with CV
+    model_cv = glm(family="gaussian", score_each_iteration=True, nfolds=3, fold_assignment='modulo', seed=1234,
+                   lambda_search=True, nlambdas=10, generate_scoring_history=True)
+    model_cv.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
+    # build gaussian model with score_iteration_interval to 1, with CV
+    model_score_each_cv = glm(family="gaussian", score_iteration_interval=1, nfolds=3, fold_assignment='modulo', 
+                              seed=1234, lambda_search=True, nlambdas=10, generate_scoring_history=True)
+    model_score_each_cv.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
+    pyunit_utils.assert_equal_scoring_history(model_cv, model_score_each_cv, col_list_compare)
+    
+    model_cv_4th = glm(family="gaussian", score_iteration_interval=4, nfolds=3, fold_assignment='modulo', seed=1234, 
+                       lambda_search=True, nlambdas=10, generate_scoring_history=True)
+    model_cv_4th.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
+    pyunit_utils.assertEqualScoringHistoryIteration(model_cv, model_cv_4th, col_list_compare)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(testGLMGaussianScoringHistory)
+else:
+    testGLMGaussianScoringHistory()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_glm_multinomial_cv.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_glm_multinomial_cv.py
@@ -1,0 +1,63 @@
+from __future__ import division
+from __future__ import print_function
+from past.utils import old_div
+import sys
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# In this test, I will check and make sure the scoring history metrics of GLM without Lambda Search
+# will contain the following: timestamp, duration, training_rmse, training_logloss, training_auc, training_pr_auc,
+# training_classification_error.
+def test_glm_scoring_history_multinomial():
+    col_list_compare = ["iterations", "objective", "negative_log_likelihood", "training_logloss", "validation_logloss",
+                        "training_classification_error", "validation_classification_error"]
+    print("Preparing dataset....")
+    h2o_data = h2o.import_file(
+        pyunit_utils.locate("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"))
+    h2o_data["C1"] = h2o_data["C1"].asfactor()
+    h2o_data["C2"] = h2o_data["C2"].asfactor()
+    h2o_data["C3"] = h2o_data["C3"].asfactor()
+    h2o_data["C4"] = h2o_data["C4"].asfactor()
+    h2o_data["C5"] = h2o_data["C5"].asfactor()
+    h2o_data["C11"] = h2o_data["C11"].asfactor()
+    splits_frames = h2o_data.split_frame(ratios=[.8], seed=1234)
+    train = splits_frames[0]
+    valid = splits_frames[1]
+
+    print("Building model with score_each_iteration turned on.")
+    h2o_model_score_each = glm(family="multinomial", score_each_iteration=True)
+    h2o_model_score_each.train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train,
+                                  validation_frame=valid)
+    print("Building model with score_interval=1.  Should generate same model as score_each_iteration turned on.")
+    h2o_model = glm(family="multinomial", score_iteration_interval=1)
+    h2o_model.train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train,
+                               validation_frame=valid)
+    # scoring history from h2o_model_score_each and h2o_model should be the same
+    pyunit_utils.assert_equal_scoring_history(h2o_model_score_each, h2o_model, col_list_compare)
+
+    print("Building model with score_each_iteration turned on and cross-validaton on.")
+    h2o_model_score_each_cv = glm(family="multinomial", score_each_iteration=True, nfolds = 2, seed=1234, 
+                                  fold_assignment="modulo")
+    h2o_model_score_each_cv.train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train, 
+                                  validation_frame=valid)
+    print("Building model with score_interval=1 and cross-validation on.  Should generate same model as "
+          "score_each_iteration and cv turned on.")
+    h2o_model_cv = glm(family="multinomial", score_iteration_interval=1, nfolds = 2, fold_assignment="modulo", seed=1234)
+    h2o_model_cv.train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train, validation_frame=valid)
+    # scoring history from h2o_model_score_each_cv and h2o_model_cv should be the same
+    pyunit_utils.assert_equal_scoring_history(h2o_model_score_each_cv, h2o_model_cv, col_list_compare)
+    
+    # check if scoring_interval is set to 4, the output should be the same for every fourth iteration
+    print("Building model with score_interval=4 and cross-validation on.  Should generate same model as "
+          "other models and same scoring history at the correct iteration.")
+    h2o_model_cv_4th = glm(family="multinomial", score_iteration_interval=3, nfolds = 2, fold_assignment="modulo", 
+                           seed=1234)
+    h2o_model_cv_4th.train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train, validation_frame=valid)
+    pyunit_utils.assertEqualScoringHistoryIteration(h2o_model_cv, h2o_model_cv_4th, col_list_compare) 
+    
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_glm_scoring_history_multinomial)
+else:
+    test_glm_scoring_history_multinomial()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_glm_multinomial_generate_scoring_history_cv.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_glm_multinomial_generate_scoring_history_cv.py
@@ -1,0 +1,65 @@
+from __future__ import division
+from __future__ import print_function
+from past.utils import old_div
+import sys
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# In this test, I will check and make sure the scoring history metrics of GLM without Lambda Search
+# will contain the following: timestamp, duration, training_rmse, training_logloss, training_auc, training_pr_auc,
+# training_classification_error.
+def test_glm_scoring_history_multinomial():
+    col_list_compare = ["iterations", "objective", "negative_log_likelihood", "training_logloss", "validation_logloss",
+                        "training_classification_error", "validation_classification_error", "deviance_train",
+                        "deviance_test"]
+    print("Preparing dataset....")
+    h2o_data = h2o.import_file(
+        pyunit_utils.locate("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"))
+    h2o_data["C1"] = h2o_data["C1"].asfactor()
+    h2o_data["C2"] = h2o_data["C2"].asfactor()
+    h2o_data["C3"] = h2o_data["C3"].asfactor()
+    h2o_data["C4"] = h2o_data["C4"].asfactor()
+    h2o_data["C5"] = h2o_data["C5"].asfactor()
+    h2o_data["C11"] = h2o_data["C11"].asfactor()
+    splits_frames = h2o_data.split_frame(ratios=[.8], seed=1234)
+    train = splits_frames[0]
+    valid = splits_frames[1]
+
+    print("Building model with score_each_iteration turned on.")
+    h2o_model_score_each = glm(family="multinomial", score_each_iteration=True, generate_scoring_history=True)
+    h2o_model_score_each.train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train,
+                                  validation_frame=valid)
+    print("Building model with score_interval=1.  Should generate same model as score_each_iteration turned on.")
+    h2o_model = glm(family="multinomial", score_iteration_interval=1, generate_scoring_history=True)
+    h2o_model.train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train,
+                               validation_frame=valid)
+    # scoring history from h2o_model_score_each and h2o_model should be the same
+    pyunit_utils.assert_equal_scoring_history(h2o_model_score_each, h2o_model, col_list_compare)
+
+    print("Building model with score_each_iteration turned on and cross-validaton on.")
+    h2o_model_score_each_cv = glm(family="multinomial", score_each_iteration=True, nfolds = 2, seed=1234, 
+                                  fold_assignment="modulo", generate_scoring_history=True)
+    h2o_model_score_each_cv.train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train, 
+                                  validation_frame=valid)
+    print("Building model with score_interval=1 and cross-validation on.  Should generate same model as "
+          "score_each_iteration and cv turned on.")
+    h2o_model_cv = glm(family="multinomial", score_iteration_interval=1, nfolds = 2, fold_assignment="modulo",
+                       seed=1234, generate_scoring_history=True)
+    h2o_model_cv.train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train, validation_frame=valid)
+    # scoring history from h2o_model_score_each_cv and h2o_model_cv should be the same
+    pyunit_utils.assert_equal_scoring_history(h2o_model_score_each_cv, h2o_model_cv, col_list_compare)
+    
+    # check if scoring_interval is set to 4, the output should be the same for every fourth iteration
+    print("Building model with score_interval=4 and cross-validation on.  Should generate same model as "
+          "other models and same scoring history at the correct iteration.")
+    h2o_model_cv_4th = glm(family="multinomial", score_iteration_interval=3, nfolds = 2, fold_assignment="modulo", 
+                           seed=1234, generate_scoring_history=True)
+    h2o_model_cv_4th.train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train, validation_frame=valid)
+    pyunit_utils.assertEqualScoringHistoryIteration(h2o_model_cv, h2o_model_cv_4th, col_list_compare) 
+    
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_glm_scoring_history_multinomial)
+else:
+    test_glm_scoring_history_multinomial()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_glm_multinomial_lambda_search_cv.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_glm_multinomial_lambda_search_cv.py
@@ -1,0 +1,67 @@
+from __future__ import division
+from __future__ import print_function
+from past.utils import old_div
+import sys
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# In this test, I will check and make sure the scoring history metrics of GLM with Lambda Search on, cv on or off will
+# contain the correct content.  It should be as before.
+def test_glm_scoring_history_multinomial():
+    col_list_compare = ["iterations", "training_logloss", "validation_logloss", "training_classification_error", 
+                        "validation_classification_error", "deviance_train", "deviance_test"]
+    print("Preparing dataset....")
+    h2o_data = h2o.import_file(
+        pyunit_utils.locate("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"))
+    h2o_data["C1"] = h2o_data["C1"].asfactor()
+    h2o_data["C2"] = h2o_data["C2"].asfactor()
+    h2o_data["C3"] = h2o_data["C3"].asfactor()
+    h2o_data["C4"] = h2o_data["C4"].asfactor()
+    h2o_data["C5"] = h2o_data["C5"].asfactor()
+    h2o_data["C11"] = h2o_data["C11"].asfactor()
+    splits_frames = h2o_data.split_frame(ratios=[.8], seed=1234)
+    train = splits_frames[0]
+    valid = splits_frames[1]
+
+    print("Building model with score_each_iteration turned on, with lambda search.")
+    h2o_model_score_each = glm(family="multinomial", score_each_iteration=True, lambda_search=True, nlambdas=10)
+    h2o_model_score_each.train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train,
+                                  validation_frame=valid)
+    print("Building model with score_interval=1.  Should generate same model as score_each_iteration turned on.")
+    h2o_model = glm(family="multinomial", score_iteration_interval=1, lambda_search=True, nlambdas=10)
+    h2o_model.train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train,
+                               validation_frame=valid)
+    pyunit_utils.assert_equal_scoring_history(h2o_model_score_each, h2o_model, col_list_compare)
+    
+    col_list_compare.append("deviance_xval")
+    col_list_compare.append("deviance_se")
+    print("Building model with score_each_iteration turned on, with lambda search and CV.")
+    h2o_model_score_each_cv = glm(family="multinomial", score_each_iteration=True, lambda_search=True, nlambdas=10, 
+                                  nfolds=2, fold_assignment='modulo')
+    h2o_model_score_each_cv .train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train,
+                           validation_frame=valid)
+    print("Building model with score_interval=1.  Should generate same model as score_each_iteration turned on, with "
+          "lambda search and CV.")
+    h2o_model_cv = glm(family="multinomial", score_iteration_interval=1, lambda_search=True, nlambdas=10, nfolds=2, 
+                       fold_assignment='modulo')
+    h2o_model_cv.train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train,
+                validation_frame=valid)
+    pyunit_utils.assert_equal_scoring_history(h2o_model_score_each_cv, h2o_model_cv, col_list_compare)
+    
+    # lambda search does not respect user choice for score_iteration_interval.  Scoring history should be the same
+    # no matter what interval you specify.  Since scoring is only done at the end, no regular training metrics are
+    # available.
+    col_list_compare = ["iteration", "deviance_train", "deviance_test", "deviance_xval", "deviance_se"]
+    h2o_model_4th_cv = glm(family="multinomial", score_iteration_interval=4, lambda_search=True, nlambdas=10, nfolds=2,
+                       fold_assignment='modulo')
+    h2o_model_4th_cv.train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train,
+                   validation_frame=valid)
+    pyunit_utils.assert_equal_scoring_history(h2o_model_cv, h2o_model_4th_cv, col_list_compare)
+    print("Done")
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_glm_scoring_history_multinomial)
+else:
+    test_glm_scoring_history_multinomial()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_glm_multinomial_lambda_search_generate_scoring_history_cv.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_glm_multinomial_lambda_search_generate_scoring_history_cv.py
@@ -1,0 +1,65 @@
+from __future__ import division
+from __future__ import print_function
+from past.utils import old_div
+import sys
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# In this test, I will check and make sure the scoring history metrics of GLM with Lambda Search on, 
+# on , cv on or off will contain the correct content.
+def test_glm_scoring_history_multinomial():
+    col_list_compare = ["iterations", "training_logloss", "validation_logloss", "training_classification_error", 
+                        "validation_classification_error", "deviance_train", "deviance_test"]
+    print("Preparing dataset....")
+    h2o_data = h2o.import_file(
+        pyunit_utils.locate("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"))
+    h2o_data["C1"] = h2o_data["C1"].asfactor()
+    h2o_data["C2"] = h2o_data["C2"].asfactor()
+    h2o_data["C3"] = h2o_data["C3"].asfactor()
+    h2o_data["C4"] = h2o_data["C4"].asfactor()
+    h2o_data["C5"] = h2o_data["C5"].asfactor()
+    h2o_data["C11"] = h2o_data["C11"].asfactor()
+    splits_frames = h2o_data.split_frame(ratios=[.8], seed=1234)
+    train = splits_frames[0]
+    valid = splits_frames[1]
+
+    print("Building model with score_each_iteration turned on, with lambda search.")
+    h2o_model_score_each = glm(family="multinomial", score_each_iteration=True, lambda_search=True, nlambdas=10, 
+                               generate_scoring_history=True)
+    h2o_model_score_each.train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train,
+                                  validation_frame=valid)
+    print("Building model with score_interval=1.  Should generate same model as score_each_iteration turned on.")
+    h2o_model = glm(family="multinomial", score_iteration_interval=1, lambda_search=True, nlambdas=10, 
+                    generate_scoring_history=True)
+    h2o_model.train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train,
+                               validation_frame=valid)
+    pyunit_utils.assert_equal_scoring_history(h2o_model_score_each, h2o_model, col_list_compare)
+    
+    col_list_compare.append("deviance_xval")
+    col_list_compare.append("deviance_se")
+    print("Building model with score_each_iteration turned on, with lambda search and CV.")
+    h2o_model_score_each_cv = glm(family="multinomial", score_each_iteration=True, lambda_search=True, nlambdas=10, 
+                                  nfolds=2, fold_assignment='modulo', generate_scoring_history=True)
+    h2o_model_score_each_cv .train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train,
+                           validation_frame=valid)
+    print("Building model with score_interval=1.  Should generate same model as score_each_iteration turned on, with "
+          "lambda search and CV.")
+    h2o_model_cv = glm(family="multinomial", score_iteration_interval=1, lambda_search=True, nlambdas=10, nfolds=2, 
+                       fold_assignment='modulo', generate_scoring_history=True)
+    h2o_model_cv.train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train,
+                validation_frame=valid)
+    pyunit_utils.assert_equal_scoring_history(h2o_model_score_each_cv, h2o_model_cv, col_list_compare)
+
+    h2o_model_4th_cv = glm(family="multinomial", score_iteration_interval=4, lambda_search=True, nlambdas=10, nfolds=2,
+                           fold_assignment='modulo', generate_scoring_history=True)
+    h2o_model_4th_cv.train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train,
+                           validation_frame=valid)
+    pyunit_utils.assertEqualScoringHistoryIteration(h2o_model_cv, h2o_model_4th_cv, col_list_compare)
+    print("Done")
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_glm_scoring_history_multinomial)
+else:
+    test_glm_scoring_history_multinomial()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_glm_tomasF.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_glm_tomasF.py
@@ -1,0 +1,23 @@
+from __future__ import division
+from __future__ import print_function
+from past.utils import old_div
+import sys
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# this test was given to me by Tomas Fryda and it was failing.  This test does not need to have an assert.  It just
+# needs to run to completion without failing.
+def test_glm_scoring_history_TomasF():
+    df = h2o.import_file(pyunit_utils.locate("smalldata/prostate/prostate.csv"))
+    df["CAPSULE"] = df["CAPSULE"].asfactor()
+
+    glmModel = glm(generate_scoring_history=True)
+    glmModel.train(y="CAPSULE", training_frame=df)
+    glmModel.scoring_history()
+    
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_glm_scoring_history_TomasF)
+else:
+    test_glm_scoring_history_TomasF()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_glm_tomasF2.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7968_scoring_history_glm_tomasF2.py
@@ -1,0 +1,30 @@
+from __future__ import division
+from __future__ import print_function
+from past.utils import old_div
+import sys
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# this test was given to me by Tomas Fryda.
+def test_glm_scoring_history_TomasF2():
+    df = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/prostate/prostate.csv")
+    df["CAPSULE"] = df["CAPSULE"].asfactor()
+    # scoring history here should be the same as before I added generate_scoring_history parameter
+    glmModel = glm(generate_scoring_history=False, lambda_search=False)
+    glmModel.train(y="CAPSULE", training_frame=df)
+    glmModel.scoring_history()
+    assert len(glmModel._model_json['output']['scoring_history'].cell_values)==5 # only four iteration, plus one at zero.
+
+    glmModel2 = glm(generate_scoring_history=True, lambda_search=False)
+    glmModel2.train(y="CAPSULE", training_frame=df)
+    glmModel2.scoring_history()
+    # scoring history in this case should be much shorter
+    assert len(glmModel._model_json['output']['scoring_history'].cell_values) > \
+           len(glmModel2._model_json['output']['scoring_history'].cell_values)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_glm_scoring_history_TomasF2)
+else:
+    test_glm_scoring_history_TomasF2()

--- a/h2o-py/tests/testdir_misc/pyunit_glm_plot.py
+++ b/h2o-py/tests/testdir_misc/pyunit_glm_plot.py
@@ -17,7 +17,7 @@ def glm_plot_test():
     glm_mult.train(ignored_columns=["ID"], y="DPROS", training_frame=prostate)
     glm_mult.plot(server=True)
 
-    glm_reg = H2OGeneralizedLinearEstimator(family="gaussian")
+    glm_reg = H2OGeneralizedLinearEstimator(family="gaussian", score_each_iteration=True, generate_scoring_history=True)
     glm_reg.train(ignored_columns=["ID"], y="CAPSULE", training_frame=prostate)
     glm_reg.plot(server=True)
 

--- a/h2o-r/h2o-package/R/glm.R
+++ b/h2o-r/h2o-package/R/glm.R
@@ -122,6 +122,8 @@
 #'        balance_classes. Defaults to 5.0.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @param custom_metric_func Reference to custom evaluation function, format: `language:keyName=funcName`
+#' @param generate_scoring_history \code{Logical}. If set to true, will generate scoring history for GLM.  This may significantly slow down the
+#'        algo. Defaults to FALSE.
 #' @param auc_type Set default multinomial AUC type. Must be one of: "AUTO", "NONE", "MACRO_OVR", "WEIGHTED_OVR", "MACRO_OVO",
 #'        "WEIGHTED_OVO". Defaults to AUTO.
 #' @return A subclass of \code{\linkS4class{H2OModel}} is returned. The specific subclass depends on the machine
@@ -232,6 +234,7 @@ h2o.glm <- function(x,
                     max_after_balance_size = 5.0,
                     max_runtime_secs = 0,
                     custom_metric_func = NULL,
+                    generate_scoring_history = FALSE,
                     auc_type = c("AUTO", "NONE", "MACRO_OVR", "WEIGHTED_OVR", "MACRO_OVO", "WEIGHTED_OVO"))
 {
   # Validate required training_frame first and other frame args: should be a valid key or an H2OFrame object
@@ -387,6 +390,8 @@ h2o.glm <- function(x,
     parms$max_runtime_secs <- max_runtime_secs
   if (!missing(custom_metric_func))
     parms$custom_metric_func <- custom_metric_func
+  if (!missing(generate_scoring_history))
+    parms$generate_scoring_history <- generate_scoring_history
   if (!missing(auc_type))
     parms$auc_type <- auc_type
 
@@ -479,6 +484,7 @@ h2o.glm <- function(x,
                                     max_after_balance_size = 5.0,
                                     max_runtime_secs = 0,
                                     custom_metric_func = NULL,
+                                    generate_scoring_history = FALSE,
                                     auc_type = c("AUTO", "NONE", "MACRO_OVR", "WEIGHTED_OVR", "MACRO_OVO", "WEIGHTED_OVO"),
                                     segment_columns = NULL,
                                     segment_models_id = NULL,
@@ -639,6 +645,8 @@ h2o.glm <- function(x,
     parms$max_runtime_secs <- max_runtime_secs
   if (!missing(custom_metric_func))
     parms$custom_metric_func <- custom_metric_func
+  if (!missing(generate_scoring_history))
+    parms$generate_scoring_history <- generate_scoring_history
   if (!missing(auc_type))
     parms$auc_type <- auc_type
 


### PR DESCRIPTION
This PR fulfills the requests in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-7968

This PR is tricky because there are multiple places where GLM scoring history is generated.  I am trying my best here.  Basically, the major change is adding deviances for train/test/cross-validation when lambda_search is off.  When lambda_search is on, deviances for train/test/cross-validation are added but is only recorded for each set of alpha and lambda values.  I extended this to for scoring_iterations when generate_scoring_history is enabled.

Completed:
1. fixed bugs when lambda search is false for all families.
2. Added new parameters generate_scoring_history to force the generation of scoring history for auto-ML.  This can slow down the GLM algo.
3. add traing/test deviance to scoring history when lambda search is false with cv on and off.  Xval deviances are added when cv is on.
4.  Check and make sure generate_scoring_history returns correct scoring history when lambda search is false with cv on and off, generate_scoring_history on and off.
5. Check and make sure train/test/xval deviances are correct with lambda_search on, cv on and off, generate_scoring_history on and off.
6. add tests to make sure new addition actually works.