### PR TITLE
PUBDEV-8245 Prevent R connect from starting h2o locally

### DIFF
--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -310,7 +310,6 @@ h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, start
 #' \dontrun{
 #' library(h2o)
 #' # Try to connect to a H2O instance running at http://localhost:54321/cluster_X
-#' # If not found, start a local H2O instance from R with the default settings.
 #' #h2o.connect(ip = "localhost", port = 54321, context_path = "cluster_X")
 #' # Or
 #' #config = list(ip = "localhost", port = 54321, context_path = "cluster_X")
@@ -335,7 +334,7 @@ h2o.connect <- function(ip = "localhost", port = 54321, strict_version_check = T
    do.call(h2o.init, c(startH2O=FALSE, config))
  } else {
    # Pass arguments directly
-   h2o.init(ip=ip, port=port, strict_version_check=strict_version_check,
+   h2o.init(ip=ip, port=port, startH2O=FALSE, strict_version_check=strict_version_check,
             proxy=proxy, https=https, cacert=cacert, insecure=insecure, password=password,
             username=username, use_spnego=use_spnego, cookies=cookies, context_path=context_path)
  }

--- a/h2o-r/tests/testdir_misc/runit_connect.R
+++ b/h2o-r/tests/testdir_misc/runit_connect.R
@@ -1,0 +1,31 @@
+setwd(normalizePath(dirname(
+  R.utils::commandArgs(asValues = TRUE)$"f"
+)))
+
+h2oRDir <- normalizePath(paste(dirname(R.utils::commandArgs(asValues=TRUE)$"f"),"..","..",sep=.Platform$file.sep))
+to_src <- c("aggregator.R", "classes.R", "connection.R","config.R", "constants.R", "logging.R", "communication.R",
+            "kvstore.R", "frame.R", "targetencoder.R", "astfun.R","automl.R", "import.R", "parse.R", "export.R", "models.R", "edicts.R",
+            "coxph.R", "coxphutils.R", "gbm.R", "glm.R", "gam.R", "glrm.R", "kmeans.R", "deeplearning.R", "randomforest.R", "generic.R",
+            "naivebayes.R", "pca.R", "svd.R", "locate.R", "grid.R", "word2vec.R", "w2vutils.R", "stackedensemble.R", "rulefit.R",
+            "predict.R", "xgboost.R", "isolationforest.R", "psvm.R", "segment.R", "tf-idf.R", "explain.R", "permutation_varimp.R", "extendedisolationforest.R")
+src_path <- paste(h2oRDir,"h2o-package","R",sep=.Platform$file.sep)
+invisible(lapply(to_src,function(x){source(paste(src_path, x, sep = .Platform$file.sep))}))
+
+source("../runitUtils/utilsR.R")
+default.packages()
+Log.info("Loaded default packages. Additional required packages must be loaded explicitly.")
+
+h2o_connect_test <- function() {
+
+  e <- tryCatch({
+    h2o.connect()
+  }, error = function(x) x)
+  
+  expect_false(is.null(e))
+  print(e)
+  err_message <- e[[1]]
+  expect_true("Cannot connect to H2O server. Please check that H2O is running at http://localhost:54321/" == err_message)
+}
+
+doTest("Error thrown when h2o.connect() is called on non-existent cluster (local cluster)",
+       h2o_connect_test)

--- a/h2o-r/tests/testdir_misc/runit_connect.R
+++ b/h2o-r/tests/testdir_misc/runit_connect.R
@@ -27,5 +27,4 @@ h2o_connect_test <- function() {
   expect_true("Cannot connect to H2O server. Please check that H2O is running at http://localhost:54321/" == err_message)
 }
 
-doTest("Error thrown when h2o.connect() is called on non-existent cluster (local cluster)",
-       h2o_connect_test)
+doTest("Test that h2o.connect() throws error when connecting to a non-existent cluster", h2o_connect_test)


### PR DESCRIPTION
This fixes the error `Can only start H2O launcher if IP address is localhost.` when the user trys to connect to a non-localhost cluster using an `ip` argument and the cluster is not found.

Fixes https://h2oai.atlassian.net/browse/PUBDEV-8245