### PR TITLE
[PUBDEV-8280] Fix ModelJsonReader.findInJson for Cases When Path Does Not Exist

### DIFF
--- a/h2o-genmodel/src/main/java/hex/genmodel/attributes/ModelJsonReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/attributes/ModelJsonReader.java
@@ -483,7 +483,11 @@ public class ModelJsonReader {
             } else break;
         }
 
-        return result;
+        if (result == null) {
+            return JsonNull.INSTANCE;
+        } else {
+            return result;   
+        }
     }
 
     /**

--- a/h2o-genmodel/src/main/java/hex/genmodel/attributes/ModelJsonReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/attributes/ModelJsonReader.java
@@ -50,9 +50,10 @@ public class ModelJsonReader {
     public static Table[] readTableArray(final JsonObject modelJson, final String tablePath) {
         Table[] tableArray;
         Objects.requireNonNull(modelJson);
-        JsonArray jsonArray = ((JsonArray) findInJson(modelJson, tablePath));
-        if (jsonArray == null)
+        JsonElement jsonElement = findInJson(modelJson, tablePath);
+        if (jsonElement.isJsonNull())
             return null;
+        JsonArray jsonArray = jsonElement.getAsJsonArray();
         tableArray = new Table[jsonArray.size()];
         for (int i = 0; i < jsonArray.size(); i++) {
             Table table = readTableJson(jsonArray.get(i).getAsJsonObject());
@@ -169,7 +170,7 @@ public class ModelJsonReader {
 
         final JsonElement jsonSourceObject = findInJson(from, elementPath);
 
-        if (jsonSourceObject instanceof JsonNull) {
+        if (jsonSourceObject.isJsonNull()) {
             LOG.warn(String.format("Element '%s' not found in JSON. Skipping. Object '%s' is not populated by values.",
                     elementPath, object.getClass().getName()));
             return;
@@ -498,7 +499,7 @@ public class ModelJsonReader {
      * @return True if the element exists under the given path in the target JSON, otherwise false
      */
     public static boolean elementExists(JsonElement jsonElement, String jsonPath){
-        final boolean isEmpty = findInJson(jsonElement, jsonPath) instanceof JsonNull;
+        final boolean isEmpty = findInJson(jsonElement, jsonPath).isJsonNull();
         return !isEmpty;
     }
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/attributes/ModelJsonReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/attributes/ModelJsonReader.java
@@ -472,7 +472,6 @@ public class ModelJsonReader {
                 continue;
 
             if (result == null) {
-                result = JsonNull.INSTANCE;
                 break;
             }
 

--- a/h2o-genmodel/src/test/java/hex/genmodel/attributes/ModelJsonReaderTest.java
+++ b/h2o-genmodel/src/test/java/hex/genmodel/attributes/ModelJsonReaderTest.java
@@ -1,0 +1,87 @@
+package hex.genmodel.attributes;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import hex.genmodel.GenModelTest;
+import org.junit.Test;
+
+import java.io.*;
+import java.net.URL;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+public class ModelJsonReaderTest {
+
+    private JsonElement loadTestingJson() throws Exception {
+        URL url = GenModelTest.class.getResource("mojo.zip");
+        File file = new File(url.toURI());
+        ZipFile zipFile = new ZipFile(file);
+        ZipEntry zipEntry = zipFile.getEntry("experimental/modelDetails.json");
+        try (InputStream inputStream = zipFile.getInputStream(zipEntry);
+            Reader reader = new InputStreamReader(inputStream)) {
+            JsonElement result = new Gson().fromJson(reader, JsonElement.class);
+            return result;
+        }
+    }
+    
+    @Test
+    public void testElementExistsOnExistingPath() throws Exception {
+        JsonElement testingJson = loadTestingJson();
+        assert ModelJsonReader.elementExists(testingJson, "output.training_metrics.model_category");
+    }
+
+    @Test
+    public void testElementExistsOnNonExistingLeafNode() throws Exception {
+        JsonElement testingJson = loadTestingJson();
+        assert !ModelJsonReader.elementExists(testingJson, "output.training_metrics.non_existing");
+    }
+
+    @Test
+    public void testElementExistsOnNullLeafNode() throws Exception {
+        JsonElement testingJson = loadTestingJson();
+        assert !ModelJsonReader.elementExists(testingJson, "output.training_metrics.description");
+    }
+
+    @Test
+    public void testElementExistsOnNonExistingRegularNode() throws Exception {
+        JsonElement testingJson = loadTestingJson();
+        assert !ModelJsonReader.elementExists(testingJson, "output.validation_metrics.model_category");
+    }
+
+    @Test
+    public void testElementExistsOnNonExistingRootNode() throws Exception {
+        JsonElement testingJson = loadTestingJson();
+        assert !ModelJsonReader.elementExists(testingJson, "non_existing.training_metrics.model_category");
+    }
+
+    @Test
+    public void testReadTableOnExistingPath() throws Exception {
+        JsonObject testingJson = loadTestingJson().getAsJsonObject();
+        assert ModelJsonReader.readTable(testingJson, "output.scoring_history") != null;
+    }
+
+    @Test
+    public void testReadTableOnNonExistingLeafNode() throws Exception {
+        JsonObject testingJson = loadTestingJson().getAsJsonObject();
+        assert ModelJsonReader.readTable(testingJson, "output.training_metrics.non_existing") == null;
+    }
+
+    @Test
+    public void testReadTableOnNullLeafNode() throws Exception {
+        JsonObject testingJson = loadTestingJson().getAsJsonObject();
+        assert ModelJsonReader.readTable(testingJson, "output.training_metrics.description") == null;
+    }
+
+    @Test
+    public void testReadTableOnNonExistingRegularNode() throws Exception {
+        JsonObject testingJson = loadTestingJson().getAsJsonObject();
+        assert ModelJsonReader.readTable(testingJson, "output.validation_metrics.cm") == null;
+    }
+
+    @Test
+    public void testReadTableOnNonExistingRootNode() throws Exception {
+        JsonObject testingJson = loadTestingJson().getAsJsonObject();
+        assert ModelJsonReader.readTable(testingJson, "non_existing.training_metrics.cm") == null;
+    }
+}


### PR DESCRIPTION
Before this PR, `ModelJsonReader.readTable` throws a null pointer exception if `findInJson` returns `null` (cannot do `null.isJsonNull`). Similarly, `ModelJsonReader.elementExists` returns `true` in this case. 