### PR TITLE
Revert Jetty upgrade - caused issues SW and in Hadoop smoke tests [nocheck]

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -66,7 +66,7 @@ defaultHiveExecVersion=1.1.0
 
 defaultWebserverModule=h2o-jetty-9
 jetty8version=8.2.0.v20160908
-jetty9version=9.4.43.v20210629
+jetty9version=9.4.11.v20180605
 servletApiVersion=3.1.0
 
 # MOJO2 Integration


### PR DESCRIPTION
This reverts commit 6aeb46432872d290158e420c0702451ec4a7fe6e.
