### PR TITLE
PUBDEV-8319: Implement a java-self-check to allow community users run on latest Java

### DIFF
--- a/h2o-app/src/main/java/water/H2OApp.java
+++ b/h2o-app/src/main/java/water/H2OApp.java
@@ -6,7 +6,7 @@ public class H2OApp extends H2OStarter {
   
   public static void main(String[] args) {
 
-    if (H2O.checkUnsupportedJava())
+    if (H2O.checkUnsupportedJava(args))
       System.exit(BAD_JAVA_VERSION_RETURN_CODE);
 
     start(args, System.getProperty("user.dir"));

--- a/h2o-core/src/main/java/water/HeartBeat.java
+++ b/h2o-core/src/main/java/water/HeartBeat.java
@@ -7,7 +7,7 @@ import water.init.JarHash;
  * Struct holding H2ONode health info.
  * @author <a href="mailto:cliffc@h2o.ai"></a>
  */
-public class HeartBeat extends Iced<HeartBeat> {
+public class HeartBeat extends Iced<HeartBeat> implements BootstrapFreezable<HeartBeat> {
   char _hb_version;             // Incrementing counter for sorting timelines better.
   int _cloud_hash;              // Cloud-membership hash
   int _cloud_name_hash;         // Hash of this cloud's name

--- a/h2o-core/src/main/java/water/JavaSelfCheck.java
+++ b/h2o-core/src/main/java/water/JavaSelfCheck.java
@@ -1,0 +1,64 @@
+package water;
+
+import water.util.UnsafeUtils;
+
+import java.util.Random;
+
+public class JavaSelfCheck {
+
+    /**
+     * Runs basic checks to ensure that H2O is compatible with the current JVM
+     * 
+     * @return true if all compatibility checks passed, false otherwise
+     */
+    public static boolean checkCompatibility() {
+        if (!checkUnsafe())
+            return false;
+        if (!checkWeaver())
+            return false;
+        return checkSerialization();
+    }
+
+    // Are we able to serialize and deserialize data?
+    private static boolean checkSerialization() {
+        byte[] bytes = AutoBuffer.serializeBootstrapFreezable(new HeartBeat());
+        return AutoBuffer.deserializeBootstrapFreezable(bytes) instanceof HeartBeat;
+    }
+
+    // Are we able to generate Icers? Does javassist work as expected?
+    private static boolean checkWeaver() {
+        // HeartBeat class is guaranteed to be part of boostrap classes, otherwise clouding couldn't work
+        Freezable<?> f = TypeMap.newFreezable(HeartBeat.class.getName());
+        if (! (f instanceof HeartBeat)) {
+            return false;
+        }
+        // check that we can generate Icer
+        return TypeMap.getIcer(f) != null;
+    }
+
+    // Is Unsafe available and working as expected?
+    private static boolean checkUnsafe() {
+        final int N = 1024;
+        final Random r = new Random();
+        final double[] doubleData = new double[N];
+        final byte[] doubleBytes = new byte[N * 8];
+        final long[] longData = new long[N];
+        final byte[] longBytes = new byte[N * 8];
+        for (int i = 0; i < N; i++) {
+            doubleData[i] = r.nextDouble();
+            UnsafeUtils.set8d(doubleBytes, i * 8, doubleData[i]);
+            longData[i] = r.nextLong();
+            UnsafeUtils.set8(longBytes, i * 8, longData[i]);
+        }
+        for (int i = 0; i < N; i++) {
+            double d = UnsafeUtils.get8d(doubleBytes, i * 8);
+            if (d != doubleData[i])
+                return false;
+            long l = UnsafeUtils.get8(longBytes, i * 8);
+            if (l != longData[i])
+                return false;
+        }
+        return true;
+    }
+
+}

--- a/h2o-core/src/main/java/water/JavaVersionSupport.java
+++ b/h2o-core/src/main/java/water/JavaVersionSupport.java
@@ -41,4 +41,9 @@ public class JavaVersionSupport {
         }
         return false;
     }
+
+    public static String describeSupportedVersions() {
+        return MIN_SUPPORTED_JAVA_VERSION + "-" + MAX_SUPPORTED_JAVA_VERSION;
+    }
+
 }

--- a/h2o-core/src/test/java/water/JavaSelfCheckTest.java
+++ b/h2o-core/src/test/java/water/JavaSelfCheckTest.java
@@ -1,0 +1,24 @@
+package water;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import water.runner.CloudSize;
+import water.runner.H2ORunner;
+
+import static org.junit.Assert.*;
+
+@CloudSize(1)
+@RunWith(H2ORunner.class)
+public class JavaSelfCheckTest {
+
+    @Test
+    public void checkCompatibility() {
+        assertTrue(JavaSelfCheck.checkCompatibility());
+    }
+
+    @Test
+    public void checkCompatibility_dynamic() throws Exception {
+        assertTrue(H2O.dynamicallyInvokeJavaSelfCheck());
+    }
+
+}

--- a/h2o-py/h2o/backend/server.py
+++ b/h2o-py/h2o/backend/server.py
@@ -276,9 +276,6 @@ class H2OLocalServer(object):
             print("  Starting server from " + self._jar_path)
             print("  Ice root: " + self._ice_root)
 
-        # Combine jar path with the optional extra classpath
-        classpath = [self._jar_path] if self._extra_classpath is None else [self._jar_path] + self._extra_classpath
-
         # Construct java command to launch the process
         cmd = [java]
 
@@ -295,7 +292,14 @@ class H2OLocalServer(object):
                 assert type(arg) is str
                 cmd += [arg]
 
-        cmd += ["-cp", os.pathsep.join(classpath), "water.H2OApp"]  # This should be the last JVM option
+        # This should be the last JVM option
+        if self._extra_classpath is None:
+            # Use jar file directly
+            cmd += ["-jar", self._jar_path]
+        else:
+            # Combine jar path with the optional extra classpath
+            classpath = [self._jar_path] + self._extra_classpath
+            cmd += ["-cp", os.pathsep.join(classpath), "water.H2OApp"]
 
         # ...add H2O options
         cmd += ["-ip", self._ip]
@@ -322,6 +326,7 @@ class H2OLocalServer(object):
         # Warning: do not change to any higher log-level, otherwise we won't be able to know which port the
         # server is listening to.
         cmd += ["-log_level", "INFO"]
+        cmd += ["-allow_unsupported_java"]
 
         # Create stdout and stderr files
         self._stdout = self._tmp_file("stdout")

--- a/h2o-py/tests/testdir_apis/H2O_Init/h2o.init_test.py
+++ b/h2o-py/tests/testdir_apis/H2O_Init/h2o.init_test.py
@@ -120,12 +120,18 @@ def h2oinit_fail_invalid_log_level():
     finally:
         h2o.cluster().shutdown()
 
+def h2oinit_with_extra_classpath():
+    try:
+        h2o.init(strict_version_check=False, extra_classpath=[os.path.realpath(__file__)], port=40000)
+    finally:
+        h2o.cluster().shutdown()
 
 # None of the tests below need a pre initialized instance
 h2oinit_default_log_dir()
 h2oinit_custom_log_dir()
 h2oinit_fail_invalid_log_level()
 h2oinitname()
+h2oinit_with_extra_classpath()
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oinit)

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -647,8 +647,12 @@ h2o.resume <- function(recovery_dir=NULL) {
   if(enable_assertions) args <- c(args, "-ea")
   if(!is.null(jvm_custom_args)) args <- c(args,jvm_custom_args)
 
-  class_path <- paste0(c(jar_file, extra_classpath), collapse=.Platform$path.sep)
-  args <- c(args, "-cp", class_path, "water.H2OApp")
+  if (!is.null(extra_classpath)) {
+    class_path <- paste0(c(jar_file, extra_classpath), collapse=.Platform$path.sep)
+    args <- c(args, "-cp", class_path, "water.H2OApp")
+  } else {
+    args <- c(args, "-jar", jar_file)
+  }
   args <- c(args, "-name", name)
   args <- c(args, "-ip", ip)
   if (bind_to_localhost) {
@@ -663,6 +667,7 @@ h2o.resume <- function(recovery_dir=NULL) {
 
   if(nthreads > 0L) args <- c(args, "-nthreads", nthreads)
   if(!is.null(license)) args <- c(args, "-license", license)
+  args <- c(args, "-allow_unsupported_java")
 
   cat("\n")
   cat(        "Note:  In case of errors look at the following log files:\n")

--- a/h2o-r/tests/testdir_jira/h2o.init_test_HOQE-16.R
+++ b/h2o-r/tests/testdir_jira/h2o.init_test_HOQE-16.R
@@ -8,6 +8,31 @@ options(h2o.dev.javacheck.disable = TRUE)
 
 library(h2o)
 
+check_cluster <- function() {
+  #Way to check if cluster is up and also get status:
+  cluster_up = h2o.clusterIsUp()
+  cluster_status = h2o.clusterStatus()
+  #Logical test to see if status is healthy or not
+  if(cluster_status$healthy == TRUE & cluster_up == TRUE){
+    cat("Cluster is up and healthy")
+  }else if(cluster_status$healthy != TRUE & cluster_up == TRUE){
+    stop("Cluster is up but not healthy")
+  }else{
+    stop("Cluster is not up and is not healthy")
+  }
+}
+
+check_cluster_and_shutdown <- function() {
+  check_cluster()
+  conn <- h2o.getConnection()
+  h2o.shutdown(prompt = FALSE)
+
+  while(h2o.clusterIsUp(conn)) {
+    print("Cluster is still up")
+    Sys.sleep(1)
+  }
+}
+
 #Sometimes we want to add extra system properties to JVM invocation (eg. allow running on unsupported Java version)
 jvm_custom_args = Sys.getenv("ADDITIONAL_TEST_JVM_OPTS")
 print(sprintf("ADDITIONAL_TEST_JVM_OPTS: %s", jvm_custom_args))
@@ -21,15 +46,13 @@ h2o.shutdown(prompt = FALSE)
 #Load up h2o and h2o.init()
 h2o.init(jvm_custom_args = jvm_custom_args)
 
-#Way to check if cluster is up and also get status:
-cluster_up = h2o.clusterIsUp()
-cluster_status = h2o.clusterStatus()
+check_cluster_and_shutdown()
 
-#Logical test to see if status is healthy or not
-if(cluster_status$healthy == TRUE & cluster_up == TRUE){
-  cat("Cluster is up and healthy")
-}else if(cluster_status$healthy != TRUE & cluster_up == TRUE){
-  stop("Cluster is up but not healthy")
-}else{
-  stop("Cluster is not up and is not healthy")
-}
+
+#We just need anything (in this case we use the h2o.jar) to add to the classpath to check that init works with extra_classpath as well
+extra_classpath <- h2o:::.h2o.downloadJar()
+
+h2o.init(jvm_custom_args = jvm_custom_args, extra_classpath = extra_classpath)
+
+check_cluster()
+h2o.shutdown(prompt = FALSE)


### PR DESCRIPTION
H2O has a strict process for certifying the product on compatible Java versions. With recent cadence of Java releases this became an issue for community users. We are usually little behind on the latest supported Java.

While there definitely are Java related issues, the fact is that with state of the Java ecosystem H2O can reliably on any modern and maintained JVM implementation.

This PR replaces a strict check for java version with a dynamic check of JVM capabilities. This means community users (users starting H2O from R/Python) should be able to run H2O even on Java versions that were not certified as long as the self-check is passed.

It also means that users can upgrade Java and keep their older version of H2O.