### PR TITLE
PUBDEV-8342: show the stacktrace on Py client in case of ServerError

### DIFF
--- a/h2o-py/h2o/backend/connection.py
+++ b/h2o-py/h2o/backend/connection.py
@@ -815,6 +815,7 @@ class H2OConnection(h2o_meta()):
 
         # Client errors (400 = "Bad Request", 404 = "Not Found", 412 = "Precondition Failed")
         if status_code in {400, 404, 412} and isinstance(data, H2OErrorV3):
+            data.show_stacktrace = False
             raise H2OResponseError(data)
 
         # Server errors (notably 500 = "Server Error")

--- a/h2o-py/h2o/schemas/error.py
+++ b/h2o-py/h2o/schemas/error.py
@@ -21,6 +21,7 @@ class H2OErrorV3(H2OSchema):
         super(H2OErrorV3, self).__init__()
         self.endpoint = None
         self.payload = None
+        self.show_stacktrace = True
 
     def __setitem__(self, key, value):
         if key in self._schema_attrs_.keys():
@@ -37,15 +38,16 @@ class H2OErrorV3(H2OSchema):
             if self.payload[1]: res += "    json: %r\n" % self.payload[1]
             if self.payload[2]: res += "    file: %r\n" % self.payload[2]
             if self.payload[3]: res += "    params: %r\n" % self.payload[3]
-        if self.stacktrace:
+        if self.show_stacktrace and self.stacktrace:
             res += "  Stacktrace: %s\n" % self._format_stacktrace(indent=6)
         return res
     
     def _format_stacktrace(self, indent=4, top=10):
-        if self.stacktrace:
-            return "\n".join(("%s%s" % ((indent*" " if i > 0 else ""), l.strip()) 
-                              for i, l in enumerate(self.stacktrace) 
-                              if i < top))
+        if not self.stacktrace:
+            return ""
+        return "\n".join(("%s%s" % ((indent*" " if i > 0 else ""), l.strip()) 
+                          for i, l in enumerate(self.stacktrace) 
+                          if i < top))
 
 
 class H2OModelBuilderErrorV3(H2OErrorV3):

--- a/h2o-py/h2o/schemas/error.py
+++ b/h2o-py/h2o/schemas/error.py
@@ -42,12 +42,11 @@ class H2OErrorV3(H2OSchema):
             res += "  Stacktrace: %s\n" % self._format_stacktrace(indent=6)
         return res
     
-    def _format_stacktrace(self, indent=4, top=10):
+    def _format_stacktrace(self, indent=4, head=10):
         if not self.stacktrace:
             return ""
-        return "\n".join(("%s%s" % ((indent*" " if i > 0 else ""), l.strip()) 
-                          for i, l in enumerate(self.stacktrace) 
-                          if i < top))
+        return "\n".join(("%s%s" % ((indent*' ' if i > 0 else ""), l.strip())
+                          for i, l in enumerate(self.stacktrace[:head])))
 
 
 class H2OModelBuilderErrorV3(H2OErrorV3):
@@ -59,9 +58,7 @@ class H2OModelBuilderErrorV3(H2OErrorV3):
         for k, v in self._props.items():
             if k in {"exception_type"}: continue
             if k == "stacktrace":
-                res += "    stacktrace =\n"
-                for line in v:
-                    res += "        %s\n" % line.strip()
+                res += "    stacktrace = %s\n" % self._format_stacktrace(indent=8, head=None)
             else:
                 res += "    %s = %r\n" % (k, v)
         return res

--- a/h2o-py/h2o/schemas/error.py
+++ b/h2o-py/h2o/schemas/error.py
@@ -57,7 +57,7 @@ class H2OModelBuilderErrorV3(H2OErrorV3):
         res = "ModelBuilderErrorV3  (%s):\n" % self.exception_type
         for k, v in self._props.items():
             if k in {"exception_type"}: continue
-            if k == "stacktrace":
+            if k == "stacktrace" and self.show_stacktrace:
                 res += "    stacktrace = %s\n" % self._format_stacktrace(indent=8, head=None)
             else:
                 res += "    %s = %r\n" % (k, v)

--- a/h2o-py/h2o/schemas/error.py
+++ b/h2o-py/h2o/schemas/error.py
@@ -37,7 +37,15 @@ class H2OErrorV3(H2OSchema):
             if self.payload[1]: res += "    json: %r\n" % self.payload[1]
             if self.payload[2]: res += "    file: %r\n" % self.payload[2]
             if self.payload[3]: res += "    params: %r\n" % self.payload[3]
+        if self.stacktrace:
+            res += "  Stacktrace: %s\n" % self._format_stacktrace(indent=6)
         return res
+    
+    def _format_stacktrace(self, indent=4, top=10):
+        if self.stacktrace:
+            return "\n".join(("%s%s" % ((indent*" " if i > 0 else ""), l.strip()) 
+                              for i, l in enumerate(self.stacktrace) 
+                              if i < top))
 
 
 class H2OModelBuilderErrorV3(H2OErrorV3):


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8342

always print ErrorV3 shortened stacktrace if available.

Rationale is to make it easier for users to report informative issues and for devs to investigate them.

Before:
```
H2OServerError: HTTP 500 Server Error:
Server error java.lang.NullPointerException:
  Error: Caught exception: java.lang.NullPointerException
  Request: None
```
Now:
```
H2OServerError: HTTP 500 Server Error:
Server error java.lang.NullPointerException:
  Error: Caught exception: java.lang.NullPointerException
  Request: None
  Stacktrace: java.lang.NullPointerException
    water.nbhm.NonBlockingHashMap.putIfMatch(NonBlockingHashMap.java:369)
    water.nbhm.NonBlockingHashMap.put(NonBlockingHashMap.java:320)
    ai.h2o.automl.AutoMLSession.getModelingSteps(AutoMLSession.java:76)
    ai.h2o.automl.ModelingStepsRegistry.getOrderedSteps(ModelingStepsRegistry.java:54)
    ai.h2o.automl.AutoML.getExecutionPlan(AutoML.java:330)
    ai.h2o.automl.AutoML.planWork(AutoML.java:359)
    ai.h2o.automl.AutoML.submit(AutoML.java:395)
    ai.h2o.automl.AutoML.startAutoML(AutoML.java:80)
    water.automl.api.AutoMLBuilderHandler.build(AutoMLBuilderHandler.java:15)
```