### PR TITLE
Remove extra character o from file locate in runit_pubdev_3847_gbm_random_attack_large

### DIFF
--- a/h2o-r/tests/testdir_jira/runit_pubdev_3847_gbm_random_attack_large.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_3847_gbm_random_attack_large.R
@@ -5,7 +5,7 @@ source("../../scripts/h2o-r-test-setup.R")
 ######################################################################################
 pubdev.3847.test <-
   function() {
-      file <- locate("smalldata/jira/pubdev_3847.csv")o
+      file <- locate("smalldata/jira/pubdev_3847.csv")
       data <- h2o.importFile(file, destination_frame = "pubdev3847.data")
       response <- "class"
       features <- setdiff(names(data), response)


### PR DESCRIPTION
Remove too many fingers problem:
 change: file <- locate("smalldata/jira/pubdev_3847.csv")o
to file <- locate("smalldata/jira/pubdev_3847.csv")