### PR TITLE
PUBDEV-8102: AutoML crashes if model parameter validation fails

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -71,7 +71,8 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
         );
     }
 
-    protected <M extends Model, MP extends Model.Parameters> Job<M> startModel(
+    @SuppressWarnings("unchecked")
+    protected <MP extends Model.Parameters> Job<M> startModel(
             final Key<M> resultKey,
             final MP params
     ) {
@@ -81,8 +82,8 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
         builder._parms = params;
         aml().eventLog().info(Stage.ModelTraining, "AutoML: starting "+resultKey+" model training")
                 .setNamedValue("start_"+_algo+"_"+_id, new Date(), EventLogEntry.epochFormat.get());
-        builder.init(false);          // validate parameters
         try {
+            builder.init(false);          // validate parameters
             return builder.trainModelOnH2ONode();
         } catch (H2OIllegalArgumentException exception) {
             aml().eventLog().warn(Stage.ModelTraining, "Skipping training of model "+resultKey+" due to exception: "+exception);

--- a/h2o-automl/src/test/java/ai/h2o/automl/dummy/DummyBuilder.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/dummy/DummyBuilder.java
@@ -4,6 +4,7 @@ import ai.h2o.automl.IAlgo;
 import hex.ModelBuilder;
 import hex.ModelCategory;
 import org.junit.Ignore;
+import water.exceptions.H2OIllegalArgumentException;
 
 @Ignore("utility class")
 public class DummyBuilder extends ModelBuilder<DummyModel, DummyModel.DummyModelParameters, DummyModel.DummyModelOutput> {
@@ -24,6 +25,14 @@ public class DummyBuilder extends ModelBuilder<DummyModel, DummyModel.DummyModel
         init(false);
     }
 
+    @Override
+    public void init(boolean expensive) {
+        super.init(expensive);
+        if (_parms._fail_on_init) {
+            throw new H2OIllegalArgumentException("Failing on request");
+        }
+    }
+    
     @Override
     public ModelCategory[] can_build() {
         return new ModelCategory[] {ModelCategory.Binomial};

--- a/h2o-automl/src/test/java/ai/h2o/automl/dummy/DummyModel.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/dummy/DummyModel.java
@@ -16,7 +16,8 @@ public class DummyModel extends Model<DummyModel, DummyModel.DummyModelParameter
 
     public static class DummyModelParameters extends Model.Parameters {
 
-        public String _tag = null;
+        public String _tag;
+        public boolean _fail_on_init;
         public IcedHashMap<String, String> _moreParams = new IcedHashMap<>();
 
         @Override


### PR DESCRIPTION
Even though builder.init(expensive = false) shouldn't cause H2OIllegalArgumentException, the reality is different (currently XGBoost does do that).

This PR prevents AutoML from crashing if model builder produces H2OIllegalArgumentException in the parameter validation phase.