### PR TITLE
Fixed test to not use advanced Python command not supported by older Python version

### DIFF
--- a/h2o-py/tests/testdir_algos/glm/pyunit_pubdev_8190-remove-collinear-columns-multinomial_jeffP.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_pubdev_8190-remove-collinear-columns-multinomial_jeffP.py
@@ -1,28 +1,16 @@
 from __future__ import division
 from __future__ import print_function
-from past.utils import old_div
 import sys
 sys.path.insert(1,"../../../")
 import h2o
 from tests import pyunit_utils
 from h2o.estimators.glm import H2OGeneralizedLinearEstimator
-import numpy as np
-from random import randint
 
 # I copied this test from Jeff Plourde.  Thank you.
 # This test just needs to run to completion without receiving any error.  There is no assert statement needed here.
-def generate_data(class_centers, sz, seed = 23):
-    rng = np.random.default_rng(seed)
-
-    X = np.vstack([rng.normal(cent, 1, size=(sz, 2)) for cent in class_centers])
-    X = np.column_stack([X, X.sum(1)])
-    y = np.concatenate([np.full(sz, cls) for cls in range(len(class_centers))])
-    train = h2o.H2OFrame(np.column_stack([y, X]))
-    train[train.col_names[0]] = train[train.col_names[0]].asfactor()
-    return train
-
 def remove_collinear_columns_multinomial():
-    train = generate_data([0,5,10], 100)
+    train = h2o.import_file(pyunit_utils.locate("smalldata/glm_test/multinomial_rcc.csv"))
+    train[0] = train[0].asfactor()
     mdl = H2OGeneralizedLinearEstimator(solver='IRLSM', family='multinomial', link='family_default', seed=76,
                                         lambda_=[0], max_iterations=100000, beta_epsilon=1e-7, early_stopping=False,
                                         standardize=True, remove_collinear_columns=True)


### PR DESCRIPTION
The np.random.default_rng command is not supported by older Python version we have on our Jenkins machine.  I just saved a generated training dataset and during testing, have the test load the training dataset back.  This avoided using the np.random.default_rng command.