### PR TITLE
Fixed runit_PUBDEV_7860_gam_tp_gaussian_dual_model.R

### DIFF
--- a/h2o-r/tests/testdir_algos/gam/runit_PUBDEV_7860_gam_tp_gaussian_dual_model.R
+++ b/h2o-r/tests/testdir_algos/gam/runit_PUBDEV_7860_gam_tp_gaussian_dual_model.R
@@ -26,9 +26,11 @@ test.model.gam.dual.modes <- function() {
         temp <- abs(coeff1[[ind]]-coeff2[[ind]])
         expect_true(temp < 1e-6, "coefficient comparison failed.")
     }
-    
     # check validation metrics
-    expect_true(abs(h2o.mse(gam_model, valid=TRUE)-h2o.mse(gam_model2, valid=TRUE)) < 1e-6)
+    mse1 = h2o.mse(gam_model, valid=TRUE)
+    mse2 = h2o.mse(gam_model2, valid=TRUE)
+    expect_true(abs(mse1-mse2)/abs(mse1) < 1e-6)
+    print("Finished dual-mode test")
 }
 
 doTest("General Additive Model test dual model specification with Gaussian family", test.model.gam.dual.modes)


### PR DESCRIPTION
This comparison failed in the test:

    expect_true(abs(mse1-mse2) < 1e-6)

However, mse1, mse2 are around values: 1329035.  Hence, if they only differ by 1 say 1329036, this test will fail.  But differing by 1 is a very small difference:  1/1329035 = 0.0000007524256 < 1e-6.  Hence, I made the change in the comparison as: expect_true(abs(mse1-mse2)/abs(mse1) < 1e-6)