### PR TITLE
PUBDEV-8290: Fix explain bugs

### DIFF
--- a/h2o-py/tests/testdir_misc/pyunit_explain.py
+++ b/h2o-py/tests/testdir_misc/pyunit_explain.py
@@ -117,6 +117,14 @@ def test_explanation_automl_regression():
     # test explain row
     assert isinstance(aml.explain_row(train, 1, render=False), H2OExplanation)
 
+    # test shortening model ids work correctly
+    from h2o.explanation._explain import _shorten_model_ids
+    model_ids = aml.leaderboard.as_data_frame()["model_id"]
+    shortened_model_ids = _shorten_model_ids(model_ids)
+    assert len(set(model_ids)) == len(set(shortened_model_ids))
+    for i in range(len(model_ids)):
+        assert len(model_ids[i]) > len(shortened_model_ids[i])
+
 
 def test_explanation_list_of_models_regression():
     train = h2o.upload_file(pyunit_utils.locate("smalldata/wine/winequality-redwhite-no-BOM.csv"))
@@ -209,6 +217,12 @@ def test_explanation_single_model_binomial_classification():
     # test explain row
     assert isinstance(gbm.explain_row(train, 1, render=False), H2OExplanation)
 
+    # test explain
+    assert isinstance(gbm.explain(train, top_n_features=-1,  render=False), H2OExplanation)
+
+    # test explain row
+    assert isinstance(gbm.explain_row(train, 1, top_n_features=-1, render=False), H2OExplanation)
+
 
 def test_explanation_automl_binomial_classification():
     train = h2o.upload_file(pyunit_utils.locate("smalldata/logreg/prostate.csv"))
@@ -244,6 +258,7 @@ def test_explanation_automl_binomial_classification():
 
     # test explain row
     assert isinstance(aml.explain_row(train, 1, render=False), H2OExplanation)
+
 
 
 def test_explanation_list_of_models_binomial_classification():

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -473,14 +473,18 @@ with_no_h2o_progress <- function(expr) {
   leaderboard <-
     as.data.frame(t(sapply(models_info$model_ids, function(m) {
       m <- models_info$get_model(m)
-      unlist(h2o.performance(m, leaderboard_frame)@metrics[c(
-        "MSE",
-        "RMSE",
-        "mae",
-        "rmsle",
+      metrics <- h2o.performance(m, leaderboard_frame)@metrics
+      unlist(metrics[intersect(c(
+        "AUC",
+        "mean_residual_deviance",
         "mean_per_class_error",
-        "logloss"
-      )])
+        "logloss",
+        "pr_auc",
+        "RMSE",
+        "MSE",
+        "mae",
+        "rmsle"
+      ), names(metrics))])
     })))
   leaderboard <- cbind(data.frame(model_id = .model_ids(models_info$model_ids), stringsAsFactors = FALSE),
                        leaderboard)
@@ -1080,6 +1084,11 @@ h2o.shap_summary_plot <-
     if (!missing(columns) && !missing(top_n_features)) {
       warning("Parameters columns, and top_n_features are mutually exclusive. Parameter top_n_features will be ignored.")
     }
+
+    if (top_n_features < 0) {
+      top_n_features <- Inf
+    }
+
     if (!(is.null(columns) ||
       is.character(columns) ||
       is.numeric(columns))) {
@@ -1285,6 +1294,9 @@ h2o.shap_explain_row_plot <-
 
     if (!missing(columns) && !missing(top_n_features)) {
       warning("Parameters columns, and top_n_features are mutually exclusive. Parameter top_n_features will be ignored.")
+    }
+    if (top_n_features < 0) {
+      top_n_features <- Inf
     }
     if (!(is.null(columns) ||
       is.character(columns) ||
@@ -2851,6 +2863,11 @@ h2o.explain <- function(object,
     is.numeric(columns))) {
     stop("Parameter columns must be either a character or numeric vector or NULL.")
   }
+
+  if (top_n_features < 0) {
+    top_n_features <- Inf
+  }
+
   skip_explanations <- c()
 
   if (!missing(include_explanations)) {
@@ -3235,6 +3252,11 @@ h2o.explain_row <- function(object,
     is.numeric(columns))) {
     stop("Parameter columns must be either a character or numeric vector or NULL.")
   }
+
+  if (top_n_features < 0) {
+    top_n_features <- Inf
+  }
+
   skip_explanations <- c()
 
   if (!missing(include_explanations)) {

--- a/h2o-r/tests/testdir_misc/runit_explain.R
+++ b/h2o-r/tests/testdir_misc/runit_explain.R
@@ -189,6 +189,12 @@ explanation_test_single_model_binomial_classification <- function() {
 
   # test explanation
   expect_true("H2OExplanation" %in% class(h2o.explain_row(gbm, train, 1)))
+
+  # test explanation
+  expect_true("H2OExplanation" %in% class(h2o.explain(gbm, train, top_n_features = -1)))
+
+  # test explanation
+  expect_true("H2OExplanation" %in% class(h2o.explain_row(gbm, train, 1, top_n_features = -1)))
 }
 
 explanation_test_automl_binomial_classification <- function() {
@@ -370,6 +376,14 @@ explanation_test_automl_multinomial_classification <- function() {
 
   # test explanation
   expect_true("H2OExplanation" %in% class(h2o.explain_row(aml, train, 1)))
+
+  # test shortening model ids work
+  model_ids <- as.character(as.list(aml@leaderboard$model_id))
+  shortened_model_ids <- .shorten_model_ids(model_ids)
+  expect_true(length(model_ids) == length(shortened_model_ids))
+  for (i in seq_along(model_ids)) {
+    expect_true(nchar(model_ids[i]) > nchar(shortened_model_ids[i]))
+  }
 }
 
 explanation_test_list_of_models_multinomial_classification <- function() {


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8290

Fix:
* Explain list of models shows incomplete leaderboard (missing AUC in binomial classification) and reorder the columns to be more in line with the leaderboard from automl
* Fix confusion matrix for binomial tasks in python (used the .confusion_matrix which used the training confusion matrix)
* Allow specifying -1 to num_of_features to show all the features (used to show all but last (in python  features[:-1]))

And add simple test to make sure `shorten_model_ids` work. 