### PR TITLE
PUBDEV-8150: Added warning message to Java, R, Python clients if use alpha in hyper-parameter

### DIFF
--- a/h2o-core/src/main/java/hex/grid/Grid.java
+++ b/h2o-core/src/main/java/hex/grid/Grid.java
@@ -131,6 +131,7 @@ public class Grid<MP extends Model.Parameters> extends Lockable<Grid<MP>> implem
         String warningMessage = "Adding alpha array to hyperparameter runs slower with gridsearch.  This is " +
                 "due to the fact that the algo has to run initialization for every alpha value.  Setting the alpha " +
                 "array as a model parameter will skip the initialization and run faster overall.";
+        Log.warn(warningMessage);
         // Append message
         String[] m = _warning_details;
         String[] nm = Arrays.copyOf(m, m.length + 1);
@@ -437,9 +438,8 @@ public class Grid<MP extends Model.Parameters> extends Lockable<Grid<MP>> implem
     for (SearchFailure f : values) {
       searchFailure.appendFailedModelParameters(f._failed_params, f._failed_raw_params, f._failure_details,
               f._failure_stack_traces);
-      searchFailure.appendWarningMessage(_hyper_names, "alpha");
     }
-
+    searchFailure.appendWarningMessage(_hyper_names, "alpha");
     return searchFailure;
   }
 

--- a/h2o-core/src/main/java/hex/schemas/GridSchemaV99.java
+++ b/h2o-core/src/main/java/hex/schemas/GridSchemaV99.java
@@ -45,6 +45,9 @@ public class GridSchemaV99 extends SchemaV3<Grid, GridSchemaV99> {
   @API(help = "List of failed parameters", direction = API.Direction.OUTPUT)
   public ModelParametersSchemaV3[] failed_params; // Using common ancestor of XXXParamsV3
 
+  @API(help = "List of detailed warning messages", direction = API.Direction.OUTPUT)
+  public String[] warning_details;
+  
   @API(help = "List of detailed failure messages", direction = API.Direction.OUTPUT)
   public String[] failure_details;
 
@@ -158,6 +161,7 @@ public class GridSchemaV99 extends SchemaV3<Grid, GridSchemaV99> {
     failure_details = failures.getFailureDetails();
     failure_stack_traces = failures.getFailureStackTraces();
     failed_raw_params = failures.getFailedRawParameters();
+    warning_details = failures.getWarningDetails();
     export_checkpoints_dir = grid.getParams() != null ? grid.getParams()._export_checkpoints_dir : null;
 
     TwoDimTable t = grid.createSummaryTable(keys, sort_by, decreasing);

--- a/h2o-py/h2o/grid/grid_search.py
+++ b/h2o-py/h2o/grid/grid_search.py
@@ -1,5 +1,8 @@
 # -*- encoding: utf-8 -*-
 from __future__ import division, print_function, absolute_import, unicode_literals
+
+import warnings
+
 from h2o.utils.compatibility import *  # NOQA
 
 import itertools
@@ -421,6 +424,9 @@ class H2OGridSearch(h2o_meta(Keyed)):
         grid_json = h2o.api("GET /99/Grids/%s" % (grid.dest_key))
         failure_messages_stacks = ""
         error_index = 0
+        if len(grid_json["warning_details"]) > 0:
+            for w_message in grid_json["warning_details"]:
+                warnings.warn(w_message);
         if len(grid_json["failure_details"]) > 0:
             print("Errors/Warnings building gridsearch model\n")
             # will raise error if no grid model is returned, store error messages here

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8150_warning_alpha_grid.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8150_warning_alpha_grid.py
@@ -1,0 +1,50 @@
+from __future__ import print_function
+from builtins import range
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+from h2o.grid.grid_search import H2OGridSearch
+
+try:    # redirect python output
+    from StringIO import StringIO  # for python 3
+except ImportError:
+    from io import StringIO  # for python 2
+
+# This test is used to make sure when a user tries to set alpha in the hyper-parameter of gridsearch, a warning
+# should appear to tell the user to set the alpha array as an parameter in the algorithm.
+def grid_alpha_search():
+    warnNumber = 1
+    hdf = h2o.upload_file(pyunit_utils.locate("smalldata/prostate/prostate_complete.csv.zip"))
+
+    print("Testing for family: TWEEDIE")
+    print("Set variables for h2o.")
+    y = "CAPSULE"
+    x = ["AGE","RACE","DCAPS","PSA","VOL","DPROS","GLEASON"]
+
+    hyper_parameters = {'alpha': [0, 0.5]}    # set hyper_parameters for grid search
+
+    print("Create models with lambda_search")
+    buffer = StringIO() # redirect output
+    sys.stderr=buffer
+    model_h2o_grid_search = H2OGridSearch(H2OGeneralizedLinearEstimator(family="tweedie", Lambda=0.5),
+                                          hyper_parameters)
+    model_h2o_grid_search.train(x=x, y=y, training_frame=hdf)
+    sys.stderr=sys.__stderr__   # redirect printout back to normal path
+
+    # check and make sure we get the correct warning message
+    warn_phrase = "Adding alpha array to hyperparameter runs slower with gridsearch."
+    try:        # for python 2.7
+        assert len(buffer.buflist)==warnNumber
+        print(buffer.buflist[0])
+        assert warn_phrase in buffer.buflist[0]
+    except:     # for python 3.
+        warns = buffer.getvalue()
+        print("*** captured warning message: {0}".format(warns))
+        assert warn_phrase in warns
+    
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(grid_alpha_search)
+else:
+    grid_alpha_search()

--- a/h2o-r/h2o-package/R/grid.R
+++ b/h2o-r/h2o-package/R/grid.R
@@ -258,8 +258,14 @@ h2o.getGrid <- function(grid_id, sort_by, decreasing, verbose = FALSE) {
   failure_details <- lapply(json$failure_details, function(msg) { msg })
   failure_stack_traces <- lapply(json$failure_stack_traces, function(msg) { msg })
   failed_raw_params <- if (is.list(json$failed_raw_params)) matrix(nrow=0, ncol=0) else json$failed_raw_params
+  warning_details <- lapply(json$warning_details, function(msg) { msg })
 
   # print out the failure/warning messages from Java if it exists
+  if (length(warning_details) > 0)  {
+    for (index in 1:length(warning_details)) {
+      warning(warning_details[[index]])
+    }
+  }
   if (length(failure_details) > 0) {
     warning("Some models were not built due to a failure, for more details run `summary(grid_object, show_stack_traces = TRUE)`")
     if (verbose) {

--- a/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_8150_alpha_warning_grid.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_8150_alpha_warning_grid.R
@@ -1,0 +1,20 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# This test is to make sure that we get a warning if we set alpha in hyper-parameter.
+check.glm.grid.cars <- function() {
+  cars <- h2o.uploadFile(locate("smalldata/junit/cars_20mpg.csv"))
+  seed <- sample(1:1000000, 1)
+  Log.info(paste0("runif seed: ",seed))
+  r <- h2o.runif(cars,seed=seed)
+  train <- cars[r > 0.2,]
+  grid_space <- list()
+  grid_space$alpha <- c(0.1, 0.5)
+  predictors <- c("displacement","power","weight","acceleration","year")
+  response_col <- "economy_20mpg"
+  family <- "binomial"
+  h2o_grid <- h2o.grid("glm", x=predictors, y=response_col, training_frame=train, family=family, hyper_params=grid_space)
+  expect_warning(h2o.grid("glm", x=predictors, y=response_col, training_frame=train, family=family, hyper_params=grid_space))
+}
+
+doTest("GLM Grid Search setting alpha using cars dataset", check.glm.grid.cars)


### PR DESCRIPTION
This PR is the second part to this JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8150.

I have added the warning message to 
- Java
- python client
- R client.

If we add more clients, we will have to add the error and warning message to each individual client.  This is the way gridsearch was implemented.  It has its own set of failure_messages and need the be processed for each client.