### PR TITLE
PUBDEV-8054: Add Java 15 support in R package DESCRIPTION file

### DIFF
--- a/h2o-r/h2o-DESCRIPTION.template
+++ b/h2o-r/h2o-DESCRIPTION.template
@@ -41,7 +41,7 @@ License: Apache License (== 2.0)
 URL: https://github.com/h2oai/h2o-3
 BugReports: https://0xdata.atlassian.net/projects/PUBDEV
 NeedsCompilation: no
-SystemRequirements: Java (>= 8, < 15)
+SystemRequirements: Java (>= 8, < 16)
 Depends: R (>= 2.13.0),
          methods,
          stats

--- a/h2o-r/h2o-DESCRIPTION.template
+++ b/h2o-r/h2o-DESCRIPTION.template
@@ -39,7 +39,7 @@ Description: R interface for 'H2O', the scalable open source machine learning
     Word2Vec, as well as a fully automatic machine learning algorithm (H2O AutoML).
 License: Apache License (== 2.0)
 URL: https://github.com/h2oai/h2o-3
-BugReports: https://0xdata.atlassian.net/projects/PUBDEV
+BugReports: https://h2oai.atlassian.net/projects/PUBDEV
 NeedsCompilation: no
 SystemRequirements: Java (>= 8, < 16)
 Depends: R (>= 2.13.0),


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8054

- Now that Java 15 support is merged, we can update the system requirements in the R DESCRIPTION file.
- Added a drive-by commit to fix the BugReports URL as well.