### PR TITLE
[PUBDEV-8257] 'cross_validation_metrics_summary' on MOJO Models Use Wrong Type for Columns

### DIFF
--- a/h2o-algos/src/test/java/hex/deeplearning/DeepLearningTest.java
+++ b/h2o-algos/src/test/java/hex/deeplearning/DeepLearningTest.java
@@ -2091,7 +2091,7 @@ public class DeepLearningTest extends TestUtil {
       Assert.assertEquals(0.86556613, ((ModelMetricsBinomial)dl._output._cross_validation_metrics)._auc._auc,1e-4);
 
       int auc_row = Arrays.binarySearch(dl._output._cross_validation_metrics_summary.getRowHeaders(), "auc");
-      Assert.assertEquals(0.86556613, (double)dl._output._cross_validation_metrics_summary.get(auc_row,0), 1e-2);
+      Assert.assertEquals(0.86556613, (Float)dl._output._cross_validation_metrics_summary.get(auc_row,0), 1e-2);
 
     } finally {
       if (tfr != null) tfr.remove();
@@ -2177,7 +2177,7 @@ public class DeepLearningTest extends TestUtil {
       Assert.assertEquals(0.9115080346106303, ((ModelMetricsBinomial)dl._output._cross_validation_metrics)._auc._auc,1e-4);
 
       int auc_row = Arrays.binarySearch(dl._output._cross_validation_metrics_summary.getRowHeaders(), "auc");
-      Assert.assertEquals(0.913637, (double)dl._output._cross_validation_metrics_summary.get(auc_row,0), 1e-4);
+      Assert.assertEquals(0.913637, (Float)dl._output._cross_validation_metrics_summary.get(auc_row,0), 1e-4);
 
     } finally {
       if (tfr != null) tfr.remove();
@@ -2218,7 +2218,7 @@ public class DeepLearningTest extends TestUtil {
       Assert.assertEquals(117.8014, ((ModelMetricsRegression)dl._output._cross_validation_metrics)._mean_residual_deviance,1e-4);
 
       int mean_residual_deviance_row = Arrays.binarySearch(dl._output._cross_validation_metrics_summary.getRowHeaders(), "mean_residual_deviance");
-      Assert.assertEquals(117.8014, (double)dl._output._cross_validation_metrics_summary.get(mean_residual_deviance_row,0), 1);
+      Assert.assertEquals(117.8014, (Float)dl._output._cross_validation_metrics_summary.get(mean_residual_deviance_row,0), 1);
 
       // the same for distribution = AUTO representing Huber:
       DeepLearningParameters parms2 = new DeepLearningParameters();

--- a/h2o-algos/src/test/java/hex/deeplearning/DeepLearningTest.java
+++ b/h2o-algos/src/test/java/hex/deeplearning/DeepLearningTest.java
@@ -2091,7 +2091,7 @@ public class DeepLearningTest extends TestUtil {
       Assert.assertEquals(0.86556613, ((ModelMetricsBinomial)dl._output._cross_validation_metrics)._auc._auc,1e-4);
 
       int auc_row = Arrays.binarySearch(dl._output._cross_validation_metrics_summary.getRowHeaders(), "auc");
-      Assert.assertEquals(0.86556613, Double.parseDouble((String)(dl._output._cross_validation_metrics_summary).get(auc_row,0)), 1e-2);
+      Assert.assertEquals(0.86556613, (double)dl._output._cross_validation_metrics_summary.get(auc_row,0), 1e-2);
 
     } finally {
       if (tfr != null) tfr.remove();
@@ -2177,7 +2177,7 @@ public class DeepLearningTest extends TestUtil {
       Assert.assertEquals(0.9115080346106303, ((ModelMetricsBinomial)dl._output._cross_validation_metrics)._auc._auc,1e-4);
 
       int auc_row = Arrays.binarySearch(dl._output._cross_validation_metrics_summary.getRowHeaders(), "auc");
-      Assert.assertEquals(0.913637, Double.parseDouble((String)(dl._output._cross_validation_metrics_summary).get(auc_row,0)), 1e-4);
+      Assert.assertEquals(0.913637, (double)dl._output._cross_validation_metrics_summary.get(auc_row,0), 1e-4);
 
     } finally {
       if (tfr != null) tfr.remove();
@@ -2218,7 +2218,7 @@ public class DeepLearningTest extends TestUtil {
       Assert.assertEquals(117.8014, ((ModelMetricsRegression)dl._output._cross_validation_metrics)._mean_residual_deviance,1e-4);
 
       int mean_residual_deviance_row = Arrays.binarySearch(dl._output._cross_validation_metrics_summary.getRowHeaders(), "mean_residual_deviance");
-      Assert.assertEquals(117.8014, Double.parseDouble((String)(dl._output._cross_validation_metrics_summary).get(mean_residual_deviance_row,0)), 1);
+      Assert.assertEquals(117.8014, (double)dl._output._cross_validation_metrics_summary.get(mean_residual_deviance_row,0), 1);
 
       // the same for distribution = AUTO representing Huber:
       DeepLearningParameters parms2 = new DeepLearningParameters();

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -1880,9 +1880,9 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     int N = cvmodels.length;
     int extra_length=2; //mean/sigma/cv1/cv2/.../cvN
     String[] colTypes = new String[N+extra_length];
-    Arrays.fill(colTypes, "string");
+    Arrays.fill(colTypes, "float");
     String[] colFormats = new String[N+extra_length];
-    Arrays.fill(colFormats, "%s");
+    Arrays.fill(colFormats, "%f");
     String[] colNames = new String[N+extra_length];
     colNames[0] = "mean";
     colNames[1] = "sd";


### PR DESCRIPTION
Flow UI before the change:
![image](https://user-images.githubusercontent.com/3674621/127869109-46c97a88-3176-4933-a9c1-63d48e04f164.png)

Flow UI after the change:
![image](https://user-images.githubusercontent.com/3674621/127869191-8a8b46df-7c0b-419b-aa8f-1f61dab242ef.png)


Serialized `cross_validation_metrics_summary` after the change: 
```
      "cross_validation_metrics_summary": {
        "name": "Cross-Validation Metrics Summary",
        "description": "",
        "columns": [
          {
            "name": "",
            "type": "string",
            "format": "%s",
            "description": ""
          },
          {
            "name": "mean",
            "type": "float",
            "format": "%f",
            "description": "mean"
          },
          {
            "name": "sd",
            "type": "float",
            "format": "%f",
            "description": "sd"
          },
          {
            "name": "cv_1_valid",
            "type": "float",
            "format": "%f",
            "description": "cv_1_valid"
          },
          {
            "name": "cv_2_valid",
            "type": "float",
            "format": "%f",
            "description": "cv_2_valid"
          },
          {
            "name": "cv_3_valid",
            "type": "float",
            "format": "%f",
            "description": "cv_3_valid"
          }
        ],
        "rowcount": 8,
        "data": [
          [
            "mae",
            "mean_residual_deviance",
            "mse",
            "null_deviance",
            "r2",
            "residual_deviance",
            "rmse",
            "rmsle"
          ],
          [
            5.249874,
            42.981117,
            42.981117,
            4241.9937,
            -0.034168337,
            4329.0825,
            6.5461693,
            0.10129108
          ],
          [
            0.100146376,
            5.8517942,
            5.8517942,
            235.73878,
            0.03448591,
            293.41086,
            0.43952286,
            0.01012987
          ],
          [
            5.134717,
            38.70422,
            38.70422,
            4206.2153,
            0.0030673447,
            4180.0557,
            6.2212715,
            0.09408198
          ],
          [
            5.316587,
            49.649975,
            49.649975,
            4493.5767,
            -0.065009356,
            4667.0977,
            7.0462737,
            0.11287285
          ],
          [
            5.2983184,
            40.589157,
            40.589157,
            4026.1895,
            -0.040563,
            4140.094,
            6.370962,
            0.09691842
          ]
        ]
      }
 ```