### PR TITLE
HEXDEV-0773: Remove log4j classes that are not relevant for H2O-3 deployments

### DIFF
--- a/h2o-assemblies/main/build.gradle
+++ b/h2o-assemblies/main/build.gradle
@@ -79,6 +79,9 @@ shadowJar {
   exclude 'test.properties'
   exclude 'cockpitlite.properties'
   exclude 'devpay_products.properties'
+  exclude 'org/apache/log4j/net/*'
+  exclude 'org/apache/log4j/jdbc/*'
+  exclude 'org/apache/log4j/nt/*'
   manifest {
     attributes 'Main-Class': 'water.H2OApp'
   }

--- a/h2o-hadoop-2/assemblyjar.gradle
+++ b/h2o-hadoop-2/assemblyjar.gradle
@@ -100,7 +100,10 @@ def hadoopShadowJarExcludes = ['META-INF/*.DSA',
                             'uploader.properties',
                             'test.properties',
                             'cockpitlite.properties',
-                            'devpay_products.properties',
+                            'devpay_products.properties', 
+                            'org/apache/log4j/net/*',
+                            'org/apache/log4j/jdbc/*',
+                            'org/apache/log4j/nt/*',
                             // the license files are excluded for OS X compatibility (this is mainly for development)
                             // OS X is unable to unpack these files from the jar on filesystem that is not case sensitive
                             'LICENSE', 'license', 'LICENSE/*', 'license/*', 'META-INF/license', 'META-INF/LICENSE'

--- a/h2o-hadoop-3/assemblyjar_common.gradle
+++ b/h2o-hadoop-3/assemblyjar_common.gradle
@@ -64,6 +64,9 @@ def hadoopShadowJarExcludes = ['META-INF/*.DSA',
                                'test.properties',
                                'cockpitlite.properties',
                                'devpay_products.properties',
+                               'org/apache/log4j/net/*',
+                               'org/apache/log4j/jdbc/*',
+                               'org/apache/log4j/nt/*',
                                // the license files are excluded for OS X compatibility (this is mainly for development)
                                // OS X is unable to unpack these files from the jar on filesystem that is not case sensitive
                                'LICENSE', 'license', 'LICENSE/*', 'license/*', 'META-INF/license', 'META-INF/LICENSE'


### PR DESCRIPTION
SocketServer is affected by vulnerability CVE-2019-17571

https://nvd.nist.gov/vuln/detail/CVE-2019-17571