### PR TITLE
PUBDEV-8326: Fix matplotlib's 3.4 issue with one value in where argument in fill_between call

### DIFF
--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -1367,8 +1367,8 @@ class ModelBase(h2o_meta(Keyed)):
             axs.set_xlim(min(x) - 0.2, max(x) + 0.2)
         if plot_stddev:
             std = pp[pp_start_index+2]
-            upper = [a + b for a, b in zip(y, std)]  # pp[1] is mean, pp[2] is std
-            lower = [a - b for a, b in zip(y, std)]
+            upper = np.array([a + b for a, b in zip(y, std)])  # pp[1] is mean, pp[2] is std
+            lower = np.array([a - b for a, b in zip(y, std)])
             if cat:
                 axs.errorbar(x, y, yerr=std, fmt=fmt, alpha=0.5, capsize=5, label=target)
             else:
@@ -1426,8 +1426,8 @@ class ModelBase(h2o_meta(Keyed)):
             max_y = max(max_y, max(y))
             if plot_stddev:  # set std
                 std = pp[pp_start_index + 2]
-                upper = [a + b for a, b in zip(y, std)]  # pp[1] is mean, pp[2] is std
-                lower = [a - b for a, b in zip(y, std)]
+                upper = np.array([a + b for a, b in zip(y, std)])  # pp[1] is mean, pp[2] is std
+                lower = np.array([a - b for a, b in zip(y, std)])
                 min_lower = min(min_lower, min(lower))
                 max_upper = max(max_upper, max(upper))
                 if cat:


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8326

There's an issue with new `matplotlib` which I think was caused by a bug on our side. 

The new version of matplotlib does not support having just one value in `where` argument. We had there `lower < upper` both of which are lists but python's behavior is to produce one boolean (`[1, 1, 1] < [1, 1, 2]` => `True`).

Semantically I think the intention was to provide a boolean array which corresponds to using numpy arrays instead of lists and this also fixes the problem with the new version of `matplotlib`.