### PR TITLE
PUBDEV-8046: Fix matplotlib import error, unintentional switch to agg, figure cropping

### DIFF
--- a/h2o-py/h2o/explanation/__init__.py
+++ b/h2o-py/h2o/explanation/__init__.py
@@ -1,15 +1,44 @@
 # -*- encoding: utf-8 -*-
 
-from ._explain import varimp_heatmap, model_correlation_heatmap, shap_explain_row_plot, shap_summary_plot,\
-    explain, explain_row, pd_plot, pd_multi_plot, ice_plot, residual_analysis_plot
 
-__all__ = [
-    "explain",
-    "explain_row",
-    "varimp_heatmap",
-    "model_correlation_heatmap",
-    "pd_multi_plot"
-]
+def _complain_about_matplotlib(*args, **kwargs):
+    raise ImportError("Plotting functionality requires matplotlib. Please install matplotlib.")
+
+
+def _register_dummy_methods():
+    import h2o.model
+    import h2o.automl._base  # NOQA
+    h2o.model.H2ORegressionModel.residual_analysis_plot = _complain_about_matplotlib
+    h2o.model.ModelBase.shap_summary_plot = _complain_about_matplotlib
+    h2o.model.ModelBase.shap_explain_row_plot = _complain_about_matplotlib
+    h2o.model.ModelBase.explain = _complain_about_matplotlib
+    h2o.model.ModelBase.explain_row = _complain_about_matplotlib
+    h2o.model.ModelBase.pd_plot = _complain_about_matplotlib
+    h2o.model.ModelBase.ice_plot = _complain_about_matplotlib
+
+    h2o.automl._base.H2OAutoMLBaseMixin.pd_multi_plot = _complain_about_matplotlib
+    h2o.automl._base.H2OAutoMLBaseMixin.varimp_heatmap = _complain_about_matplotlib
+    h2o.automl._base.H2OAutoMLBaseMixin.model_correlation_heatmap = _complain_about_matplotlib
+    h2o.automl._base.H2OAutoMLBaseMixin.explain = _complain_about_matplotlib
+    h2o.automl._base.H2OAutoMLBaseMixin.explain_row = _complain_about_matplotlib
+
+
+try:
+    import numpy
+    import matplotlib
+    from ._explain import varimp_heatmap, model_correlation_heatmap, shap_explain_row_plot, shap_summary_plot,\
+        explain, explain_row, pd_plot, pd_multi_plot, ice_plot, residual_analysis_plot
+
+    __all__ = [
+        "explain",
+        "explain_row",
+        "varimp_heatmap",
+        "model_correlation_heatmap",
+        "pd_multi_plot"
+    ]
+except ImportError as e:  # Numpy, Matplotlib
+    _register_dummy_methods()
+    raise e
 
 
 def register_explain_methods():
@@ -29,4 +58,3 @@ def register_explain_methods():
     h2o.automl._base.H2OAutoMLBaseMixin.model_correlation_heatmap = model_correlation_heatmap
     h2o.automl._base.H2OAutoMLBaseMixin.explain = explain
     h2o.automl._base.H2OAutoMLBaseMixin.explain_row = explain_row
-


### PR DESCRIPTION
Fixes issues mentioned on internal channel regarding usage of the python's `explanation` module and in https://h2oai.atlassian.net/browse/PUBDEV-8046 as the main part regarding `matplotlib.backend` largely overlapped.

Namely:
* Unclear exception when `matplotlib` is missing
* CLI usage problems - Varimp plot and later plots were rendered by "Agg" backend instead of the one that was set before the  `.explain` was called
* Cropping of the legend in some backends (not present in Jupyter)


GUI usage tested on Jupyter and Spyder.
CLI usage tested with `MacOSX` (macOS BigSur) and `TkAgg` (Ubuntu Focal) `matplotlib` backends.