### PR TITLE
Fix runit_export_file test

### DIFF
--- a/h2o-r/tests/testdir_misc/runit_export_file.R
+++ b/h2o-r/tests/testdir_misc/runit_export_file.R
@@ -41,7 +41,7 @@ test.export.file <- function(parts) {
   H.pred <- as.data.frame(mypred)
   print(head(H.pred))
 
-  expect_identical(R.pred, H.pred)
+  expect_equal(R.pred, H.pred)
 }
 
 test.export.file.single <- function() test.export.file(1)


### PR DESCRIPTION
We cannot expect identical frames because we are using a different double
serialization on the backend
- for as.data.frame we use Double.toHexString(d)
- for exportFile we use RyuDouble.doubleToString(d)

This can produce differences on 1e-16