### PR TITLE
Remove h2o-k8s-comp from published projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,6 @@ ext {
       project(':h2o-genmodel-ext-jgrapht'),
       project(':h2o-k8s'),
       project(':h2o-k8s-int'),
-      project(':h2o-k8s-comp'),
       project(':h2o-genmodel-ext-deepwater'),
       project(':h2o-clustering')
     ]


### PR DESCRIPTION
This module doesn't produce a jar artefact, it is not meant to be published (only added there by accident)