### PR TITLE
PUBDEV-8267: Fixed NPE from multiple runs with knots specified in frame

### DIFF
--- a/h2o-algos/src/main/java/hex/gam/GAM.java
+++ b/h2o-algos/src/main/java/hex/gam/GAM.java
@@ -150,7 +150,7 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
         gamIndex = csInd++;
       knots[gamIndex] = new double[_parms._gam_columns[outIndex].length][];
       if (tempKey != null && (tempKey.length() > 0)) {  // read knots location from Frame given by user      
-        final Frame knotFrame = Scope.track((Frame) DKV.getGet(Key.make(tempKey)));
+        final Frame knotFrame = DKV.getGet(Key.make(tempKey));
         double[][] knotContent = new double[(int) knotFrame.numRows()][_parms._gam_columns[outIndex].length];
         final ArrayUtils.FrameToArray f2a = new ArrayUtils.FrameToArray(0,
                 _parms._gam_columns[outIndex].length - 1, knotFrame.numRows(), knotContent);

--- a/h2o-r/tests/testdir_algos/gam/runit_PUBDEV_8267_twice_run_npe.R
+++ b/h2o-r/tests/testdir_algos/gam/runit_PUBDEV_8267_twice_run_npe.R
@@ -1,0 +1,24 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# copied test from JIRA by Erin
+test.model.gam.multiple.runs.npe <- function() {
+  knots1 <- c(-1.99905699, -0.98143075, 0.02599159, 1.00770987, 1.99942290)
+  frame_Knots1 <- as.h2o(knots1)
+  h2o_data <- h2o.importFile(locate("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"))
+  h2o_data[["C1"]] <- as.factor(h2o_data[["C1"]])
+  gam_model <- h2o.gam(x = "C6", y = "C1", training_frame = h2o_data, family = 'multinomial', gam_columns = "C6", scale = 1,
+                       num_knots = 5, knot_ids = h2o.keyof(frame_Knots1))
+  mse1 <- h2o.mse(gam_model)
+  gam_model <- h2o.gam(x = "C6", y = "C1", training_frame = h2o_data, family = 'multinomial', gam_columns = "C6", scale = 1,
+                       num_knots = 5, knot_ids = h2o.keyof(frame_Knots1))
+  mse2 <- h2o.mse(gam_model)
+  gam_model <- h2o.gam(x = "C6", y = "C1", training_frame = h2o_data, family = 'multinomial', gam_columns = "C6", scale = 1,
+                       num_knots = 5, knot_ids = h2o.keyof(frame_Knots1))
+  mse3 <- h2o.mse(gam_model)
+  expect_true(abs(mse1-mse2) < 1e-6) # all metrics should equal
+  expect_true(abs(mse2-mse3) < 1e-6)
+}
+
+doTest("General Additive Model test for multiple run NPE found", test.model.gam.multiple.runs.npe)
+


### PR DESCRIPTION
This PR resolves the issue in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8267

I removed adding the frame for knots from being tracked in Scope.  This actually delete the frame after scope exit.  

Add junit and runit tests to make sure my fix works and there is no leaked keys.