### PR TITLE
PUBDEV-8492: fix GLM zero weight prediction error

### DIFF
--- a/h2o-algos/src/main/java/hex/DataInfo.java
+++ b/h2o-algos/src/main/java/hex/DataInfo.java
@@ -1213,7 +1213,7 @@ public class DataInfo extends Keyed<DataInfo> {
     row.cid = rid;
     if(_weights)
       row.weight = chunks[weightChunkId()].atd(rid);
-    if(row.weight == 0) return row;
+   // if(row.weight == 0) return row;
     if (_skipMissing) {
       int N = _cats + _nums;
       for (int i = 0; i < N; ++i)

--- a/h2o-algos/src/main/java/hex/DataInfo.java
+++ b/h2o-algos/src/main/java/hex/DataInfo.java
@@ -1213,7 +1213,7 @@ public class DataInfo extends Keyed<DataInfo> {
     row.cid = rid;
     if(_weights)
       row.weight = chunks[weightChunkId()].atd(rid);
-   // if(row.weight == 0) return row;
+    if(row.weight == 0) return row;
     if (_skipMissing) {
       int N = _cats + _nums;
       for (int i = 0; i < N; ++i)

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -1861,7 +1861,11 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     final boolean detectedComputeMetrics = computeMetrics && (adaptFrm.vec(_output.responseName()) != null && !adaptFrm.vec(_output.responseName()).isBad());
     String [] domain = _output.nclasses()<=1 ? null : !detectedComputeMetrics ? _output._domains[_output._domains.length-1] : adaptFrm.lastVec().domain();
     // Score the dataset, building the class distribution & predictions
-    return new GLMScore(j, this, _output._dinfo.scoringInfo(_output._names,adaptFrm),domain,detectedComputeMetrics, generatePredictions);
+    GLMScore scoreObj = new GLMScore(j, this, _output._dinfo.scoringInfo(_output._names,adaptFrm),domain, 
+            detectedComputeMetrics, generatePredictions);
+    if (_parms._keep_cross_validation_predictions)
+      scoreObj._notKeepCVPred = false;
+    return scoreObj;
   }
   /** Score an already adapted frame.  Returns a new Frame with new result
    *  vectors, all in the DKV.  Caller responsible for deleting.  Input is

--- a/h2o-algos/src/main/java/hex/glm/GLMScore.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMScore.java
@@ -121,8 +121,8 @@ public class GLMScore extends MRTask<GLMScore> {
     if(_dinfo._responses != 0)res[0] = (float) r.response[0];
     if (r.predictors_bad) {
       Arrays.fill(ps,Double.NaN);
-    } else if(r.weight == 0) {
-      Arrays.fill(ps,0);
+/*    } else if(r.weight == 0) {
+      Arrays.fill(ps,0);*/
     } else {
       scoreRow(r, r.offset, ps);
       if (_computeMetrics && !r.response_bad)

--- a/h2o-algos/src/test/java/hex/glm/GLMTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMTest.java
@@ -2358,4 +2358,6 @@ public class GLMTest  extends TestUtil {
       Scope.exit();
     }
   }
+  
+  
 }


### PR DESCRIPTION
This PR fixed the bug caught by Zuzana: https://h2oai.atlassian.net/browse/PUBDEV-8249.

When there is a weight vector and when its value == 0, two things happen:
1. The extractDenseRow will not read in a new row when weight == 0.  However, this problem does not exist for extractSparseRow;
2. During scoring, if weight == 0, all prediction output will be 0.

I remove the check for weight == 0 in both cases and ran Zuzana's test.  It is working now.