### PR TITLE
PUBDEV-8329: don't handle zero weights

### DIFF
--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/rulefit/RuleFitMojoModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/rulefit/RuleFitMojoModel.java
@@ -46,15 +46,6 @@ public class RuleFitMojoModel extends MojoModel {
     
     _linearModel.score0(linearModelInput, preds);
     
-    // if current weight is zero, zero the prediction
-    if (_weightsColumn != null) {
-      int weightsId = Arrays.asList(_linearNames).indexOf("linear." + _weightsColumn);
-      double currWeight = test[weightsId];
-      if (currWeight == 0.0) {
-        for (int i = 0; i < preds.length; i++)
-          preds[i] *= currWeight;
-      }
-    }
     
     return preds;
   }
@@ -69,7 +60,4 @@ public class RuleFitMojoModel extends MojoModel {
     return newtest;
   }
 
-    @Override public int nfeatures() {
-      return _names.length;
-    }
 }


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8329

When rfit mojo gets trained, features contains response column.

This is caused by RuleFitMojoModel#nfeatures() what was needed for handling zero weights block in RuleFitMojoModel#score0(). But since https://h2oai.atlassian.net/browse/PUBDEV-8249 got clarified as not a bug, this is not needed and it also causes this bug.
