### PR TITLE
Log4j2 produces a warning on Java 10+ [nocheck]

### DIFF
--- a/h2o-assemblies/main/build.gradle
+++ b/h2o-assemblies/main/build.gradle
@@ -85,6 +85,7 @@ shadowJar {
   exclude 'devpay_products.properties'
   manifest {
     attributes 'Main-Class': 'water.H2OApp'
+    attributes 'Multi-Release': 'true'
   }
   transform(com.github.jengelman.gradle.plugins.shadow.transformers.IncludeResourceTransformer.class) {
     file = file("${buildDir}/reports/license/dependency-license.xml")


### PR DESCRIPTION
java -Dsys.ai.h2o.debug.noJavaVersionCheck=true -jar h2o.jar
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.

Fix based on https://stackoverflow.com/questions/53049346/is-log4j2-compatible-with-java-11