### PR TITLE
PUBDEV-8229: Warn if H2O doesn't have enough memory to run XGBoost

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -384,6 +384,9 @@ final public class H2O {
     /** specifies a file to write when the node is up */
     public String notify_local;
 
+    /** what the is ratio of available off-heap memory to maximum JVM heap memory */
+    public double off_heap_memory_ratio = 0;
+
     //-----------------------------------------------------------------------------------
     // HDFS & AWS
     //-----------------------------------------------------------------------------------
@@ -599,6 +602,10 @@ final public class H2O {
       else if (s.matches("notify_local")) {
         i = s.incrementAndCheck(i, args);
         trgt.notify_local = args[i];
+      }
+      else if (s.matches("off_heap_memory_ratio")) {
+        i = s.incrementAndCheck(i, args);
+        trgt.off_heap_memory_ratio = Double.parseDouble(args[i]);
       }
       else if (s.matches("user_name")) {
         i = s.incrementAndCheck(i, args);

--- a/h2o-extensions/xgboost/build.gradle
+++ b/h2o-extensions/xgboost/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     compileOnly "javax.servlet:javax.servlet-api:${servletApiVersion}"
     compile "org.apache.httpcomponents:httpclient:${httpClientVersion}"
     compile "org.apache.httpcomponents:httpmime:${httpClientVersion}"
+    compile "com.github.oshi:oshi-core:5.7.4"
 
     // XGBoost dependencies published into Maven central by H2O
     // Versioning rules may differ for XGBoost artifacts published by H2O

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/MemoryCheck.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/MemoryCheck.java
@@ -1,0 +1,41 @@
+package hex.tree.xgboost;
+
+import oshi.SystemInfo;
+import oshi.hardware.GlobalMemory;
+import oshi.hardware.HardwareAbstractionLayer;
+import water.util.PrettyPrint;
+
+public class MemoryCheck {
+
+    public static Report runCheck(double offHeapRatio) {
+        SystemInfo systemInfo = new SystemInfo();
+        HardwareAbstractionLayer hardware = systemInfo.getHardware();
+        GlobalMemory globalMemory = hardware.getMemory();
+        Runtime runtime = Runtime.getRuntime();
+        long available = globalMemory.getAvailable();
+        long availableOffHeap = Math.max(available - (runtime.maxMemory() - runtime.totalMemory()), 0);
+        long desiredOffHeap = (long) (runtime.maxMemory() * offHeapRatio);
+        return new Report(availableOffHeap, desiredOffHeap);
+    }
+    
+    public static class Report {
+        public final long _available_off_heap;
+        public final long _desired_off_heap;
+
+        public Report(long available_off_heap, long desired_off_heap) {
+            _available_off_heap = available_off_heap;
+            _desired_off_heap = desired_off_heap;
+        }
+
+        public boolean isOffHeapRequirementMet() {
+            return _available_off_heap >= _desired_off_heap;
+        }
+
+        @Override
+        public String toString() {
+            return "Estimated Available Off-Heap (assuming JVM heap reaches maximum size): " + PrettyPrint.bytes(_available_off_heap) + 
+                    ", Desired Off-Heap: " + PrettyPrint.bytes(_desired_off_heap);
+        }
+    }
+
+}

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostExtension.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostExtension.java
@@ -80,10 +80,11 @@ public class XGBoostExtension extends AbstractH2OExtension {
   public void onLocalNodeStarted() {
     if (!isEnabled())
       return;
+    final double ratio = H2O.ARGS.off_heap_memory_ratio;
     if (H2O.ARGS.off_heap_memory_ratio > 0) {
-      MemoryCheck.Report report = MemoryCheck.runCheck(H2O.ARGS.off_heap_memory_ratio);
+      MemoryCheck.Report report = MemoryCheck.runCheck(ratio);
       if (!report.isOffHeapRequirementMet()) {
-        LOG.warn("There doesn't seem to be enough memory available for XGBoost model training, " +
+        LOG.warn("There doesn't seem to be enough memory available for XGBoost model training (off_heap_memory_ratio=" + ratio + "), " +
                 "training XGBoost models is not advised. Details: " + report);
       }
     }

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostExtension.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostExtension.java
@@ -6,6 +6,7 @@ import hex.tree.xgboost.util.NativeLibrary;
 import hex.tree.xgboost.util.NativeLibraryLoaderChain;
 import org.apache.log4j.Logger;
 import water.AbstractH2OExtension;
+import water.H2O;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -73,6 +74,19 @@ public class XGBoostExtension extends AbstractH2OExtension {
       return null;
     }
     return(NativeLibraryLoaderChain) loader;
+  }
+
+  @Override
+  public void onLocalNodeStarted() {
+    if (!isEnabled())
+      return;
+    if (H2O.ARGS.off_heap_memory_ratio > 0) {
+      MemoryCheck.Report report = MemoryCheck.runCheck(H2O.ARGS.off_heap_memory_ratio);
+      if (!report.isOffHeapRequirementMet()) {
+        LOG.warn("There doesn't seem to be enough memory available for XGBoost model training, " +
+                "training XGBoost models is not advised. Details: " + report);
+      }
+    }
   }
 
   private boolean initXgboost() {


### PR DESCRIPTION
This will need to be activated by specifying a desired ration on
H2O invocation.

Since the problem primarily affects standalone H2O started from Py/R
we should only add this flag to Py/R clients:

Eg.:
-off_heap_memory_ratio 0.75