### PR TITLE
PUBDEV-8053: Update Java Links to singular place in the documentation & add info about Java requirements [nocheck]

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Refer to the [h2o-droplets GitHub repository](https://github.com/h2oai/h2o-dropl
 <a name="Building"></a>
 ## 4. Building H2O-3
 
-Getting started with H2O development requires [JDK 1.7](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements), [Node.js](https://nodejs.org/), [Gradle](https://gradle.org/), [Python](https://www.python.org/) and [R](http://www.r-project.org/).  We use the Gradle wrapper (called `gradlew`) to ensure up-to-date local versions of Gradle and other dependencies are installed in your development directory.
+Getting started with H2O development requires [JDK 1.8+](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements), [Node.js](https://nodejs.org/), [Gradle](https://gradle.org/), [Python](https://www.python.org/) and [R](http://www.r-project.org/).  We use the Gradle wrapper (called `gradlew`) to ensure up-to-date local versions of Gradle and other dependencies are installed in your development directory.
 
 ### 4.1. Before building
 
@@ -248,7 +248,7 @@ open target/docs-website/h2o-docs/index.html
 
 ##### Step 3: Install JDK
 
-Install [Java 1.7](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements) and add the appropriate directory `C:\Program Files\Java\jdk1.7.0_65\bin` with java.exe to PATH in Environment Variables. To make sure the command prompt is detecting the correct Java version, run:
+Install [Java 1.8+](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements) and add the appropriate directory `C:\Program Files\Java\jdk1.7.0_65\bin` with java.exe to PATH in Environment Variables. To make sure the command prompt is detecting the correct Java version, run:
 
     javac -version
 
@@ -319,7 +319,7 @@ If you don't have [Homebrew](http://brew.sh/), we recommend installing it.  It m
 
 ##### Step 1. Install JDK
 
-Install [Java 1.7](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirementsl). To make sure the command prompt is detecting the correct Java version, run:
+Install [Java 1.8+](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirementsl). To make sure the command prompt is detecting the correct Java version, run:
 
     javac -version
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Refer to the [h2o-droplets GitHub repository](https://github.com/h2oai/h2o-dropl
 <a name="Building"></a>
 ## 4. Building H2O-3
 
-Getting started with H2O development requires [JDK 1.7](http://www.oracle.com/technetwork/java/javase/downloads/), [Node.js](https://nodejs.org/), [Gradle](https://gradle.org/), [Python](https://www.python.org/) and [R](http://www.r-project.org/).  We use the Gradle wrapper (called `gradlew`) to ensure up-to-date local versions of Gradle and other dependencies are installed in your development directory.
+Getting started with H2O development requires [JDK 1.7](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements), [Node.js](https://nodejs.org/), [Gradle](https://gradle.org/), [Python](https://www.python.org/) and [R](http://www.r-project.org/).  We use the Gradle wrapper (called `gradlew`) to ensure up-to-date local versions of Gradle and other dependencies are installed in your development directory.
 
 ### 4.1. Before building
 
@@ -248,7 +248,7 @@ open target/docs-website/h2o-docs/index.html
 
 ##### Step 3: Install JDK
 
-Install [Java 1.7](http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html) and add the appropriate directory `C:\Program Files\Java\jdk1.7.0_65\bin` with java.exe to PATH in Environment Variables. To make sure the command prompt is detecting the correct Java version, run:
+Install [Java 1.7](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements) and add the appropriate directory `C:\Program Files\Java\jdk1.7.0_65\bin` with java.exe to PATH in Environment Variables. To make sure the command prompt is detecting the correct Java version, run:
 
     javac -version
 
@@ -319,7 +319,7 @@ If you don't have [Homebrew](http://brew.sh/), we recommend installing it.  It m
 
 ##### Step 1. Install JDK
 
-Install [Java 1.7](http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html). To make sure the command prompt is detecting the correct Java version, run:
+Install [Java 1.7](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirementsl). To make sure the command prompt is detecting the correct Java version, run:
 
     javac -version
 
@@ -395,7 +395,7 @@ Note: on a regular machine it may take very long time (about an hour) to run all
 
 ##### Step 2. Install JDK:
 
-Install [Java 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html). Installation instructions can be found here [JDK installation](http://askubuntu.com/questions/56104/how-can-i-install-sun-oracles-proprietary-java-jdk-6-7-8-or-jre). To make sure the command prompt is detecting the correct Java version, run:
+Install [Java 8](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements). Installation instructions can be found here [JDK installation](http://askubuntu.com/questions/56104/how-can-i-install-sun-oracles-proprietary-java-jdk-6-7-8-or-jre). To make sure the command prompt is detecting the correct Java version, run:
 
     javac -version
 

--- a/h2o-algos/src/main/java/hex/tree/DHistogram.java
+++ b/h2o-algos/src/main/java/hex/tree/DHistogram.java
@@ -238,7 +238,7 @@ public final class DHistogram extends Iced {
     if (isInt > 0 && maxEx - min <= xbins) {
       assert ((long) min) == min : "Overflow for integer/categorical histogram: minimum value cannot be cast to long without loss: (long)" + min + " != " + min + "!";                // No overflow
       xbins = (char) ((long) maxEx - (long) min);  // Shrink bins
-      _step = 1.0f;                           // Fixed stepsize
+      _step = 1.0f;                           // Fixed step size
     } else {
       _step = xbins / (maxEx - min);              // Step size for linear interpolation, using mul instead of div
       if(_step <= 0 || Double.isInfinite(_step) || Double.isNaN(_step))

--- a/h2o-docs/src/product/aws.rst
+++ b/h2o-docs/src/product/aws.rst
@@ -289,7 +289,7 @@ Downloading Java and H2O
 
 1. Download
    `Java <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements>`__
-   (JDK 1.7 or later) if it is not already available on the instance.
+   (JDK 1.8+ or later) if it is not already available on the instance.
 2. To download H2O, run the ``wget`` command with the link to the zip
    file available on our `website <http://h2o.ai/download/>`__ by
    copying the link associated with the **Download** button for the

--- a/h2o-docs/src/product/aws.rst
+++ b/h2o-docs/src/product/aws.rst
@@ -288,7 +288,7 @@ Downloading Java and H2O
 ------------------------
 
 1. Download
-   `Java <http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html>`__
+   `Java <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements>`__
    (JDK 1.7 or later) if it is not already available on the instance.
 2. To download H2O, run the ``wget`` command with the link to the zip
    file available on our `website <http://h2o.ai/download/>`__ by

--- a/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
+++ b/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
@@ -321,7 +321,7 @@ Otherwise, download PuTTY and follow these instructions:
 Downloading Java and H2O
 ''''''''''''''''''''''''
 
-1. Download `Java <https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html>`__ (JDK 1.8 or later) if it is not already available on the instance.
+1. Download `Java <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements>`__ (JDK 1.8 or later) if it is not already available on the instance.
 2. To download H2O, run the ``wget`` command with the link to the zip file available on our `website <http://h2o.ai/download/>`__ by copying the link associated with the **Download** button for the selected H2O build.
 
    ::

--- a/h2o-docs/src/product/faq/general-troubleshooting.rst
+++ b/h2o-docs/src/product/faq/general-troubleshooting.rst
@@ -92,12 +92,7 @@ The following error message displayed when I tried to launch H2O. What should I 
             at java.lang.ClassLoader.loadClass(Unknown Source)
     Could not find the main class: water.H2OApp. Program will exit.
 
-This error output indicates that your Java version is not supported.
-Upgrade to `Java 7
-(JVM) <http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html>`__
-or
-`later <http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html>`__
-and H2O should launch successfully.
+This error output indicates that your Java version is not supported. Make sure to check and upgrade to the `supported Java versions <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements>`__ and H2O should launch successfully.
 
 --------------
 

--- a/h2o-docs/src/product/faq/general.rst
+++ b/h2o-docs/src/product/faq/general.rst
@@ -103,9 +103,7 @@ Why is H2O not launching from the command line?
     at java.lang.Class.initializeClass(libgcj.so.10)
     ...4 more
 
-The only prerequisite for running H2O is a compatible version of Java.
-We recommend Oracle's `Java
-1.7 <http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html>`__.
+The only prerequisite for running H2O is a compatible version of `Java <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements>`__.
 
 --------------
 

--- a/h2o-docs/src/product/howto/H2O-DevS3Creds.md
+++ b/h2o-docs/src/product/howto/H2O-DevS3Creds.md
@@ -192,8 +192,7 @@ Otherwise, download PuTTY and follow these instructions:
 ### Downloading Java and H2O
 
 
-1. Download [Java](http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html
-) (JDK 1.7 or later) if it is not already available on the instance. 
+1. Download [Java](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements) (JDK 1.7 or later) if it is not already available on the instance. 
 
 2. To download H2O, run the `wget` command with the link to the zip file available on our [website](http://h2o.ai/download/) by copying the link associated with the **Download** button for the selected H2O build. 
 	

--- a/h2o-docs/src/product/howto/H2O-DevS3Creds.md
+++ b/h2o-docs/src/product/howto/H2O-DevS3Creds.md
@@ -192,7 +192,7 @@ Otherwise, download PuTTY and follow these instructions:
 ### Downloading Java and H2O
 
 
-1. Download [Java](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements) (JDK 1.7 or later) if it is not already available on the instance. 
+1. Download [Java](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements) (JDK 1.8 or later) if it is not already available on the instance. 
 
 2. To download H2O, run the `wget` command with the link to the zip file available on our [website](http://h2o.ai/download/) by copying the link associated with the **Download** button for the selected H2O build. 
 	

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -34,18 +34,13 @@ At a minimum, we recommend the following for compatibility with H2O:
 Java Requirements
 ~~~~~~~~~~~~~~~~~
 
-Java is always required to run H2O. To build H2O or run H2O tests, the 64-bit JDK is required. To run the H2O binary using either the command line, R, or Python packages, only 64-bit JRE is required.
+H2O can run on Java. To build H2O or run H2O tests, the 64-bit JDK is required. To run the H2O binary using either the command line, R, or Python packages, only 64-bit JRE is required.
 
-H2O supports the following versions of Java:
+H2O supports the following versions of Java: 
 
-- `Java SE 15 <https://www.oracle.com/java/technologies/javase/jdk15-archive-downloads.html>`__
-- `Java SE 14 <https://www.oracle.com/java/technologies/javase/jdk14-archive-downloads.html>`__
-- `Java SE 13 <https://www.oracle.com/java/technologies/javase/jdk13-archive-downloads.html>`__
-- `Java SE 12 <https://www.oracle.com/java/technologies/javase/jdk12-archive-downloads.html>`__
-- `Java SE 11 <https://www.oracle.com/java/technologies/javase/jdk11-archive-downloads.html>`__
-- `Java SE 10 <https://www.oracle.com/java/technologies/java-archive-javase10-downloads.html>`__
-- `Java SE 9 <https://www.oracle.com/java/technologies/javase/javase9-archive-downloads.html>`__
-- `Java SE 8 <https://www.oracle.com/java/technologies/javase/javase8u211-later-archive-downloads.html>`__
+- Java SE 15, 14, 13, 12, 11, 10, 9, 8
+
+Click `here <https://jdk.java.net/archive/>`__ to download the latest supported version.
 
 Additional Requirements
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -23,19 +23,29 @@ At a minimum, we recommend the following for compatibility with H2O:
    -  Ubuntu 12.04
    -  RHEL/CentOS 6 or later
 
--  **Languages**: Scala, R, and Python are not required to use H2O unless you want to use H2O in those environments, but Java is always required. Supported versions include:
-
-   -  Java 8, 9, 10, 11, 12, 13, 14, 15
-
-      - To build H2O or run H2O tests, the 64-bit JDK is required.
-      - To run the H2O binary using either the command line, R, or Python packages, only 64-bit JRE is required.
-      - Both of these are available on the `Java download page <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`__.
+-  **Languages**: Scala, R, and Python are not required to use H2O unless you want to use H2O in those environments, but Java is always required (see `below <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements>`__).
 
    -  Scala 2.10 or later
    -  R version 3 or later
    -  Python 2.7.x, 3.5.x, 3.6.x 
 
 -  **Browser**: An internet browser is required to use H2O's web UI, Flow. Supported versions include the latest version of Chrome, Firefox, Safari, or Internet Explorer.
+
+Java Requirements
+~~~~~~~~~~~~~~~~~
+
+Java is always required to run H2O. To build H2O or run H2O tests, the 64-bit JDK is required. To run the H2O binary using either the command line, R, or Python packages, only 64-bit JRE is required.
+
+H2O supports the following versions of Java:
+
+- `Java SE 15 <https://www.oracle.com/java/technologies/javase/jdk15-archive-downloads.html>`__
+- `Java SE 14 <https://www.oracle.com/java/technologies/javase/jdk14-archive-downloads.html>`__
+- `Java SE 13 <https://www.oracle.com/java/technologies/javase/jdk13-archive-downloads.html>`__
+- `Java SE 12 <https://www.oracle.com/java/technologies/javase/jdk12-archive-downloads.html>`__
+- `Java SE 11 <https://www.oracle.com/java/technologies/javase/jdk11-archive-downloads.html>`__
+- `Java SE 10 <https://www.oracle.com/java/technologies/java-archive-javase10-downloads.html>`__
+- `Java SE 9 <https://www.oracle.com/java/technologies/javase/javase9-archive-downloads.html>`__
+- `Java SE 8 <https://www.oracle.com/java/technologies/javase/javase8u211-later-archive-downloads.html>`__
 
 Additional Requirements
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/h2o-py/h2o/backend/server.py
+++ b/h2o-py/h2o/backend/server.py
@@ -439,7 +439,7 @@ class H2OLocalServer(object):
 
         # not found...
         raise H2OStartupError("Cannot find Java. Please install the latest JRE from\n"
-                              "http://www.oracle.com/technetwork/java/javase/downloads/index.html")
+                              "http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements")
 
 
     def _tmp_file(self, kind):

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -630,12 +630,12 @@ h2o.resume <- function(recovery_dir=NULL) {
   if (!is.null(jver_error)) {
     stop(jver_error, "\n",
     "Please download the latest Java SE JDK from the following URL:\n",
-    "https://www.oracle.com/technetwork/java/javase/downloads/index.html")
+    "http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements")
   }
   if(any(grepl("Client VM", jver))) {
     warning("You have a 32-bit version of Java. H2O works best with 64-bit Java.\n",
             "Please download the latest Java SE JDK from the following URL:\n",
-            "https://www.oracle.com/technetwork/java/javase/downloads/index.html")
+            "http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements")
 
     # Set default max_memory to be 1g for 32-bit JVM.
     if(is.null(max_memory)) max_memory = "1g"


### PR DESCRIPTION
For: https://h2oai.atlassian.net/browse/PUBDEV-8053

I added the Java Requirements section right below the [requirements](http://www.oracle.com/technetwork/java/javase/downloads/index.html) in the welcome doc. Most all of the information I was able to grab on Java requirements was from that original requirements section. Please let me know any other information you'd like for me to add.

As for the java version links, I was only able to find those archived oracle download links (especially for the older versions). The java download page currently only lists versions 16, 15, 11(LTS), 8, & 7, so I directly linked to each archived version. 