### PR TITLE
Adding POSIXct format to as.h2o .

### DIFF
--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -4020,14 +4020,17 @@ h2o.range <- function(x,na.rm = FALSE,finite = FALSE) {
 is.h2o <- function(x) inherits(x, "H2OFrame")
 
 h2o.class.map <- function() {
-  c("integer64"="numeric",
+  c(
+    "integer64"="numeric",
     "integer"="numeric",
     "double"="numeric",
     "complex"="numeric",
     "logical"="enum",
     "factor"="enum",
     "character"="string",
-    "Date"="Time")
+    "Date"="Time",
+    "POSIXct"="Time"
+  )
 }
 
 destination_frame.guess <- function(x) {
@@ -4168,7 +4171,10 @@ as.h2o.data.frame <- function(x, destination_frame="", use_datatable=TRUE, ...) 
   verbose <- getOption("h2o.verbose", FALSE)
   if (verbose) pt <- proc.time()[[3]]
   if (use_datatable && getOption("h2o.fwrite", TRUE) && use.package("data.table")) {
-    data.table::fwrite(x, tmpf, na="NA_h2o", row.names=FALSE, showProgress=FALSE)
+    data.table::fwrite(
+      x, tmpf,
+      na = "NA_h2o", row.names = FALSE, showProgress = FALSE, dateTimeAs = "write.csv"
+    )
     fun <- "fwrite"
   } else {
     write.csv(x, file = tmpf, row.names = FALSE, na="NA_h2o")


### PR DESCRIPTION
The [`{modeltime.h2o}` R package](https://github.com/business-science/modeltime.h2o) uses H2O to fit time series models.
R's most common DateTime class is `POSIXct`, however, `{h2o}`'s `as.h2o` function does not allow loading `POSIXct`columns, as can bee seen in the following reprex:
```r
> library("dplyr")
> library("h2o")
> library("lubridate")
> hourly_calls <- tibble(
+   ds = seq.POSIXt(now() - days(7), now(), by = "hour"),
+   calls = rpois(7 * 24 + 1, lambda = 4)
+ )
> h2o.init()
> as.h2o(hourly_calls)

ERROR: Unexpected HTTP Status code: 412 Precondition Failed (url = http://localhost:54321/3/Parse)

water.exceptions.H2OIllegalArgumentException
 [1] "water.exceptions.H2OIllegalArgumentException: Provided column type POSIXct is unknown.  Cannot proceed with parse due to invalid argument."
...
[41] "    java.base/java.lang.Thread.run(Thread.java:829)"                                                                                       

Error in .h2o.doSafeREST(h2oRestApiVersion = h2oRestApiVersion, urlSuffix = page,  : 
  

ERROR MESSAGE:

Provided column type POSIXct is unknown.  Cannot proceed with parse due to invalid argument.
```

This issue makes `{modeltime.h2o}` useless for DateTime time series problems. And as previously reported at https://github.com/business-science/modeltime.h2o/issues/22

This simple fix allows H2O's R package to allow handling `POSIXct` columns.

Please let me know if further edits should be addressed.