### PR TITLE
Added support for load balancers to h2o-helm.

### DIFF
--- a/h2o-helm/templates/loadbalancer.yaml
+++ b/h2o-helm/templates/loadbalancer.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.loadbalancer.enabled -}}
+{{- $fullName := include "h2o-helm.fullname" . -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-load-balancer
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "h2o-helm.labels" . | nindent 4 }}
+spec:
+  type: LoadBalancer
+  selector:
+  {{- include "h2o-helm.selectorLabels" . | nindent 4 }}
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 54321
+{{- end }}

--- a/h2o-helm/values.yaml
+++ b/h2o-helm/values.yaml
@@ -36,7 +36,7 @@ service:
 ingress:
   enabled: false
   annotations: { }
-    # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
@@ -45,6 +45,9 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+
+loadbalancer:
+  enabled: false
 
 # For reproducibility, H2O must always have the very same resources allocated throughout the whole container lifetime
 resources:


### PR DESCRIPTION
Added `loadbalancer.yaml` and updated `values.yaml` templates to enable support for load balancers if the k8s deployments supports it.  (Option for ingress still exists).