### PR TITLE
PUBDEV-8250: Monotone constraints in GBM can cause issues with reproducing the model

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram2.java
+++ b/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram2.java
@@ -6,6 +6,7 @@ import water.*;
 import water.fvec.*;
 import water.util.ArrayUtils;
 import water.util.IcedBitSet;
+import water.util.Log;
 import water.util.VecUtils;
 import static hex.tree.SharedTree.ScoreBuildOneTree;
 
@@ -70,11 +71,12 @@ public class ScoreBuildHistogram2 extends ScoreBuildHistogram {
   final IcedBitSet _activeCols;
   final int _respIdx;
   final int _predsIdx;
-  // for debugging purposes
   final boolean _reproducibleHistos;
-  final boolean _reduceHistoPrecision;
+  // only for debugging purposes
+  final boolean _reduceHistoPrecision; // if enabled allows to test that histograms are 100% reproducible when reproducibleHistos are enabled
 
-  public ScoreBuildHistogram2(ScoreBuildOneTree sb, int k, int ncols, int nbins, DTree tree, int leaf, DHistogram[][] hcs, DistributionFamily family, 
+  public ScoreBuildHistogram2(ScoreBuildOneTree sb, int treeNum, int k, int ncols, int nbins, DTree tree, int leaf,
+                              DHistogram[][] hcs, DistributionFamily family,
                               int respIdx, int weightIdx, int predsIdx, int workIdx, int nidIdxs) {
     super(sb, k, ncols, nbins, tree, leaf, hcs, family, weightIdx, workIdx, nidIdxs);
     _numLeafs = _hcs.length;
@@ -95,10 +97,13 @@ public class ScoreBuildHistogram2 extends ScoreBuildHistogram {
     }
     _activeCols = activeCols;
     _hcs = ArrayUtils.transpose(_hcs);
-    // initialize debugging parameters
+    // override defaults using debugging parameters where applicable
     SharedTree.SharedTreeDebugParams dp = sb._st.getDebugParams();
-    _reproducibleHistos = dp._reproducible_histos;
+    _reproducibleHistos = tree._parms.forceStrictlyReproducibleHistograms() || dp._reproducible_histos;
     _reduceHistoPrecision = !dp._keep_orig_histo_precision;
+    if (_reproducibleHistos && treeNum == 0 && k == 0 && leaf == 0) {
+      Log.info("Using a deterministic way of building histograms");
+    }
   }
 
   @Override

--- a/h2o-algos/src/main/java/hex/tree/SharedTree.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTree.java
@@ -625,7 +625,8 @@ public abstract class SharedTree<
       // Pass 2: Build new summary DHistograms on the new child Nodes every row
       // got assigned into.  Collect counts, mean, variance, min, max per bin,
       // per column.
-      new ScoreBuildHistogram2(this,_k, _st._ncols, _nbins, _tree, _leafOffsets[_k], _hcs[_k], _family, 
+      int treeNum = ((SharedTreeModel.SharedTreeOutput) _st._model._output)._ntrees;
+      new ScoreBuildHistogram2(this, treeNum, _k, _st._ncols, _nbins, _tree, _leafOffsets[_k], _hcs[_k], _family,
               _respIdx, _weightIdx, _predsIdx, _workIdx, _nidIdx).dfork2(null,_fr2,_build_tree_one_node);
     }
     @Override public void onCompletion(CountedCompleter caller) {

--- a/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
@@ -116,6 +116,17 @@ public abstract class SharedTreeModel<
       return this;
     }
 
+    /**
+     * Do we need to enable strictly deterministic way of building histograms?
+     *
+     * Used eg. when monotonicity constraints in GBM are enabled, by default disabled
+     *
+     * @return true if histograms should be built in deterministic way
+     */
+    public boolean forceStrictlyReproducibleHistograms() {
+      return false;
+    }
+
   }
 
   @Override public ModelMetrics.MetricBuilder makeMetricBuilder(String[] domain) {

--- a/h2o-algos/src/test/java/hex/tree/SharedTreeTest.java
+++ b/h2o-algos/src/test/java/hex/tree/SharedTreeTest.java
@@ -63,6 +63,11 @@ public class SharedTreeTest extends TestUtil  {
   }
 
   @Test
+  public void testStrictHistogramReproducibilityIsDisabledByDefault() {
+    assertFalse(_parms.forceStrictlyReproducibleHistograms());
+  }
+
+  @Test
   public void testNAPredictor_cat() {
     checkNAPredictor(twoVecFrameBuilder()
             .withVecTypes(Vec.T_CAT, Vec.T_CAT)

--- a/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
+++ b/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
@@ -79,9 +79,9 @@ public class GBMTest extends TestUtil {
     if ("EmulateConstraints".equals(test_type)) {
       return new GBMModel.GBMParameters() {
         @Override
-        Constraints emptyConstraints(Frame f) {
+        Constraints emptyConstraints(int numCols) {
           if (_distribution == DistributionFamily.gaussian || _distribution == DistributionFamily.bernoulli || _distribution == DistributionFamily.tweedie) {
-            return new Constraints(new int[f.numCols()], DistributionFactory.getDistribution(this), true);
+            return new Constraints(new int[numCols], DistributionFactory.getDistribution(this), true);
           } else 
             return null;
         }
@@ -4559,6 +4559,17 @@ public class GBMTest extends TestUtil {
       if (model != null) model.delete();
       if (fr  != null) fr.remove();
       Scope.exit();
+    }
+  }
+
+  @Test
+  public void testMonotoneConstraintsTriggerStrictlyReproducibleHistograms() {
+    GBMModel.GBMParameters p = makeGBMParameters();
+    p._distribution = gaussian;
+    if (test_type.equals("EmulateConstraints")) {
+      assertTrue(p.forceStrictlyReproducibleHistograms());
+    } else {
+      assertFalse(p.forceStrictlyReproducibleHistograms());
     }
   }
 


### PR DESCRIPTION
If a dataset has highly correlated columns and monotonicity constraints are used on one of them, independent attempts to build the same model with identical parameters can lead to slightly different models. This is caused by non-determinism in histogram building - this non-determinism is compensated for split points but monotone constraints are not leveraging the same mechanism.

The solution is to avoid any non-determinism when monotone constraints are used.