### PR TITLE
Add Pull Request Badge app

### DIFF
--- a/.github/pr-badge.yml
+++ b/.github/pr-badge.yml
@@ -1,0 +1,5 @@
+- label: "JIRA"
+  message: "$issuePrefix"
+  color: "#0052CC"
+  url: "https://h2oai.atlassian.net/browse/$issuePrefix"
+  when: "$issuePrefix"


### PR DESCRIPTION
[![PUBDEV-1](https://badgen.net/badge/JIRA/PUBDEV-1/0052CC)](https://h2oai.atlassian.net/browse/PUBDEV-1)
<img src="https://user-images.githubusercontent.com/1393946/109433021-68202500-7a0e-11eb-93a2-5ed8ae8cde32.png" width=344/>

Hello 👋 

I've noticed that h2o is heavily leveraging the redhat issue tracker and most pull requests add a link to the related issue. You might be interested in the GitHub App I wrote to automate this process https://pullrequestbadge.com. 

If a pull request title or the branch name starts with an issue prefix e.g. `PUBDEV-123`, the [Pull Request Badge GitHub App](https://github.com/marketplace/pull-request-badge) does automatically insert a badge to the pull request descriptions based on the config provided in this pull request. 

Pull Request Badge is always free for public repositories. If you have any questions please let me know. 

## Setup steps
1. Go to the [GitHub Marketplace listing](https://github.com/marketplace/pull-request-badge)
2. Choose the free plan and follow the instructions. 
3. Merge this pull request 😉 

Obviously, please feel free to close this pull request if you're not interested in using the app. 