### PR TITLE
Remove public final modifier from GLM mojo score0 function

### DIFF
--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/glm/GlmMojoModelBase.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/glm/GlmMojoModelBase.java
@@ -25,7 +25,7 @@ abstract class GlmMojoModelBase extends MojoModel {
   void init() { /* do nothing by default */ }
 
   @Override
-  public final double[] score0(double[] data, double[] preds) {
+  public double[] score0(double[] data, double[] preds) {
     if (_meanImputation)
       imputeMissingWithMeans(data);
 


### PR DESCRIPTION
This PR fixes a bug found when trying to auto-generate files for GLM in mojoland. When baking new recipes, mojoland sends a GET request for the function `double[] score0(double[] data, double[] preds)`. GLM currently has a `public final` modifier on this function, causing an exception to be thrown when baking new recipes for GLM in mojoland. By removing the `final` modifier from the function, the PR solves the bug.