### PR TITLE
XGBoost: Added support for extracting platform-native libraries to a directory

### DIFF
--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostExtension.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostExtension.java
@@ -65,15 +65,21 @@ public class XGBoostExtension extends AbstractH2OExtension {
     }
   }
 
+  public static NativeLibraryLoaderChain getLoader() throws IOException {
+    INativeLibLoader loader = NativeLibLoader.getLoader();
+    if (! (loader instanceof NativeLibraryLoaderChain)) {
+      LOG.warn("Unexpected XGBoost library loader found. Custom loaders are not supported in this version. " +
+              "XGBoost extension will be disabled.");
+      return null;
+    }
+    return(NativeLibraryLoaderChain) loader;
+  }
+
   private boolean initXgboost() {
     try {
-      INativeLibLoader loader = NativeLibLoader.getLoader();
-      if (! (loader instanceof NativeLibraryLoaderChain)) {
-        LOG.warn("Unexpected XGBoost library loader found. Custom loaders are not supported in this version. " +
-                "XGBoost extension will be disabled.");
+      NativeLibraryLoaderChain chainLoader = getLoader();
+      if (chainLoader == null)
         return false;
-      }
-      NativeLibraryLoaderChain chainLoader = (NativeLibraryLoaderChain) loader;
       NativeLibrary lib = chainLoader.getLoadedLibrary();
       nativeLibInfo = new NativeLibInfo(lib);
       return true;

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/util/NativeLibraryLoaderChain.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/util/NativeLibraryLoaderChain.java
@@ -44,8 +44,6 @@ public class NativeLibraryLoaderChain implements INativeLibLoader {
     this(
       // GPU & OpenMP support enabled - backend will be decided at runtime based on availability
       nativeLibrary("xgboost4j_gpu", new NativeLibrary.CompilationFlags[] {WITH_GPU, WITH_OMP}),
-      // OpenMP 3.x support enabled (when libgomp1 4.x is not available - eg. Ubuntu 14.04)
-      nativeLibrary("xgboost4j_omp", new NativeLibrary.CompilationFlags[] {WITH_OMP}),
       // Minimum version of library - no gpu, no omp
       nativeLibrary("xgboost4j_minimal", EMPTY_COMPILATION_FLAGS)
     );
@@ -56,6 +54,10 @@ public class NativeLibraryLoaderChain implements INativeLibLoader {
     nativeLibs = libs;
   }
 
+  public NativeLibrary[] getNativeLibs() {
+    return nativeLibs;
+  }
+  
   @Override
   public void loadNativeLibs() throws IOException {
     LinkedList<IOException> exs = new LinkedList<>();

--- a/h2o-extensions/xgboost/src/main/java/water/tools/XGBoostLibExtractTool.java
+++ b/h2o-extensions/xgboost/src/main/java/water/tools/XGBoostLibExtractTool.java
@@ -1,0 +1,35 @@
+package water.tools;
+
+import hex.tree.xgboost.XGBoostExtension;
+import hex.tree.xgboost.util.NativeLibrary;
+import hex.tree.xgboost.util.NativeLibraryLoaderChain;
+
+import java.io.File;
+import java.io.IOException;
+
+public class XGBoostLibExtractTool {
+
+    public static void main(String[] args) throws IOException {
+        if (args.length != 1) {
+            System.err.println("XGBoostLibExtractTool: Specify target directory where to extract XGBoost native libraries.");
+            System.exit(-1);
+        }
+        File dir = new File(args[0]);
+        if (!dir.exists()) {
+            System.err.println("XGBoostLibExtractTool: Directory '" + dir.getAbsolutePath() + "' doesn't exist.");
+            System.exit(-1);
+        }
+        NativeLibraryLoaderChain loader = XGBoostExtension.getLoader();
+        if (loader == null) {
+            System.err.println("XGBoostLibExtractTool: Failed to locate native libraries.");
+            System.exit(-1);
+        }
+        for (NativeLibrary lib : loader.getNativeLibs()) {
+            if (!lib.isBundled())
+                continue;
+            File libFile = lib.extractTo(dir);
+            System.out.println("Extracted native library: " + libFile.getAbsolutePath());
+        }
+    }
+
+}


### PR DESCRIPTION
```
XGB_LIB_DIR=$PWD/xgb_lib_dir

mkdir -p $XGB_LIB_DIR
java -cp build/h2o.jar water.tools.XGBoostLibExtractTool $XGB_LIB_DIR

java -Djava.library.path=$XGB_LIB_DIR -jar build/h2o.jar
```

This is meant to be used in R:
1. H2O Jar is downloaded
2. native libraries extracted in package directory (alongside the jar)
3. h2o.init is modified to set `java.library.path` to the directory that holds the libraries, no data is written to a temporary directory or anywhere else