### PR TITLE
PUBDEV-8167: Screeplot fails for PCA in R and Python

### DIFF
--- a/h2o-bindings/bin/custom/R/gen_pca.py
+++ b/h2o-bindings/bin/custom/R/gen_pca.py
@@ -19,9 +19,9 @@ if(!missing(x))
 h2o.screeplot <- function(model, type=c("barplot", "lines")) {
     type <- match.arg(type)
     if (type == "barplot") {
-        barplot(t(model@model$importance)[,1], xlab = "Components", ylab = "Variances", main = "Scree Plot")
+        graphics::barplot(t(model@model$importance)[,1], xlab = "Components", ylab = "Variances", main = "Scree Plot")
     } else {
-        plot(t(model@model$importance)[,1], xlab = "Components", ylab = "Variances", main = "Scree Plot",
+        graphics::plot(t(model@model$importance)[,1], xlab = "Components", ylab = "Variances", main = "Scree Plot",
                type = "l", lty = "dashed", col = "blue", lwd = 2)
     }
 }

--- a/h2o-bindings/bin/custom/R/gen_pca.py
+++ b/h2o-bindings/bin/custom/R/gen_pca.py
@@ -6,6 +6,26 @@ parms$training_frame <- training_frame
 if(!missing(x))
   parms$ignored_columns <- .verify_datacols(training_frame, x)$cols_ignore
 """,
+    module="""
+.h2o.fill_pca <- function(model, parameters, allparams) {
+    model$variable_importances <- model$importance
+    return(model)
+}
+
+#' Scree Plot
+#' @param model  A PCA model
+#' @param type  Type of the plot. Either "barplot" or "lines".
+#' @export
+h2o.screeplot <- function(model, type=c("barplot", "lines")) {
+    type <- match.arg(type)
+    if (type == "barplot") {
+        barplot(t(model@model$importance)[,1], xlab = "Components", ylab = "Variances", main = "Scree Plot")
+    } else {
+        plot(t(model@model$importance)[,1], xlab = "Components", ylab = "Variances", main = "Scree Plot",
+               type = "l", lty = "dashed", col = "blue", lwd = 2)
+    }
+}
+"""
 )
 
 doc = dict(

--- a/h2o-py/h2o/model/dim_reduction.py
+++ b/h2o-py/h2o/model/dim_reduction.py
@@ -94,19 +94,17 @@ class H2ODimReductionModel(ModelBase):
         return h2o.get_frame(j["model_metrics"][0]["predictions"]["frame_id"]["name"])
 
 
-    def screeplot(self, type="barplot", **kwargs):
+    def screeplot(self, type="barplot", server=False):
         """
         Produce the scree plot.
 
         Library ``matplotlib`` is required for this function.
 
         :param str type: either ``"barplot"`` or ``"lines"``.
+        :param bool server: if true set server settings to matplotlib and show the graph
         """
         # check for matplotlib. exit if absent.
-        is_server = kwargs.pop("server")
-        if kwargs:
-            raise ValueError("Unknown arguments %s to screeplot()" % ", ".join(kwargs.keys()))
-        plt = get_matplotlib_pyplot(is_server)
+        plt = get_matplotlib_pyplot(server)
         if plt is None:
             return
 
@@ -115,8 +113,11 @@ class H2ODimReductionModel(ModelBase):
         plt.ylabel('Variances')
         plt.title('Scree Plot')
         plt.xticks(list(range(1, len(variances) + 1)))
+
         if type == "barplot":
             plt.bar(list(range(1, len(variances) + 1)), variances)
         elif type == "lines":
             plt.plot(list(range(1, len(variances) + 1)), variances, 'b--')
-        if not is_server: plt.show()
+
+        if not server:
+            plt.show()

--- a/h2o-py/h2o/model/dim_reduction.py
+++ b/h2o-py/h2o/model/dim_reduction.py
@@ -101,7 +101,7 @@ class H2ODimReductionModel(ModelBase):
         Library ``matplotlib`` is required for this function.
 
         :param str type: either ``"barplot"`` or ``"lines"``.
-        :param bool server: if true set server settings to matplotlib and show the graph
+        :param bool server: if true set server settings to matplotlib and do not show the graph
         """
         # check for matplotlib. exit if absent.
         plt = get_matplotlib_pyplot(server)

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -1471,7 +1471,7 @@ class ModelBase(h2o_meta(Keyed)):
         Plot the variable importance for a trained model.
 
         :param num_of_features: the number of features shown in the plot (default is 10 or all if less than 10).
-        :param server: if true set server settings to matplotlib and show the graph
+        :param server: if true set server settings to matplotlib and do not show the graph
 
         :returns: None.
         """

--- a/h2o-py/tests/testdir_algos/pca/pyunit_pca_importance.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_pca_importance.py
@@ -16,15 +16,19 @@ def test_pca_importance():
 
 def test_pca_screeplot():
   import matplotlib
+  import matplotlib.pyplot as plt
   matplotlib.use("agg")
   arrestsH2O = h2o.upload_file(pyunit_utils.locate("smalldata/pca_test/USArrests.csv"))
   fitH2O = H2OPrincipalComponentAnalysisEstimator(k=4, transform="DEMEAN")
   fitH2O.train(x=list(range(4)), training_frame=arrestsH2O)
 
-  # the following should not fail
+  # The following should not fail
   fitH2O.screeplot()
   fitH2O.screeplot(server=True)
   fitH2O.screeplot(type="lines", server=True)
+  
+  # Free the memory
+  plt.close("all")
 
 
 pyunit_utils.run_tests([

--- a/h2o-py/tests/testdir_algos/pca/pyunit_pca_importance.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_pca_importance.py
@@ -1,0 +1,33 @@
+from __future__ import print_function
+from builtins import range
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator
+
+
+def test_pca_importance():
+  arrestsH2O = h2o.upload_file(pyunit_utils.locate("smalldata/pca_test/USArrests.csv"))
+  fitH2O = H2OPrincipalComponentAnalysisEstimator(k=4, transform="DEMEAN")
+  fitH2O.train(x=list(range(4)), training_frame=arrestsH2O)
+  assert fitH2O.varimp()
+
+
+def test_pca_screeplot():
+  import matplotlib
+  matplotlib.use("agg")
+  arrestsH2O = h2o.upload_file(pyunit_utils.locate("smalldata/pca_test/USArrests.csv"))
+  fitH2O = H2OPrincipalComponentAnalysisEstimator(k=4, transform="DEMEAN")
+  fitH2O.train(x=list(range(4)), training_frame=arrestsH2O)
+
+  # the following should not fail
+  fitH2O.screeplot()
+  fitH2O.screeplot(server=True)
+  fitH2O.screeplot(type="lines", server=True)
+
+
+pyunit_utils.run_tests([
+  test_pca_importance,
+  test_pca_screeplot
+])

--- a/h2o-r/h2o-package/R/pca.R
+++ b/h2o-r/h2o-package/R/pca.R
@@ -200,9 +200,9 @@ h2o.prcomp <- function(training_frame,
 h2o.screeplot <- function(model, type=c("barplot", "lines")) {
     type <- match.arg(type)
     if (type == "barplot") {
-        barplot(t(model@model$importance)[,1], xlab = "Components", ylab = "Variances", main = "Scree Plot")
+        graphics::barplot(t(model@model$importance)[,1], xlab = "Components", ylab = "Variances", main = "Scree Plot")
     } else {
-        plot(t(model@model$importance)[,1], xlab = "Components", ylab = "Variances", main = "Scree Plot",
+        graphics::plot(t(model@model$importance)[,1], xlab = "Components", ylab = "Variances", main = "Scree Plot",
                type = "l", lty = "dashed", col = "blue", lwd = 2)
     }
 }

--- a/h2o-r/h2o-package/R/pca.R
+++ b/h2o-r/h2o-package/R/pca.R
@@ -186,3 +186,24 @@ h2o.prcomp <- function(training_frame,
   segment_models <- .h2o.segmentModelsJob('pca', segment_parms, parms, h2oRestApiVersion=3)
   return(segment_models)
 }
+
+
+.h2o.fill_pca <- function(model, parameters, allparams) {
+    model$variable_importances <- model$importance
+    return(model)
+}
+
+#' Scree Plot
+#' @param model  A PCA model
+#' @param type  Type of the plot. Either "barplot" or "lines".
+#' @export
+h2o.screeplot <- function(model, type=c("barplot", "lines")) {
+    type <- match.arg(type)
+    if (type == "barplot") {
+        barplot(t(model@model$importance)[,1], xlab = "Components", ylab = "Variances", main = "Scree Plot")
+    } else {
+        plot(t(model@model$importance)[,1], xlab = "Components", ylab = "Variances", main = "Scree Plot", 
+               type = "l", lty = "dashed", col = "blue", lwd = 2)
+    }
+}
+

--- a/h2o-r/h2o-package/R/pca.R
+++ b/h2o-r/h2o-package/R/pca.R
@@ -202,7 +202,7 @@ h2o.screeplot <- function(model, type=c("barplot", "lines")) {
     if (type == "barplot") {
         barplot(t(model@model$importance)[,1], xlab = "Components", ylab = "Variances", main = "Scree Plot")
     } else {
-        plot(t(model@model$importance)[,1], xlab = "Components", ylab = "Variances", main = "Scree Plot", 
+        plot(t(model@model$importance)[,1], xlab = "Components", ylab = "Variances", main = "Scree Plot",
                type = "l", lty = "dashed", col = "blue", lwd = 2)
     }
 }

--- a/h2o-r/tests/testdir_algos/pca/runit_pca_importance.R
+++ b/h2o-r/tests/testdir_algos/pca/runit_pca_importance.R
@@ -1,0 +1,28 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+test.pca.importances <- function() {
+  arrestsH2O <- h2o.uploadFile(locate("smalldata/pca_test/USArrests.csv"), destination_frame = "arrestsH2O")
+  fitH2O <- h2o.prcomp(arrestsH2O, k = 4, transform = "DEMEAN")
+  expect_equal(fitH2O@model$importance, h2o.varimp(fitH2O))
+}
+
+test.pca.screeplot <- function() {
+  arrestsH2O <- h2o.uploadFile(locate("smalldata/pca_test/USArrests.csv"), destination_frame = "arrestsH2O")
+  fitH2O <- h2o.prcomp(arrestsH2O, k = 4, transform = "DEMEAN")
+  f <- tempfile(fileext = ".pdf")
+  tryCatch({
+    pdf(f)
+    h2o.screeplot(fitH2O)
+    dev.off()
+    expect_true(file.exists(f))
+  }, finally={
+    unlink(f)
+  })
+  }
+
+doSuite("PCA Test: Retrieving/Plotting importances",
+    makeSuite(
+    test.pca.importances,
+    test.pca.screeplot
+    ))


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8167

Problem in python was that it always expected `server` in `kwargs` so I made it optional.

In R, the varimp wasn't supported so I added support for it by copying `model$importance` to `model$variable_importances` in the `.h2o.fill_pca` and I also added `h2o.screeplot` which does the same thing as the one in python.