### PR TITLE
[Docs] For include / exclude algos options, make it clear that algorithms in list are usable

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/exclude_algos.rst
+++ b/h2o-docs/src/product/data-science/algo-params/exclude_algos.rst
@@ -11,12 +11,12 @@ This option allows you to specify a list of algorithms that should not be includ
 
 The algorithms that can be specified include:
 
-- DRF (including both the Random Forest and Extremely Randomized Trees (XRT) models)
-- GLM
-- XGBoost (XGBoost GBM)
-- GBM (H2O GBM)
-- DeepLearning (Fully-connected multi-layer artificial neural network)
-- StackedEnsemble
+- ``DRF`` (including both the Random Forest and Extremely Randomized Trees (XRT) models)
+- ``GLM``
+- ``XGBoost`` (XGBoost GBM)
+- ``GBM`` (H2O GBM)
+- ``DeepLearning`` (Fully-connected multi-layer artificial neural network)
+- ``StackedEnsemble``
 
 Related Parameters
 ~~~~~~~~~~~~~~~~~~

--- a/h2o-docs/src/product/data-science/algo-params/include_algos.rst
+++ b/h2o-docs/src/product/data-science/algo-params/include_algos.rst
@@ -11,12 +11,12 @@ This option allows you to specify a list of algorithms to include in an AutoML r
 
 The algorithms that can be specified include:
 
-- DRF (including both the Random Forest and Extremely Randomized Trees (XRT) models)
-- GLM
-- XGBoost (XGBoost GBM)
-- GBM (H2O GBM)
-- DeepLearning (Fully-connected multi-layer artificial neural network)
-- StackedEnsemble
+- ``DRF`` (including both the Random Forest and Extremely Randomized Trees (XRT) models)
+- ``GLM``
+- ``XGBoost`` (XGBoost GBM)
+- ``GBM`` (H2O GBM)
+- ``DeepLearning`` (Fully-connected multi-layer artificial neural network)
+- ``StackedEnsemble``
 
 Related Parameters
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR edits the documentation for the include / exclude algos options.

See https://h2oai.slack.com/archives/C04KNHH2H/p1615584988003500 for more info.

![chrome_LlYurvV7o9](https://user-images.githubusercontent.com/51676687/111003118-2b2c2a80-834c-11eb-959a-35c9061dba06.png)
