### PR TITLE
Make sure testJavaScoring tests all rows, not just a subset [nocheck]

### DIFF
--- a/h2o-algos/src/test/java/hex/tree/drf/DRFPredictContribsTest.java
+++ b/h2o-algos/src/test/java/hex/tree/drf/DRFPredictContribsTest.java
@@ -1,5 +1,6 @@
 package hex.tree.drf;
 
+import hex.Model;
 import hex.genmodel.algos.tree.SharedTreeNode;
 import hex.genmodel.algos.tree.SharedTreeSubgraph;
 import hex.genmodel.algos.tree.TreeSHAP;
@@ -180,8 +181,13 @@ public class DRFPredictContribsTest extends TestUtil {
                     .doAll(new byte[]{Vec.T_CAT, Vec.T_NUM, Vec.T_NUM}, contributions)
                     .outputFrame(null, new String[]{"predict", "p0", "p1"}, new String[][]{new String[]{"0", "1"}, null, null});
             Scope.track(predsFromContribs);
-            
-            assertTrue(drf.testJavaScoring(fr, predsFromContribs, 1e-5, 1e-7));
+
+            Model.JavaScoringOptions options = new Model.JavaScoringOptions();
+            if (!Boolean.getBoolean("reproduce.PUBDEV-8264")) { // FIXME - works only by chance - fails on full data
+                options._fraction = 0.1;
+            }
+            options._abs_epsilon = 1e-7;
+            assertTrue(drf.testJavaScoring(fr, predsFromContribs, 1e-5, options));
 
             // Now test MOJO scoring
             EasyPredictModelWrapper.Config cfg = new EasyPredictModelWrapper.Config()


### PR DESCRIPTION
Originally testJavaScoring was using a fraction of the dataset to test (10%), with this change it uses the full dataset. The reason for this change is that for small synthetic data (few rows) it didn’t actually test any rows.

With this change enabled I found 2 code issues:

- https://h2oai.atlassian.net/browse/PUBDEV-8263
- https://h2oai.atlassian.net/browse/PUBDEV-8264