### PR TITLE
PUBDEV-8092: Job polling fail tolerance implementation for R according to the same python implementation in PUBDEV-8034 

### DIFF
--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -799,9 +799,43 @@ h2o.list_jobs <- function() {
   df
 }
 
-h2o.get_job <- function(job_key) {
+h2o.get_job <- function(job_key, jobPollSuccess = FALSE, jobIsRecoverable = FALSE) {
   myJobUrlSuffix <- paste0(.h2o.__JOBS, "/", job_key)
-  rawResponse <- .h2o.doSafeGET(urlSuffix = myJobUrlSuffix)
+
+  # If request fail, repeat the request unless it is stopifnot(..) error or job is no longer exists in the cluster (e.g. in case of restart)
+  i <- 0
+  while (i < 30) {
+    rawResponse <- try(.h2o.doSafeGET(urlSuffix = myJobUrlSuffix))
+    if(class(rawResponse) == "try-error" && jobPollSuccess){
+      error_type <- attr(rawResponse,"condition")
+      if (jobIsRecoverable) {
+        print(sprintf("Job request failed %s, waiting for cluster to restart.", error_type$message))
+        Sys.sleep(10)
+      } else {
+        # This type of error handling is not ideal and safe for changes inside of the API
+        if(grepl("Job is missing", error_type$message, fixed = TRUE)) {
+          print(sprintf("Job is no longer exists: %s", error_type$message))
+          break
+        }
+        if (grepl("is not TRUE", error_type$message, fixed = TRUE)) {
+          print(sprintf("Request validation failed %s", error_type$message))
+          break
+        }
+        print(sprintf("Job request failed %s, will retry after 3s.", error_type$message))
+        Sys.sleep(3)
+      }
+      i <- i + 1
+    } else {
+      break
+    }
+  }
+
+  # If request is still errored, stop with last error
+  if(class(rawResponse) == "try-error") {
+    stop(rawResponse)
+  }
+
+  # Parse job from response
   jsonObject <- .h2o.fromJSON(jsonlite::fromJSON(rawResponse, simplifyDataFrame=FALSE))
   jobs <- jsonObject$jobs
   if (length(jobs) > 1) {
@@ -928,10 +962,14 @@ h2o.show_progress <- function() assign("PROGRESS_BAR", TRUE, .pkg.env)
   if (progressBar) pb <- txtProgressBar(style = 3L)
   keepRunning <- TRUE
   tryCatch({
+    jobPollSuccess <- FALSE
+    jobIsRecoverable <- FALSE
     while (keepRunning) {
-      job <- h2o.get_job(job_key)
+      job <- h2o.get_job(job_key, jobPollSuccess, jobIsRecoverable)
       status <- job$status
       stopifnot(is.character(status))
+      jobPollSuccess <- TRUE
+      jobIsRecoverable <- job$auto_recoverable
 
       # check failed up front...
       if( status == "FAILED" ) {

--- a/h2o-r/tests/testdir_misc/runit_job_polling_retry.R
+++ b/h2o-r/tests/testdir_misc/runit_job_polling_retry.R
@@ -1,0 +1,29 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+jobRequestCounter <- 0
+origSafeGet <- .h2o.doSafeGET
+
+.h2o.doSafeGET <- function(h2oRestApiVersion, urlSuffix, parms, ...) {
+  if (jobRequestCounter == 2) {
+    jobRequestCounter <<- jobRequestCounter + 1
+    stop("Simulated connection error")
+  } else {
+    jobRequestCounter <<- jobRequestCounter + 1
+    origSafeGet(h2oRestApiVersion, urlSuffix, parms, ...)
+  }
+}
+
+test.jobPoolRetry <- function () {
+  set.seed(1234)
+  N = 1e4
+  random_data <- data.frame(
+    x = c(rnorm(N, 0, 0.5), rnorm(N*0.05, -1.5, 1)),
+    y = c(rnorm(N, 0, 0.5), rnorm(N*0.05,  1.5, 1))
+  )
+  random_data.hex <- as.h2o(random_data)
+
+  h2o.isolationForest(ntrees = 100, training_frame = random_data.hex)
+}
+
+doTest("Test Job poll retry", test.jobPoolRetry)


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8092
https://h2oai.atlassian.net/browse/PUBDEV-8034

I followed the python implementation as much as possible. I exclude from repeating the cases if Job is not found in the cluster or 
if function inputs' validation fail. The check is done with string compare though and AFAIK it fails with API version 4.


[PUBDEV-8092-job-poll-patch.txt](https://github.com/h2oai/h2o-3/files/6352393/PUBDEV-8092-job-poll-patch.txt)
[PUBDEV-8092-job-poll-patch-test.txt](https://github.com/h2oai/h2o-3/files/6352398/PUBDEV-8092-job-poll-patch-test.txt)

