### PR TITLE
PUBDEV-8134: log python version before buildClientDist task to better…

### DIFF
--- a/docker/scripts/install_python_version
+++ b/docker/scripts/install_python_version
@@ -57,7 +57,6 @@ for python_version in "${array[@]}"; do
   su jenkins -c "virtualenv -p python${python_version} /envs/h2o_env_python${python_version}"
 
   echo "###### Installing dependencies for Python ${python_version} ######"
-  su jenkins -c ". /envs/h2o_env_python${python_version}/bin/activate && pip uninstall setuptools -y && pip install setuptools" # resinstalling setuptools fixes install issues for sphinx-osexample
   su jenkins -c ". /envs/h2o_env_python${python_version}/bin/activate && grep -v \"^#\" test-requirements.txt | sed -r 's/(.*)/\"\\1\"/' | xargs -n 1 -L 1 pip install"
   if [[ ${major} == "3" ]]; then
     su jenkins -c ". /envs/h2o_env_python${python_version}/bin/activate && grep -v \"^#\" docs-requirements.txt | sed -r 's/(.*)/\"\\1\"/' | xargs -n 1 -L 1 pip install"    


### PR DESCRIPTION
… diagnose the problem


https://h2oai.atlassian.net/browse/PUBDEV-8134


after d84f6ae:
- setuptools is there during pythonVersion (added pip list there)
- its also there during next task verifyDependencies, because it gets verified by verify_requirements.py and it is listed in conda/h2o/meta.yaml
- added pip list log directly into buildClientDist before running the failing command


it will be something like this https://stackoverflow.com/questions/37341614/modules-are-installed-using-pip-on-osx-but-not-found-when-importing


because

when
ssh jenkins@mr-0xe2
docker run -it --rm -v /home/0xdiag:/home/0xdiag -v /home/jenkins/slave_dir_from_mr-0xc1/workspace/hadoop-multinode-pipeline_master:/app harbor.h2o.ai/opsh2oai/h2o-3-hadoop-hdp-2.2-0xd-edge:84 bash
source envs/h2o_env_python3.6/bin/activate

setuptools is in pip list result but

(h2o_env_python3.6) root@f1ac451dfed6:/envs# python
Python 3.6.12 (default, Aug 18 2020, 02:08:22) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from setuptools import setup, find_packages
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'setuptools'

and

(h2o_env_python3.6) root@f1ac451dfed6:/envs# which -a python
/envs/h2o_env_python3.6/bin/python
/usr/bin/python

and 

from setuptools import setup, find_packages

works when I do it outside of h2o_env_python3.6




