### PR TITLE
[PUBDEV-8069] Expose Actual Settings on EasyPredictModelWrapper

### DIFF
--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
@@ -70,6 +70,11 @@ public class EasyPredictModelWrapper implements Serializable {
   private final int glrmIterNumber; // allow user to set GLRM mojo iteration number in constructing x.
 
   private final PredictContributions predictContributions;
+
+  public boolean getEnableLeafAssignment() { return enableLeafAssignment; }
+  public boolean getEnableGLRMReconstruct() { return enableGLRMReconstruct; }
+  public boolean getEnableStagedProbabilities() { return enableStagedProbabilities; }
+  public boolean getEnableContributions() { return enableContributions; }
   
   /**
    * Observer interface with methods corresponding to errors during the prediction.


### PR DESCRIPTION
This goal of this PR is to expose the following private fields of `EasyPredictModelWrapper` for internal usage in Sparkling Water:

- `enableLeafAssignment`
- `enableGLRMReconstruct`
- `enableStagedProbabilities`
- `enableContributions`