### PR TITLE
PUBDEV-8312: Speed-up GBM by optimizing histogram building

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/DTree.java
+++ b/h2o-algos/src/main/java/hex/tree/DTree.java
@@ -328,7 +328,7 @@ public class DTree extends Iced {
         final boolean hasNAs = (_nasplit == DHistogram.NASplitDir.NALeft && way == 0 || 
                 _nasplit == DHistogram.NASplitDir.NARight && way == 1) && h.hasNABin();
 
-        nhists[j] = DHistogram.make(h._name, adj_nbins, h._isInt, min, maxEx, hasNAs,h._seed*0xDECAF+(way+1), parms, h._globalQuantilesKey, cs, h._checkFloatSplits);
+        nhists[j] = DHistogram.make(h._name, adj_nbins, h._isInt, min, maxEx, h._intOpt, hasNAs,h._seed*0xDECAF+(way+1), parms, h._globalQuantilesKey, cs, h._checkFloatSplits);
         cnt++;                    // At least some chance of splitting
       }
       return cnt == 0 ? null : nhists;

--- a/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
@@ -79,6 +79,10 @@ public abstract class SharedTreeModel<
 
     public double[] _sample_rate_per_class; //fraction of rows to sample for each tree, per class
 
+    public boolean useRowSampling() {
+      return _sample_rate < 1 || _sample_rate_per_class != null;
+    }
+
     public boolean _calibrate_model = false; // Use Platt Scaling
     public Key<Frame> _calibration_frame;
 
@@ -86,6 +90,14 @@ public abstract class SharedTreeModel<
 
     public double _col_sample_rate_change_per_level = 1.0f; //relative change of the column sampling rate for every level
     public double _col_sample_rate_per_tree = 1.0f; //fraction of columns to sample for each tree
+
+    public boolean useColSampling() {
+      return _col_sample_rate_change_per_level != 1.0f || _col_sample_rate_per_tree != 1.0f;
+    }
+
+    public boolean isStochastic() {
+      return useRowSampling() || useColSampling();
+    }
 
     public boolean _parallel_main_model_building = false;
 

--- a/h2o-algos/src/main/java/hex/tree/gbm/GBMModel.java
+++ b/h2o-algos/src/main/java/hex/tree/gbm/GBMModel.java
@@ -42,6 +42,11 @@ public class GBMModel extends SharedTreeModelWithContributions<GBMModel, GBMMode
       _pred_noise_bandwidth =0;
     }
 
+    @Override
+    public boolean useColSampling() {
+      return super.useColSampling() || _col_sample_rate != 1.0;
+    }
+
     public String algoName() { return "GBM"; }
     public String fullName() { return "Gradient Boosting Machine"; }
     public String javaName() { return GBMModel.class.getName(); }

--- a/h2o-algos/src/test/java/hex/tree/DTreeSplitTest.java
+++ b/h2o-algos/src/test/java/hex/tree/DTreeSplitTest.java
@@ -43,7 +43,7 @@ public class DTreeSplitTest {
         double min = ArrayUtils.minValue(data);
         double max = ArrayUtils.maxValue(data);
         double maxEx = DHistogram.find_maxEx(max, 0);
-        DHistogram histo = new DHistogram("histo" + nbins, nbins, 2, (byte) 0, min, maxEx, false, 0,
+        DHistogram histo = new DHistogram("histo" + nbins, nbins, 2, (byte) 0, min, maxEx, false, false, 0,
                 SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, checkFloatSplits);
         histo.init();
         histo.updateHisto(

--- a/h2o-algos/src/test/java/hex/tree/DTreeTest.java
+++ b/h2o-algos/src/test/java/hex/tree/DTreeTest.java
@@ -17,7 +17,7 @@ public class DTreeTest {
     double[] ys = new double[]{0,          1,          0,   1  };
     int[] rows  = new int[]   {0,          1,          2,   3  };
 
-    DHistogram hs = new DHistogram("test_hs", 2, 2, (byte) 0, 0, 2, true, 0.01,
+    DHistogram hs = new DHistogram("test_hs", 2, 2, (byte) 0, 0, 2, false, true, 0.01,
             SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 123, null, null, false);
     hs.init();
     hs.updateHisto(ws, null, cs, ys, null, rows, rows.length, 0);
@@ -31,7 +31,7 @@ public class DTreeTest {
     assertNull(s2); // not enough improvement => no split
 
     // 3. allow negative (!!!) split improvement, min_rows = #NAs + 1
-    DHistogram hsN = new DHistogram("test_hs", 2, 2, (byte) 0, 0, 2, true, -9,
+    DHistogram hsN = new DHistogram("test_hs", 2, 2, (byte) 0, 0, 2, false, true, -9,
             SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 123, null, null, false);
     hsN.init();
     hsN.updateHisto(ws, null, cs, ys, null, rows, rows.length, 0);
@@ -74,7 +74,7 @@ public class DTreeTest {
             .withNewConstraint(0, 0, max_pred);
     assertEquals(min_pred, c._min, 0);
     assertEquals(max_pred, c._max, 0);
-    return new DHistogram("test_hs", nbins, 2, (byte) 0, 0, 10, false, 0.01,
+    return new DHistogram("test_hs", nbins, 2, (byte) 0, 0, 10, false, false, 0.01,
             SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 123, null, c, false);
   }
   

--- a/h2o-algos/src/test/java/hex/tree/HistogramTest.java
+++ b/h2o-algos/src/test/java/hex/tree/HistogramTest.java
@@ -126,7 +126,7 @@ public class HistogramTest extends TestUtil {
       }
       DHistogram.HistoQuantiles hq = new DHistogram.HistoQuantiles(Key.make(), splitPts);
       DKV.put(hq);
-      DHistogram hist = new DHistogram("myhisto",nbins,nbins_cats,isInt,min,maxEx,false,0,histoType,seed,hq._key,null, false);
+      DHistogram hist = new DHistogram("myhisto",nbins,nbins_cats,isInt,min,maxEx,false,false,0,histoType,seed,hq._key,null, false);
       hist.init();
       int N=10000000;
       int bin=-1;
@@ -163,7 +163,7 @@ public class HistogramTest extends TestUtil {
     double maxEx = 6.900000000000001;
     long seed = 1234;
     SharedTreeModel.SharedTreeParameters.HistogramType histoType = SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive;
-    DHistogram hist = new DHistogram("myhisto", nbins, nbins_cats, isInt, min, maxEx,false, 0, histoType, seed, null, null, false);
+    DHistogram hist = new DHistogram("myhisto", nbins, nbins_cats, isInt, min, maxEx, false,false, 0, histoType, seed, null, null, false);
     hist.init();
     assert(hist.binAt(0)==min);
     assert(hist.binAt(nbins-1)<maxEx);
@@ -179,7 +179,7 @@ public class HistogramTest extends TestUtil {
     double maxEx = 6.900000000000001;
     long seed = 1234;
     SharedTreeModel.SharedTreeParameters.HistogramType histoType = SharedTreeModel.SharedTreeParameters.HistogramType.Random;
-    DHistogram hist = new DHistogram("myhisto", nbins, nbins_cats, isInt, min, maxEx, false,0, histoType, seed, null, null, false);
+    DHistogram hist = new DHistogram("myhisto", nbins, nbins_cats, isInt, min, maxEx, false, false,0, histoType, seed, null, null, false);
     hist.init();
     assert(hist.binAt(0)==min);
     assert(hist.binAt(nbins-1)<maxEx);
@@ -198,7 +198,7 @@ public class HistogramTest extends TestUtil {
     double[] splitPts = new double[]{1,1.5,2,2.5,3,4,5,6.1,6.2,6.3,6.7,6.8,6.85};
     Key k = Key.make();
     DKV.put(new DHistogram.HistoQuantiles(k,splitPts));
-    DHistogram hist = new DHistogram("myhisto",nbins,nbins_cats,isInt,min,maxEx,false,0,histoType,seed,k,null, false);
+    DHistogram hist = new DHistogram("myhisto",nbins,nbins_cats,isInt,min,maxEx,false,false,0,histoType,seed,k,null, false);
     hist.init();
     assert(hist.binAt(0)==min);
     assert(hist.binAt(nbins-1)<maxEx);

--- a/h2o-algos/src/test/java/hex/tree/SharedTreeModelTest.java
+++ b/h2o-algos/src/test/java/hex/tree/SharedTreeModelTest.java
@@ -1,0 +1,76 @@
+package hex.tree;
+
+import hex.tree.gbm.GBMModel;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SharedTreeModelTest {
+
+    @Test
+    public void testUseRowSampling() {
+        // disabled by default
+        assertFalse(new TestParameters().useRowSampling());
+        // enabled by user
+        {
+            TestParameters tp = new TestParameters();
+            tp._sample_rate = 1 - 1e-9;
+            assertTrue(tp.useRowSampling());
+        }
+        {
+            TestParameters tp = new TestParameters();
+            tp._sample_rate_per_class = new double[0];
+            assertTrue(tp.useRowSampling());
+        }
+    }
+
+    @Test
+    public void testUseColSampling() {
+        // disabled by default
+        assertFalse(new TestParameters().useColSampling());
+        // enabled by user
+        {
+            TestParameters tp = new TestParameters();
+            tp._col_sample_rate_change_per_level = 1 - 1e-9;
+            assertTrue(tp.useColSampling());
+        }
+        {
+            TestParameters tp = new TestParameters();
+            tp._col_sample_rate_per_tree = 1 - 1e-9;
+            assertTrue(tp.useColSampling());
+        }
+    }
+
+    @Test
+    public void testIsStochastic() {
+        // false by default
+        assertFalse(new TestParameters().isStochastic());
+        // true if col/row sampling is enabled
+        {
+            TestParameters tp = new TestParameters();
+            tp._force_col_sampling = true;
+            assertTrue(tp.isStochastic());
+        }
+        {
+            TestParameters tp = new TestParameters();
+            tp._force_row_sampling = true;
+            assertTrue(tp.isStochastic());
+        }
+    }
+    
+    private static class TestParameters extends GBMModel.GBMParameters {
+        boolean _force_row_sampling;
+        boolean _force_col_sampling;
+
+        @Override
+        public boolean useColSampling() {
+            return _force_col_sampling || super.useColSampling();
+        }
+
+        @Override
+        public boolean useRowSampling() {
+            return _force_row_sampling || super.useRowSampling();
+        }
+    }
+    
+}

--- a/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
+++ b/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
@@ -4879,4 +4879,39 @@ public class GBMTest extends TestUtil {
     }
   }
 
+  @Test
+  public void testMulticlassStopping() {
+    try {
+      Scope.enter();
+      Frame f = new TestFrameBuilder()
+              .withDataForCol(0, ar(0, 1, 2))
+              .withDataForCol(1, new String[]{"a", "b", "c"})
+              .withVecTypes(Vec.T_NUM, Vec.T_CAT)
+              .build();
+
+      GBMModel.GBMParameters p = makeGBMParameters();
+      p._response_column = f.lastVecName();
+      p._ntrees = 1000;
+      p._max_depth = 1;
+      p._train = f._key;
+      p._min_rows = 1;
+      p._distribution = multinomial;
+      p._learn_rate = 1;
+
+      GBMModel model = new GBM(p).trainModel().get();
+      Scope.track_generic(model);
+
+      assertTrue(model._output._ntrees < 1000);
+      
+      int lastTreeIndex = model._output._ntrees - 1;
+      for (int i = 0; i < f.lastVec().domain().length; i++) {
+        SharedTreeSubgraph lastTree = model.getSharedTreeSubgraph(lastTreeIndex, i);
+        assertTrue(lastTree.rootNode.isLeaf());
+        assertEquals(lastTree.rootNode.getPredValue(), 0f, 0f);
+      }
+    } finally {
+      Scope.exit();
+    }
+  }
+
 }

--- a/h2o-core/src/main/java/water/fvec/ChunkVisitor.java
+++ b/h2o-core/src/main/java/water/fvec/ChunkVisitor.java
@@ -194,7 +194,6 @@ public abstract class ChunkVisitor {
     public final int [] vals;
     private int _k = 0;
     private final int _na;
-    IntAryVisitor(int [] vals){this(vals,(int)C4Chunk._NA);}
     IntAryVisitor(int [] vals, int NA){this.vals = vals; _na = NA;}
     @Override
     public void addValue(int val) {vals[_k++] = val;}


### PR DESCRIPTION
1. Optimize binning for small-cardinality categoricals
2. Collocate response data by tree-node for faster random access in CPU cache
3. Stop model building if new trees cannot bring an improvement (won't change the model)