### PR TITLE
PUBDEV-8096: Added note about memory use when using XGBoost/AutoML to user guide [nocheck]

### DIFF
--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -146,6 +146,7 @@ If the user sets ``nfolds == 0``, then cross-validation metrics will not be avai
 
 ``H2OAutoML`` can interact with the ``h2o.sklearn`` module. The ``h2o.sklearn`` module exposes 2 wrappers for ``H2OAutoML`` (``H2OAutoMLClassifier`` and ``H2OAutoMLRegressor``), which expose the standard API familiar to ``sklearn`` users: ``fit``, ``predict``, ``fit_predict``, ``score``, ``get_params``, and ``set_params``. It accepts various formats as input data (H2OFrame, ``numpy`` array, ``pandas`` Dataframe) which allows them to be combined with pure ``sklearn`` components in pipelines. For an example using ``H2OAutoML`` with the ``h2o.sklearn`` module, click `here <https://github.com/h2oai/h2o-tutorials/blob/master/tutorials/sklearn-integration/H2OAutoML_as_sklearn_estimator.ipynb>`__.
 
+XGBoost requires its own memory outside the H2O (Java) cluster. When running AutoML with XGBoost, be sure you allow H2O-3 no more than 2/3 of the total available RAM.
 
 Explainability
 --------------

--- a/h2o-docs/src/product/data-science/xgboost.rst
+++ b/h2o-docs/src/product/data-science/xgboost.rst
@@ -416,7 +416,11 @@ Below is a simple example showing how to build a XGBoost model.
 
     # Extract feature interactions:
     feature_interactions = titanic_xgb.feature_interaction()
-  
+
+Note
+''''
+
+XGBoost requires its own memory outside the H2O (Java) cluster. When running XGBoost, be sure you allow H2O-3 no more than 2/3 of the total available RAM.
 
 FAQs
 ~~~~


### PR DESCRIPTION
For: [PUBDEV-8096](https://h2oai.atlassian.net/browse/PUBDEV-8096) / [PUBDEV-8095](https://h2oai.atlassian.net/browse/PUBDEV-8095)

I added the note to the "notes" section of AutoML and then added the note directly beneath the XGBoost example. Let me know if you would like anything changed!