### PR TITLE
PUBDEV-8181: Fix misuse of is in python

### DIFF
--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -184,7 +184,7 @@ class H2OAutoML(H2OAutoMLBaseMixin, Keyed):
 
         assert_is_type(nfolds, int)
         assert nfolds >= 0, "nfolds set to " + str(nfolds) + "; nfolds cannot be negative. Use nfolds >=2 if you want cross-valiated metrics and Stacked Ensembles or use nfolds = 0 to disable."
-        assert nfolds is not 1, "nfolds set to " + str(nfolds) + "; nfolds = 1 is an invalid value. Use nfolds >=2 if you want cross-valiated metrics and Stacked Ensembles or use nfolds = 0 to disable."
+        assert nfolds != 1, "nfolds set to " + str(nfolds) + "; nfolds = 1 is an invalid value. Use nfolds >=2 if you want cross-valiated metrics and Stacked Ensembles or use nfolds = 0 to disable."
         self.nfolds = self.build_control["nfolds"] = nfolds
 
         assert_is_type(balance_classes, bool)

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -2961,7 +2961,7 @@ class H2OFrame(Keyed):
         # This code should be removed / reworked once we have a more consistent strategy of dealing with frames.
         self._ex._eager_frame()
 
-        if by is not None or group_by_frame is not "_":
+        if by is not None or group_by_frame != "_":
             res = H2OFrame._expr(
                 expr=ExprNode("h2o.impute", self, column, method, combine_method, by, group_by_frame, values))._frame()
         else:


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8181

In new python versions, we get syntax warning about using `is` where we should use `==`. The former should be used to compare "pointers" (`id(obj1) == id(obj2)`), while the latter compares the value.