### PR TITLE
Fix failing test learning curve plot [nocheck]

### DIFF
--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -2699,6 +2699,7 @@ h2o.learning_curve_plot <- function(model,
     labels <- sort(unique(scoring_history$type))
 
   labels <- names(colors)[names(colors) %in% labels]
+  colors <- colors[labels]
   p <- ggplot2::ggplot(ggplot2::aes_string(
     x = "x",
     y = "metric",


### PR DESCRIPTION
In a new version of `ggplot2`, there seems to be a new consistency check that requires to have the same amount of aesthetics (color in this case) as entries in the legend.

This fix removes the unused colors so that `ggplot2` gets only those colors that are actually used.