### PR TITLE
PUBDEV-8292: Changed time limits for merge/sort benchmark

### DIFF
--- a/scripts/jenkins/groovy/compareBenchmarksStage.groovy
+++ b/scripts/jenkins/groovy/compareBenchmarksStage.groovy
@@ -250,7 +250,7 @@ def call(final pipelineContext, final stageConfig, final benchmarkFolderConfig) 
         'merge': [
             'fileSize100millionRows2ColsallxyTF': [
                 [100000000, 2]: [
-                    'train_time_min': 33,
+                    'train_time_min': 30,
                     'train_time_max': 37
                 ]
             ],
@@ -262,7 +262,7 @@ def call(final pipelineContext, final stageConfig, final benchmarkFolderConfig) 
             ],
             'fileSize100millionRows2ColsallxyFF': [
                 [100000000, 2]: [
-                    'train_time_min': 33,
+                    'train_time_min': 30,
                     'train_time_max': 37
                 ]
             ],
@@ -283,7 +283,7 @@ def call(final pipelineContext, final stageConfig, final benchmarkFolderConfig) 
             'fileSize10millionRows2Cols': [
                 [10000000, 2]: [
                     'train_time_min': 2,
-                    'train_time_max': 5
+                    'train_time_max': 7
                 ]
             ]
         ],


### PR DESCRIPTION
This PR resolves the failure in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8292

I grabbed the results of multiple failing benchmark runs here: 

<img width="823" alt="image" src="https://user-images.githubusercontent.com/7231712/130491367-2b7ad18f-6f94-4ec1-ad5d-a2616c8c5d61.png">

I just adjust the run times according to my new results.


