### PR TITLE
Downgrade to release image #39 to avoid issue with Sphinx [nocheck]

### DIFF
--- a/scripts/jenkins/groovy/buildConfig.groovy
+++ b/scripts/jenkins/groovy/buildConfig.groovy
@@ -195,7 +195,9 @@ class BuildConfig {
   }
 
   String getReleaseImage() {
-    return "${DOCKER_REGISTRY}/opsh2oai/h2o-3/${DEFAULT_RELEASE_IMAGE_NAME}:${DEFAULT_IMAGE_VERSION_TAG}"
+    // FIXME: Version 40 has an issue with Sphinx, temporarily downgrade to 39 for release only 
+    def versionTag = DEFAULT_IMAGE_VERSION_TAG == 40 ? 39 : DEFAULT_IMAGE_VERSION_TAG;
+    return "${DOCKER_REGISTRY}/opsh2oai/h2o-3/${DEFAULT_RELEASE_IMAGE_NAME}:${versionTag}"
   }
 
   String getHadoopImageVersion() {


### PR DESCRIPTION
Image #40 breaks documentation - see internal discussion

https://h2oai.slack.com/archives/C04KNHH2H/p1631514069021100
