### PR TITLE
Fix SE AUTOMetalearner by removing alpha search

### DIFF
--- a/h2o-algos/src/main/java/hex/ensemble/Metalearners.java
+++ b/h2o-algos/src/main/java/hex/ensemble/Metalearners.java
@@ -215,7 +215,6 @@ public class Metalearners {
             //specific to AUTO mode
             parms._non_negative = true;
             //parms._alpha = new double[] {0.0, 0.25, 0.5, 0.75, 1.0};
-            parms._alpha = new double[] {0.5, 1.0};    
 
             // feature columns are already homogeneous (probabilities); when standardization is enabled,
             // there can be information loss if some columns have very low probabilities compared with others for example (bad model)


### PR DESCRIPTION
Having `parms._alpha = new double[] {0.5, 1.0};` caused an issue in GLM for multinomial tasks.

In [1] the `_ginfo` is `null`.

[1] https://github.com/h2oai/h2o-3/blob/3a8bd05e7ba8373b46a7825dd0a828e4255fc9d8/h2o-algos/src/main/java/hex/glm/ComputationState.java#L532 


This issue caused `tests/testdir_algos/stackedensemble/pyunit_stackedensemble_with_poor_models.py` to fail as well as `testBasicEnsembleAUTOMetalearner`.
