### PR TITLE
PUBDEV-8174: remove algo-specific logic from Py base classes

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -108,8 +108,8 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
     };
   }
 
-  @Override public boolean havePojo() { return !_parms._HGLM; }
-  @Override public boolean haveMojo() { return !_parms._HGLM; }
+  @Override public boolean havePojo() { return true; }
+  @Override public boolean haveMojo() { return true; }
 
   private double _lambdaCVEstimate = Double.NaN; // lambda cross-validation estimate
   private int _bestCVSubmodel;  // best submodel index found during cv

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -108,8 +108,8 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
     };
   }
 
-  @Override public boolean havePojo() { return true; }
-  @Override public boolean haveMojo() { return true; }
+  @Override public boolean havePojo() { return !_parms._HGLM; }
+  @Override public boolean haveMojo() { return !_parms._HGLM; }
 
   private double _lambdaCVEstimate = Double.NaN; // lambda cross-validation estimate
   private int _bestCVSubmodel;  // best submodel index found during cv

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -1915,13 +1915,13 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
 
   @Override
   public boolean haveMojo() {
-    if (_parms.interactionSpec() == null) return super.haveMojo();
+    if (!_parms._HGLM && _parms.interactionSpec() == null) return super.haveMojo();
     else return false;
   }
 
   @Override
   public boolean havePojo() {
-    if (_parms.interactionSpec() == null) return super.havePojo();
+    if (!_parms._HGLM && _parms.interactionSpec() == null) return super.havePojo();
     else return false;
   }
 

--- a/h2o-bindings/bin/custom/python/gen_aggregator.py
+++ b/h2o-bindings/bin/custom/python/gen_aggregator.py
@@ -1,4 +1,5 @@
 rest_api_version = 99
+supervised_learning = False
 
 
 def class_extensions():

--- a/h2o-bindings/bin/custom/python/gen_deeplearning.py
+++ b/h2o-bindings/bin/custom/python/gen_deeplearning.py
@@ -1,3 +1,12 @@
+options = dict(
+    verbose=True,
+    model_extensions=[
+        'h2o.model.extensions.ScoringHistory',
+        'h2o.model.extensions.VariableImportance',
+    ],
+)
+
+
 def module_extensions():
     class H2OAutoEncoderEstimator(H2ODeepLearningEstimator):
         """
@@ -12,9 +21,12 @@ def module_extensions():
         >>> model = H2OAutoEncoderEstimator()
         >>> model.train(x=range(4), training_frame=fr)
         """
+
+        supervised_learning = False
+        
         def __init__(self, **kwargs):
             super(H2OAutoEncoderEstimator, self).__init__(**kwargs)
-            self._parms['autoencoder'] = True
+            self._parms['autoencoder'] = True          
 
 
 extensions = dict(

--- a/h2o-bindings/bin/custom/python/gen_deeplearning.py
+++ b/h2o-bindings/bin/custom/python/gen_deeplearning.py
@@ -1,7 +1,7 @@
 options = dict(
     verbose=True,
     model_extensions=[
-        'h2o.model.extensions.ScoringHistory',
+        'h2o.model.extensions.ScoringHistoryDL',
         'h2o.model.extensions.VariableImportance',
     ],
 )

--- a/h2o-bindings/bin/custom/python/gen_deeplearning.py
+++ b/h2o-bindings/bin/custom/python/gen_deeplearning.py
@@ -26,7 +26,7 @@ def module_extensions():
         
         def __init__(self, **kwargs):
             super(H2OAutoEncoderEstimator, self).__init__(**kwargs)
-            self._parms['autoencoder'] = True          
+            self._parms['autoencoder'] = True
 
 
 extensions = dict(

--- a/h2o-bindings/bin/custom/python/gen_defaults.py
+++ b/h2o-bindings/bin/custom/python/gen_defaults.py
@@ -8,3 +8,15 @@ def update_param(name, param):
         return param
     return None  # means no change
 
+
+# extra logic common to several algos
+overrides = dict(
+    checkpoint=dict(
+        setter="""
+assert_is_type(checkpoint, None, str, H2OEstimator)
+key = checkpoint.key if isinstance(checkpoint, H2OEstimator) else checkpoint
+self._parms["{sname}"] = key
+"""
+    ),
+)
+

--- a/h2o-bindings/bin/custom/python/gen_defaults.py
+++ b/h2o-bindings/bin/custom/python/gen_defaults.py
@@ -7,16 +7,3 @@ def update_param(name, param):
         param['values'].remove('anomaly_score')
         return param
     return None  # means no change
-
-
-# extra logic common to several algos
-overrides = dict(
-    checkpoint=dict(
-        setter="""
-assert_is_type(checkpoint, None, str, H2OEstimator)
-key = checkpoint.key if isinstance(checkpoint, H2OEstimator) else checkpoint
-self._parms["{sname}"] = key
-"""
-    ),
-)
-

--- a/h2o-bindings/bin/custom/python/gen_drf.py
+++ b/h2o-bindings/bin/custom/python/gen_drf.py
@@ -1,3 +1,11 @@
+options = dict(
+    verbose=True,
+    model_extensions=[
+        'h2o.model.extensions.ScoringHistory',
+        'h2o.model.extensions.VariableImportance',
+        'h2o.model.extensions.Trees',
+    ],
+)
 deprecated_params = dict(offset_column=None)
 
 doc = dict(

--- a/h2o-bindings/bin/custom/python/gen_drf.py
+++ b/h2o-bindings/bin/custom/python/gen_drf.py
@@ -1,7 +1,7 @@
 options = dict(
     verbose=True,
     model_extensions=[
-        'h2o.model.extensions.ScoringHistory',
+        'h2o.model.extensions.ScoringHistoryTrees',
         'h2o.model.extensions.VariableImportance',
         'h2o.model.extensions.Trees',
     ],

--- a/h2o-bindings/bin/custom/python/gen_gam.py
+++ b/h2o-bindings/bin/custom/python/gen_gam.py
@@ -1,3 +1,8 @@
+options = dict(
+    model_extensions=[
+        'h2o.model.extensions.ScoringHistoryGLM',
+    ],
+)
 deprecated_params = dict(Lambda='lambda_')
 
 

--- a/h2o-bindings/bin/custom/python/gen_gbm.py
+++ b/h2o-bindings/bin/custom/python/gen_gbm.py
@@ -5,6 +5,7 @@ options = dict(
         'h2o.model.extensions.VariableImportance',
         'h2o.model.extensions.FeatureInteraction',
         'h2o.model.extensions.Trees',
+        'h2o.model.extensions.HStatistic',
     ],
 )
 

--- a/h2o-bindings/bin/custom/python/gen_gbm.py
+++ b/h2o-bindings/bin/custom/python/gen_gbm.py
@@ -1,3 +1,14 @@
+options = dict(
+    verbose=True,
+    model_extensions=[
+        'h2o.model.extensions.ScoringHistory',
+        'h2o.model.extensions.VariableImportance',
+        'h2o.model.extensions.FeatureInteraction',
+        'h2o.model.extensions.Trees',
+    ],
+)
+
+
 def update_param(name, param):
     if name == 'distribution':
         param['values'].remove('ordinal')

--- a/h2o-bindings/bin/custom/python/gen_gbm.py
+++ b/h2o-bindings/bin/custom/python/gen_gbm.py
@@ -1,7 +1,7 @@
 options = dict(
     verbose=True,
     model_extensions=[
-        'h2o.model.extensions.ScoringHistory',
+        'h2o.model.extensions.ScoringHistoryTrees',
         'h2o.model.extensions.VariableImportance',
         'h2o.model.extensions.FeatureInteraction',
         'h2o.model.extensions.Trees',

--- a/h2o-bindings/bin/custom/python/gen_generic.py
+++ b/h2o-bindings/bin/custom/python/gen_generic.py
@@ -1,3 +1,6 @@
+supervised_learning = False
+
+
 def class_extensions():
     def _requires_training_frame(self):
         """

--- a/h2o-bindings/bin/custom/python/gen_generic.py
+++ b/h2o-bindings/bin/custom/python/gen_generic.py
@@ -1,14 +1,8 @@
 supervised_learning = False
+options = dict(requires_training_frame=False)
 
 
 def class_extensions():
-    def _requires_training_frame(self):
-        """
-        Determines if Generic model requires a training frame.
-        :return: False.
-        """
-        return False
-
     @staticmethod
     def from_file(file=str):
         """

--- a/h2o-bindings/bin/custom/python/gen_glm.py
+++ b/h2o-bindings/bin/custom/python/gen_glm.py
@@ -1,3 +1,10 @@
+options = dict(
+    model_extensions=[
+        'h2o.model.extensions.ScoringHistoryGLM',
+        'h2o.model.extensions.StandardCoef',
+        'h2o.model.extensions.VariableImportance',
+    ],
+)
 deprecated_params = dict(Lambda='lambda_')
 
 

--- a/h2o-bindings/bin/custom/python/gen_glrm.py
+++ b/h2o-bindings/bin/custom/python/gen_glrm.py
@@ -1,3 +1,6 @@
+supervised_learning = False
+
+
 doc = dict(
     __class__="""
 Builds a generalized low rank model of a H2O dataset.

--- a/h2o-bindings/bin/custom/python/gen_isolationforest.py
+++ b/h2o-bindings/bin/custom/python/gen_isolationforest.py
@@ -1,3 +1,11 @@
+options = dict(
+    model_extensions=[
+        'h2o.model.extensions.Trees',
+    ],
+)
+supervised_learning = False
+
+
 def update_param(name, param):
     if name == 'stopping_metric':
         param['values'] = ['AUTO', 'anomaly_score', 'deviance', 'logloss', 'mse', 'rmse', 'mae', 'rmsle',

--- a/h2o-bindings/bin/custom/python/gen_kmeans.py
+++ b/h2o-bindings/bin/custom/python/gen_kmeans.py
@@ -1,3 +1,6 @@
+supervised_learning = False
+
+
 doc = dict(
     __class__="""Performs k-means clustering on an H2O dataset.""",
 )

--- a/h2o-bindings/bin/custom/python/gen_pca.py
+++ b/h2o-bindings/bin/custom/python/gen_pca.py
@@ -1,3 +1,6 @@
+supervised_learning = False
+
+
 def class_extensions():
     def init_for_pipeline(self):
         """

--- a/h2o-bindings/bin/custom/python/gen_svd.py
+++ b/h2o-bindings/bin/custom/python/gen_svd.py
@@ -1,4 +1,6 @@
 rest_api_version = 99
+supervised_learning = False
+
 
 def class_extensions():
     def init_for_pipeline(self):

--- a/h2o-bindings/bin/custom/python/gen_word2vec.py
+++ b/h2o-bindings/bin/custom/python/gen_word2vec.py
@@ -1,14 +1,8 @@
 supervised_learning = False
+options = dict(requires_training_frame=False)
 
 
 def class_extensions():
-    def _requires_training_frame(self):
-        """
-        Determines if Word2Vec algorithm requires a training frame.
-        :return: False.
-        """
-        return False
-
     @staticmethod
     def from_external(external=H2OFrame):
         """

--- a/h2o-bindings/bin/custom/python/gen_word2vec.py
+++ b/h2o-bindings/bin/custom/python/gen_word2vec.py
@@ -1,3 +1,6 @@
+supervised_learning = False
+
+
 def class_extensions():
     def _requires_training_frame(self):
         """

--- a/h2o-bindings/bin/custom/python/gen_xgboost.py
+++ b/h2o-bindings/bin/custom/python/gen_xgboost.py
@@ -5,6 +5,7 @@ options = dict(
         'h2o.model.extensions.VariableImportance',
         'h2o.model.extensions.FeatureInteraction',
         'h2o.model.extensions.Trees',
+        'h2o.model.extensions.HStatistic',
     ],
 )
 

--- a/h2o-bindings/bin/custom/python/gen_xgboost.py
+++ b/h2o-bindings/bin/custom/python/gen_xgboost.py
@@ -1,3 +1,14 @@
+options = dict(
+    verbose=True,
+    model_extensions=[
+        'h2o.model.extensions.ScoringHistory',
+        'h2o.model.extensions.VariableImportance',
+        'h2o.model.extensions.FeatureInteraction',
+        'h2o.model.extensions.Trees',
+    ],
+)
+
+
 def class_extensions():
     @staticmethod
     def available():
@@ -20,6 +31,52 @@ def class_extensions():
             return False
         else:
             return True
+
+    def convert_H2OXGBoostParams_2_XGBoostParams(self):
+        """
+        In order to use convert_H2OXGBoostParams_2_XGBoostParams and convert_H2OFrame_2_DMatrix, you must import
+        the following toolboxes: xgboost, pandas, numpy and scipy.sparse.
+
+        Given an H2OXGBoost model, this method will generate the corresponding parameters that should be used by
+        native XGBoost in order to give exactly the same result, assuming that the same dataset
+        (derived from h2oFrame) is used to train the native XGBoost model.
+
+        Follow the steps below to compare H2OXGBoost and native XGBoost:
+
+         1. Train the H2OXGBoost model with H2OFrame trainFile and generate a prediction:
+
+          - h2oModelD = H2OXGBoostEstimator(\*\*h2oParamsD) # parameters specified as a dict()
+          - h2oModelD.train(x=myX, y=y, training_frame=trainFile) # train with H2OFrame trainFile
+          - h2oPredict = h2oPredictD = h2oModelD.predict(trainFile)
+
+         2. Derive the DMatrix from H2OFrame:
+         
+          - nativeDMatrix = trainFile.convert_H2OFrame_2_DMatrix(myX, y, h2oModelD)
+
+         3. Derive the parameters for native XGBoost:
+         
+          - nativeParams = h2oModelD.convert_H2OXGBoostParams_2_XGBoostParams()
+
+         4. Train your native XGBoost model and generate a prediction:
+         
+          - nativeModel = xgb.train(params=nativeParams[0], dtrain=nativeDMatrix, num_boost_round=nativeParams[1])
+          - nativePredict = nativeModel.predict(data=nativeDMatrix, ntree_limit=nativeParams[1]
+
+         5. Compare the predictions h2oPredict from H2OXGBoost, nativePredict from native XGBoost.
+
+        :return: nativeParams, num_boost_round
+        """
+        import xgboost as xgb
+
+        nativeParams = self._model_json["output"]["native_parameters"]
+        nativeXGBoostParams = dict()
+
+        for (a,keyname,keyvalue) in nativeParams.cell_values:
+            nativeXGBoostParams[keyname]=keyvalue
+        paramsSet = self.full_parameters
+
+        return nativeXGBoostParams, paramsSet['ntrees']['actual_value']
+
 
 
 extensions = dict(

--- a/h2o-bindings/bin/custom/python/gen_xgboost.py
+++ b/h2o-bindings/bin/custom/python/gen_xgboost.py
@@ -1,7 +1,7 @@
 options = dict(
     verbose=True,
     model_extensions=[
-        'h2o.model.extensions.ScoringHistory',
+        'h2o.model.extensions.ScoringHistoryTrees',
         'h2o.model.extensions.VariableImportance',
         'h2o.model.extensions.FeatureInteraction',
         'h2o.model.extensions.Trees',

--- a/h2o-bindings/bin/gen_python.py
+++ b/h2o-bindings/bin/gen_python.py
@@ -3,7 +3,9 @@
 from __future__ import unicode_literals
 from copy import deepcopy
 from functools import partial
+from io import StringIO
 from inspect import getsource
+from pprint import pformat
 import sys
 
 import bindings as bi
@@ -229,7 +231,7 @@ def gen_module(schema, algo):
     yield "    supervised_learning = %s" % get_customizations_for(algo, 'supervised_learning', True)
     options = get_customizations_for(algo, 'options')
     if options:
-        yield "    _options_ = %s" % repr(options)
+        yield "    _options_ = %s" % reformat_block(pformat(options), prefix=' '*16, prefix_first=False)
     yield ""
     if deprecated_params:
         yield reformat_block("@deprecated_params(%s)" % deprecated_params, indent=4)

--- a/h2o-bindings/bin/gen_python.py
+++ b/h2o-bindings/bin/gen_python.py
@@ -143,7 +143,6 @@ def gen_module(schema, algo):
     as the type translation is done in this file.
     """
     classname = algo_to_classname(algo)
-    rest_api_version = get_customizations_for(algo, 'rest_api_version')
     extra_imports = get_customizations_for(algo, 'extensions.__imports__')
     class_doc = get_customizations_for(algo, 'doc.__class__')
     class_examples = get_customizations_for(algo, 'examples.__class__')
@@ -227,6 +226,10 @@ def gen_module(schema, algo):
     yield '    """'
     yield ""
     yield '    algo = "%s"' % algo
+    yield "    supervised_learning = %s" % get_customizations_for(algo, 'supervised_learning', True)
+    options = get_customizations_for(algo, 'options')
+    if options:
+        yield "    _options_ = %s" % repr(options)
     yield ""
     if deprecated_params:
         yield reformat_block("@deprecated_params(%s)" % deprecated_params, indent=4)
@@ -256,6 +259,7 @@ def gen_module(schema, algo):
             yield "        self._id = self._parms['model_id'] = model_id"
         else:
             yield "        self.%s = %s" % (pname, pname)
+    rest_api_version = get_customizations_for(algo, 'rest_api_version')
     if rest_api_version:
         yield '        self._parms["_rest_version"] = %s' % rest_api_version
     yield ""
@@ -292,7 +296,7 @@ def gen_module(schema, algo):
             yield ""
             yield reformat_block(property_examples, 8)
         yield '        """'
-        property_getter = get_customizations_for(algo, "overrides.{}.getter".format(pname))  # check gen_stackedensemble.py for an example
+        property_getter = get_customizations_or_defaults_for(algo, "overrides.{}.getter".format(pname))  # check gen_stackedensemble.py for an example
         if property_getter:
             yield reformat_block(property_getter.format(**locals()), 8)
         else:
@@ -301,7 +305,7 @@ def gen_module(schema, algo):
         yield ""
         yield "    @%s.setter" % pname
         yield "    def %s(self, %s):" % (pname, pname)
-        property_setter = get_customizations_for(algo, "overrides.{}.setter".format(pname))  # check gen_stackedensemble.py for an example
+        property_setter = get_customizations_or_defaults_for(algo, "overrides.{}.setter".format(pname))  # check gen_stackedensemble.py for an example
         if property_setter:
             yield reformat_block(property_setter.format(**locals()), 8)
         elif "H2OFrame" in ptype:                

--- a/h2o-bindings/bin/gen_python.py
+++ b/h2o-bindings/bin/gen_python.py
@@ -370,14 +370,17 @@ def gen_init(modules):
 
 module = sys.modules[__name__]
 
+
 def _algo_for_estimator_(shortname, cls):
     if shortname == 'H2OAutoEncoderEstimator':
         return 'autoencoder'
     return cls.algo
 
+
 _estimator_cls_by_algo_ = {_algo_for_estimator_(name, cls): cls
                            for name, cls in inspect.getmembers(module, inspect.isclass)
                            if hasattr(cls, 'algo')}
+
 
 def create_estimator(algo, **params):
     if algo not in _estimator_cls_by_algo_:

--- a/h2o-py/docs/model_categories.rst
+++ b/h2o-py/docs/model_categories.rst
@@ -14,6 +14,14 @@ Model Categories
     :undoc-members:
     :show-inheritance:
 
+:mod:`MetricsBase`
+----------------
+
+.. automodule:: h2o.model.metrics_base
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 :mod:`Binomial Classification`
 ------------------------------
 
@@ -38,25 +46,42 @@ Model Categories
     :undoc-members:
     :show-inheritance:
 
+:mod:`Dimensionality Reduction`
+-------------------------------
+
+.. automodule:: h2o.model.dim_reduction
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 :mod:`Clustering Methods`
 -------------------------
 
 .. automodule:: h2o.model.clustering
-      :members:
-      :undoc-members:
-      :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 :mod:`AutoEncoders`
 -------------------
 
 .. automodule:: h2o.model.autoencoder
-      :members:
-      :undoc-members:
-      :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 :mod:`Word Embedding`
 ----------------------
 .. automodule:: h2o.model.word_embedding
-      :members:
-      :undoc-members:
-      :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+..
+    Disabled until entry methods get removed from ModelBase
+    :mod:`Optional Features`
+    -------------------------
+    .. automodule:: h2o.model.extensions
+        :members:
+        :undoc-members:
+        :show-inheritance:

--- a/h2o-py/h2o/estimators/__init__.py
+++ b/h2o-py/h2o/estimators/__init__.py
@@ -33,14 +33,17 @@ from .xgboost import H2OXGBoostEstimator
 
 module = sys.modules[__name__]
 
+
 def _algo_for_estimator_(shortname, cls):
     if shortname == 'H2OAutoEncoderEstimator':
         return 'autoencoder'
     return cls.algo
 
+
 _estimator_cls_by_algo_ = {_algo_for_estimator_(name, cls): cls
                            for name, cls in inspect.getmembers(module, inspect.isclass)
                            if hasattr(cls, 'algo')}
+
 
 def create_estimator(algo, **params):
     if algo not in _estimator_cls_by_algo_:

--- a/h2o-py/h2o/estimators/aggregator.py
+++ b/h2o-py/h2o/estimators/aggregator.py
@@ -19,6 +19,7 @@ class H2OAggregatorEstimator(H2OEstimator):
     """
 
     algo = "aggregator"
+    supervised_learning = False
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]

--- a/h2o-py/h2o/estimators/coxph.py
+++ b/h2o-py/h2o/estimators/coxph.py
@@ -20,6 +20,7 @@ class H2OCoxProportionalHazardsEstimator(H2OEstimator):
     """
 
     algo = "coxph"
+    supervised_learning = True
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]

--- a/h2o-py/h2o/estimators/deeplearning.py
+++ b/h2o-py/h2o/estimators/deeplearning.py
@@ -32,6 +32,8 @@ class H2ODeepLearningEstimator(H2OEstimator):
     """
 
     algo = "deeplearning"
+    supervised_learning = True
+    _options_ = {'verbose': True, 'model_extensions': ['h2o.model.extensions.ScoringHistory', 'h2o.model.extensions.VariableImportance']}
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]
@@ -1043,7 +1045,8 @@ class H2ODeepLearningEstimator(H2OEstimator):
     @checkpoint.setter
     def checkpoint(self, checkpoint):
         assert_is_type(checkpoint, None, str, H2OEstimator)
-        self._parms["checkpoint"] = checkpoint
+        key = checkpoint.key if isinstance(checkpoint, H2OEstimator) else checkpoint
+        self._parms["checkpoint"] = key
 
     @property
     def pretrained_autoencoder(self):
@@ -3226,6 +3229,9 @@ class H2OAutoEncoderEstimator(H2ODeepLearningEstimator):
     >>> model = H2OAutoEncoderEstimator()
     >>> model.train(x=range(4), training_frame=fr)
     """
+
+    supervised_learning = False
+
     def __init__(self, **kwargs):
         super(H2OAutoEncoderEstimator, self).__init__(**kwargs)
-        self._parms['autoencoder'] = True
+        self._parms['autoencoder'] = True          

--- a/h2o-py/h2o/estimators/deeplearning.py
+++ b/h2o-py/h2o/estimators/deeplearning.py
@@ -1045,8 +1045,7 @@ class H2ODeepLearningEstimator(H2OEstimator):
     @checkpoint.setter
     def checkpoint(self, checkpoint):
         assert_is_type(checkpoint, None, str, H2OEstimator)
-        key = checkpoint.key if isinstance(checkpoint, H2OEstimator) else checkpoint
-        self._parms["checkpoint"] = key
+        self._parms["checkpoint"] = checkpoint
 
     @property
     def pretrained_autoencoder(self):

--- a/h2o-py/h2o/estimators/deeplearning.py
+++ b/h2o-py/h2o/estimators/deeplearning.py
@@ -3234,4 +3234,4 @@ class H2OAutoEncoderEstimator(H2ODeepLearningEstimator):
 
     def __init__(self, **kwargs):
         super(H2OAutoEncoderEstimator, self).__init__(**kwargs)
-        self._parms['autoencoder'] = True          
+        self._parms['autoencoder'] = True

--- a/h2o-py/h2o/estimators/deeplearning.py
+++ b/h2o-py/h2o/estimators/deeplearning.py
@@ -33,7 +33,7 @@ class H2ODeepLearningEstimator(H2OEstimator):
 
     algo = "deeplearning"
     supervised_learning = True
-    _options_ = {'verbose': True, 'model_extensions': ['h2o.model.extensions.ScoringHistory', 'h2o.model.extensions.VariableImportance']}
+    _options_ = {'verbose': True, 'model_extensions': ['h2o.model.extensions.ScoringHistoryDL', 'h2o.model.extensions.VariableImportance']}
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]

--- a/h2o-py/h2o/estimators/deeplearning.py
+++ b/h2o-py/h2o/estimators/deeplearning.py
@@ -33,7 +33,9 @@ class H2ODeepLearningEstimator(H2OEstimator):
 
     algo = "deeplearning"
     supervised_learning = True
-    _options_ = {'verbose': True, 'model_extensions': ['h2o.model.extensions.ScoringHistoryDL', 'h2o.model.extensions.VariableImportance']}
+    _options_ = {'model_extensions': ['h2o.model.extensions.ScoringHistoryDL',
+                                      'h2o.model.extensions.VariableImportance'],
+                 'verbose': True}
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]

--- a/h2o-py/h2o/estimators/estimator_base.py
+++ b/h2o-py/h2o/estimators/estimator_base.py
@@ -8,7 +8,6 @@ from h2o.utils.compatibility import *  # NOQA
 
 from datetime import datetime
 import inspect
-import types
 import warnings
 
 import h2o

--- a/h2o-py/h2o/estimators/estimator_base.py
+++ b/h2o-py/h2o/estimators/estimator_base.py
@@ -372,13 +372,13 @@ class H2OEstimator(ModelBase):
         m._model_json = model_json
         m._have_pojo = model_json.get('have_pojo', True)
         m._have_mojo = model_json.get('have_mojo', True)
+        m._start_time = model_json.get('output', {}).get('start_time', None)
+        m._end_time = model_json.get('output', {}).get('end_time', None)
+        m._run_time = model_json.get('output', {}).get('run_time', None)
         m._metrics_class = metrics_class
         m._metrics_class_valid = metrics_class_valid
         m._parms = self._parms
         m._estimator_type = self._estimator_type
-        m._start_time = model_json.get('output', {}).get('start_time', None)
-        m._end_time = model_json.get('output', {}).get('end_time', None)
-        m._run_time = model_json.get('output', {}).get('run_time', None)
         m._options_ = self._options_
 
         if model_id is not None and model_json is not None and metrics_class is not None:

--- a/h2o-py/h2o/estimators/estimator_base.py
+++ b/h2o-py/h2o/estimators/estimator_base.py
@@ -367,7 +367,7 @@ class H2OEstimator(ModelBase):
 
     def _resolve_model(self, model_id, model_json):
         metrics_class, model_class, metrics_class_valid = H2OEstimator._metrics_class(model_json)
-        m = model_class()
+        m = model_class() if model_class else self._model
         m._id = model_id
         m._model_json = model_json
         m._have_pojo = model_json.get('have_pojo', True)
@@ -512,7 +512,7 @@ class H2OEstimator(ModelBase):
             model_class = H2OCoxPHModel
         elif model_type == "TargetEncoder":
             metrics_class = H2OTargetEncoderMetrics
-            model_class = h2o.estimators.H2OTargetEncoderEstimator
+            model_class = None
         else:
             raise NotImplementedError(model_type)
         if valid_metrics_class is None:

--- a/h2o-py/h2o/estimators/estimator_base.py
+++ b/h2o-py/h2o/estimators/estimator_base.py
@@ -16,7 +16,7 @@ from h2o.base import Keyed
 from h2o.exceptions import H2OValueError, H2OResponseError
 from h2o.frame import H2OFrame
 from h2o.job import H2OJob
-from h2o.utils.mixin import load_ext, mixin
+from h2o.utils.mixin import assign, load_ext, mixin
 from h2o.utils.shared_utils import quoted
 from h2o.utils.typechecks import assert_is_type, is_type, numeric, FunctionType
 from ..model.autoencoder import H2OAutoEncoderModel
@@ -57,6 +57,10 @@ class H2OEstimator(ModelBase):
     """
     
     supervised_learning = None  # overridden in implementation
+
+    def __init__(self):
+        super(H2OEstimator, self).__init__()
+        self._model = self
 
     def start(self, x, y=None, training_frame=None, offset_column=None, fold_column=None,
               weights_column=None, validation_frame=None, **params):
@@ -398,8 +402,8 @@ class H2OEstimator(ModelBase):
                 m.parms[p["name"]] = p
                 
         extensions = [load_ext(ext) for ext in self._options_.get('model_extensions', [])]
-        mixin(self, model_class, *extensions)
-        self.__dict__.update(m.__dict__.copy())
+        mixin(self._model, model_class, *extensions)
+        assign(self._model, m)
 
 
     #------ Scikit-learn Interface Methods -------

--- a/h2o-py/h2o/estimators/estimator_base.py
+++ b/h2o-py/h2o/estimators/estimator_base.py
@@ -405,7 +405,6 @@ class H2OEstimator(ModelBase):
         mixin(self._model, model_class, *extensions)
         assign(self._model, m)
 
-
     #------ Scikit-learn Interface Methods -------
 
     def fit(self, X, y=None, **params):

--- a/h2o-py/h2o/estimators/estimator_base.py
+++ b/h2o-py/h2o/estimators/estimator_base.py
@@ -218,7 +218,7 @@ class H2OEstimator(ModelBase):
                     model_id=None, verbose=False, extend_parms_fn=None):
         has_default_training_frame = hasattr(self, 'training_frame') and self.training_frame is not None
         training_frame = H2OFrame._validate(training_frame, 'training_frame',
-                                            required=self._requires_training_frame() and not has_default_training_frame)
+                                            required=self._options_.get('requires_training_frame', True) and not has_default_training_frame)
         validation_frame = H2OFrame._validate(validation_frame, 'validation_frame')
         assert_is_type(y, None, int, str)
         assert_is_type(x, None, int, str, [str, int], {str, int})
@@ -467,13 +467,6 @@ class H2OEstimator(ModelBase):
         for param in args:
             if param is not None:
                 raise H2OValueError("No training frame defined, yet the parameter %d is has been specified.", param)
-
-    def _requires_training_frame(self):
-        """
-        Determines if a training frame is required for given algorithm.
-        :return: True as a default value. Can be overridden by any specific algorithm.
-        """
-        return True
 
     @staticmethod
     def _metrics_class(model_json):

--- a/h2o-py/h2o/estimators/gam.py
+++ b/h2o-py/h2o/estimators/gam.py
@@ -31,6 +31,8 @@ class H2OGeneralizedAdditiveEstimator(H2OEstimator):
     """
 
     algo = "gam"
+    supervised_learning = True
+    _options_ = {'model_extensions': ['h2o.model.extensions.ScoringHistoryGLM']}
 
     @deprecated_params({'Lambda': 'lambda_'})
     def __init__(self,

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -23,6 +23,8 @@ class H2OGradientBoostingEstimator(H2OEstimator):
     """
 
     algo = "gbm"
+    supervised_learning = True
+    _options_ = {'verbose': True, 'model_extensions': ['h2o.model.extensions.ScoringHistory', 'h2o.model.extensions.VariableImportance', 'h2o.model.extensions.FeatureInteraction', 'h2o.model.extensions.Trees']}
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]
@@ -1528,7 +1530,8 @@ class H2OGradientBoostingEstimator(H2OEstimator):
     @checkpoint.setter
     def checkpoint(self, checkpoint):
         assert_is_type(checkpoint, None, str, H2OEstimator)
-        self._parms["checkpoint"] = checkpoint
+        key = checkpoint.key if isinstance(checkpoint, H2OEstimator) else checkpoint
+        self._parms["checkpoint"] = key
 
     @property
     def sample_rate(self):

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -24,7 +24,11 @@ class H2OGradientBoostingEstimator(H2OEstimator):
 
     algo = "gbm"
     supervised_learning = True
-    _options_ = {'verbose': True, 'model_extensions': ['h2o.model.extensions.ScoringHistoryTrees', 'h2o.model.extensions.VariableImportance', 'h2o.model.extensions.FeatureInteraction', 'h2o.model.extensions.Trees']}
+    _options_ = {'model_extensions': ['h2o.model.extensions.ScoringHistoryTrees',
+                                      'h2o.model.extensions.VariableImportance',
+                                      'h2o.model.extensions.FeatureInteraction',
+                                      'h2o.model.extensions.Trees'],
+                 'verbose': True}
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -27,7 +27,8 @@ class H2OGradientBoostingEstimator(H2OEstimator):
     _options_ = {'model_extensions': ['h2o.model.extensions.ScoringHistoryTrees',
                                       'h2o.model.extensions.VariableImportance',
                                       'h2o.model.extensions.FeatureInteraction',
-                                      'h2o.model.extensions.Trees'],
+                                      'h2o.model.extensions.Trees',
+                                      'h2o.model.extensions.HStatistic'],
                  'verbose': True}
 
     def __init__(self,

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -1530,8 +1530,7 @@ class H2OGradientBoostingEstimator(H2OEstimator):
     @checkpoint.setter
     def checkpoint(self, checkpoint):
         assert_is_type(checkpoint, None, str, H2OEstimator)
-        key = checkpoint.key if isinstance(checkpoint, H2OEstimator) else checkpoint
-        self._parms["checkpoint"] = key
+        self._parms["checkpoint"] = checkpoint
 
     @property
     def sample_rate(self):

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -24,7 +24,7 @@ class H2OGradientBoostingEstimator(H2OEstimator):
 
     algo = "gbm"
     supervised_learning = True
-    _options_ = {'verbose': True, 'model_extensions': ['h2o.model.extensions.ScoringHistory', 'h2o.model.extensions.VariableImportance', 'h2o.model.extensions.FeatureInteraction', 'h2o.model.extensions.Trees']}
+    _options_ = {'verbose': True, 'model_extensions': ['h2o.model.extensions.ScoringHistoryTrees', 'h2o.model.extensions.VariableImportance', 'h2o.model.extensions.FeatureInteraction', 'h2o.model.extensions.Trees']}
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]

--- a/h2o-py/h2o/estimators/generic.py
+++ b/h2o-py/h2o/estimators/generic.py
@@ -19,6 +19,7 @@ class H2OGenericEstimator(H2OEstimator):
     """
 
     algo = "generic"
+    supervised_learning = False
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]

--- a/h2o-py/h2o/estimators/generic.py
+++ b/h2o-py/h2o/estimators/generic.py
@@ -20,6 +20,7 @@ class H2OGenericEstimator(H2OEstimator):
 
     algo = "generic"
     supervised_learning = False
+    _options_ = {'requires_training_frame': False}
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]
@@ -99,13 +100,6 @@ class H2OGenericEstimator(H2OEstimator):
         assert_is_type(path, None, str)
         self._parms["path"] = path
 
-
-    def _requires_training_frame(self):
-        """
-        Determines if Generic model requires a training frame.
-        :return: False.
-        """
-        return False
 
     @staticmethod
     def from_file(file=str):

--- a/h2o-py/h2o/estimators/glm.py
+++ b/h2o-py/h2o/estimators/glm.py
@@ -30,6 +30,8 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     """
 
     algo = "glm"
+    supervised_learning = True
+    _options_ = {'model_extensions': ['h2o.model.extensions.ScoringHistoryGLM', 'h2o.model.extensions.StandardCoef', 'h2o.model.extensions.VariableImportance']}
 
     @deprecated_params({'Lambda': 'lambda_'})
     def __init__(self,
@@ -514,7 +516,8 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     @checkpoint.setter
     def checkpoint(self, checkpoint):
         assert_is_type(checkpoint, None, str, H2OEstimator)
-        self._parms["checkpoint"] = checkpoint
+        key = checkpoint.key if isinstance(checkpoint, H2OEstimator) else checkpoint
+        self._parms["checkpoint"] = key
 
     @property
     def export_checkpoints_dir(self):

--- a/h2o-py/h2o/estimators/glm.py
+++ b/h2o-py/h2o/estimators/glm.py
@@ -31,7 +31,9 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
 
     algo = "glm"
     supervised_learning = True
-    _options_ = {'model_extensions': ['h2o.model.extensions.ScoringHistoryGLM', 'h2o.model.extensions.StandardCoef', 'h2o.model.extensions.VariableImportance']}
+    _options_ = {'model_extensions': ['h2o.model.extensions.ScoringHistoryGLM',
+                                      'h2o.model.extensions.StandardCoef',
+                                      'h2o.model.extensions.VariableImportance']}
 
     @deprecated_params({'Lambda': 'lambda_'})
     def __init__(self,

--- a/h2o-py/h2o/estimators/glm.py
+++ b/h2o-py/h2o/estimators/glm.py
@@ -516,8 +516,7 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     @checkpoint.setter
     def checkpoint(self, checkpoint):
         assert_is_type(checkpoint, None, str, H2OEstimator)
-        key = checkpoint.key if isinstance(checkpoint, H2OEstimator) else checkpoint
-        self._parms["checkpoint"] = key
+        self._parms["checkpoint"] = checkpoint
 
     @property
     def export_checkpoints_dir(self):

--- a/h2o-py/h2o/estimators/glrm.py
+++ b/h2o-py/h2o/estimators/glrm.py
@@ -20,6 +20,7 @@ class H2OGeneralizedLowRankEstimator(H2OEstimator):
     """
 
     algo = "glrm"
+    supervised_learning = False
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]

--- a/h2o-py/h2o/estimators/isolation_forest.py
+++ b/h2o-py/h2o/estimators/isolation_forest.py
@@ -24,6 +24,8 @@ class H2OIsolationForestEstimator(H2OEstimator):
     """
 
     algo = "isolationforest"
+    supervised_learning = False
+    _options_ = {'model_extensions': ['h2o.model.extensions.Trees']}
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]

--- a/h2o-py/h2o/estimators/kmeans.py
+++ b/h2o-py/h2o/estimators/kmeans.py
@@ -20,6 +20,7 @@ class H2OKMeansEstimator(H2OEstimator):
     """
 
     algo = "kmeans"
+    supervised_learning = False
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]

--- a/h2o-py/h2o/estimators/naive_bayes.py
+++ b/h2o-py/h2o/estimators/naive_bayes.py
@@ -25,6 +25,7 @@ class H2ONaiveBayesEstimator(H2OEstimator):
     """
 
     algo = "naivebayes"
+    supervised_learning = True
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]

--- a/h2o-py/h2o/estimators/pca.py
+++ b/h2o-py/h2o/estimators/pca.py
@@ -19,6 +19,7 @@ class H2OPrincipalComponentAnalysisEstimator(H2OEstimator):
     """
 
     algo = "pca"
+    supervised_learning = False
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]

--- a/h2o-py/h2o/estimators/psvm.py
+++ b/h2o-py/h2o/estimators/psvm.py
@@ -19,6 +19,7 @@ class H2OSupportVectorMachineEstimator(H2OEstimator):
     """
 
     algo = "psvm"
+    supervised_learning = True
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -23,7 +23,7 @@ class H2ORandomForestEstimator(H2OEstimator):
 
     algo = "drf"
     supervised_learning = True
-    _options_ = {'verbose': True, 'model_extensions': ['h2o.model.extensions.ScoringHistory', 'h2o.model.extensions.VariableImportance', 'h2o.model.extensions.Trees']}
+    _options_ = {'verbose': True, 'model_extensions': ['h2o.model.extensions.ScoringHistoryTrees', 'h2o.model.extensions.VariableImportance', 'h2o.model.extensions.Trees']}
 
     @deprecated_params({'offset_column': None})
     def __init__(self,

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -22,6 +22,8 @@ class H2ORandomForestEstimator(H2OEstimator):
     """
 
     algo = "drf"
+    supervised_learning = True
+    _options_ = {'verbose': True, 'model_extensions': ['h2o.model.extensions.ScoringHistory', 'h2o.model.extensions.VariableImportance', 'h2o.model.extensions.Trees']}
 
     @deprecated_params({'offset_column': None})
     def __init__(self,
@@ -1411,7 +1413,8 @@ class H2ORandomForestEstimator(H2OEstimator):
     @checkpoint.setter
     def checkpoint(self, checkpoint):
         assert_is_type(checkpoint, None, str, H2OEstimator)
-        self._parms["checkpoint"] = checkpoint
+        key = checkpoint.key if isinstance(checkpoint, H2OEstimator) else checkpoint
+        self._parms["checkpoint"] = key
 
     @property
     def col_sample_rate_change_per_level(self):

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -23,7 +23,10 @@ class H2ORandomForestEstimator(H2OEstimator):
 
     algo = "drf"
     supervised_learning = True
-    _options_ = {'verbose': True, 'model_extensions': ['h2o.model.extensions.ScoringHistoryTrees', 'h2o.model.extensions.VariableImportance', 'h2o.model.extensions.Trees']}
+    _options_ = {'model_extensions': ['h2o.model.extensions.ScoringHistoryTrees',
+                                      'h2o.model.extensions.VariableImportance',
+                                      'h2o.model.extensions.Trees'],
+                 'verbose': True}
 
     @deprecated_params({'offset_column': None})
     def __init__(self,

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -1413,8 +1413,7 @@ class H2ORandomForestEstimator(H2OEstimator):
     @checkpoint.setter
     def checkpoint(self, checkpoint):
         assert_is_type(checkpoint, None, str, H2OEstimator)
-        key = checkpoint.key if isinstance(checkpoint, H2OEstimator) else checkpoint
-        self._parms["checkpoint"] = key
+        self._parms["checkpoint"] = checkpoint
 
     @property
     def col_sample_rate_change_per_level(self):

--- a/h2o-py/h2o/estimators/rulefit.py
+++ b/h2o-py/h2o/estimators/rulefit.py
@@ -21,6 +21,7 @@ class H2ORuleFitEstimator(H2OEstimator):
     """
 
     algo = "rulefit"
+    supervised_learning = True
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -63,6 +63,7 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     """
 
     algo = "stackedensemble"
+    supervised_learning = True
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]

--- a/h2o-py/h2o/estimators/svd.py
+++ b/h2o-py/h2o/estimators/svd.py
@@ -19,6 +19,7 @@ class H2OSingularValueDecompositionEstimator(H2OEstimator):
     """
 
     algo = "svd"
+    supervised_learning = False
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]

--- a/h2o-py/h2o/estimators/targetencoder.py
+++ b/h2o-py/h2o/estimators/targetencoder.py
@@ -24,6 +24,7 @@ class H2OTargetEncoderEstimator(H2OEstimator):
     """
 
     algo = "targetencoder"
+    supervised_learning = True
 
     @deprecated_params({'k': 'inflection_point', 'f': 'smoothing', 'noise_level': 'noise'})
     def __init__(self,

--- a/h2o-py/h2o/estimators/word2vec.py
+++ b/h2o-py/h2o/estimators/word2vec.py
@@ -19,6 +19,7 @@ class H2OWord2vecEstimator(H2OEstimator):
     """
 
     algo = "word2vec"
+    supervised_learning = False
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]

--- a/h2o-py/h2o/estimators/word2vec.py
+++ b/h2o-py/h2o/estimators/word2vec.py
@@ -20,6 +20,7 @@ class H2OWord2vecEstimator(H2OEstimator):
 
     algo = "word2vec"
     supervised_learning = False
+    _options_ = {'requires_training_frame': False}
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]
@@ -419,13 +420,6 @@ class H2OWord2vecEstimator(H2OEstimator):
         assert_is_type(export_checkpoints_dir, None, str)
         self._parms["export_checkpoints_dir"] = export_checkpoints_dir
 
-
-    def _requires_training_frame(self):
-        """
-        Determines if Word2Vec algorithm requires a training frame.
-        :return: False.
-        """
-        return False
 
     @staticmethod
     def from_external(external=H2OFrame):

--- a/h2o-py/h2o/estimators/xgboost.py
+++ b/h2o-py/h2o/estimators/xgboost.py
@@ -21,6 +21,8 @@ class H2OXGBoostEstimator(H2OEstimator):
     """
 
     algo = "xgboost"
+    supervised_learning = True
+    _options_ = {'verbose': True, 'model_extensions': ['h2o.model.extensions.ScoringHistory', 'h2o.model.extensions.VariableImportance', 'h2o.model.extensions.FeatureInteraction', 'h2o.model.extensions.Trees']}
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]
@@ -1125,7 +1127,8 @@ class H2OXGBoostEstimator(H2OEstimator):
     @checkpoint.setter
     def checkpoint(self, checkpoint):
         assert_is_type(checkpoint, None, str, H2OEstimator)
-        self._parms["checkpoint"] = checkpoint
+        key = checkpoint.key if isinstance(checkpoint, H2OEstimator) else checkpoint
+        self._parms["checkpoint"] = key
 
     @property
     def export_checkpoints_dir(self):
@@ -2424,3 +2427,48 @@ class H2OXGBoostEstimator(H2OEstimator):
             return False
         else:
             return True
+
+    def convert_H2OXGBoostParams_2_XGBoostParams(self):
+        """
+        In order to use convert_H2OXGBoostParams_2_XGBoostParams and convert_H2OFrame_2_DMatrix, you must import
+        the following toolboxes: xgboost, pandas, numpy and scipy.sparse.
+
+        Given an H2OXGBoost model, this method will generate the corresponding parameters that should be used by
+        native XGBoost in order to give exactly the same result, assuming that the same dataset
+        (derived from h2oFrame) is used to train the native XGBoost model.
+
+        Follow the steps below to compare H2OXGBoost and native XGBoost:
+
+         1. Train the H2OXGBoost model with H2OFrame trainFile and generate a prediction:
+
+          - h2oModelD = H2OXGBoostEstimator(\*\*h2oParamsD) # parameters specified as a dict()
+          - h2oModelD.train(x=myX, y=y, training_frame=trainFile) # train with H2OFrame trainFile
+          - h2oPredict = h2oPredictD = h2oModelD.predict(trainFile)
+
+         2. Derive the DMatrix from H2OFrame:
+
+          - nativeDMatrix = trainFile.convert_H2OFrame_2_DMatrix(myX, y, h2oModelD)
+
+         3. Derive the parameters for native XGBoost:
+
+          - nativeParams = h2oModelD.convert_H2OXGBoostParams_2_XGBoostParams()
+
+         4. Train your native XGBoost model and generate a prediction:
+
+          - nativeModel = xgb.train(params=nativeParams[0], dtrain=nativeDMatrix, num_boost_round=nativeParams[1])
+          - nativePredict = nativeModel.predict(data=nativeDMatrix, ntree_limit=nativeParams[1]
+
+         5. Compare the predictions h2oPredict from H2OXGBoost, nativePredict from native XGBoost.
+
+        :return: nativeParams, num_boost_round
+        """
+        import xgboost as xgb
+
+        nativeParams = self._model_json["output"]["native_parameters"]
+        nativeXGBoostParams = dict()
+
+        for (a,keyname,keyvalue) in nativeParams.cell_values:
+            nativeXGBoostParams[keyname]=keyvalue
+        paramsSet = self.full_parameters
+
+        return nativeXGBoostParams, paramsSet['ntrees']['actual_value']

--- a/h2o-py/h2o/estimators/xgboost.py
+++ b/h2o-py/h2o/estimators/xgboost.py
@@ -22,7 +22,7 @@ class H2OXGBoostEstimator(H2OEstimator):
 
     algo = "xgboost"
     supervised_learning = True
-    _options_ = {'verbose': True, 'model_extensions': ['h2o.model.extensions.ScoringHistory', 'h2o.model.extensions.VariableImportance', 'h2o.model.extensions.FeatureInteraction', 'h2o.model.extensions.Trees']}
+    _options_ = {'verbose': True, 'model_extensions': ['h2o.model.extensions.ScoringHistoryTrees', 'h2o.model.extensions.VariableImportance', 'h2o.model.extensions.FeatureInteraction', 'h2o.model.extensions.Trees']}
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]

--- a/h2o-py/h2o/estimators/xgboost.py
+++ b/h2o-py/h2o/estimators/xgboost.py
@@ -1127,8 +1127,7 @@ class H2OXGBoostEstimator(H2OEstimator):
     @checkpoint.setter
     def checkpoint(self, checkpoint):
         assert_is_type(checkpoint, None, str, H2OEstimator)
-        key = checkpoint.key if isinstance(checkpoint, H2OEstimator) else checkpoint
-        self._parms["checkpoint"] = key
+        self._parms["checkpoint"] = checkpoint
 
     @property
     def export_checkpoints_dir(self):

--- a/h2o-py/h2o/estimators/xgboost.py
+++ b/h2o-py/h2o/estimators/xgboost.py
@@ -25,7 +25,8 @@ class H2OXGBoostEstimator(H2OEstimator):
     _options_ = {'model_extensions': ['h2o.model.extensions.ScoringHistoryTrees',
                                       'h2o.model.extensions.VariableImportance',
                                       'h2o.model.extensions.FeatureInteraction',
-                                      'h2o.model.extensions.Trees'],
+                                      'h2o.model.extensions.Trees',
+                                      'h2o.model.extensions.HStatistic'],
                  'verbose': True}
 
     def __init__(self,

--- a/h2o-py/h2o/estimators/xgboost.py
+++ b/h2o-py/h2o/estimators/xgboost.py
@@ -22,7 +22,11 @@ class H2OXGBoostEstimator(H2OEstimator):
 
     algo = "xgboost"
     supervised_learning = True
-    _options_ = {'verbose': True, 'model_extensions': ['h2o.model.extensions.ScoringHistoryTrees', 'h2o.model.extensions.VariableImportance', 'h2o.model.extensions.FeatureInteraction', 'h2o.model.extensions.Trees']}
+    _options_ = {'model_extensions': ['h2o.model.extensions.ScoringHistoryTrees',
+                                      'h2o.model.extensions.VariableImportance',
+                                      'h2o.model.extensions.FeatureInteraction',
+                                      'h2o.model.extensions.Trees'],
+                 'verbose': True}
 
     def __init__(self,
                  model_id=None,  # type: Optional[Union[None, str, H2OEstimator]]

--- a/h2o-py/h2o/grid/grid_search.py
+++ b/h2o-py/h2o/grid/grid_search.py
@@ -390,6 +390,8 @@ class H2OGridSearch(h2o_meta(Keyed)):
             else:
                 y = y if y in training_frame.names else training_frame.names[y]
                 self.model._estimator_type = "classifier" if training_frame.types[y] == "enum" else "regressor"
+        else:
+            self.model._estimator_type = "unsupervised"
         self._model_build(x, y, training_frame, validation_frame, algo_params)
 
     def _model_build(self, x, y, tframe, vframe, kwargs):

--- a/h2o-py/h2o/grid/grid_search.py
+++ b/h2o-py/h2o/grid/grid_search.py
@@ -17,6 +17,7 @@ from h2o.two_dim_table import H2OTwoDimTable
 from h2o.display import H2ODisplay
 from h2o.grid.metrics import *  # NOQA
 from h2o.utils.metaclass import backwards_compatibility, deprecated_fn, h2o_meta
+from h2o.utils.mixin import assign, mixin
 from h2o.utils.shared_utils import quoted, stringify_dict_as_map
 from h2o.utils.typechecks import assert_is_type, is_type
 
@@ -466,8 +467,8 @@ class H2OGridSearch(h2o_meta(Keyed)):
         # m._metrics_class = metrics_class
         m._parms = self._parms
         self.export_checkpoints_dir = m._grid_json["export_checkpoints_dir"]
-        H2OEstimator.mixin(self, model_class)
-        self.__dict__.update(m.__dict__.copy())
+        mixin(self, model_class)
+        assign(self, m)
 
 
     def __getitem__(self, item):
@@ -1563,8 +1564,8 @@ class H2OGridSearch(h2o_meta(Keyed)):
         m._grid_json = grid_json
         # m._metrics_class = metrics_class
         m._parms = grid._parms
-        H2OEstimator.mixin(grid, model_class)
-        grid.__dict__.update(m.__dict__.copy())
+        mixin(grid, model_class)
+        assign(grid, m)
         return grid
 
 

--- a/h2o-py/h2o/model/__init__.py
+++ b/h2o-py/h2o/model/__init__.py
@@ -18,6 +18,8 @@ from .metrics_base import H2OMultinomialModelMetrics
 from .metrics_base import H2OOrdinalModelMetrics
 from .metrics_base import H2ORegressionModelMetrics
 
-__all__ = ["H2OAutoEncoderModel", "H2OBinomialModel", "H2OClusteringModel",
-           "ConfusionMatrix", "H2ODimReductionModel", "MetricsBase", "ModelBase",
-           "H2OModelFuture", "H2OSegmentModels"]
+# order here impacts order of presentation in generated documentation
+__all__ = ["ModelBase", "MetricsBase", 
+           "H2OBinomialModel", "H2OMultinomialModel", "H2ORegressionModel", "H2OOrdinalModel",
+           "H2OClusteringModel", "H2ODimReductionModel", "H2OAutoEncoderModel",
+           "ConfusionMatrix", "H2OModelFuture", "H2OSegmentModels"]

--- a/h2o-py/h2o/model/binomial.py
+++ b/h2o-py/h2o/model/binomial.py
@@ -4,6 +4,7 @@ from h2o.utils.compatibility import *  # NOQA
 
 from h2o.exceptions import H2OValueError
 from h2o.utils.typechecks import assert_is_type
+from .extensions import has_extension
 from .model_base import ModelBase
 
 
@@ -764,7 +765,7 @@ class H2OBinomialModel(ModelBase):
         >>> model.train(x=predictors, y=response, training_frame=benign)
         >>> model.plot(timestep="AUTO", metric="objective", server=False)
         """
-        if not hasattr(self, 'scoring_history_plot'):
+        if not has_extension(self, 'ScoringHistory'):
             raise H2OValueError("Scoring history plot is not available for this type of model (%s)." % self.algo)
             
         valid_metrics = self._allowed_metrics('binomial')

--- a/h2o-py/h2o/model/binomial.py
+++ b/h2o-py/h2o/model/binomial.py
@@ -47,7 +47,6 @@ class H2OBinomialModel(ModelBase):
         """
         return self.metric('f1', thresholds, train, valid, xval)
 
-
     def F2(self, thresholds=None, train=False, valid=False, xval=False):
         """
         Get the F2 for a set of thresholds.
@@ -86,7 +85,6 @@ class H2OBinomialModel(ModelBase):
         """
         return self.metric('f2', thresholds, train, valid, xval)
 
-
     def F0point5(self, thresholds=None, train=False, valid=False, xval=False):
         """
         Get the F0.5 for a set of thresholds.
@@ -123,7 +121,6 @@ class H2OBinomialModel(ModelBase):
         >>> F0point5 = gbm.F0point5(train=True,  valid=True,  xval=True)
         """
         return self.metric('f0point5', thresholds, train, valid, xval)
-
 
     def accuracy(self, thresholds=None, train=False, valid=False, xval=False):
         """
@@ -163,7 +160,6 @@ class H2OBinomialModel(ModelBase):
         """
         return self.metric('accuracy', thresholds, train, valid, xval)
 
-
     def error(self, thresholds=None, train=False, valid=False, xval=False):
         """
         Get the error for a set of thresholds.
@@ -201,7 +197,6 @@ class H2OBinomialModel(ModelBase):
         >>> gbm.error(train=True, valid=True, xval=True)
         """
         return self.metric('error', thresholds, train, valid, xval)
-
 
     def precision(self, thresholds=None, train=False, valid=False, xval=False):
         """
@@ -241,7 +236,6 @@ class H2OBinomialModel(ModelBase):
         """
         return self.metric('precision', thresholds, train, valid, xval)
 
-
     def tpr(self, thresholds=None, train=False, valid=False, xval=False):
         """
         Get the True Positive Rate for a set of thresholds.
@@ -279,7 +273,6 @@ class H2OBinomialModel(ModelBase):
         >>> gbm.tpr(train=True, valid=True, xval=True)
         """
         return self.metric('tpr', thresholds, train, valid, xval)
-
 
     def tnr(self, thresholds=None, train=False, valid=False, xval=False):
         """
@@ -319,7 +312,6 @@ class H2OBinomialModel(ModelBase):
         """
         return self.metric('tnr', thresholds, train, valid, xval)
 
-
     def fnr(self, thresholds=None, train=False, valid=False, xval=False):
         """
         Get the False Negative Rates for a set of thresholds.
@@ -357,7 +349,6 @@ class H2OBinomialModel(ModelBase):
         >>> gbm.fnr(train=True, valid=True, xval=True)
         """
         return self.metric('fnr', thresholds, train, valid, xval)
-
 
     def fpr(self, thresholds=None, train=False, valid=False, xval=False):
         """
@@ -397,7 +388,6 @@ class H2OBinomialModel(ModelBase):
         """
         return self.metric('fpr', thresholds, train, valid, xval)
 
-
     def recall(self, thresholds=None, train=False, valid=False, xval=False):
         """
         Get the recall for a set of thresholds (aka True Positive Rate).
@@ -435,7 +425,6 @@ class H2OBinomialModel(ModelBase):
         >>> gbm.recall(train=True, valid=True, xval=True)
         """
         return self.metric('recall', thresholds, train, valid, xval)
-
 
     def sensitivity(self, thresholds=None, train=False, valid=False, xval=False):
         """
@@ -475,7 +464,6 @@ class H2OBinomialModel(ModelBase):
         """
         return self.metric('sensitivity', thresholds, train, valid, xval)
 
-
     def fallout(self, thresholds=None, train=False, valid=False, xval=False):
         """
         Get the fallout for a set of thresholds (aka False Positive Rate).
@@ -513,7 +501,6 @@ class H2OBinomialModel(ModelBase):
         >>> gbm.fallout(train=True, valid=True, xval=True)
         """
         return self.metric('fallout', thresholds, train, valid, xval)
-
 
     def missrate(self, thresholds=None, train=False, valid=False, xval=False):
         """
@@ -553,7 +540,6 @@ class H2OBinomialModel(ModelBase):
         """
         return self.metric('missrate', thresholds, train, valid, xval)
 
-
     def specificity(self, thresholds=None, train=False, valid=False, xval=False):
         """
         Get the specificity for a set of thresholds (aka True Negative Rate).
@@ -591,7 +577,6 @@ class H2OBinomialModel(ModelBase):
         >>> gbm.specificity(train=True, valid=True, xval=True)
         """
         return self.metric('specificity', thresholds, train, valid, xval)
-
 
     def mcc(self, thresholds=None, train=False, valid=False, xval=False):
         """
@@ -631,7 +616,6 @@ class H2OBinomialModel(ModelBase):
         """
         return self.metric('mcc', thresholds, train, valid, xval)
 
-
     def max_per_class_error(self, thresholds=None, train=False, valid=False, xval=False):
         """
         Get the max per class error for a set of thresholds.
@@ -670,7 +654,6 @@ class H2OBinomialModel(ModelBase):
         """
         return self.metric('max_per_class_error', thresholds, train, valid, xval)
 
-
     def mean_per_class_error(self, thresholds=None, train=False, valid=False, xval=False):
         """
         Get the mean per class error for a set of thresholds.
@@ -708,7 +691,6 @@ class H2OBinomialModel(ModelBase):
         >>> gbm.mean_per_class_error(train=True, valid=True, xval=True)
         """
         return self.metric('mean_per_class_error', thresholds, train, valid, xval)
-
 
     def metric(self, metric, thresholds=None, train=False, valid=False, xval=False):
         """
@@ -762,7 +744,6 @@ class H2OBinomialModel(ModelBase):
                 m[k] = v.metric(metric, thresholds=thresholds)
         return list(m.values())[0] if len(m) == 1 else m
 
-
     def plot(self, timestep="AUTO", metric="AUTO", server=False, **kwargs):
         """
         Plot training set (and validation set if available) scoring history for an H2OBinomialModel.
@@ -783,16 +764,15 @@ class H2OBinomialModel(ModelBase):
         >>> model.train(x=predictors, y=response, training_frame=benign)
         >>> model.plot(timestep="AUTO", metric="objective", server=False)
         """
-        assert_is_type(metric, "AUTO", "logloss", "auc", "classification_error", "rmse", "objective", 
-                       "negative_log_likelihood")
-        if self._model_json["algo"] in ("deeplearning", "xgboost", "drf", "gbm"):
-            # make sure metric is not those of GLM metrics for other models
-            if metric in ("negative_log_likelihood", "objective"):
-                raise H2OValueError("Metrics: negative_log_likelihood, objective are only for glm models.")
-            if metric == "AUTO":
-                metric = "logloss"
-        self._plot(timestep=timestep, metric=metric, server=server)
-
+        if not hasattr(self, 'scoring_history_plot'):
+            raise H2OValueError("Plotting not implemented for this type of model")
+            
+        valid_metrics = self._allowed_metrics('binomial')
+        if valid_metrics is not None:
+            assert_is_type(metric, 'AUTO', *valid_metrics), "metric for H2OBinomialModel must be one of %s" % valid_metrics
+        if metric == "AUTO":
+            metric = self._default_metric('binomial') or 'AUTO'
+        self.scoring_history_plot(timestep=timestep, metric=metric, server=server)
 
     def roc(self, train=False, valid=False, xval=False):
         """
@@ -830,7 +810,6 @@ class H2OBinomialModel(ModelBase):
         >>> gbm.roc(train=True, valid=True, xval=True)
         """
         return self._delegate_to_metrics('roc', train, valid, xval)
-
 
     def gains_lift(self, train=False, valid=False, xval=False):
         """
@@ -932,7 +911,6 @@ class H2OBinomialModel(ModelBase):
         return self._delegate_to_metrics('confusion_matrix', train, valid, xval,
                                          metrics=metrics, thresholds=thresholds)
 
-
     def find_threshold_by_max_metric(self, metric, train=False, valid=False, xval=False):
         """
         If all are False (default), then return the training metric value.
@@ -971,7 +949,6 @@ class H2OBinomialModel(ModelBase):
         >>> max_metric
         """
         return self._delegate_to_metrics('find_threshold_by_max_metric', train, valid, xval, metric=metric)
-
 
     def find_idx_by_threshold(self, threshold, train=False, valid=False, xval=False):
         """
@@ -1012,7 +989,6 @@ class H2OBinomialModel(ModelBase):
         >>> idx_threshold
         """
         return self._delegate_to_metrics('find_idx_by_threshold', train, valid, xval, threshold=threshold)
-
 
     def _delegate_to_metrics(self, method, train=False, valid=False, xval=False, **kwargs):
         tm = ModelBase._get_metrics(self, train, valid, xval)

--- a/h2o-py/h2o/model/binomial.py
+++ b/h2o-py/h2o/model/binomial.py
@@ -765,7 +765,7 @@ class H2OBinomialModel(ModelBase):
         >>> model.plot(timestep="AUTO", metric="objective", server=False)
         """
         if not hasattr(self, 'scoring_history_plot'):
-            raise H2OValueError("Plotting not implemented for this type of model")
+            raise H2OValueError("Scoring history plot is not available for this type of model (%s)." % self.algo)
             
         valid_metrics = self._allowed_metrics('binomial')
         if valid_metrics is not None:

--- a/h2o-py/h2o/model/extensions/__init__.py
+++ b/h2o-py/h2o/model/extensions/__init__.py
@@ -3,9 +3,7 @@ A collection of mixins optionally added to the model if the feature is supported
 """
 
 from .feature_interaction import FeatureInteraction
-from .scoring_history import ScoringHistory, ScoringHistoryGLM
+from .scoring_history import ScoringHistory, ScoringHistoryDL, ScoringHistoryGLM, ScoringHistoryTrees
 from .std_coef import StandardCoef
 from .trees import Trees
 from .varimp import VariableImportance
-
-__all__ = ["FeatureInteraction", "ScoringHistory", "ScoringHistoryGLM", "StandardCoef", "Trees", "VariableImportance"]

--- a/h2o-py/h2o/model/extensions/__init__.py
+++ b/h2o-py/h2o/model/extensions/__init__.py
@@ -1,0 +1,11 @@
+"""
+A collection of mixins optionally added to the model if the feature is supported for the given model.
+"""
+
+from .feature_interaction import FeatureInteraction
+from .scoring_history import ScoringHistory, ScoringHistoryGLM
+from .std_coef import StandardCoef
+from .trees import Trees
+from .varimp import VariableImportance
+
+__all__ = ["FeatureInteraction", "ScoringHistory", "ScoringHistoryGLM", "StandardCoef", "Trees", "VariableImportance"]

--- a/h2o-py/h2o/model/extensions/__init__.py
+++ b/h2o-py/h2o/model/extensions/__init__.py
@@ -1,9 +1,49 @@
 """
 A collection of mixins optionally added to the model if the feature is supported for the given model.
 """
+import sys
 
 from .feature_interaction import FeatureInteraction
+from .h_statistic import HStatistic
 from .scoring_history import ScoringHistory, ScoringHistoryDL, ScoringHistoryGLM, ScoringHistoryTrees
 from .std_coef import StandardCoef
 from .trees import Trees
 from .varimp import VariableImportance
+
+module = sys.modules[__name__]
+
+
+def has_extension(model, ext):  # type: (ModelBase, str) -> bool 
+    """
+    Any short class name visible in this module is considered as a valid model extension.
+    For example, the extension mixin class `h2o.model.extensions.VariableImportance` will be checked using
+    
+    .. code-block:: python
+    
+        has_extension(model, 'VariableImportance')
+        
+    Also, when there are multiple implementations of the same extension, it is recommended to test only for the base class.
+    For example, to test if the model supports scoring history, simply use:
+    
+    .. code-block:: python
+    
+        has_extension(model, 'ScoringHistory')
+        
+    :param model: the model to check.
+    :param ext: the name of the extension that may be available or not on the model.
+    :return: True iff the model supports the extension.
+    """
+    ext_cls = getattr(module, ext, None)
+    if ext_cls is None:
+        raise ValueError("Unknown model extension `%s`: see module `%s` for the full list of supported extensions." % (ext, __name__))
+    return isinstance(model, ext_cls)
+
+
+__all__ = [  # mainly useful here for the generated documentation
+    'FeatureInteraction', 
+    'HStatistic', 
+    'ScoringHistory', 
+    'StandardCoef', 
+    'Trees', 
+    'VariableImportance'
+]

--- a/h2o-py/h2o/model/extensions/feature_interaction.py
+++ b/h2o-py/h2o/model/extensions/feature_interaction.py
@@ -1,0 +1,54 @@
+import h2o
+
+
+class FeatureInteraction:
+
+    def feature_interaction(self, max_interaction_depth=100, max_tree_depth=100, max_deepening=-1, path=None):
+        """
+        Feature interactions and importance, leaf statistics and split value histograms in a tabular form.
+        Available for XGBoost and GBM.
+
+        Metrics:
+        Gain - Total gain of each feature or feature interaction.
+        FScore - Amount of possible splits taken on a feature or feature interaction.
+        wFScore - Amount of possible splits taken on a feature or feature interaction weighed by 
+        the probability of the splits to take place.
+        Average wFScore - wFScore divided by FScore.
+        Average Gain - Gain divided by FScore.
+        Expected Gain - Total gain of each feature or feature interaction weighed by the probability to gather the gain.
+        Average Tree Index
+        Average Tree Depth
+
+        :param max_interaction_depth: Upper bound for extracted feature interactions depth. Defaults to 100.
+        :param max_tree_depth: Upper bound for tree depth. Defaults to 100.
+        :param max_deepening: Upper bound for interaction start deepening (zero deepening => interactions 
+            starting at root only). Defaults to -1.
+        :param path: (Optional) Path where to save the output in .xlsx format (e.g. ``/mypath/file.xlsx``).
+            Please note that Pandas and XlsxWriter need to be installed for using this option. Defaults to None.
+
+
+        :examples:
+        >>> boston = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/BostonHousing.csv")
+        >>> predictors = boston.columns[:-1]
+        >>> response = "medv"
+        >>> boston['chas'] = boston['chas'].asfactor()
+        >>> train, valid = boston.split_frame(ratios=[.8])
+        >>> boston_xgb = H2OXGBoostEstimator(seed=1234)
+        >>> boston_xgb.train(y=response, x=predictors, training_frame=train)
+        >>> feature_interactions = boston_xgb.feature_interaction()
+        """
+        kwargs = {}
+        kwargs["model_id"] = self.model_id
+        kwargs["max_interaction_depth"] = max_interaction_depth
+        kwargs["max_tree_depth"] = max_tree_depth
+        kwargs["max_deepening"] = max_deepening
+
+        json = h2o.api("POST /3/FeatureInteraction", data=kwargs)
+        if path is not None:
+            import pandas as pd
+            writer = pd.ExcelWriter(path, engine='xlsxwriter')
+            for fi in json['feature_interaction']:
+                fi.as_data_frame().to_excel(writer, sheet_name=fi._table_header)
+            writer.save()
+
+        return json['feature_interaction']

--- a/h2o-py/h2o/model/extensions/feature_interaction.py
+++ b/h2o-py/h2o/model/extensions/feature_interaction.py
@@ -3,7 +3,7 @@ import h2o
 
 class FeatureInteraction:
 
-    def feature_interaction(self, max_interaction_depth=100, max_tree_depth=100, max_deepening=-1, path=None):
+    def _feature_interaction(self, max_interaction_depth=100, max_tree_depth=100, max_deepening=-1, path=None):
         """
         Feature interactions and importance, leaf statistics and split value histograms in a tabular form.
         Available for XGBoost and GBM.

--- a/h2o-py/h2o/model/extensions/h_statistic.py
+++ b/h2o-py/h2o/model/extensions/h_statistic.py
@@ -1,0 +1,36 @@
+import h2o
+
+
+class HStatistic:
+
+    def _h(self, frame, variables):
+        """
+        Calculates Friedman and Popescu's H statistics, in order to test for the presence of an interaction between specified variables in h2o gbm and xgb models.
+        H varies from 0 to 1. It will have a value of 0 if the model exhibits no interaction between specified variables and a correspondingly larger value for a 
+        stronger interaction effect between them. NaN is returned if a computation is spoiled by weak main effects and rounding errors.
+        
+        See Jerome H. Friedman and Bogdan E. Popescu, 2008, "Predictive learning via rule ensembles", *Ann. Appl. Stat.*
+        **2**:916-954, http://projecteuclid.org/download/pdfview_1/euclid.aoas/1223908046, s. 8.1.
+
+        
+        :param frame: the frame that current model has been fitted to
+        :param variables: variables of the interest
+        :return: H statistic of the variables 
+        
+        :examples:
+        >>> prostate_train = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/logreg/prostate_train.csv")
+        >>> prostate_train["CAPSULE"] = prostate_train["CAPSULE"].asfactor()
+        >>> gbm_h2o = H2OGradientBoostingEstimator(ntrees=100, learn_rate=0.1,
+        >>>                                 max_depth=5,
+        >>>                                 min_rows=10,
+        >>>                                 distribution="bernoulli")
+        >>> gbm_h2o.train(x=list(range(1,prostate_train.ncol)),y="CAPSULE", training_frame=prostate_train)
+        >>> h = gbm_h2o.h(prostate_train, ['DPROS','DCAPS'])
+        """
+        kwargs = dict(
+            model_id=self.model_id, 
+            frame=frame.key, 
+            variables=variables
+        )
+        json = h2o.api("POST /3/FriedmansPopescusH", data=kwargs)
+        return json['h']

--- a/h2o-py/h2o/model/extensions/scoring_history.py
+++ b/h2o-py/h2o/model/extensions/scoring_history.py
@@ -1,0 +1,126 @@
+from h2o.exceptions import H2OValueError
+from h2o.utils.ext_dependencies import get_matplotlib_pyplot
+from h2o.utils.shared_utils import can_use_pandas
+from h2o.utils.typechecks import assert_is_type
+
+
+class ScoringHistory:
+    
+    _default_metrics_ = dict(
+        binomial='logloss',
+        multinomial='classification_error',
+        regression='rmse',
+    )
+    _allowed_metrics_ = dict(
+        binomial=['logloss', 'auc', 'classification_error', 'rmse'],
+        multinomial=['logloss', 'classification_error', 'rmse'],
+        regression=['rmse', 'deviance', 'mae']
+    )
+    
+    def _default_metric(self, type_):
+        return self._default_metrics_.get(type_)
+    
+    def _allowed_metrics(self, type_):
+        return self._allowed_metrics_.get(type_, [])
+    
+    def scoring_history_plot(self, timestep, metric, server=False):
+        plt = get_matplotlib_pyplot(server)
+        if plt is None: return
+        
+        scoring_history = self.scoring_history()
+
+        # Set timestep
+        if self._model_json["algo"] in ("gbm", "drf", "xgboost"):
+            assert_is_type(timestep, "AUTO", "duration", "number_of_trees")
+            if timestep == "AUTO":
+                timestep = "number_of_trees"
+        else:  # self._model_json["algo"] == "deeplearning":
+            # Delete first row of DL scoring history since it contains NAs & NaNs
+            if scoring_history["samples"][0] == 0:
+                scoring_history = scoring_history[1:]
+            assert_is_type(timestep, "AUTO", "epochs",  "samples", "duration")
+            if timestep == "AUTO":
+                timestep = "epochs"
+
+        training_metric = "training_{}".format(metric)
+        validation_metric = "validation_{}".format(metric)
+        if timestep == "duration":
+            dur_colname = "duration_{}".format(scoring_history["duration"][1].split()[1])
+            scoring_history[dur_colname] = [str(x).split()[0] for x in scoring_history["duration"]]
+            timestep = dur_colname
+
+        if can_use_pandas():
+            valid = validation_metric in list(scoring_history)
+            ylim = (scoring_history[[training_metric, validation_metric]].min().min(),
+                    scoring_history[[training_metric, validation_metric]].max().max()) if valid \
+                else (scoring_history[training_metric].min(), scoring_history[training_metric].max())
+        else:
+            valid = validation_metric in scoring_history.col_header
+            ylim = (min(min(scoring_history[[training_metric, validation_metric]])),
+                    max(max(scoring_history[[training_metric, validation_metric]]))) if valid \
+                else (min(scoring_history[training_metric]), max(scoring_history[training_metric]))
+        if ylim[0] == ylim[1]: ylim = (0, 1)
+
+        if valid:  # Training and validation scoring history
+            plt.xlabel(timestep)
+            plt.ylabel(metric)
+            plt.title("Scoring History")
+            plt.ylim(ylim)
+            plt.plot(scoring_history[timestep], scoring_history[training_metric], label="Training")
+            plt.plot(scoring_history[timestep], scoring_history[validation_metric], color="orange",
+                     label="Validation")
+            plt.legend()
+        else:  # Training scoring history only
+            plt.xlabel(timestep)
+            plt.ylabel(training_metric)
+            plt.title("Training Scoring History")
+            plt.ylim(ylim)
+            plt.plot(scoring_history[timestep], scoring_history[training_metric])
+        if not server:
+            plt.show()
+
+
+class ScoringHistoryGLM(ScoringHistory):
+
+    _default_metrics_ = {}
+    _allowed_metrics_ = dict(
+        binomial=["logloss", "auc", "classification_error", "rmse", "objective", "negative_log_likelihood"]
+        # for others, validation is done in the plot function below
+    )
+    
+    def scoring_history_plot(self, timestep, metric, server=False):
+        plt = get_matplotlib_pyplot(server)
+        if plt is None: return
+        
+        scoring_history = self.scoring_history()
+
+        if self.actual_params.get("lambda_search"):
+            allowed_timesteps = ["iteration", "duration"]
+            allowed_metrics = ["deviance_train", "deviance_test", "deviance_xval"]
+            # When provided with multiple alpha values, scoring history contains history of all...
+            scoring_history = scoring_history[scoring_history["alpha"] == self._model_json["output"]["alpha_best"]]
+        elif self.actual_params.get("HGLM"):
+            allowed_timesteps = ["iterations", "duration"]
+            allowed_metrics = ["convergence", "sumetaieta02"]
+        else:
+            allowed_timesteps = ["iterations", "duration"]
+            allowed_metrics = ["objective", "negative_log_likelihood"]
+        if metric == "AUTO":
+            metric = allowed_metrics[0]
+        elif metric not in allowed_metrics:
+            raise H2OValueError("for {}, metric must be one of: {}".format(self.algo.upper(),
+                                                                           ", ".join(allowed_metrics)))
+
+        if timestep == "AUTO":
+            timestep = allowed_timesteps[0]
+        elif timestep not in allowed_timesteps:
+            raise H2OValueError("for {}, timestep must be one of: {}".format(self.algo.upper(),
+                                                                             ", ".join(allowed_timesteps)))
+
+        plt.xlabel(timestep)
+        plt.ylabel(metric)
+        plt.title("Validation Scoring History")
+        style = "b-" if len(scoring_history[timestep]) > 1 else "bx"
+        plt.plot(scoring_history[timestep], scoring_history[metric], style)
+        if not server:
+            plt.show()

--- a/h2o-py/h2o/model/extensions/std_coef.py
+++ b/h2o-py/h2o/model/extensions/std_coef.py
@@ -1,4 +1,3 @@
-from h2o.exceptions import H2OValueError
 from h2o.utils.ext_dependencies import get_matplotlib_pyplot
 from h2o.utils.typechecks import assert_is_type, I
 

--- a/h2o-py/h2o/model/extensions/std_coef.py
+++ b/h2o-py/h2o/model/extensions/std_coef.py
@@ -5,7 +5,7 @@ from h2o.utils.typechecks import assert_is_type, I
 
 class StandardCoef:
 
-    def std_coef_plot(self, num_of_features=None, server=False):
+    def _std_coef_plot(self, num_of_features=None, server=False):
         """
         Plot a GLM model"s standardized coefficient magnitudes.
 
@@ -15,10 +15,6 @@ class StandardCoef:
         :returns: None.
         """
         assert_is_type(num_of_features, None, I(int, lambda x: x > 0))
-
-        # check that model is a glm
-        if self._model_json["algo"] != "glm":
-            raise H2OValueError("This function is available for GLM models only")
 
         plt = get_matplotlib_pyplot(server)
         if not plt: return

--- a/h2o-py/h2o/model/extensions/std_coef.py
+++ b/h2o-py/h2o/model/extensions/std_coef.py
@@ -1,0 +1,120 @@
+from h2o.exceptions import H2OValueError
+from h2o.utils.ext_dependencies import get_matplotlib_pyplot
+from h2o.utils.typechecks import assert_is_type, I
+
+
+class StandardCoef:
+
+    def std_coef_plot(self, num_of_features=None, server=False):
+        """
+        Plot a GLM model"s standardized coefficient magnitudes.
+
+        :param num_of_features: the number of features shown in the plot.
+        :param server: if true set server settings to matplotlib and show the graph
+
+        :returns: None.
+        """
+        assert_is_type(num_of_features, None, I(int, lambda x: x > 0))
+
+        # check that model is a glm
+        if self._model_json["algo"] != "glm":
+            raise H2OValueError("This function is available for GLM models only")
+
+        plt = get_matplotlib_pyplot(server)
+        if not plt: return
+
+        # get unsorted tuple of labels and coefficients
+        unsorted_norm_coef = self.coef_norm().items()
+        # drop intercept value then sort tuples by the coefficient"s absolute value
+        drop_intercept = [tup for tup in unsorted_norm_coef if tup[0] != "Intercept"]
+        norm_coef = sorted(drop_intercept, key=lambda x: abs(x[1]), reverse=True)
+
+        signage = []
+        for element in norm_coef:
+            # if positive including zero, color blue, else color orange (use same colors as Flow)
+            if element[1] >= 0:
+                signage.append("#1F77B4")  # blue
+            else:
+                signage.append("#FF7F0E")  # dark orange
+
+        # get feature labels and their corresponding magnitudes
+        feature_labels = [tup[0] for tup in norm_coef]
+        norm_coef_magn = [abs(tup[1]) for tup in norm_coef]
+        # specify bar centers on the y axis, but flip the order so largest bar appears at top
+        pos = range(len(feature_labels))[::-1]
+        # specify the bar lengths
+        val = norm_coef_magn
+
+        # check number of features, default is all the features
+        if num_of_features is None:
+            num_of_features = len(val)
+
+        # plot horizontal plot
+        fig, ax = plt.subplots(1, 1, figsize=(14, 10))
+        # create separate plot for the case where num_of_features = 1
+        if num_of_features == 1:
+            plt.barh(pos[0], val[0],
+                     align="center", height=0.8, color=signage[0], edgecolor="none")
+            # Hide the right and top spines, color others grey
+            ax.spines["right"].set_visible(False)
+            ax.spines["top"].set_visible(False)
+            ax.spines["bottom"].set_color("#7B7B7B")
+            ax.spines["left"].set_color("#7B7B7B")
+            # Only show ticks on the left and bottom spines
+            ax.yaxis.set_ticks_position("left")
+            ax.xaxis.set_ticks_position("bottom")
+            plt.yticks([0], feature_labels[0])
+            ax.margins(None, 0.5)
+
+        else:
+            plt.barh(pos[0:num_of_features], val[0:num_of_features],
+                     align="center", height=0.8, color=signage[0:num_of_features], edgecolor="none")
+            # Hide the right and top spines, color others grey
+            ax.spines["right"].set_visible(False)
+            ax.spines["top"].set_visible(False)
+            ax.spines["bottom"].set_color("#7B7B7B")
+            ax.spines["left"].set_color("#7B7B7B")
+            # Only show ticks on the left and bottom spines
+            ax.yaxis.set_ticks_position("left")
+            ax.xaxis.set_ticks_position("bottom")
+            plt.yticks(pos[0:num_of_features], feature_labels[0:num_of_features])
+            ax.margins(None, 0.05)
+
+        # generate custom fake lines that will be used as legend entries:
+        # check if positive and negative values exist
+        # if positive create positive legend
+        if "#1F77B4" in signage[0:num_of_features] and "#FF7F0E" not in signage[0:num_of_features]:
+            color_ids = ("Positive",)
+            markers = [plt.Line2D([0, 0], [0, 0], color=color, marker="s", linestyle="")
+                       for color in signage[0:num_of_features]]
+            lgnd = plt.legend(markers, color_ids, numpoints=1, loc="best", frameon=False, fontsize=13)
+            lgnd.legendHandles[0]._legmarker.set_markersize(10)
+        # if neg create neg legend
+        elif "#FF7F0E" in signage[0:num_of_features] and "#1F77B4" not in signage[0:num_of_features]:
+            color_ids = ("Negative",)
+            markers = [plt.Line2D([0, 0], [0, 0], color=color, marker="s", linestyle="")
+                       for color in set(signage[0:num_of_features])]
+            lgnd = plt.legend(markers, color_ids, numpoints=1, loc="best", frameon=False, fontsize=13)
+            lgnd.legendHandles[0]._legmarker.set_markersize(10)
+        # if both provide both colors in legend
+        else:
+            color_ids = ("Positive", "Negative")
+            markers = [plt.Line2D([0, 0], [0, 0], color=color, marker="s", linestyle="")
+                       for color in ['#1F77B4', '#FF7F0E']] # blue should always be positive, orange negative
+            lgnd = plt.legend(markers, color_ids, numpoints=1, loc="best", frameon=False, fontsize=13)
+            lgnd.legendHandles[0]._legmarker.set_markersize(10)
+            lgnd.legendHandles[1]._legmarker.set_markersize(10)
+
+        # Hide the right and top spines, color others grey
+        ax.spines["right"].set_visible(False)
+        ax.spines["top"].set_visible(False)
+        ax.spines["bottom"].set_color("#7B7B7B")
+        ax.spines["left"].set_color("#7B7B7B")
+
+        # Only show ticks on the left and bottom spines
+        plt.yticks(pos[0:num_of_features], feature_labels[0:num_of_features])
+        plt.tick_params(axis="x", which="minor", bottom="off", top="off",  labelbottom="off")
+        plt.title("Standardized Coef. Magnitudes: H2O GLM", fontsize=20)
+        # show plot
+        if server:
+            plt.show()

--- a/h2o-py/h2o/model/extensions/trees.py
+++ b/h2o-py/h2o/model/extensions/trees.py
@@ -1,0 +1,11 @@
+class Trees:
+
+    def ntrees_actual(self):
+        """
+        Returns actual number of trees in a tree model. If early stopping enabled, GBM can reset the ntrees value.
+        In this case, the actual ntrees value is less than the original ntrees value a user set before
+        building the model.
+    
+        Type: ``float``
+        """
+        return self.summary()['number_of_trees'][0]

--- a/h2o-py/h2o/model/extensions/trees.py
+++ b/h2o-py/h2o/model/extensions/trees.py
@@ -1,6 +1,6 @@
 class Trees:
 
-    def ntrees_actual(self):
+    def _ntrees_actual(self):
         """
         Returns actual number of trees in a tree model. If early stopping enabled, GBM can reset the ntrees value.
         In this case, the actual ntrees value is less than the original ntrees value a user set before

--- a/h2o-py/h2o/model/extensions/varimp.py
+++ b/h2o-py/h2o/model/extensions/varimp.py
@@ -4,7 +4,7 @@ from h2o.utils.typechecks import assert_is_type
 
 class VariableImportance:
 
-    def varimp_plot(self, num_of_features=None, server=False):
+    def _varimp_plot(self, num_of_features=None, server=False):
         """
         Plot the variable importance for a trained model.
 

--- a/h2o-py/h2o/model/extensions/varimp.py
+++ b/h2o-py/h2o/model/extensions/varimp.py
@@ -1,0 +1,72 @@
+from h2o.utils.ext_dependencies import get_matplotlib_pyplot
+from h2o.utils.typechecks import assert_is_type
+
+
+class VariableImportance:
+
+    def varimp_plot(self, num_of_features=None, server=False):
+        """
+        Plot the variable importance for a trained model.
+
+        :param num_of_features: the number of features shown in the plot (default is 10 or all if less than 10).
+        :param server: if true set server settings to matplotlib and show the graph
+
+        :returns: None.
+        """
+        assert_is_type(num_of_features, None, int)
+        assert_is_type(server, bool)
+
+        plt = get_matplotlib_pyplot(server)
+        if plt is None:
+            return
+
+        # get the variable importances as a list of tuples, do not use pandas dataframe
+        importances = self.varimp(use_pandas=False)
+        # features labels correspond to the first value of each tuple in the importances list
+        feature_labels = [tup[0] for tup in importances]
+        # relative importances correspond to the first value of each tuple in the importances list
+        scaled_importances = [tup[2] for tup in importances]
+        # specify bar centers on the y axis, but flip the order so largest bar appears at top
+        pos = range(len(feature_labels))[::-1]
+        # specify the bar lengths
+        val = scaled_importances
+
+        # default to 10 or less features if num_of_features is not specified
+        if num_of_features is None:
+            num_of_features = min(len(val), 10)
+
+        fig, ax = plt.subplots(1, 1, figsize=(14, 10))
+        # create separate plot for the case where num_of_features == 1
+        if num_of_features == 1:
+            plt.barh(pos[0:num_of_features], val[0:num_of_features], align="center",
+                     height=0.8, color="#1F77B4", edgecolor="none")
+            # Hide the right and top spines, color others grey
+            ax.spines["right"].set_visible(False)
+            ax.spines["top"].set_visible(False)
+            ax.spines["bottom"].set_color("#7B7B7B")
+            ax.spines["left"].set_color("#7B7B7B")
+            # Only show ticks on the left and bottom spines
+            ax.yaxis.set_ticks_position("left")
+            ax.xaxis.set_ticks_position("bottom")
+            plt.yticks(pos[0:num_of_features], feature_labels[0:num_of_features])
+            ax.margins(None, 0.5)
+
+        else:
+            plt.barh(pos[0:num_of_features], val[0:num_of_features], align="center",
+                     height=0.8, color="#1F77B4", edgecolor="none")
+            # Hide the right and top spines, color others grey
+            ax.spines["right"].set_visible(False)
+            ax.spines["top"].set_visible(False)
+            ax.spines["bottom"].set_color("#7B7B7B")
+            ax.spines["left"].set_color("#7B7B7B")
+            # Only show ticks on the left and bottom spines
+            ax.yaxis.set_ticks_position("left")
+            ax.xaxis.set_ticks_position("bottom")
+            plt.yticks(pos[0:num_of_features], feature_labels[0:num_of_features])
+            plt.ylim([min(pos[0:num_of_features])- 1, max(pos[0:num_of_features])+1])
+            # ax.margins(y=0.5)
+
+        # check which algorithm was used to select right plot title
+        plt.title("Variable Importance: H2O %s" % self._model_json["algo_full_name"], fontsize=20)
+        if not server:
+            plt.show()

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -429,6 +429,63 @@ class ModelBase(h2o_meta(Keyed)):
             return model["scoring_history"].as_data_frame()
         print("No score history for this model")
 
+    def ntrees_actual(self):
+        """
+        Returns actual number of trees in a tree model. If early stopping enabled, GBM can reset the ntrees value.
+        In this case, the actual ntrees value is less than the original ntrees value a user set before
+        building the model.
+    
+        Type: ``float``
+        """
+        # For now, redirect to h2o.model.extensions.trees for models that support the feature, and print legacy message for others..
+        # Later, the method will be exposed only for models supporting the feature.
+        if hasattr(self, '_ntrees_actual'):
+            return self._ntrees_actual()
+        print("No actual number of trees for this model")    
+
+    def feature_interaction(self, max_interaction_depth=100, max_tree_depth=100, max_deepening=-1, path=None):
+        """
+        Feature interactions and importance, leaf statistics and split value histograms in a tabular form.
+        Available for XGBoost and GBM.
+
+        Metrics:
+        Gain - Total gain of each feature or feature interaction.
+        FScore - Amount of possible splits taken on a feature or feature interaction.
+        wFScore - Amount of possible splits taken on a feature or feature interaction weighed by 
+        the probability of the splits to take place.
+        Average wFScore - wFScore divided by FScore.
+        Average Gain - Gain divided by FScore.
+        Expected Gain - Total gain of each feature or feature interaction weighed by the probability to gather the gain.
+        Average Tree Index
+        Average Tree Depth
+
+        :param max_interaction_depth: Upper bound for extracted feature interactions depth. Defaults to 100.
+        :param max_tree_depth: Upper bound for tree depth. Defaults to 100.
+        :param max_deepening: Upper bound for interaction start deepening (zero deepening => interactions 
+            starting at root only). Defaults to -1.
+        :param path: (Optional) Path where to save the output in .xlsx format (e.g. ``/mypath/file.xlsx``).
+            Please note that Pandas and XlsxWriter need to be installed for using this option. Defaults to None.
+
+
+        :examples:
+        >>> boston = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/BostonHousing.csv")
+        >>> predictors = boston.columns[:-1]
+        >>> response = "medv"
+        >>> boston['chas'] = boston['chas'].asfactor()
+        >>> train, valid = boston.split_frame(ratios=[.8])
+        >>> boston_xgb = H2OXGBoostEstimator(seed=1234)
+        >>> boston_xgb.train(y=response, x=predictors, training_frame=train)
+        >>> feature_interactions = boston_xgb.feature_interaction()
+        """
+        # For now, redirect to h2o.model.extensions.feature_interaction for models that support the feature, and print legacy message for others..
+        # Later, the method will be exposed only for models supporting the feature.
+        if hasattr(self, '_feature_interaction'):
+            return self._feature_interaction(max_interaction_depth=max_interaction_depth, 
+                                             max_tree_depth=max_tree_depth, 
+                                             max_deepening=max_deepening, 
+                                             path=path)
+        print("No calculation available for this model")
+
     def h(self, frame, variables):
         """
         Calculates Friedman and Popescu's H statistics, in order to test for the presence of an interaction between specified variables in h2o gbm and xgb models.
@@ -1379,6 +1436,38 @@ class ModelBase(h2o_meta(Keyed)):
         axs.xaxis.grid()
         axs.yaxis.grid()
         
+    def varimp_plot(self, num_of_features=None, server=False):
+        """
+        Plot the variable importance for a trained model.
+
+        :param num_of_features: the number of features shown in the plot (default is 10 or all if less than 10).
+        :param server: if true set server settings to matplotlib and show the graph
+
+        :returns: None.
+        """
+        # For now, redirect to h2o.model.extensions.varimp for models that support the feature, and raise legacy error for others.
+        # Later, the method will be exposed only for models supporting the feature.
+        if hasattr(self, '_varimp_plot'):
+            return self._varimp_plot(num_of_features=num_of_features, server=server)
+        else:
+            raise H2OValueError("Variable importance plot is not available for this type of model (%s)." % self.algo)
+
+    def std_coef_plot(self, num_of_features=None, server=False):
+        """
+        Plot a model's standardized coefficient magnitudes.
+
+        :param num_of_features: the number of features shown in the plot.
+        :param server: if true set server settings to matplotlib and show the graph
+
+        :returns: None.
+        """
+        # For now, redirect to h2o.model.extensions.std_coef for models that support the feature, and raise legacy error for others.
+        # Later, the method will be exposed only for models supporting the feature.
+        if hasattr(self, '_std_coef_plot'):
+            return self._std_coef_plot(num_of_features=num_of_features, server=server)
+        else:
+            raise H2OValueError("Standardized coefficient plot is not available for this type of model (%s)." % self.algo)
+
     @staticmethod
     def _check_targets(y_actual, y_predicted):
         """Check that y_actual and y_predicted have the same length.

--- a/h2o-py/h2o/model/multinomial.py
+++ b/h2o-py/h2o/model/multinomial.py
@@ -240,7 +240,7 @@ class H2OMultinomialModel(ModelBase):
         >>> gbm.plot(metric="AUTO", timestep="AUTO")
         """
         if not hasattr(self, 'scoring_history_plot'):
-            raise H2OValueError("Plotting not implemented for this type of model")
+            raise H2OValueError("Scoring history plot is not available for this type of model (%s)." % self.algo)
 
         valid_metrics = self._allowed_metrics('multinomial')
         if valid_metrics is not None:

--- a/h2o-py/h2o/model/multinomial.py
+++ b/h2o-py/h2o/model/multinomial.py
@@ -4,6 +4,7 @@ from h2o.utils.compatibility import *  # NOQA
 
 import h2o
 from h2o.utils.typechecks import assert_is_type
+from ..exceptions import H2OValueError
 from ..frame import H2OFrame
 from .model_base import ModelBase
 
@@ -238,12 +239,12 @@ class H2OMultinomialModel(ModelBase):
         ...           validation_frame=valid)
         >>> gbm.plot(metric="AUTO", timestep="AUTO")
         """
+        if not hasattr(self, 'scoring_history_plot'):
+            raise H2OValueError("Plotting not implemented for this type of model")
 
-        if self._model_json["algo"] in ("deeplearning", "xgboost", "drf", "gbm"):
-            if metric == "AUTO":
-                metric = "classification_error"
-            elif metric not in ("logloss", "classification_error", "rmse"):
-                raise ValueError(
-                    "metric for H2OMultinomialModel must be one of: AUTO, logloss, classification_error, rmse")
-
-        self._plot(timestep=timestep, metric=metric, **kwargs)
+        valid_metrics = self._allowed_metrics('multinomial')
+        if valid_metrics is not None:
+            assert_is_type(metric, 'AUTO', *valid_metrics), "metric for H2OMultinomialModel must be one of %s" % valid_metrics
+        if metric == "AUTO":
+            metric = self._default_metric('multinomial') or 'AUTO'
+        self.scoring_history_plot(timestep=timestep, metric=metric, **kwargs)

--- a/h2o-py/h2o/model/multinomial.py
+++ b/h2o-py/h2o/model/multinomial.py
@@ -6,6 +6,7 @@ import h2o
 from h2o.utils.typechecks import assert_is_type
 from ..exceptions import H2OValueError
 from ..frame import H2OFrame
+from .extensions import has_extension
 from .model_base import ModelBase
 
 
@@ -239,7 +240,7 @@ class H2OMultinomialModel(ModelBase):
         ...           validation_frame=valid)
         >>> gbm.plot(metric="AUTO", timestep="AUTO")
         """
-        if not hasattr(self, 'scoring_history_plot'):
+        if not has_extension(self, 'ScoringHistory'):
             raise H2OValueError("Scoring history plot is not available for this type of model (%s)." % self.algo)
 
         valid_metrics = self._allowed_metrics('multinomial')

--- a/h2o-py/h2o/model/ordinal.py
+++ b/h2o-py/h2o/model/ordinal.py
@@ -76,6 +76,6 @@ class H2OOrdinalModel(ModelBase):
         :returns: A scoring history plot.
         """
         if not hasattr(self, 'scoring_history_plot'):
-            raise H2OValueError("Plotting not implemented for this type of model")
+            raise H2OValueError("Scoring history plot is not available for this type of model (%s)." % self.algo)
 
         self.scoring_history_plot(timestep=timestep, metric=metric, **kwargs)

--- a/h2o-py/h2o/model/ordinal.py
+++ b/h2o-py/h2o/model/ordinal.py
@@ -6,6 +6,7 @@ import h2o
 from h2o.utils.typechecks import assert_is_type
 from ..exceptions import H2OValueError
 from ..frame import H2OFrame
+from .extensions import has_extension
 from .model_base import ModelBase
 
 
@@ -75,7 +76,7 @@ class H2OOrdinalModel(ModelBase):
 
         :returns: A scoring history plot.
         """
-        if not hasattr(self, 'scoring_history_plot'):
+        if not has_extension(self, 'ScoringHistory'):
             raise H2OValueError("Scoring history plot is not available for this type of model (%s)." % self.algo)
 
         self.scoring_history_plot(timestep=timestep, metric=metric, **kwargs)

--- a/h2o-py/h2o/model/ordinal.py
+++ b/h2o-py/h2o/model/ordinal.py
@@ -4,6 +4,7 @@ from h2o.utils.compatibility import *  # NOQA
 
 import h2o
 from h2o.utils.typechecks import assert_is_type
+from ..exceptions import H2OValueError
 from ..frame import H2OFrame
 from .model_base import ModelBase
 
@@ -74,5 +75,7 @@ class H2OOrdinalModel(ModelBase):
 
         :returns: A scoring history plot.
         """
+        if not hasattr(self, 'scoring_history_plot'):
+            raise H2OValueError("Plotting not implemented for this type of model")
 
-        self._plot(timestep=timestep, metric=metric, **kwargs)
+        self.scoring_history_plot(timestep=timestep, metric=metric, **kwargs)

--- a/h2o-py/h2o/model/regression.py
+++ b/h2o-py/h2o/model/regression.py
@@ -41,7 +41,7 @@ class H2ORegressionModel(ModelBase):
         >>> gbm.plot(timestep="AUTO", metric="AUTO",)
         """
         if not hasattr(self, 'scoring_history_plot'):
-            raise H2OValueError("Plotting not implemented for this type of model")
+            raise H2OValueError("Scoring history plot is not available for this type of model (%s)." % self.algo)
 
         valid_metrics = self._allowed_metrics('regression')
         if valid_metrics is not None:

--- a/h2o-py/h2o/model/regression.py
+++ b/h2o-py/h2o/model/regression.py
@@ -1,9 +1,10 @@
 # -*- encoding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 # noinspection PyUnresolvedReferences
-from h2o.exceptions import H2OValueError
 from h2o.utils.compatibility import *  # NOQA
 
+from h2o.exceptions import H2OValueError
+from h2o.model.extensions import has_extension
 from h2o.model.model_base import ModelBase
 from h2o.utils.shared_utils import _colmean
 from h2o.utils.typechecks import assert_is_type
@@ -40,7 +41,7 @@ class H2ORegressionModel(ModelBase):
         ...           validation_frame=valid)
         >>> gbm.plot(timestep="AUTO", metric="AUTO",)
         """
-        if not hasattr(self, 'scoring_history_plot'):
+        if not has_extension(self, 'ScoringHistory'):
             raise H2OValueError("Scoring history plot is not available for this type of model (%s)." % self.algo)
 
         valid_metrics = self._allowed_metrics('regression')

--- a/h2o-py/h2o/sklearn/__init__.py
+++ b/h2o-py/h2o/sklearn/__init__.py
@@ -32,10 +32,11 @@ import sys
 
 from sklearn.base import ClassifierMixin, RegressorMixin
 
+from h2o.utils.mixin import register_module
 from .. import automl
 from .. import estimators
 from .. import transforms
-from .wrapper import estimator, params_as_h2o_frames, register_module, transformer, H2OConnectionMonitorMixin, \
+from .wrapper import estimator, params_as_h2o_frames, transformer, H2OConnectionMonitorMixin, \
     H2OEstimatorPredictProbabilitiesSupport, H2OEstimatorScoreSupport, H2OEstimatorTransformSupport
 
 module = sys.modules[__name__]

--- a/h2o-py/h2o/sklearn/wrapper.py
+++ b/h2o-py/h2o/sklearn/wrapper.py
@@ -611,7 +611,6 @@ class BaseSklearnEstimator(BaseEstimator, BaseEstimatorMixin, H2OConnectionMonit
             print(self)
 
 
-
 class H2OtoSklearnEstimator(BaseSklearnEstimator):
     """
     The base wrapper class exposing `sklearn` estimator methods.
@@ -743,7 +742,6 @@ class H2OtoSklearnTransformer(BaseSklearnEstimator, TransformerMixin):
         if hasattr(self._estimator, 'inverse_transform') and callable(self._estimator.inverse_transform):
             return self._estimator.inverse_transform(X)
         raise AttributeError("{} does not support 'inverse_transform'.".format(self.__class__.__name__))
-
 
 
 class H2OEstimatorPredictProbabilitiesSupport(BaseEstimatorMixin):

--- a/h2o-py/h2o/sklearn/wrapper.py
+++ b/h2o-py/h2o/sklearn/wrapper.py
@@ -7,8 +7,6 @@ The only requirements from the original estimator are the following:
 """
 from collections import defaultdict, OrderedDict
 from functools import wraps
-import sys
-import types
 from weakref import ref
 
 from sklearn.base import is_classifier, is_regressor, BaseEstimator, TransformerMixin, ClassifierMixin, RegressorMixin
@@ -17,7 +15,7 @@ from .. import h2o, H2OFrame
 from ..utils.compatibility import PY2
 from ..utils.metaclass import decoration_info
 from ..utils.shared_utils import can_use_numpy, can_use_pandas
-from ..utils.mixin import Mixin
+from ..utils.mixin import Mixin, register_class
 
 try:
     from inspect import Parameter, signature
@@ -29,29 +27,6 @@ except ImportError:
 
 if can_use_numpy():
     import numpy as np
-
-
-def register_module(module_name):
-    """
-    Creates and globally registers a module with given name.
-
-    :param module_name: the name of the module to register.
-    :return: the module with given name.
-    """
-    if module_name not in sys.modules:
-        mod = types.ModuleType(module_name)
-        sys.modules[module_name] = mod
-    return sys.modules[module_name]
-
-
-def register_class(cls):
-    """
-    Register a class module, and adds it to it's module.
-
-    :param cls: the class to register.
-    """
-    module = register_module(cls.__module__)
-    setattr(module, cls.__name__, cls)
 
 
 def _unwrap(fn):

--- a/h2o-py/h2o/sklearn/wrapper.py
+++ b/h2o-py/h2o/sklearn/wrapper.py
@@ -6,8 +6,7 @@ The only requirements from the original estimator are the following:
 
 """
 from collections import defaultdict, OrderedDict
-import copy
-from functools import partial, update_wrapper, wraps
+from functools import wraps
 import sys
 import types
 from weakref import ref
@@ -18,6 +17,7 @@ from .. import h2o, H2OFrame
 from ..utils.compatibility import PY2
 from ..utils.metaclass import decoration_info
 from ..utils.shared_utils import can_use_numpy, can_use_pandas
+from ..utils.mixin import Mixin
 
 try:
     from inspect import Parameter, signature
@@ -29,42 +29,6 @@ except ImportError:
 
 if can_use_numpy():
     import numpy as np
-
-
-def mixin(obj, *mixins):
-    """
-    Function adding one or more mixin class to the list of parent classes of the current object.
-    This is done by dynamically changing the class hierarchy of the current object,
-    not only by adding the mixin methods to the object.
-
-    :param obj: the object on which to apply the mixins.
-    :param mixins: the list of mixin classes to add to the object.
-    :return: the extended object.
-    """
-    obj.__class__ = type(obj.__class__.__name__, (obj.__class__,)+tuple(mixins), dict())
-    return obj
-
-
-class Mixin(object):
-    """
-    Context manager used to temporarily add mixins to an object.
-    """
-
-    def __init__(self, obj, *mixins):
-        """
-        :param obj: the object on which the mixins are temporarily added.
-        :param mixins: the list of mixins to apply.
-        """
-        self._inst = mixin(copy.copy(obj), *mixins)  # no deepcopy necessary, we just want to ensure mixin methods are not added to original instance
-
-    def __enter__(self):
-        if hasattr(self._inst, '__enter__'):
-            return self._inst.__enter__()
-        return self._inst
-
-    def __exit__(self, *args):
-        if hasattr(self._inst, '__exit__'):
-            self._inst.__exit__()
 
 
 def register_module(module_name):

--- a/h2o-py/h2o/transforms/decomposition.py
+++ b/h2o-py/h2o/transforms/decomposition.py
@@ -6,8 +6,7 @@ from ..estimators import H2OPrincipalComponentAnalysisEstimator, H2OSingularValu
 
 class H2OPCA(H2OEstimator):
     """ Principal Component Analysis """
-    algo = H2OPrincipalComponentAnalysisEstimator.algo
-
+    
     def __init__(self, 
                  model_id=None,
                  k=None,
@@ -71,6 +70,7 @@ class H2OPCA(H2OEstimator):
         :returns: A new instance of H2OPCA.
 
         """
+        allowed_params = locals().keys()
         super(self.__class__, self).__init__()
         self._delegate = H2OPrincipalComponentAnalysisEstimator(
             model_id=model_id,
@@ -87,6 +87,7 @@ class H2OPCA(H2OEstimator):
         )
         self._delegate._model = self
         assign(self, self._delegate)
+        self._parms = {k: v for k, v in self._delegate._parms.items() if k in allowed_params}
 
     def transform(self, X, y=None, **params):
         """
@@ -141,6 +142,7 @@ class H2OSVD(H2OEstimator):
 
         :returns: a new H2OSVD model
         """
+        allowed_params = locals().keys()
         super(self.__class__, self).__init__()
         self._delegate = H2OSingularValueDecompositionEstimator(
             nv=nv,
@@ -152,6 +154,7 @@ class H2OSVD(H2OEstimator):
         )
         self._delegate._model = self
         assign(self, self._delegate)
+        self._parms = {k: v for k, v in self._delegate._parms.items() if k in allowed_params}
 
     def transform(self, X, y=None, **params):
         """

--- a/h2o-py/h2o/transforms/decomposition.py
+++ b/h2o-py/h2o/transforms/decomposition.py
@@ -153,9 +153,6 @@ class H2OSVD(H2OEstimator):
         self._delegate._model = self
         assign(self, self._delegate)
 
-    def fit(self, X, y=None, **params):
-        return self._delegate.fit(X)
-
     def transform(self, X, y=None, **params):
         """
         Transform the given H2OFrame with the fitted SVD model.

--- a/h2o-py/h2o/transforms/decomposition.py
+++ b/h2o-py/h2o/transforms/decomposition.py
@@ -4,13 +4,13 @@ from ..model import ModelBase
 from .transform_base import H2OTransformer
 
 
-class H2OTransformerProxy(H2OTransformer, ModelBase):
+class _H2OTransformerProxy(H2OTransformer, ModelBase):
     """
     The order or base classes is important here as we don't want to inherit the instance properties of ModelBase.
     """
 
     def __init__(self, delegate, allowed_params):
-        super(H2OTransformerProxy, self).__init__()
+        super(_H2OTransformerProxy, self).__init__()
         self._delegate = delegate
         self._allowed_params = allowed_params
 
@@ -19,7 +19,7 @@ class H2OTransformerProxy(H2OTransformer, ModelBase):
 
     def __setattr__(self, key, value):
         if key in ['_delegate', '_allowed_params']:
-            super(H2OTransformerProxy, self).__setattr__(key, value)
+            super(_H2OTransformerProxy, self).__setattr__(key, value)
         else:
             setattr(self._delegate, key, value)
         
@@ -35,18 +35,18 @@ class H2OTransformerProxy(H2OTransformer, ModelBase):
 
     def transform(self, X, y=None, **params):
         """
-        Transform the given H2OFrame with the fitted PCA model.
+        Transform the given H2OFrame using the fitted model.
 
         :param H2OFrame X: May contain NAs and/or categorical data.
-        :param H2OFrame y: Ignored for PCA. Should be None.
+        :param H2OFrame y: Ignored by transformers. Should be None.
         :param params: Ignored.
 
-        :returns: The input H2OFrame transformed by the Principal Components.
+        :returns: The transformed H2OFrame.
         """
         return self._delegate.predict(X)
 
 
-class H2OPCA(H2OTransformerProxy):
+class H2OPCA(_H2OTransformerProxy):
     """ Principal Component Analysis """
     
     def __init__(self, 
@@ -131,7 +131,7 @@ class H2OPCA(H2OTransformerProxy):
         )
 
 
-class H2OSVD(H2OTransformerProxy):
+class H2OSVD(_H2OTransformerProxy):
     """ Singular Value Decomposition """
 
     def __init__(self, 

--- a/h2o-py/h2o/transforms/decomposition.py
+++ b/h2o-py/h2o/transforms/decomposition.py
@@ -98,7 +98,7 @@ class H2OPCA(H2OEstimator):
 
         :returns: The input H2OFrame transformed by the Principal Components.
         """
-        return self._delegate.predict(X)
+        return self.predict(X)
 
 
 class H2OSVD(H2OEstimator):
@@ -166,9 +166,10 @@ class H2OSVD(H2OEstimator):
 
         :returns: The input H2OFrame transformed by the SVD.
         """
-        return self._delegate.predict(X)
+        return self.predict(X)
 
 
-# copies all class properties from estimator to transformer
-assign(H2OPCA, H2OPrincipalComponentAnalysisEstimator, filtr=lambda k, v: not callable(v))
-assign(H2OSVD, H2OSingularValueDecompositionEstimator, filtr=lambda k, v: not callable(v))
+# copies class attributes (except methods and properties) from estimator to transformer
+__cls_props_from_delegate__ = lambda k, v: type(v) is not property and not callable(v)
+assign(H2OPCA, H2OPrincipalComponentAnalysisEstimator, filtr=__cls_props_from_delegate__)
+assign(H2OSVD, H2OSingularValueDecompositionEstimator, filtr=__cls_props_from_delegate__)

--- a/h2o-py/h2o/transforms/decomposition.py
+++ b/h2o-py/h2o/transforms/decomposition.py
@@ -1,10 +1,12 @@
 from h2o.frame import H2OFrame
+from h2o.utils.mixin import assign
 from ..estimators.estimator_base import H2OEstimator
 from ..estimators import H2OPrincipalComponentAnalysisEstimator, H2OSingularValueDecompositionEstimator
 
 
 class H2OPCA(H2OEstimator):
     """ Principal Component Analysis """
+    algo = H2OPrincipalComponentAnalysisEstimator.algo
 
     def __init__(self, 
                  model_id=None,
@@ -84,7 +86,7 @@ class H2OPCA(H2OEstimator):
             compute_metrics=compute_metrics
         )
         self._delegate._model = self
-        self._parms = self._delegate._parms
+        assign(self, self._delegate)
 
     def transform(self, X, y=None, **params):
         """
@@ -149,7 +151,7 @@ class H2OSVD(H2OEstimator):
             svd_method=svd_method
         )
         self._delegate._model = self
-        self._parms = self._delegate._parms
+        assign(self, self._delegate)
 
     def fit(self, X, y=None, **params):
         return self._delegate.fit(X)
@@ -165,3 +167,8 @@ class H2OSVD(H2OEstimator):
         :returns: The input H2OFrame transformed by the SVD.
         """
         return self._delegate.predict(X)
+
+
+# copies all class properties from estimator to transformer
+assign(H2OPCA, H2OPrincipalComponentAnalysisEstimator, filtr=lambda k, v: not callable(v))
+assign(H2OSVD, H2OSingularValueDecompositionEstimator, filtr=lambda k, v: not callable(v))

--- a/h2o-py/h2o/transforms/decomposition.py
+++ b/h2o-py/h2o/transforms/decomposition.py
@@ -1,11 +1,16 @@
 from h2o.frame import H2OFrame
 from ..estimators import H2OPrincipalComponentAnalysisEstimator, H2OSingularValueDecompositionEstimator
+from ..model import ModelBase
 from .transform_base import H2OTransformer
 
 
-class H2OTransformerProxy(H2OTransformer):
+class H2OTransformerProxy(H2OTransformer, ModelBase):
+    """
+    The order or base classes is important here as we don't want to inherit the instance properties of ModelBase.
+    """
 
     def __init__(self, delegate, allowed_params):
+        super(H2OTransformerProxy, self).__init__()
         self._delegate = delegate
         self._allowed_params = allowed_params
 

--- a/h2o-py/h2o/transforms/preprocessing.py
+++ b/h2o-py/h2o/transforms/preprocessing.py
@@ -31,16 +31,13 @@ class H2OScaler(H2OTransformer):
         self._means = None
         self._stds = None
 
-
     @property
     def means(self):
         return self._means
 
-
     @property
     def stds(self):
         return self._stds
-
 
     def fit(self, X, y=None, **params):
         """
@@ -63,7 +60,6 @@ class H2OScaler(H2OTransformer):
             self._stds = False
         return self
 
-
     def transform(self, X, y=None, **params):
         """
         Scale an H2OFrame with the fitted means and standard deviations.
@@ -74,7 +70,6 @@ class H2OScaler(H2OTransformer):
         :returns: A scaled H2OFrame.
         """
         return X.scale(self.means, self.stds)
-
 
     def inverse_transform(self, X, y=None, **params):
         """
@@ -90,28 +85,20 @@ class H2OScaler(H2OTransformer):
         return X
 
 
-
-
 class H2OColSelect(H2OTransformer):
 
     def __init__(self, cols):
         self.cols = cols
 
-
     def fit(self, X, y=None, **params):
         return self
-
 
     def transform(self, X, y=None, **params):
         return X[self.cols]
 
-
     def to_rest(self, step_name):
         args = [step_name, "H2OColSelect", ("(cols_py dummy %r)" % self.cols), False, "|"]
         return super(H2OColSelect, self).to_rest(args)
-
-
-
 
 
 class H2OColOp(H2OTransformer):
@@ -165,8 +152,6 @@ class H2OColOp(H2OTransformer):
             [step_name, self.__class__.__name__, ast, self.inplace, "|".join(new_col_names)])
 
 
-
-
 class H2OBinaryOp(H2OColOp):
     """Perform a binary operation on a column.
 
@@ -188,7 +173,6 @@ class H2OBinaryOp(H2OColOp):
     def _transform_helper(self, X, **params):
         if self.left is None: return self.fun(X[self.col], X[self.right.col] if self.right_is_col else self.right)
         return self.fun(X[self.left.col] if self.left_is_col else self.left, X[self.col])
-
 
 
 class H2OCol(object):

--- a/h2o-py/h2o/transforms/transform_base.py
+++ b/h2o-py/h2o/transforms/transform_base.py
@@ -31,8 +31,8 @@ class H2OTransformer(object):
       - to_rest
     """
 
-    # def __init__(self):
-    #   self.parms=None
+    def __init__(self):
+        pass
 
 
     def fit(self, X, y=None, **params):

--- a/h2o-py/h2o/tree/tree.py
+++ b/h2o-py/h2o/tree/tree.py
@@ -1,8 +1,6 @@
 import math
 
 import h2o
-from h2o.estimators import H2OXGBoostEstimator
-from h2o.utils.metaclass import deprecated_fn
 
 
 class H2OTree(object):
@@ -406,7 +404,7 @@ class H2OTree(object):
     def __decode_categoricals(self, model, levels):
         string_levels = len(self._left_children) * [None]
 
-        if type(model) is H2OXGBoostEstimator:
+        if model.algo == 'xgboost':
             return string_levels
 
         for i in range(0, len(self._left_children)):

--- a/h2o-py/h2o/utils/mixin.py
+++ b/h2o-py/h2o/utils/mixin.py
@@ -64,7 +64,7 @@ def assign(obj, objs, deepcopy=False, reserved=False, filtr=None):
     _filtr = (lambda k, v: not _is_reserved_name(k) and (filtr is None or filtr(k, v))) if not reserved else filtr
     objs = objs if isinstance(objs, (list, tuple)) else [objs]
     for o in objs:
-        props = o.__dict__
+        props = vars(o)
         if _filtr:
             props = {k: v for k, v in props.items() if _filtr(k, v)}
         if deepcopy:
@@ -79,10 +79,11 @@ def rebind(obj, *mixins):
     inspect the methods from each mixin and bind them each to the object.
     """
     for m in reversed(mixins): 
-        for name in m.__dict__:
+        for name in vars(m):
             if _is_reserved_name(name): continue
-            if not callable(m.__dict__[name]): continue
-            obj.__dict__[name] = m.__dict__[name].__get__(obj)
+            attr = getattr(m, name)
+            if not callable(attr): continue
+            setattr(obj, name, attr.__get__(obj))
 
 
 def _is_reserved_name(name):

--- a/h2o-py/h2o/utils/mixin.py
+++ b/h2o-py/h2o/utils/mixin.py
@@ -1,5 +1,7 @@
 import copy
 from importlib import import_module
+import sys
+import types
 
 
 __mixin_classes_cache__ = {}
@@ -27,6 +29,29 @@ def mixin(target, *mixins):
     target.__class__ = cls
     return target
 
+
+def register_module(module_name):
+    """
+    Creates and globally registers a module with given name.
+
+    :param module_name: the name of the module to register.
+    :return: the module with given name.
+    """
+    if module_name not in sys.modules:
+        mod = types.ModuleType(module_name)
+        sys.modules[module_name] = mod
+    return sys.modules[module_name]
+
+
+def register_class(cls):
+    """
+    Register a class module, and adds it to it's module.
+
+    :param cls: the class to register.
+    """
+    module = register_module(cls.__module__)
+    setattr(module, cls.__name__, cls)
+    
 
 class Mixin:
     """

--- a/h2o-py/h2o/utils/mixin.py
+++ b/h2o-py/h2o/utils/mixin.py
@@ -1,0 +1,59 @@
+import copy
+from importlib import import_module
+
+
+def load_ext(name):
+    mod, cls = name.rsplit('.', 1)
+    module = import_module(mod)
+    return getattr(module, cls)
+    
+    
+def rebind(obj, *mixins):
+    """
+    inspect the methods from each mixin and bind them each to the object.
+    """
+    for m in reversed(mixins):
+        for name in m.__dict__:
+            if name.startswith("__") and name.endswith("__"): continue
+            if not callable(m.__dict__[name]): continue
+            obj.__dict__[name] = m.__dict__[name].__get__(obj)
+
+
+def mixin(obj, *mixins):
+    """
+    Function adding one or more mixin class to the list of parent classes of the current object.
+    It's the safest and recommended way to apply mixins as it just adds metaclasses to the class hierarchy of the object.
+
+    :param obj: the object on which to apply the mixins.
+    :param mixins: the list of mixin classes to add to the object.
+    :return: the extended object.
+    """
+    if not mixins:
+        return obj
+    cls = type(obj.__class__.__name__, (obj.__class__,)+tuple(mixins), dict())
+    cls.__module__ = obj.__class__.__module__
+    obj.__class__ = cls
+    return obj
+
+
+class Mixin:
+    """
+    Context manager used to temporarily add mixins to an object.
+    """
+
+    def __init__(self, obj, *mixins):
+        """
+        :param obj: the object on which the mixins are temporarily added.
+        :param mixins: the list of mixins to apply.
+        """
+        self._inst = mixin(copy.copy(obj), *mixins)  # no deepcopy necessary, we just want to ensure mixin methods are not added to original instance
+
+    def __enter__(self):
+        if hasattr(self._inst, '__enter__'):
+            return self._inst.__enter__()
+        return self._inst
+
+    def __exit__(self, *args):
+        if hasattr(self._inst, '__exit__'):
+            self._inst.__exit__()
+

--- a/h2o-py/h2o/utils/mixin.py
+++ b/h2o-py/h2o/utils/mixin.py
@@ -2,6 +2,9 @@ import copy
 from importlib import import_module
 
 
+__mixin_classes_cache__ = {}
+
+
 def mixin(obj, *mixins):
     """
     Function adding one or more mixin class to the list of parent classes of the current object.
@@ -15,8 +18,12 @@ def mixin(obj, *mixins):
     mixins = filter(lambda m: m and m not in mro, mixins)
     if not mixins:
         return obj
-    cls = type(obj.__class__.__name__, (obj.__class__,)+tuple(mixins), dict())
-    cls.__module__ = obj.__class__.__module__
+    bases = (obj.__class__,)+tuple(mixins)
+    cls = __mixin_classes_cache__.get(bases, None)
+    if cls is None:
+        cls = type(obj.__class__.__name__, bases, dict())
+        cls.__module__ = obj.__class__.__module__
+        __mixin_classes_cache__[bases] = cls
     obj.__class__ = cls
     return obj
 

--- a/h2o-py/h2o/utils/mixin.py
+++ b/h2o-py/h2o/utils/mixin.py
@@ -11,7 +11,8 @@ def mixin(obj, *mixins):
     :param mixins: the list of mixin classes to add to the object.
     :return: the extended object.
     """
-    mixins = filter(None, mixins)
+    mro = obj.__class__.mro()
+    mixins = filter(lambda m: m and m not in mro, mixins)
     if not mixins:
         return obj
     cls = type(obj.__class__.__name__, (obj.__class__,)+tuple(mixins), dict())

--- a/h2o-py/h2o/utils/mixin.py
+++ b/h2o-py/h2o/utils/mixin.py
@@ -2,42 +2,10 @@ import copy
 from importlib import import_module
 
 
-def load_ext(name):
-    mod, cls = name.rsplit('.', 1)
-    module = import_module(mod)
-    return getattr(module, cls)
-    
-
-def assign(obj, *objs):
-    """
-    Copies all the instance properties from extensions to obj.
-    The last property added takes precedence over the previous ones.
-    For example, when applying ``assign(obj, ext1, ext2)``: 
-    if all `obj`, `ext1` and `ext2` contain the property `prop` then the final object will be assigned `prop` from `ext2`.
-    :param obj: the instance that will receive the properties from others.
-    :param objs: the instances whose properties will be added to the first instance.
-    :return: the modified instance `obj`.
-    """
-    for ext in objs:
-        obj.__dict__.update(ext.__dict__.copy())
-    return obj
-    
-    
-def rebind(obj, *mixins):
-    """
-    inspect the methods from each mixin and bind them each to the object.
-    """
-    for m in reversed(mixins): 
-        for name in m.__dict__:
-            if name.startswith("__") and name.endswith("__"): continue
-            if not callable(m.__dict__[name]): continue
-            obj.__dict__[name] = m.__dict__[name].__get__(obj)
-
-
 def mixin(obj, *mixins):
     """
     Function adding one or more mixin class to the list of parent classes of the current object.
-    It's the safest and recommended way to apply mixins as it just adds metaclasses to the class hierarchy of the object.
+    It's the safest and recommended way to apply mixins as it just adds base classes to the class hierarchy of the object.
 
     :param obj: the object on which to apply the mixins.
     :param mixins: the list of mixin classes to add to the object.
@@ -61,7 +29,7 @@ class Mixin:
         :param obj: the object on which the mixins are temporarily added.
         :param mixins: the list of mixins to apply.
         """
-        self._inst = mixin(copy.copy(obj), *mixins)  # no deepcopy necessary, we just want to ensure mixin methods are not added to original instance
+        self._inst = mixin(copy.copy(obj), *mixins)  # no deepcopy necessary, we just want to ensure that the mixin methods are not added to original instance
 
     def __enter__(self):
         if hasattr(self._inst, '__enter__'):
@@ -71,4 +39,52 @@ class Mixin:
     def __exit__(self, *args):
         if hasattr(self._inst, '__exit__'):
             self._inst.__exit__()
+
+
+def load_ext(name):
+    mod, cls = name.rsplit('.', 1)
+    module = import_module(mod)
+    return getattr(module, cls)
+
+
+def assign(obj, objs, deepcopy=False, reserved=False, filtr=None):
+    """
+    Copies (shallow) all the instance properties from objs to obj.
+    The last property added takes precedence over the previous ones.
+    For example, when applying ``assign(obj, ext1, ext2)``: 
+    if all `obj`, `ext1` and `ext2` contain the property `prop` then the final object will be assigned `prop` from `ext2`.
+    :param obj: the instance that will receive the properties from others.
+    :param objs: the instances whose properties will be added to the first instance.
+    :param deepcopy: True if the added properties should be deep copied (default: False).
+    :param reserved: True if reserved properties (e.g. __dict__, __doc__, ...) should also be assigned (default: False).
+    :param filtr: function fn(key, value) returning True for the properties that should be assigned.
+        If None (default), then all are assigned.
+    :return: the modified instance `obj`.
+    """
+    _filtr = (lambda k, v: not _is_reserved_name(k) and (filtr is None or filtr(k, v))) if not reserved else filtr
+    objs = objs if isinstance(objs, (list, tuple)) else [objs]
+    for o in objs:
+        props = o.__dict__
+        if _filtr:
+            props = {k: v for k, v in props.items() if _filtr(k, v)}
+        if deepcopy:
+            props = copy.deepcopy(props)
+        for k, v in props.items():
+            setattr(obj, k, v)
+    return obj
+    
+    
+def rebind(obj, *mixins):
+    """
+    inspect the methods from each mixin and bind them each to the object.
+    """
+    for m in reversed(mixins): 
+        for name in m.__dict__:
+            if _is_reserved_name(name): continue
+            if not callable(m.__dict__[name]): continue
+            obj.__dict__[name] = m.__dict__[name].__get__(obj)
+
+
+def _is_reserved_name(name):
+    return name.startswith("__") and name.endswith("__")
 

--- a/h2o-py/h2o/utils/mixin.py
+++ b/h2o-py/h2o/utils/mixin.py
@@ -11,6 +11,7 @@ def mixin(obj, *mixins):
     :param mixins: the list of mixin classes to add to the object.
     :return: the extended object.
     """
+    mixins = filter(None, mixins)
     if not mixins:
         return obj
     cls = type(obj.__class__.__name__, (obj.__class__,)+tuple(mixins), dict())
@@ -62,13 +63,14 @@ def assign(obj, objs, deepcopy=False, reserved=False, filtr=None):
     :return: the modified instance `obj`.
     """
     _filtr = (lambda k, v: not _is_reserved_name(k) and (filtr is None or filtr(k, v))) if not reserved else filtr
-    objs = objs if isinstance(objs, (list, tuple)) else [objs]
+    objs = filter(None, objs if isinstance(objs, (list, tuple)) else [objs])
     for o in objs:
         props = vars(o)
         if _filtr:
             props = {k: v for k, v in props.items() if _filtr(k, v)}
         if deepcopy:
             props = copy.deepcopy(props)
+        # print("%s, assigned attributes: %s" % (obj.__class__, list(props.keys())))
         for k, v in props.items():
             setattr(obj, k, v)
     return obj
@@ -78,6 +80,7 @@ def rebind(obj, *mixins):
     """
     inspect the methods from each mixin and bind them each to the object.
     """
+    mixins = filter(None, mixins)
     for m in reversed(mixins): 
         for name in vars(m):
             if _is_reserved_name(name): continue

--- a/h2o-py/h2o/utils/mixin.py
+++ b/h2o-py/h2o/utils/mixin.py
@@ -7,12 +7,27 @@ def load_ext(name):
     module = import_module(mod)
     return getattr(module, cls)
     
+
+def assign(obj, *objs):
+    """
+    Copies all the instance properties from extensions to obj.
+    The last property added takes precedence over the previous ones.
+    For example, when applying ``assign(obj, ext1, ext2)``: 
+    if all `obj`, `ext1` and `ext2` contain the property `prop` then the final object will be assigned `prop` from `ext2`.
+    :param obj: the instance that will receive the properties from others.
+    :param objs: the instances whose properties will be added to the first instance.
+    :return: the modified instance `obj`.
+    """
+    for ext in objs:
+        obj.__dict__.update(ext.__dict__.copy())
+    return obj
+    
     
 def rebind(obj, *mixins):
     """
     inspect the methods from each mixin and bind them each to the object.
     """
-    for m in reversed(mixins):
+    for m in reversed(mixins): 
         for name in m.__dict__:
             if name.startswith("__") and name.endswith("__"): continue
             if not callable(m.__dict__[name]): continue

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -64,14 +64,9 @@ from h2o.model.clustering import H2OClusteringModel
 from h2o.model.multinomial import H2OMultinomialModel
 from h2o.model.ordinal import H2OOrdinalModel
 from h2o.model.regression import H2ORegressionModel
-from h2o.estimators.gbm import H2OGradientBoostingEstimator
-from h2o.estimators.deeplearning import H2ODeepLearningEstimator
-from h2o.estimators.glm import H2OGeneralizedLinearEstimator
-from h2o.estimators.gam import H2OGeneralizedAdditiveEstimator
-from h2o.estimators.kmeans import H2OKMeansEstimator
-from h2o.estimators.naive_bayes import H2ONaiveBayesEstimator
-from h2o.estimators.random_forest import H2ORandomForestEstimator
-from h2o.transforms.decomposition import H2OPCA
+from h2o.estimators import H2OGradientBoostingEstimator, H2ODeepLearningEstimator, H2OGeneralizedLinearEstimator, \
+    H2OGeneralizedAdditiveEstimator, H2OKMeansEstimator, H2ONaiveBayesEstimator, H2ORandomForestEstimator, \
+    H2OPrincipalComponentAnalysisEstimator
 from h2o.utils.typechecks import is_type
 from h2o.utils.shared_utils import temp_ctr  # unused in this file  but exposed here for symmetry with rest_ctr
 
@@ -353,7 +348,7 @@ def javapredict(algo, equality, train, test, x, y, compile_only=False, separator
     elif algo == "gam": model = H2OGeneralizedAdditiveEstimator(**kwargs)
     elif algo == "naive_bayes": model = H2ONaiveBayesEstimator(**kwargs)
     elif algo == "kmeans": model = H2OKMeansEstimator(**kwargs)
-    elif algo == "pca": model = H2OPCA(**kwargs)
+    elif algo == "pca": model = H2OPrincipalComponentAnalysisEstimator(**kwargs)
     else: raise ValueError
     if algo == "kmeans" or algo == "pca": model.train(x=x, training_frame=train)
     else: model.train(x=x, y=y, training_frame=train)

--- a/h2o-py/tests/testdir_algos/deeplearning/pyunit_cv_cars_deeplearning_medium.py
+++ b/h2o-py/tests/testdir_algos/deeplearning/pyunit_cv_cars_deeplearning_medium.py
@@ -40,6 +40,7 @@ def cv_cars_dl():
   dl1 = H2ODeepLearningEstimator(nfolds=nfolds,fold_assignment="Random",hidden=[20,20],epochs=10)
   dl1.train(x=predictors,y=response_col,training_frame=cars)
   dl2 = H2ODeepLearningEstimator(nfolds=nfolds,fold_assignment="Random",hidden=[20,20],epochs=10)
+  dl2.train(x=predictors,y=response_col,training_frame=cars)
   try:
     pyunit_utils.check_models(dl1, dl2, True)
     assert False, "Expected models to be different over repeated Random runs"

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_multinomial_large.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_multinomial_large.py
@@ -140,7 +140,7 @@ def stackedensemble_multinomial_test():
     # Train a stacked ensemble using the GBM and GLM above
     stack = H2OStackedEnsembleEstimator(base_models=[my_gbm.model_id,  my_rf.model_id, my_xgb.model_id, my_nb.model_id, my_dnn.model_id, my_glm.model_id])
     stack.train(x=x, y=y, training_frame=train, validation_frame=test)  # also test that validation_frame is working
-    assert type(stack) == h2o.estimators.stackedensemble.H2OStackedEnsembleEstimator
+    assert isinstance(stack, h2o.estimators.stackedensemble.H2OStackedEnsembleEstimator)
     assert stack.type == "classifier"
 
     # Check that prediction works
@@ -151,11 +151,11 @@ def stackedensemble_multinomial_test():
 
     # Evaluate ensemble performance
     perf_stack_train = stack.model_performance()
-    assert type(perf_stack_train) == h2o.model.metrics_base.H2OMultinomialModelMetrics
+    assert isinstance(perf_stack_train, h2o.model.metrics_base.H2OMultinomialModelMetrics)
     perf_stack_valid = stack.model_performance(valid=True)
-    assert type(perf_stack_valid) == h2o.model.metrics_base.H2OMultinomialModelMetrics
+    assert isinstance(perf_stack_valid, h2o.model.metrics_base.H2OMultinomialModelMetrics)
     perf_stack_test = stack.model_performance(test_data=test)
-    assert type(perf_stack_test) == h2o.model.metrics_base.H2OMultinomialModelMetrics
+    assert isinstance(perf_stack_test, h2o.model.metrics_base.H2OMultinomialModelMetrics)
 
 
     # Check that stack perf is better (smaller) than the best (smaller) base learner perf:

--- a/h2o-py/tests/testdir_misc/pyunit_checkpointing.py
+++ b/h2o-py/tests/testdir_misc/pyunit_checkpointing.py
@@ -13,18 +13,17 @@ def checkpointing_test():
     gbm = H2OGradientBoostingEstimator(ntrees=1)
     gbm.train(x=["Origin", "Dest"], y="Distance", training_frame=airlines, validation_frame=airlines)
     
-    checkpointed_gbm = H2OGradientBoostingEstimator(ntrees = 2, checkpoint=gbm)
+    checkpointed_gbm = H2OGradientBoostingEstimator(ntrees=2, checkpoint=gbm)
     checkpointed_gbm.train(x=["Origin", "Dest"], y="Distance", training_frame=airlines, validation_frame=airlines)
-    assert checkpointed_gbm.checkpoint == gbm
+    print(checkpointed_gbm.checkpoint)
+    assert checkpointed_gbm.checkpoint == gbm.model_id
 
-    checkpointed_gbm = H2OGradientBoostingEstimator(ntrees = 2, checkpoint=gbm.model_id)
+    checkpointed_gbm = H2OGradientBoostingEstimator(ntrees=2, checkpoint=gbm.model_id)
     checkpointed_gbm.train(x=["Origin", "Dest"], y="Distance", training_frame=airlines, validation_frame=airlines)
     assert checkpointed_gbm.checkpoint == gbm.model_id
     
 
-
 if __name__ == "__main__":
     pyunit_utils.standalone_test(checkpointing_test)
-
 else:
     checkpointing_test()

--- a/h2o-py/tests/testdir_misc/pyunit_checkpointing.py
+++ b/h2o-py/tests/testdir_misc/pyunit_checkpointing.py
@@ -15,8 +15,7 @@ def checkpointing_test():
     
     checkpointed_gbm = H2OGradientBoostingEstimator(ntrees=2, checkpoint=gbm)
     checkpointed_gbm.train(x=["Origin", "Dest"], y="Distance", training_frame=airlines, validation_frame=airlines)
-    print(checkpointed_gbm.checkpoint)
-    assert checkpointed_gbm.checkpoint == gbm.model_id
+    assert checkpointed_gbm.checkpoint == gbm
 
     checkpointed_gbm = H2OGradientBoostingEstimator(ntrees=2, checkpoint=gbm.model_id)
     checkpointed_gbm.train(x=["Origin", "Dest"], y="Distance", training_frame=airlines, validation_frame=airlines)

--- a/h2o-py/tests/testdir_misc/pyunit_mean_per_class_error.py
+++ b/h2o-py/tests/testdir_misc/pyunit_mean_per_class_error.py
@@ -7,10 +7,8 @@ from h2o.estimators.gbm import H2OGradientBoostingEstimator
 from h2o.grid import H2OGridSearch
 
 
-def pyunit_mean_per_class_error():
+def test_mean_per_class_error_binomial():
     gbm = H2OGradientBoostingEstimator(nfolds=3, fold_assignment="Random", seed=1234)
-
-    ## Binomial
     cars = h2o.import_file(pyunit_utils.locate("smalldata/junit/cars_20mpg.csv"))
     cars["economy_20mpg"] = cars["economy_20mpg"].asfactor()
     r = cars[0].runif(seed=1234)
@@ -20,7 +18,7 @@ def pyunit_mean_per_class_error():
     predictors = ["displacement","power","weight","acceleration","year"]
     gbm.distribution = "bernoulli"
     gbm.train(y=response_col, x=predictors, validation_frame=valid, training_frame=train)
-    print(gbm)
+    # print(gbm)
     mpce = gbm.mean_per_class_error([0.5,0.8]) ## different thresholds
     assert (abs(mpce[0][1] - 0.008264) < 1e-5)
     assert (abs(mpce[1][1] - 0.018716) < 1e-5)
@@ -29,8 +27,8 @@ def pyunit_mean_per_class_error():
     print(gbm.model_performance(train).mean_per_class_error(thresholds=[0.3,0.5]))
 
 
-
-    ## Multinomial
+def test_mean_per_class_error_multinomial():
+    gbm = H2OGradientBoostingEstimator(nfolds=3, fold_assignment="Random", seed=1234)
     cars = h2o.import_file(pyunit_utils.locate("smalldata/junit/cars_20mpg.csv"))
     cars["cylinders"] = cars["cylinders"].asfactor()
     r = cars[0].runif(seed=1234)
@@ -40,7 +38,8 @@ def pyunit_mean_per_class_error():
     predictors = ["displacement","power","weight","acceleration","year"]
     gbm.distribution="multinomial"
     gbm.train(x=predictors,y=response_col, training_frame=train, validation_frame=valid)
-    print(gbm)
+    # print(gbm)
+    print(gbm.__class__.__mro__)
     mpce = gbm.mean_per_class_error(train=True)
     assert( mpce == 0 )
     mpce = gbm.mean_per_class_error(valid=True)
@@ -51,7 +50,17 @@ def pyunit_mean_per_class_error():
     assert(abs(mpce - 0.35127653471 ) < 1e-5)
 
 
-
+def test_mean_per_class_error_grid():
+    gbm = H2OGradientBoostingEstimator(nfolds=3, fold_assignment="Random", seed=1234)
+    cars = h2o.import_file(pyunit_utils.locate("smalldata/junit/cars_20mpg.csv"))
+    cars["cylinders"] = cars["cylinders"].asfactor()
+    r = cars[0].runif(seed=1234)
+    train = cars[r > .2]
+    valid = cars[r <= .2]
+    response_col = "cylinders"
+    predictors = ["displacement","power","weight","acceleration","year"]
+    gbm.distribution="multinomial"
+    
     ## Early stopping
     gbm.stopping_rounds=2
     gbm.stopping_metric="mean_per_class_error"
@@ -96,4 +105,8 @@ def pyunit_mean_per_class_error():
     print(grid.get_grid("mean_per_class_error"))
 
 
-pyunit_utils.standalone_test(pyunit_mean_per_class_error)
+pyunit_utils.run_tests([
+    test_mean_per_class_error_binomial,
+    test_mean_per_class_error_multinomial,
+    test_mean_per_class_error_grid
+])

--- a/h2o-py/tests/testdir_pipeline/pyunit_scale_pca_rf.py
+++ b/h2o-py/tests/testdir_pipeline/pyunit_scale_pca_rf.py
@@ -18,7 +18,10 @@ def scale_pca_rf_pipe():
                    ("pca", H2OPCA(k=2)),
                    ("rf", H2ORandomForestEstimator(seed=42,ntrees=50))])
   pipe.fit(iris[:4],iris[4])
-  print(pipe)
+  pca = pipe['pca']
+  assert pca.model_id == pca._delegate.model_id
+  assert pca._model_json == pca._delegate._model_json
+  pca.download_pojo()
 
 
 def scale_pca_rf_pipe_new_import():
@@ -66,7 +69,7 @@ def scale_pca_rf_pipe_new_import():
 
 if __name__ == "__main__":
   pyunit_utils.standalone_test(scale_pca_rf_pipe)
-  pyunit_utils.standalone_test(scale_pca_rf_pipe_new_import)
+  # pyunit_utils.standalone_test(scale_pca_rf_pipe_new_import)
 else:
   scale_pca_rf_pipe()
-  scale_pca_rf_pipe_new_import()
+  # scale_pca_rf_pipe_new_import()

--- a/h2o-py/tests/testdir_pipeline/pyunit_scale_pca_rf.py
+++ b/h2o-py/tests/testdir_pipeline/pyunit_scale_pca_rf.py
@@ -69,7 +69,7 @@ def scale_pca_rf_pipe_new_import():
 
 if __name__ == "__main__":
   pyunit_utils.standalone_test(scale_pca_rf_pipe)
-  # pyunit_utils.standalone_test(scale_pca_rf_pipe_new_import)
+  pyunit_utils.standalone_test(scale_pca_rf_pipe_new_import)
 else:
   scale_pca_rf_pipe()
-  # scale_pca_rf_pipe_new_import()
+  scale_pca_rf_pipe_new_import()

--- a/h2o-py/tests/testdir_sklearn/pyunit_sklearn_params.py
+++ b/h2o-py/tests/testdir_sklearn/pyunit_sklearn_params.py
@@ -112,39 +112,40 @@ def test_all_params_can_be_set_as_properties():
 
 def test_params_conflicting_with_sklearn_api_are_still_available():
     pca = H2OPCA()
-    assert pca.transform != 'NONE'
+    assert pca.transform != 'none'
     assert callable(pca.transform), "`transform` method from sklearn API has been replaced by a property"
     # conflicting param can be accessed normally using get_params()
-    assert pca.get_params()['transform'] == 'NONE'
+    print(pca.get_params())
+    assert pca.get_params()['transform'] == 'none'
     # property is accessible directly using a trailing underscore
-    assert pca.transform_ == 'NONE'
+    assert pca.transform_ == 'none'
 
-    pca = H2OPCA(transform='DEMEAN')
+    pca = H2OPCA(transform='demean')
     assert callable(pca.transform), "`transform` method from sklearn API has been replaced by a property"
-    assert pca.get_params()['transform'] == 'DEMEAN'
-    assert pca.transform_ == 'DEMEAN'
+    assert pca.get_params()['transform'] == 'demean'
+    assert pca.transform_ == 'demean'
 
     # conflicting param can be modified normally using set_params()
-    pca.set_params(transform='DESCALE')
-    assert pca.get_params()['transform'] == 'DESCALE'
-    assert pca.transform_ == 'DESCALE'
+    pca.set_params(transform='descale')
+    assert pca.get_params()['transform'] == 'descale'
+    assert pca.transform_ == 'descale'
 
     # conflicting property can be set directly using a trailing underscore
-    pca.transform_ = 'NORMALIZE'
-    assert pca.get_params()['transform'] == 'NORMALIZE'
-    assert pca.transform_ == 'NORMALIZE'
+    pca.transform_ = 'normalize'
+    assert pca.get_params()['transform'] == 'normalize'
+    assert pca.transform_ == 'normalize'
 
 
 def test_params_are_correctly_passed_to_underlying_transformer():
     pca = H2OPCA(seed=seed)
-    pca.set_params(transform='DEMEAN', k=3)
+    pca.set_params(transform='demean', k=3)
     pca.model_id = "dummy"
     assert pca.estimator is None
     pca._make_estimator()  # normally done when calling `fit`
     assert pca.estimator
     parms = pca.estimator._parms
     assert parms['seed'] == seed
-    assert parms['transform'] == 'DEMEAN'
+    assert parms['transform'] == 'demean'
     assert parms['k'] == 3
     assert parms['model_id'] == "dummy"
     assert parms['max_iterations'] is None


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8174

The goal of this PR is to use a proper OO approach in our Python implementation, especially regarding the `estimators` and `models`.
Too often, base classes were executing code specific to their implementations, making code hard to read, painful to debug, and bug-prone.

This PR uses a declarative approach to dynamically add functionalities to algos at estimator or model level.
#### Example
In `gen_drf.py`:
```python
options = dict(
    verbose=True,
    model_extensions=[
        'h2o.model.extensions.ScoringHistory',
        'h2o.model.extensions.VariableImportance',
        'h2o.model.extensions.Trees',
    ],
)
```
tells that DRF supports `verbose` mode during training, and declares some extensions, which are mixin classes dynamically added to the model after training.

Those extensions allow us to group code by functionality, and to expose them only to models that support them.

Finally, algos can have their own implementation of some functionalities, for example in `gen_glm.py`:
```python
options = dict(
    model_extensions=[
        'h2o.model.extensions.ScoringHistoryGLM',
        'h2o.model.extensions.StandardCoef',
        'h2o.model.extensions.VariableImportance',
    ],
)
```