### PR TITLE
PUBDEV-8279: Fixed typo in replacing-values.rst code example docs

### DIFF
--- a/h2o-docs/src/product/data-munging/replacing-values.rst
+++ b/h2o-docs/src/product/data-munging/replacing-values.rst
@@ -22,7 +22,7 @@ This example shows how to replace numeric values in a frame of data. Note that i
 
         # Replace by row mask. The example below searches for value less than 4.4 in the 
         # sepal_len column and replaces those values with 4.6. 
-        df[df[, "sepal_len"] <- 4.4, "sepal_len"] <- 4.6
+        df[df[, "sepal_len"] < 4.4, "sepal_len"] <- 4.6
 
         # Replace using ifelse. Similar to the previous example, 
         # this replaces values less than 4.6 with 4.6. 


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8279

Fix typo in code example at h2o-docs/src/product/data-munging/replacing-values.rst 

Previous example showed the following typo, using an assignment operator (<-) rather than less than symbol (<) to replace values less than 4.4

`df[df[, "sepal_len"] <- 4.4, "sepal_len"] <- 4.6`