### PR TITLE
PUBDEV-8233: Add StackedEnsembles To AutoML's Time Budget

### DIFF
--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -316,7 +316,8 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
       List<Frame> baseModelPredictions = new ArrayList<>();
 
       for (Key<Model> k : baseModelKeys) {
-        if (stop_requested())
+        // if training we can stop prematurely due to a timeout but computing validation scores should be allowed to finish
+        if (stop_requested() && isTraining)
           throw new Job.JobCancelledException();
 
         if (_model._output._metalearner == null || _model.isUsefulBaseModel(k)) {

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/StackedEnsembleStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/StackedEnsembleStepsProvider.java
@@ -34,7 +34,7 @@ public class StackedEnsembleStepsProvider
 
             StackedEnsembleModelStep(String id, int weight, AutoML autoML) {
                 super(Algo.StackedEnsemble, id, weight, autoML);
-                _ignoredConstraints = new AutoML.Constraint[] {AutoML.Constraint.TIMEOUT, AutoML.Constraint.MODEL_COUNT};
+                _ignoredConstraints = new AutoML.Constraint[] {AutoML.Constraint.MODEL_COUNT};
             }
 
             @Override


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8233

Currently, StackedEnsembles ignore the time constraint from AutoML which is fine for a lot of situations since the metalearner is usually very fast to train. 

However, in some situations SEs take much more time than expected. This behavior was observed mainly on multinomial tasks. One good example is 1h training on Covertype dataset which very often takes 1h30mins and the main contributing factor is the StackedEnsemble.

The goal of this PR is to speed up automl training in cases where it uses more time than it should, this will possibly influence the performance of the SE models in these cases so another goal is to have SE in the top 5 models in 95+% of the datasets we use for benchmark.

# Results

## Multinomial 
In multinomial tasks, this PR fails to comply with the rule "95% of runs should have SE in the top 5". But I compared it with previous experiments and the amount of runs with SE in the top 5 increased.

To get more robust comparison I made a plot for the ratio of SE presence in top N - N is on x-axis. Apart from using all old runs I also used `logit_on` PR run as that is IIRC the last PR that we benchmarked that got merged (at least on multinomial datasets).

![Unknown-2](https://user-images.githubusercontent.com/61695433/125624028-469bfcb2-f27f-4e0b-8d15-9cf4e909a8f2.png)


I also looked at how big the impact from limiting SE run time on logloss is and there doesn't seem to be a big one - in CoverType, I think there might be some increase in logloss since we use less time by order of magnitude. In other cases, especially those where we finish before the time limit runs out, I think the differences in logloss might be just caused by noise. In the table below I show only the increases of logloss:
<img width="1156" alt="Screen Shot 2021-07-14 at 14 41 31" src="https://user-images.githubusercontent.com/61695433/125623994-7c8e7ba2-ed37-44e8-aa9e-49cb4f54392c.png">

Trained SEs per dataset (should be == 20):
<img width="359" alt="Screen Shot 2021-07-15 at 19 31 37" src="https://user-images.githubusercontent.com/61695433/125927370-ce2a5109-cd5a-47ce-96ef-4d6a4c3719c4.png">

## Binomial

For binomial, I got quite a lot of failures (121 lines in `failures.csv`) but I think the general trend seems to be the same as in the other task.

<img width="959" alt="Screen Shot 2021-07-15 at 18 58 47" src="https://user-images.githubusercontent.com/61695433/125927276-f4229ace-52ae-446c-9424-7f4d5dee8fdc.png">

Cases where the performance was worse:
<img width="970" alt="Screen Shot 2021-07-15 at 18 59 19" src="https://user-images.githubusercontent.com/61695433/125927302-003057bc-48f1-4fa7-a616-eac1a5e37f2b.png">

Trained SEs per dataset (should be == 20):
<img width="318" alt="Screen Shot 2021-07-15 at 18 59 37" src="https://user-images.githubusercontent.com/61695433/125927309-615c3c88-8fc2-45b9-bacd-876fd342222f.png">

## Regression
41 lines in `failures.csv` so this task also has some "missing data".
<img width="964" alt="Screen Shot 2021-07-15 at 18 33 38" src="https://user-images.githubusercontent.com/61695433/125926291-ad31e5ea-e019-46fc-9952-b47e884ffc26.png">

Cases where the performance was worse:
<img width="1121" alt="Screen Shot 2021-07-15 at 18 33 55" src="https://user-images.githubusercontent.com/61695433/125926346-39d67978-3358-4cac-bda6-fc76c20fff6b.png">

Trained SEs per dataset (should be == 20):
<img width="331" alt="Screen Shot 2021-07-15 at 18 34 28" src="https://user-images.githubusercontent.com/61695433/125926380-4a21744c-da2e-4b72-90be-502c0aaffdd1.png">


# Summary
Even though we don't have all the data due to some failures, I think it is safe to say that this PR doesn't make AutoML much worse (quite a lot of tasks end up actually tiny bit better) and at the same time it cuts down the longest running runs so I think it's safe to say that we can merge it.