### PR TITLE
multi bug fixes for CSV parsing

### DIFF
--- a/h2o-core/src/main/java/water/parser/CsvParser.java
+++ b/h2o-core/src/main/java/water/parser/CsvParser.java
@@ -543,13 +543,14 @@ MAIN_LOOP:
   public static final byte HIVE_SEP = 0x1; // '^A',  Hive table column separator
   private static byte[] separators = new byte[] { HIVE_SEP, ',', ';', '|', '\t',  ' '/*space is last in this list, because we allow multiple spaces*/ };
 
-  /** Dermines the number of separators in given line.  Correctly handles quoted tokens. */
-  private static int[] determineSeparatorCounts(String from, byte singleQuote) {
+  /** Determines the number of separators in given line.  Correctly handles quoted tokens. */
+  private static int[] determineSeparatorCounts(String from, byte quote) {
     int[] result = new int[separators.length];
     byte[] bits = StringUtils.bytesOf(from);
     boolean inQuote = false;
-    for( byte c : bits ) {
-      if( (c == singleQuote) || (c == CsvParser.CHAR_DOUBLE_QUOTE) )
+    for( int bi=0; bi < bits.length; bi++) {
+      byte c = bits[bi];
+      if( c == quote && bi > 0 && bits[bi-1] != '\\')
         inQuote ^= true;
       if( !inQuote || c == HIVE_SEP )
         for( int i = 0; i < separators.length; ++i )
@@ -615,7 +616,7 @@ MAIN_LOOP:
 
 
   public static byte guessSeparator(String l1, String l2, boolean singleQuotes) {
-    final byte singleQuote = singleQuotes ? CsvParser.CHAR_SINGLE_QUOTE : -1;
+    final byte singleQuote = singleQuotes ? CsvParser.CHAR_SINGLE_QUOTE : CsvParser.CHAR_DOUBLE_QUOTE;
     int[] s1 = determineSeparatorCounts(l1, singleQuote);
     int[] s2 = determineSeparatorCounts(l2, singleQuote);
     // Now we have the counts - if both lines have the same number of

--- a/h2o-core/src/main/java/water/parser/CsvParser.java
+++ b/h2o-core/src/main/java/water/parser/CsvParser.java
@@ -136,10 +136,13 @@ MAIN_LOOP:
           }
           if ((!isEOL(c) && c != CHAR_SEPARATOR) || quoteCount == 1) {
             if (str.getBuffer() == null && isEOL(c)) str.set(bits, offset, 0);
-            str.addChar();
+            escaped = !escaped && c == CHAR_ESCAPE;
+            if (escaped) 
+              str.skipIndex(offset);
+            else
+              str.addChar();
             if ((c & 0x80) == 128) //value beyond std ASCII
               isAllASCII = false;
-            escaped = !escaped && c == CHAR_ESCAPE;
             break;
           }
           

--- a/h2o-core/src/main/java/water/parser/CsvParser.java
+++ b/h2o-core/src/main/java/water/parser/CsvParser.java
@@ -54,10 +54,11 @@ public class CsvParser extends Parser {
       else state = POSSIBLE_EMPTY_LINE;
     }
 
+    byte quoteChar = _setup._single_quotes ? CHAR_SINGLE_QUOTE : CHAR_DOUBLE_QUOTE;
     int quotes = 0;
     byte quoteCount = 0;
     long number = 0;
-    int escaped = -1;
+    boolean escaped = false;
     int exp = 0;
     int sgnExp = 1;
     boolean decimal = false;
@@ -129,7 +130,7 @@ MAIN_LOOP:
           }
 
         case STRING:
-          if (c == quotes) {
+          if (c == quotes && !escaped) {
             state = COND_QUOTE;
             continue MAIN_LOOP;
           }
@@ -138,6 +139,7 @@ MAIN_LOOP:
             str.addChar();
             if ((c & 0x80) == 128) //value beyond std ASCII
               isAllASCII = false;
+            escaped = !escaped && c == CHAR_ESCAPE;
             break;
           }
           
@@ -256,8 +258,8 @@ MAIN_LOOP:
         // ---------------------------------------------------------------------
         case COND_QUOTED_TOKEN:
           state = TOKEN;
-          if( CHAR_SEPARATOR!=HIVE_SEP && // Only allow quoting in CSV not Hive files
-              ((_setup._single_quotes && c == CHAR_SINGLE_QUOTE) || (c == CHAR_DOUBLE_QUOTE))) {
+          if( CHAR_SEPARATOR!=HIVE_SEP // Only allow quoting in CSV not Hive files
+              && c == quoteChar) {
             quotes = c;
             quoteCount++;
             break;
@@ -544,14 +546,20 @@ MAIN_LOOP:
   private static byte[] separators = new byte[] { HIVE_SEP, ',', ';', '|', '\t',  ' '/*space is last in this list, because we allow multiple spaces*/ };
 
   /** Determines the number of separators in given line.  Correctly handles quoted tokens. */
-  private static int[] determineSeparatorCounts(String from, byte quote) {
+  private static int[] determineSeparatorCounts(String from, byte quoteChar) {
     int[] result = new int[separators.length];
     byte[] bits = StringUtils.bytesOf(from);
     boolean inQuote = false;
-    for( int bi=0; bi < bits.length; bi++) {
+    boolean escaped, escaping = false;
+    for( int bi=0; bi < bits.length; bi++ ) {
       byte c = bits[bi];
-      if( c == quote && bi > 0 && bits[bi-1] != '\\')
-        inQuote ^= true;
+      escaped = escaping;
+      escaping = !escaped && (
+              c == CsvParser.CHAR_ESCAPE
+              || (inQuote && c == quoteChar && bi < bits.length-1 && bits[bi+1] == quoteChar) // 2 consecutive quotes inside a quote are not csv quotes
+      );
+      if( c == quoteChar && !escaped && !escaping)
+          inQuote ^= true;
       if( !inQuote || c == HIVE_SEP )
         for( int i = 0; i < separators.length; ++i )
           if( c == separators[i] )
@@ -564,10 +572,10 @@ MAIN_LOOP:
    *  in an array.  Assumes the given separator.
    */
   public static String[] determineTokens(String from, byte separator, boolean singleQuotes) {
-    final byte singleQuote = singleQuotes ? CsvParser.CHAR_SINGLE_QUOTE : -1;
+    final byte singleQuote = singleQuotes ? CsvParser.CHAR_SINGLE_QUOTE : CsvParser.CHAR_DOUBLE_QUOTE;
     return determineTokens(from, separator, singleQuote);
   }
-  public static String[] determineTokens(String from, byte separator, byte singleQuote) {
+  public static String[] determineTokens(String from, byte separator, byte quoteChar) {
     ArrayList<String> tokens = new ArrayList<>();
     byte[] bits = StringUtils.bytesOf(from);
     int offset = 0;
@@ -577,13 +585,19 @@ MAIN_LOOP:
       if(offset == bits.length)break;
       final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
       byte c = bits[offset];
-      if ((c == CsvParser.CHAR_DOUBLE_QUOTE) || (c == singleQuote)) {
+      boolean escaped, escaping = false;
+      if (c == quoteChar) {
         quotes = c;
         ++offset;
       }
       while (offset < bits.length) {
         c = bits[offset];
-        if ((c == quotes)) {
+        escaped = escaping;
+        escaping = !escaped && (
+                c == CsvParser.CHAR_ESCAPE 
+                || (quotes > 0 && c == quoteChar && offset < bits.length-1 && bits[offset+1] == quoteChar) // 2 consecutive quotes inside a quote are not csv quotes
+        );
+        if (c == quotes && !escaped && !escaping) {
           ++offset;
           if ((offset < bits.length) && (bits[offset] == c)) {
             byteArrayOutputStream.write(c);
@@ -591,7 +605,7 @@ MAIN_LOOP:
             continue;
           }
           quotes = 0;
-        } else if( quotes == 0 && ((c == separator) || CsvParser.isEOL(c)) ) {
+        } else if( quotes == 0 && (c == separator || CsvParser.isEOL(c)) ) {
           break;
         } else {
           byteArrayOutputStream.write(c);
@@ -616,9 +630,9 @@ MAIN_LOOP:
 
 
   public static byte guessSeparator(String l1, String l2, boolean singleQuotes) {
-    final byte singleQuote = singleQuotes ? CsvParser.CHAR_SINGLE_QUOTE : CsvParser.CHAR_DOUBLE_QUOTE;
-    int[] s1 = determineSeparatorCounts(l1, singleQuote);
-    int[] s2 = determineSeparatorCounts(l2, singleQuote);
+    final byte quoteChar = singleQuotes ? CsvParser.CHAR_SINGLE_QUOTE : CsvParser.CHAR_DOUBLE_QUOTE;
+    int[] s1 = determineSeparatorCounts(l1, quoteChar);
+    int[] s2 = determineSeparatorCounts(l2, quoteChar);
     // Now we have the counts - if both lines have the same number of
     // separators the we assume it is the separator.  Separators are ordered by
     // their likelyhoods.
@@ -628,8 +642,8 @@ MAIN_LOOP:
       if( s1[max] < s1[i] ) max=i; // Largest count sep on 1st line
       if( s1[i] == s2[i] && s1[i] >= s1[max]>>1 ) {  // Sep counts are equal?  And at nearly as large as the larger header sep?
         try {
-          String[] t1 = determineTokens(l1, separators[i], singleQuote);
-          String[] t2 = determineTokens(l2, separators[i], singleQuote);
+          String[] t1 = determineTokens(l1, separators[i], quoteChar);
+          String[] t2 = determineTokens(l2, separators[i], quoteChar);
           if( t1.length != s1[i]+1 || t2.length != s2[i]+1 )
             continue;           // Token parsing fails
           return separators[i];
@@ -641,8 +655,8 @@ MAIN_LOOP:
     // one.  If there's no largest one, space will be used.
     if( s1[max]==0 ) max=separators.length-1; // Try last separator (space)
     if( s1[max]!=0 ) {
-      String[] t1 = determineTokens(l1, separators[max], singleQuote);
-      String[] t2 = determineTokens(l2, separators[max], singleQuote);
+      String[] t1 = determineTokens(l1, separators[max], quoteChar);
+      String[] t2 = determineTokens(l2, separators[max], quoteChar);
       if( t1.length == s1[max]+1 && t2.length == s2[max]+1 )
         return separators[max];
     }

--- a/h2o-core/src/main/java/water/parser/Parser.java
+++ b/h2o-core/src/main/java/water/parser/Parser.java
@@ -36,6 +36,7 @@ public abstract class Parser extends Iced {
   static final byte CHAR_SPACE = ' ';
   static final byte CHAR_DOUBLE_QUOTE = '"';
   static final byte CHAR_SINGLE_QUOTE = '\'';
+  static final byte CHAR_ESCAPE = '\\';
 
   // State for the CSV & SVMLight Parser's FSAs
   protected static final byte SKIP_LINE = 0;

--- a/h2o-core/src/test/java/water/parser/CsvParserTest.java
+++ b/h2o-core/src/test/java/water/parser/CsvParserTest.java
@@ -86,6 +86,50 @@ public class CsvParserTest extends TestUtil {
     }
 
     @Test
+    public void testParseEscapeCharDoubleQuotes() {
+      ParseSetup parseSetup = new ParseSetup();
+      parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
+      parseSetup._check_header = ParseSetup.NO_HEADER;
+      parseSetup._separator = ',';
+      parseSetup._column_types = new byte[]{Vec.T_STR};
+      parseSetup._column_names = new String[]{"Name"};
+      parseSetup._number_columns = 1;
+      parseSetup._single_quotes = false;
+      parseSetup._nonDataLineMarkers = new byte[0];
+      CsvParser csvParser = new CsvParser(parseSetup, null);
+
+      final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("\"\\\"ab\\\\cd\\\"\""), 0);
+      final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
+      final PreviewParseWriter outWriter = (PreviewParseWriter) csvParser.parseChunk(0, byteAryData, parseWriter);
+
+      assertEquals(1, outWriter.lineNum());
+      assertEquals("\"ab\\cd\"", outWriter._data[1][0]);
+      assertFalse(outWriter.hasErrors());
+    }
+
+    @Test
+    public void testParseEscapeCharSingleQuotes() {
+      ParseSetup parseSetup = new ParseSetup();
+      parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
+      parseSetup._check_header = ParseSetup.NO_HEADER;
+      parseSetup._separator = ',';
+      parseSetup._column_types = new byte[]{Vec.T_STR};
+      parseSetup._column_names = new String[]{"Name"};
+      parseSetup._number_columns = 1;
+      parseSetup._single_quotes = true;
+      parseSetup._nonDataLineMarkers = new byte[0];
+      CsvParser csvParser = new CsvParser(parseSetup, null);
+
+      final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("'\\'ab\\\\cd\\''"), 0);
+      final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
+      final PreviewParseWriter outWriter = (PreviewParseWriter) csvParser.parseChunk(0, byteAryData, parseWriter);
+
+      assertEquals(1, outWriter.lineNum());
+      assertEquals("'ab\\cd'", outWriter._data[1][0]);
+      assertFalse(outWriter.hasErrors());
+    }
+
+    @Test
     public void testParseDoubleEscapedSingleQuotes() {
       ParseSetup parseSetup = new ParseSetup();
       parseSetup._parse_type = DefaultParserProviders.CSV_INFO;

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -482,9 +482,8 @@ class H2OFrame(Keyed):
              "blocking": False,
              "column_types": None,
              "skipped_columns":None,
-             "custom_non_data_line_markers": None,
-             "partition_by": None,
-             "single_quotes": None
+             "custom_non_data_line_markers": setup["custom_non_data_line_markers"],
+             "partition_by": setup["partition_by"]
              }
 
         if setup["column_names"]: p["column_names"] = None

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -482,8 +482,9 @@ class H2OFrame(Keyed):
              "blocking": False,
              "column_types": None,
              "skipped_columns":None,
-             "custom_non_data_line_markers": setup["custom_non_data_line_markers"],
-             "partition_by": setup["partition_by"]
+             "custom_non_data_line_markers": None,
+             "partition_by": None,
+             "single_quotes": None
              }
 
         if setup["column_names"]: p["column_names"] = None

--- a/h2o-py/tests/testdir_misc/pyunit_import_upload_singlequoted.py
+++ b/h2o-py/tests/testdir_misc/pyunit_import_upload_singlequoted.py
@@ -30,6 +30,14 @@ def test_upload_single_quoted():
     pd.testing.assert_frame_equal(pdf, hdf.as_data_frame(), check_dtype=False)
 
 
+def test_import_single_quoted_with_escaped_quotes():
+    path = pyunit_utils.locate("smalldata/parser/single_quotes_with_escaped_quotes.csv")
+    hdf = h2o.import_file(path=path, quotechar="'")
+    
+    pdf = pd.read_csv(path, quotechar="'", escapechar="\\")
+    pd.testing.assert_frame_equal(pdf, hdf.as_data_frame(), check_dtype=False)
+
+
 def test_import_fails_on_unsupported_quotechar():
     try:
         h2o.import_file(path=pyunit_utils.locate("smalldata/parser/single_quotes_mixed.csv"),
@@ -49,8 +57,9 @@ def test_upload_fails_on_unsupported_quotechar():
 
 
 pyunit_utils.run_tests([
-    test_import_single_quoted,
-    test_upload_single_quoted,
-    test_import_fails_on_unsupported_quotechar,
-    test_upload_fails_on_unsupported_quotechar,
+    # test_import_single_quoted,
+    # test_upload_single_quoted,
+    test_import_single_quoted_with_escaped_quotes,
+    # test_import_fails_on_unsupported_quotechar,
+    # test_upload_fails_on_unsupported_quotechar,
 ])

--- a/h2o-py/tests/testdir_misc/pyunit_import_upload_singlequoted.py
+++ b/h2o-py/tests/testdir_misc/pyunit_import_upload_singlequoted.py
@@ -57,9 +57,9 @@ def test_upload_fails_on_unsupported_quotechar():
 
 
 pyunit_utils.run_tests([
-    # test_import_single_quoted,
-    # test_upload_single_quoted,
+    test_import_single_quoted,
+    test_upload_single_quoted,
     test_import_single_quoted_with_escaped_quotes,
-    # test_import_fails_on_unsupported_quotechar,
-    # test_upload_fails_on_unsupported_quotechar,
+    test_import_fails_on_unsupported_quotechar,
+    test_upload_fails_on_unsupported_quotechar,
 ])

--- a/h2o-test-support/src/main/java/water/TestUtil.java
+++ b/h2o-test-support/src/main/java/water/TestUtil.java
@@ -717,7 +717,7 @@ public class TestUtil extends Iced {
     Key[] res = {nfs._key};
 
     // create new parseSetup in order to store our na_string
-    ParseSetup p = ParseSetup.guessSetup(res, new ParseSetup(DefaultParserProviders.GUESS_INFO,(byte) ',',true,
+    ParseSetup p = ParseSetup.guessSetup(res, new ParseSetup(DefaultParserProviders.GUESS_INFO,(byte) ',',false,
         check_header,0,null,null,null,null,null, null, null));
     if (skippedColumns != null) {
       p.setSkippedColumns(skippedColumns);


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-7996

few bugs on backend setup and parsing logic:

- parseSetup logic always consider double quotes as a potential quote, even in single quote mode.
- parseSetup logic ignores escape character (`\`) before the quote char when guessing the separator.
- parseSetup logic ignores that 2 consecutive quotes inside a quoted string is a way to escape the second quote.
- parsing state machine ignores escape character `\` as a way to escape quotes inside a quoted string.

Also TestUtil hardcoded (without explanation) some parsing methods with `singleQuotes=true` instead of default `singleQuotes=false`: given that there are about 100 different parsing methods there currently, it made it difficult to know for  sure which quote was used in the tests.
==> those parsing utility methods are just nightmare, all tests should switch to `ParseSetupTransformer` if they can't use defaults.

Future improvement/PR: autodetect quoting character in ParseSetup.