### PR TITLE
PUBDEV-8072 correct use of remove_collinear_columns for GLM

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -2757,6 +2757,11 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
   
   private Solver defaultSolver() {
     Solver s = Solver.IRLSM;
+    if (_parms._remove_collinear_columns) { // choose IRLSM if remove_collinear_columns is true
+      Log.info(LogMsg("picked solver " + s));
+      _parms._solver = s;
+      return s;
+    }
     int max_active = 0;
     if(_parms._family == Family.multinomial )
       for(int c = 0; c < _nclass; ++c)

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -304,6 +304,23 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     public boolean _generate_scoring_history = false; // if true, will generate scoring history but will slow algo down
     
     public void validate(GLM glm) {
+      if (_remove_collinear_columns) {
+        if (!(Solver.IRLSM.equals(_solver) || Solver.AUTO.equals(_solver)))
+          glm.warn("remove_collinear_columns", "remove_collinear_columns only works when IRLSM (or " +
+                  "AUTO which will default to IRLSM when remove_collinear_columns=true) is chosen as the solver.  " +
+                  "Otherwise, remove_collinear_columns is not enabled.");
+
+        if (_lambda_search) {
+          glm.warn("remove_collinear_columns", "remove_collinear_columns should only be used with " +
+                  "no regularization, i.e. lambda=0.0.  It is used improperly here with lambda_search.  " +
+                  "Please disable lambda_search and set lambda=0.");
+        } else if (_lambda != null) {
+          boolean nonZeroLambda = Arrays.stream(_lambda).sum() > 0;
+          if (nonZeroLambda)
+            glm.warn("remove_collinear_columns", "remove_collinear_columns should only be used with " +
+                    "no regularization, i.e. lambda=0.0.  It is used improperly here.  Please set lambda=0.");
+        }
+      }
       if (_solver.equals(Solver.COORDINATE_DESCENT_NAIVE) && _family.equals(Family.multinomial))
         throw H2O.unimpl("Naive coordinate descent is not supported for multinomial.");
       if ((_lambda != null) && _lambda_search)

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8072_remove_collinear_columns.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8072_remove_collinear_columns.py
@@ -1,0 +1,54 @@
+from __future__ import division
+from __future__ import print_function
+from past.utils import old_div
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+
+try:    # redirect python output
+    from StringIO import StringIO  # for python 3
+except ImportError:
+    from io import StringIO  # for python 2
+
+# This test is used to ensured that the correct warning message is received if user tries to use 
+# remove_collinear_columns with solver other than IRLSM
+def test_GLM_RCC_warning():
+    warnNumber = 1
+    hdf = h2o.upload_file(pyunit_utils.locate("smalldata/prostate/prostate_complete.csv.zip"))
+
+    print("Testing for family: TWEEDIE")
+    print("Set variables for h2o.")
+    y = "CAPSULE"
+    x = ["AGE","RACE","DCAPS","PSA","VOL","DPROS","GLEASON"]
+
+    print("Create models with canonical link: TWEEDIE")
+    buffer = StringIO() # redirect output
+    sys.stderr=buffer
+    model_h2o_tweedie = H2OGeneralizedLinearEstimator(family="tweedie", link="tweedie", alpha=0.5, Lambda=0.1, 
+                                                      remove_collinear_columns=True, solver="coordinate_descent")
+    model_h2o_tweedie.train(x=x, y=y, training_frame=hdf)   # this should generate a warning message
+    model_h2o_tweedie_wo_rcc = H2OGeneralizedLinearEstimator(family="tweedie", link="tweedie", alpha=0.5, Lambda=0.1,
+                                                             solver="coordinate_descent")
+    sys.stderr=sys.__stderr__   # redirect printout back to normal path
+    model_h2o_tweedie_wo_rcc.train(x=x, y=y, training_frame=hdf) # no warning message here.
+    
+    # since remove_collinear_columns have no effect, this two models should be the same
+    pyunit_utils.assertCoefDictEqual(model_h2o_tweedie.coef(), model_h2o_tweedie_wo_rcc.coef())
+    
+    # check and make sure we get the correct warning message
+    warn_phrase = "remove_collinear_columns only works when IRLSM"
+    try:        # for python 2.7
+        assert len(buffer.buflist)==warnNumber
+        print(buffer.buflist[0])
+        assert warn_phrase in buffer.buflist[0]
+    except:     # for python 3.
+        warns = buffer.getvalue()
+        print("*** captured warning message: {0}".format(warns))
+        assert warn_phrase in warns
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(test_GLM_RCC_warning)
+else:
+  test_GLM_RCC_warning()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8072_remove_collinear_columns_warnings.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8072_remove_collinear_columns_warnings.py
@@ -1,0 +1,66 @@
+from __future__ import division
+from __future__ import print_function
+from past.utils import old_div
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+
+try:    # redirect python output
+    from StringIO import StringIO  # for python 3
+except ImportError:
+    from io import StringIO  # for python 2
+
+# This test is used to ensured that the correct warning message is received if user tries to use 
+# remove_collinear_columns with lambda_search or non-zero lambda
+def test_GLM_RCC_warning():
+    warnNumber = 1
+    hdf = h2o.upload_file(pyunit_utils.locate("smalldata/prostate/prostate_complete.csv.zip"))
+
+    print("Testing for family: TWEEDIE")
+    print("Set variables for h2o.")
+    y = "CAPSULE"
+    x = ["AGE","RACE","DCAPS","PSA","VOL","DPROS","GLEASON"]
+
+    print("Create models with lambda_search")
+    buffer = StringIO() # redirect output
+    sys.stderr=buffer
+    model_h2o_tweedie = H2OGeneralizedLinearEstimator(family="tweedie", link="tweedie", lambda_search=True, 
+                                                      remove_collinear_columns=True, solver="irlsm")
+    model_h2o_tweedie.train(x=x, y=y, training_frame=hdf)   # this should generate a warning message
+    sys.stderr=sys.__stderr__   # redirect printout back to normal path
+    
+    # check and make sure we get the correct warning message
+    warn_phrase = "It is used improperly here with lambda_search"
+    try:        # for python 2.7
+        assert len(buffer.buflist)==warnNumber
+        print(buffer.buflist[0])
+        assert warn_phrase in buffer.buflist[0]
+    except:     # for python 3.
+        warns = buffer.getvalue()
+        print("*** captured warning message: {0}".format(warns))
+        assert warn_phrase in warns
+    
+    print("Create models with non-zero lambda")
+    buffer = StringIO() # redirect output
+    sys.stderr=buffer
+    model_h2o_tweedie = H2OGeneralizedLinearEstimator(family="tweedie", link="tweedie", Lambda=0.01,
+                                                  remove_collinear_columns=True, solver="irlsm")
+    model_h2o_tweedie.train(x=x, y=y, training_frame=hdf)   # this should generate a warning message
+    sys.stderr=sys.__stderr__   # redirect printout back to normal path
+    # check and make sure we get the correct warning message
+    warn_phrase = "It is used improperly here.  Please set lambda=0"
+    try:        # for python 2.7
+        assert len(buffer.buflist)==warnNumber
+        print(buffer.buflist[0])
+        assert warn_phrase in buffer.buflist[0]
+    except:     # for python 3.
+        warns = buffer.getvalue()
+        print("*** captured warning message: {0}".format(warns))
+        assert warn_phrase in warns
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(test_GLM_RCC_warning)
+else:
+  test_GLM_RCC_warning()


### PR DESCRIPTION
This PR resolves the issue in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8072

The implementation is correct.  However, the documentation is not clear.  I have asked Hannah to fix it.  In addition, remove_collinear_columns is only used when solver=IRLSM.  Hence, I added a warning message to inform the user that remove_collinear_columns is not used if the solver is not IRLSM.