### PR TITLE
PUBDEV-7884: Enable Java 15

### DIFF
--- a/h2o-core/src/main/java/water/JavaVersionSupport.java
+++ b/h2o-core/src/main/java/water/JavaVersionSupport.java
@@ -8,7 +8,7 @@ public class JavaVersionSupport {
     // Make sure that the following is logically consistent with whitelist in R code - see function .h2o.check_java_version in connection.R.
     // Upgrade of the javassist library should be considered when adding support for a new java version.
     public static final int MIN_SUPPORTED_JAVA_VERSION = 8;
-    public static final int MAX_SUPPORTED_JAVA_VERSION = 14;
+    public static final int MAX_SUPPORTED_JAVA_VERSION = 15;
 
     /**
      * Checks for the version of Java this instance of H2O was ran with and compares it with supported versions.

--- a/h2o-core/src/test/java/water/JavaVersionSupportTest.java
+++ b/h2o-core/src/test/java/water/JavaVersionSupportTest.java
@@ -31,7 +31,7 @@ public class JavaVersionSupportTest {
         @Parameterized.Parameters
         public static Collection<Object[]> data() {
             return Arrays.asList(new Object[][]{
-                    {8}, {9}, {10}, {11}, {12}, {13}, {14}
+                    {8}, {9}, {10}, {11}, {12}, {13}, {14}, {15}
             });
         }
 
@@ -73,7 +73,7 @@ public class JavaVersionSupportTest {
         @Parameterized.Parameters
         public static Collection<Object[]> data() {
             return Arrays.asList(new Object[][]{
-                    {7}, {15}
+                    {7}, {16}
             });
         }
 

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -25,7 +25,7 @@ At a minimum, we recommend the following for compatibility with H2O:
 
 -  **Languages**: Scala, R, and Python are not required to use H2O unless you want to use H2O in those environments, but Java is always required. Supported versions include:
 
-   -  Java 8, 9, 10, 11, 12, 13, 14
+   -  Java 8, 9, 10, 11, 12, 13, 14, 15
 
       - To build H2O or run H2O tests, the 64-bit JDK is required.
       - To run the H2O binary using either the command line, R, or Python packages, only 64-bit JRE is required.

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -318,10 +318,6 @@ test-junit-1x:
 test-junit-1x-jenkins:
 	$(call sed_test_scripts)
 	@$(MAKE) -f $(THIS_FILE) test-junit-1x
-	
-test-junit-latest:
-    ADDITIONAL_TEST_JVM_OPTS="-Dsys.ai.h2o.debug.allowJavaVersions=15" \
-        ./gradlew test -x h2o-ext-mojo-pipeline:test -x h2o-automl:test -x h2o-ext-xgboost:testMultiNode -x h2o-ext-target-encoder:testMultiNode -x h2o-clustering:test $$ADDITIONAL_GRADLE_OPTS
 
 test-junit-latest-jenkins:
 	$(call sed_test_scripts)
@@ -333,10 +329,6 @@ test-junit-smoke-jenkins:
 
 test-junit-smoke:
 	DOONLY=$$(head -n 1 tests/doOnlyJunitSmokeTestList) ./gradlew h2o-core:test h2o-algos:test $$ADDITIONAL_GRADLE_OPTS
-
-test-junit-latest-smoke:
-	ADDITIONAL_TEST_JVM_OPTS="-Dsys.ai.h2o.debug.allowJavaVersions=15" DOONLY=$$(head -n 1 tests/doOnlyJunitSmokeTestList) \
-	    ./gradlew h2o-core:test h2o-algos:test $$ADDITIONAL_GRADLE_OPTS
 
 test-junit-latest-smoke-jenkins:
 	$(call sed_test_scripts)

--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -331,7 +331,7 @@ def call(final pipelineContext) {
       imageSpecifier: "python-2.7-jdk-14"
     ],
     [
-      stageName: 'Java 15 JUnit', target: 'test-junit-latest-jenkins', pythonVersion: '2.7', javaVersion: 15,
+      stageName: 'Java 15 JUnit', target: 'test-junit-1x-jenkins', pythonVersion: '2.7', javaVersion: 15,
       timeoutValue: 180, component: pipelineContext.getBuildConfig().COMPONENT_JAVA,
       additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY],
       imageSpecifier: "python-2.7-jdk-15"
@@ -401,7 +401,7 @@ def call(final pipelineContext) {
       component: pipelineContext.getBuildConfig().COMPONENT_JAVA
     ],
     [
-      stageName: 'Java 15 Smoke', target: 'test-junit-latest-smoke-jenkins', javaVersion: 15, timeoutValue: 20,
+      stageName: 'Java 15 Smoke', target: 'test-junit-smoke-jenkins', javaVersion: 15, timeoutValue: 20,
       component: pipelineContext.getBuildConfig().COMPONENT_JAVA
     ],
     [


### PR DESCRIPTION
H2O is now certified to work well on Java 15: we were running the full test suite on J15 for the last 4 weeks and found now issue