### PR TITLE
PUBDEV-8197 : Switch already removed pandas.DataFrame.as_matrix to pandas.DataFrame.values

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -4030,8 +4030,9 @@ class H2OFrame(Keyed):
         data = pandaF[newX].values
         label = pandaF[[yresp]].values
 
-        return xgb.DMatrix(data=csr_matrix(data), label=label) \
-            if h2oXGBoostModel._model_json['output']['sparse'] else xgb.DMatrix(data=data, label=label)
+        return xgb.DMatrix(data=csr_matrix(data), label=label, feature_names=newX) \
+            if h2oXGBoostModel._model_json['output']['sparse'] else xgb.DMatrix(data=data, 
+                                                                                label=label, feature_names=newX)
 
     def pivot(self, index, column, value):
         """


### PR DESCRIPTION
This PR fixes the issue in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8197

Currently, calling `convert_H2OFrame_2_DMatrix` will return an error if the installed `pandas` library is > 1.0, because `as_matrix` method was removed in `pandas` 1.x

Changes made: 
1. Switch `as_matrix` to `.values`
2. Expose the interim `pandas.DataFrame` object using parameter `return_pandas`
3. Add feature names to DMatrix