### PR TITLE
PUBDEV-8353: Removed GLM from balance_classes page

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/balance_classes.rst
+++ b/h2o-docs/src/product/data-science/algo-params/balance_classes.rst
@@ -1,7 +1,7 @@
 ``balance_classes``
 -------------------
 
-- Available in: GBM, DRF, Deep Learning, GLM, Naïve-Bayes, AutoML
+- Available in: GBM, DRF, Deep Learning, Naïve-Bayes, AutoML
 - Hyperparameter: yes
 
 Description


### PR DESCRIPTION
For: https://h2oai.atlassian.net/browse/PUBDEV-8353