### PR TITLE
PUBDEV-8207: fix test h statistic failing n gpu

### DIFF
--- a/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
+++ b/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
@@ -38,6 +38,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static hex.genmodel.utils.DistributionFamily.*;
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.*;
 import static water.fvec.FVecFactory.makeByteVec;
 
@@ -4359,13 +4360,13 @@ public class GBMTest extends TestUtil {
 
   @Test
   public void testHStatistic() {
-    Frame fr=null;
+    Frame fr = null;
     GBMModel model = null;
     Scope.enter();
     try {
       Frame f = Scope.track(parse_test_file("smalldata/logreg/prostate.csv"));
       f.replace(f.find("CAPSULE"), f.vec("CAPSULE").toNumericVec());
-      DKV.put(f);
+      Scope.track(f);
 
       GBMModel.GBMParameters parms = makeGBMParameters();
       parms._response_column = "CAPSULE";
@@ -4374,14 +4375,11 @@ public class GBMTest extends TestUtil {
       parms._seed = 1234L;
 
       model = new GBM(parms).trainModel().get();
-
       double h = model.getFriedmanPopescusH(f, new String[] {"GLEASON","VOL"});
-      assertEquals(h, 0.0, 1e-5);
-
-      DKV.remove(f._key);
+      assertTrue(Double.isNaN(h) || (h >= 0.0 && h <= 1.0));
     } finally {
-      if( model != null ) model.delete();
-      if( fr  != null )   fr.remove();
+      if (model != null) model.delete();
+      if (fr  != null) fr.remove();
       Scope.exit();
     }
   }

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTest.java
@@ -2462,7 +2462,7 @@ public class XGBoostTest extends TestUtil {
       
       model = new hex.tree.xgboost.XGBoost(parms).trainModel().get();
       double h = model.getFriedmanPopescusH(irisFrame, new String[] {"sepal_len","sepal_wid"});
-      assertEquals(h, 0.0, 1e-5);
+      assertTrue(Double.isNaN(h) || (h >= 0.0 && h <= 1.0));
     } finally {
       Scope.exit();
       if (model != null) model.delete();


### PR DESCRIPTION
Assertion error is caused by different resulting model on gpu vs cpu.

Numerically is h statistic tested here: hex/tree/FriedmanPopescusHTest.java.

In XGBoostTest.java and GBMTest.java it is tested that it can be called from the model, so fixing the problem here by relaxing the test assert to expect either NaN or double in range 0 to 1 - meaning that output is in expected range, since I am not testing here against specific reference number. 