### PR TITLE
PUBDEV-8242: Fix splits NA vs Rest to be correctly represented

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/DTree.java
+++ b/h2o-algos/src/main/java/hex/tree/DTree.java
@@ -150,12 +150,13 @@ public class DTree extends Iced {
     final double _tree_p0, _tree_p1;
 
     public Split(int col, int bin, DHistogram.NASplitDir nasplit, IcedBitSet bs, byte equal, double se, double se0, double se1, double n0, double n1, double p0, double p1, double tree_p0, double tree_p1) {
-      assert(nasplit!= DHistogram.NASplitDir.None);
-      assert(equal!=1); //no longer done
+      assert nasplit != DHistogram.NASplitDir.None;
+      assert nasplit != DHistogram.NASplitDir.NAvsREST || bs == null : "Split type NAvsREST shouldn't have a bitset";
+      assert equal != 1; //no longer done
       // FIXME: Disabled for testing PUBDEV-6495:
       // assert se > se0+se1 || se==Double.MAX_VALUE; // No point in splitting unless error goes down
-      assert(col>=0);
-      assert(bin>=0);
+      assert col >= 0;
+      assert bin >= 0;
       _col = col;  _bin = bin; _nasplit = nasplit; _bs = bs;  _equal = equal;  _se = se;
       _n0 = n0;  _n1 = n1;  _se0 = se0;  _se1 = se1;
       _p0 = p0;  _p1 = p1;
@@ -176,9 +177,9 @@ public class DTree extends Iced {
     // elements.
     float splat(DHistogram hs[]) {
       DHistogram h = hs[_col];
+      assert _nasplit != DHistogram.NASplitDir.NAvsREST : "Shouldn't be called for NA split type 'NA vs REST'";
       assert _bin > 0 && _bin < h.nbins();
       assert _bs==null : "Dividing point is a bitset, not a bin#, so dont call splat() as result is meaningless";
-      if (_nasplit == DHistogram.NASplitDir.NAvsREST) return -1;
       assert _equal != 1;
       assert _equal==0; // not here for bitset splits, just range splits
       // Find highest non-empty bin below the split
@@ -702,8 +703,10 @@ public class DTree extends Iced {
 
       // NA handling correction
       res++; //1 byte for NA split dir
-      if (_split._nasplit == DHistogram.NASplitDir.NAvsREST)
-        res -= _split._equal == 3 ? 6 + _split._bs.numBytes() : 4; //don't need certain stuff
+      if (_split._nasplit == DHistogram.NASplitDir.NAvsREST) {
+        assert _split._equal == 0;
+        res -= 4; // we don't need to represent the actual split value
+      }
 
       Node left = _tree.node(_nids[0]);
       int lsz = left.size();
@@ -1304,7 +1307,8 @@ public class DTree extends Iced {
     // For categorical (unordered) predictors, we sorted the bins by average
     // prediction then found the optimal split on sorted bins
     IcedBitSet bs = null;       // In case we need an arbitrary bitset
-    if( idxs != null ) {        // We sorted bins; need to build a bitset
+    if (idxs != null            // We sorted bins; need to build a bitset
+            && nasplit != DHistogram.NASplitDir.NAvsREST) { // NA vs REST don't need a bitset
       final int off = (int) hs._min;
       bs = new IcedBitSet(nbins, off);
       equal = fillBitSet(hs, off, idxs, best, nbins, bs);
@@ -1320,6 +1324,7 @@ public class DTree extends Iced {
     assert constraint == 0 || constraint * tree_p0 <= constraint * tree_p1;
     assert (Double.isNaN(min) || min <= tree_p0) && (Double.isNaN(max) || tree_p0 <= max);
     assert (Double.isNaN(min) || min <= tree_p1) && (Double.isNaN(max) || tree_p1 <= max);
+
     Split split = new Split(col, best, nasplit, bs, equal, seBefore, best_seL, best_seR, nLeft, nRight, node_p0, node_p1, tree_p0, tree_p1);
     if (LOG.isTraceEnabled()) LOG.trace("splitting on " + hs._name + ": " + split);
     return split;

--- a/h2o-algos/src/test/java/hex/tree/drf/DRFTest.java
+++ b/h2o-algos/src/test/java/hex/tree/drf/DRFTest.java
@@ -26,6 +26,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
@@ -1943,6 +1944,91 @@ public class DRFTest extends TestUtil {
           assertTrue(node.isLeaf());
           assertEquals(nodeId, node.getNodeNumber());
         }
+      }
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test
+  public void testCategoricalSplitNAvsREST() {
+    Scope.enter();
+    try {
+      String[] dataCol1 = ArrayUtils.toString(ArrayUtils.seq(0, 64));
+      String[] dataCol2 = new String[dataCol1.length];
+      double[] response = new double[dataCol1.length];
+      double[] weights = new double[response.length];
+      for (int i = 0; i < response.length; i++) {
+          if (i <= 50) {
+              response[i] = i / 100.0;
+              weights[i] = 1.0;
+              dataCol2[i] = null;
+          } else if (i <= 57) {
+              response[i] = 10;
+              weights[i] = 100;
+              dataCol2[i] = null;
+          } else {
+              response[i] = 11;
+              weights[i] = 100;
+              dataCol2[i] = i % 2 == 0 ? "A" : "B";
+          }
+      }
+      
+      Frame f = new TestFrameBuilder()
+              .withColNames("C0", "C1", "response", "weight")
+              .withVecTypes(Vec.T_CAT, Vec.T_CAT, Vec.T_NUM, Vec.T_NUM)
+              .withDataForCol(0, dataCol2)
+              .withDataForCol(1, dataCol1)
+              .withDataForCol(2, response)
+              .withDataForCol(3, weights)
+              .build();
+      f.vec(0).setNA(0);
+
+      System.out.println(f.toTwoDimTable(0, (int) f.numRows(), false));
+      
+      DRFModel.DRFParameters parms = new DRFModel.DRFParameters();
+      parms._response_column = "response";
+      parms._train = f._key;
+      parms._ntrees = 1;
+      parms._seed = 1234L;
+      parms._max_depth = 4;
+      parms._sample_rate = 1.0;
+      parms._weights_column = "weight";
+      parms._mtries = f.numCols() - 2;
+      parms._nbins_cats = 32;
+
+      DRFModel model = new DRF(parms).trainModel().get();
+      Scope.track_generic(model);
+
+      Map<Integer, Integer> actualWeights = new HashMap<>();
+      
+      Frame nodeIds = model.scoreLeafNodeAssignment(
+              f, Model.LeafNodeAssignment.LeafNodeAssignmentType.Node_ID, Key.make());
+      nodeIds.add(f);
+      System.out.println(nodeIds.toTwoDimTable(0, (int) f.numRows(), false));
+      Scope.track(nodeIds);
+      for (int i = 0; i < nodeIds.numRows(); i++) {
+          int nodeId = (int) nodeIds.vec(0).at(i);
+          int weight = (int) nodeIds.vec("weight").at(i);
+          if (!actualWeights.containsKey(nodeId)) {
+              actualWeights.put(nodeId, 0);
+          }
+          actualWeights.put(nodeId, actualWeights.get(nodeId) + weight);
+      }
+
+      SharedTreeSubgraph tree0 = model.getSharedTreeSubgraph(0, 0);
+      // check that we reproduced the edge case that triggers the bug:
+      // we have a node that has a split "NAvsREST" whose parent is a bitset split
+      List<SharedTreeNode> naVsRestNodes = tree0.nodesArray.stream()
+              .filter(SharedTreeNode::isNaVsRest).collect(Collectors.toList());
+      assertEquals(1, naVsRestNodes.size());
+      assertTrue(naVsRestNodes.get(0).getParent().isBitset());
+      for (SharedTreeNode n : tree0.nodesArray) {
+          if (n.isLeaf()) {
+              int expectedWeight = (int) n.getWeight();
+              assertEquals("Weight in node #" + n.getNodeNumber() + " should match",
+                      expectedWeight, (int) actualWeights.get(n.getNodeNumber()));
+          }
       }
     } finally {
       Scope.exit();


### PR DESCRIPTION

Categorical splits NAvsREST are not represented by a bitset in the
CompressedTrees - there is a bunch of places in the code where the bitset is
removed. However, the type of split stays categorical equal = 2 or 3.

This means the scoring logic interprets the split as categorical. While
no bitset is actually parsed from the tree, the scoreTree method can
erroneously re-use a previous bitset split instead of creating a fresh new
one.

This will result in misclassification of the observations in the tree nodes.