### PR TITLE
PUBDEV-8135: On Hadoop optionally use S3A to configure S3 client for PersistS3

### DIFF
--- a/h2o-core/src/main/java/water/persist/S3ClientFactory.java
+++ b/h2o-core/src/main/java/water/persist/S3ClientFactory.java
@@ -1,0 +1,7 @@
+package water.persist;
+
+public interface S3ClientFactory {
+
+    <T> T newClientInstance();
+
+}

--- a/h2o-core/src/main/java/water/util/ReflectionUtils.java
+++ b/h2o-core/src/main/java/water/util/ReflectionUtils.java
@@ -142,4 +142,14 @@ public class ReflectionUtils {
       }
     }
   }
+
+  @SuppressWarnings("unchecked")
+  public static <T> T newInstance(String className, Class<T> instanceOf) throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+    Class<?> cls = Class.forName(className);
+    if (! instanceOf.isAssignableFrom(cls)) {
+      throw new IllegalStateException("Class " + className + " is not an instance of " + instanceOf.getName() + ".");
+    }
+    return (T) cls.newInstance();
+  }
+
 }

--- a/h2o-core/src/test/java/water/util/ReflectionUtilsTest.java
+++ b/h2o-core/src/test/java/water/util/ReflectionUtilsTest.java
@@ -1,0 +1,28 @@
+package water.util;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import water.parser.DecryptionTool;
+import water.parser.NullDecryptionTool;
+
+import static org.junit.Assert.*;
+
+public class ReflectionUtilsTest {
+
+    @Rule
+    public ExpectedException ee = ExpectedException.none();
+    
+    @Test
+    public void newInstance() throws Exception {
+        DecryptionTool instance = ReflectionUtils.newInstance(NullDecryptionTool.class.getName(), DecryptionTool.class);
+        assertNotNull(instance);
+    }
+
+    @Test
+    public void newInstance_invalid() throws Exception {
+        ee.expectMessage("Class water.parser.NullDecryptionTool is not an instance of java.lang.Number.");
+        ReflectionUtils.newInstance(NullDecryptionTool.class.getName(), Number.class);
+    }
+
+}

--- a/h2o-persist-hdfs/src/main/java/water/persist/S3AClientFactory.java
+++ b/h2o-persist-hdfs/src/main/java/water/persist/S3AClientFactory.java
@@ -1,0 +1,32 @@
+package water.persist;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import water.util.ReflectionUtils;
+
+import java.io.IOException;
+import java.net.URI;
+
+import static water.H2O.OptArgs.SYSTEM_PROP_PREFIX;
+
+public class S3AClientFactory implements S3ClientFactory {
+
+    public final static String S3A_FACTORY_PROTOTYPE_URI = System.getProperty(
+            SYSTEM_PROP_PREFIX + "persist.s3a.factoryPrototypeUri", "s3a://www.h2o.ai/");
+
+    @Override
+    public <T> T newClientInstance() {
+        try {
+            FileSystem fs = FileSystem.get(URI.create(S3A_FACTORY_PROTOTYPE_URI), PersistHdfs.CONF);
+            if (fs instanceof S3AFileSystem) {
+                return ReflectionUtils.getFieldValue(fs, "s3"); 
+            } else {
+                throw new IllegalStateException("File system corresponding to schema s3a is not an instance of S3AFileSystem, " +
+                        "it is " + (fs != null ? fs.getClass().getName() : "undefined") + ".");
+            }
+        } catch (IOException e) {
+            throw new RuntimeException();
+        }
+    }
+
+}

--- a/h2o-persist-s3/src/test/java/water/persist/CustomCredentialsProvider.java
+++ b/h2o-persist-s3/src/test/java/water/persist/CustomCredentialsProvider.java
@@ -1,0 +1,28 @@
+package water.persist;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import org.junit.Ignore;
+
+@Ignore
+public class CustomCredentialsProvider implements AWSCredentialsProvider {
+    @Override
+    public AWSCredentials getCredentials() {
+        return new AWSCredentials() {
+            @Override
+            public String getAWSAccessKeyId() {
+                return "testAccessKeyId";
+            }
+
+            @Override
+            public String getAWSSecretKey() {
+                return "testSecretKey";
+            }
+        };
+    }
+
+    @Override
+    public void refresh() {
+
+    }
+}

--- a/h2o-persist-s3/src/test/java/water/persist/PersistS3Test.java
+++ b/h2o-persist-s3/src/test/java/water/persist/PersistS3Test.java
@@ -1,9 +1,9 @@
 package water.persist;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import org.junit.After;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -456,4 +456,25 @@ public class PersistS3Test extends TestUtil {
       DKV.remove(Key.make(IcedS3Credentials.S3_CREDENTIALS_DKV_KEY));
     }
   }
+
+  @Test
+  public void testCustomCredentialsProvider() {
+    AWSCredentialsProvider[] defaultProviders =
+            PersistS3.H2OAWSCredentialsProviderChain.constructProviderChain(null);
+    AWSCredentialsProvider[] extendedProviders = 
+            PersistS3.H2OAWSCredentialsProviderChain.constructProviderChain(CustomCredentialsProvider.class.getName());
+    assertEquals(defaultProviders.length + 1, extendedProviders.length);
+    assertTrue(extendedProviders[0] instanceof CustomCredentialsProvider);
+  }
+
+  @Test
+  public void testCustomCredentialsProvider_ignoreInvalid() {
+    AWSCredentialsProvider[] defaultProviders =
+            PersistS3.H2OAWSCredentialsProviderChain.constructProviderChain(null);
+    AWSCredentialsProvider[] extendedProviders =
+            PersistS3.H2OAWSCredentialsProviderChain.constructProviderChain("no.such.class");
+    assertEquals(defaultProviders.length, extendedProviders.length);
+  }
+
+
 }


### PR DESCRIPTION
The idea here is that we can get S3 client configured from S3A filesystem implementation, users than don't need to configure everything 2x if they want both S3A and S3.

Example:

hadoop jar h2odriver.jar -Dfs.s3a.access.key=XXX -Dfs.s3a.secret.key=YYY -JJ -Dsys.ai.h2o.persist.s3.clientFactoryClass=water.persist.S3AClientFactory -n 1 -mapperXmx 10g -J -hdfs_config -J job.xml