### PR TITLE
Fix runit_lift_xval.R test

### DIFF
--- a/h2o-core/src/test/java/hex/FoldAssignmentTest.java
+++ b/h2o-core/src/test/java/hex/FoldAssignmentTest.java
@@ -80,7 +80,7 @@ public class FoldAssignmentTest {
     }
 
     @Test
-    public void fromUserFoldSpecification() {
+    public void fromUserFoldSpecification_categorical() {
         try {
             Scope.enter();
             Vec fold = Scope.track(ivec(1, 3));
@@ -94,6 +94,24 @@ public class FoldAssignmentTest {
 
             assertEquals(0.0, foldIndices.at(0), 0);
             assertEquals(1.0, foldIndices.at(1), 0);
+        } finally {
+            Scope.exit();
+        }
+    }
+
+    @Test
+    public void fromUserFoldSpecification_indices() {
+        try {
+            Scope.enter();
+            Vec fold = Scope.track(ivec(1, 2, 3));
+            Scope.track(fold);
+
+            FoldAssignment fa = FoldAssignment.fromUserFoldSpecification(3, fold);
+            Vec foldIndices = fa.getAdaptedFold();
+            Scope.track(foldIndices);
+
+            Vec expectedFoldIndices = Scope.track(ivec(0, 1, 2));
+            assertVecEquals(expectedFoldIndices, foldIndices, 0);
         } finally {
             Scope.exit();
         }

--- a/h2o-r/tests/testdir_misc/runit_lift_xval.R
+++ b/h2o-r/tests/testdir_misc/runit_lift_xval.R
@@ -43,13 +43,14 @@ test.xval.lift <- function(conn){
 	cv1 = h2o.getModel("cv_gbm_cv_1")
 	cv2 = h2o.getModel("cv_gbm_cv_2")
 	
-	#Define and use weights column to build equivalent gbm models 
-	ww[ss]=0
+	#Define and use weights column to build equivalent gbm models
+	ww <- rep(0, rowss) 
+	ww[ss] = 1
 	wi = as.h2o(ww,destination_frame = "weight_col")
 	a = h2o.assign(h2o.cbind(a,wi),key = "bank")
 	gg1 = h2o.gbm(x = myX,y = myY,training_frame = a,weights_column = "x0",ntrees = 5,model_id = "gbm1")
-	ww = rep(0,rowss)
-	ww[ss]=1
+	ww <- rep(1, rowss)
+	ww[ss] <- 0
 	wi = as.h2o(ww,destination_frame = "weight_col")
 	a = h2o.assign(h2o.cbind(a,wi),key = "bank")
 	gg2 = h2o.gbm(x = myX,y = myY,training_frame = a,weights_column = "x1",ntrees = 5,model_id = "gbm2")


### PR DESCRIPTION
We changed the way cv folds are assigned in https://github.com/h2oai/h2o-3/pull/5345

This affects fold specification that doesn't start from 0, eg. 1, 2, 3

Old way was to use modulo operator resulting in effective fold assignment:
1, 2, 0

New way is to respect the fold order, resulting in fold assignment 0, 1, 2