### PR TITLE
PUBDEV-8354-remove balance_classes from GLM.  

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/ANOVAGLMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/ANOVAGLMV3.java
@@ -41,9 +41,6 @@ public class ANOVAGLMV3 extends ModelBuilderSchema<ANOVAGLM, ANOVAGLMV3, ANOVAGL
             "stopping_metric",
             "early_stopping",
             "stopping_tolerance",
-            "balance_classes",
-            "class_sampling_factors",
-            "max_after_balance_size",
             "max_runtime_secs",
             "save_transformed_framekeys",
             "highest_interaction_term",
@@ -117,33 +114,6 @@ public class ANOVAGLMV3 extends ModelBuilderSchema<ANOVAGLM, ANOVAGLMV3, ANOVAGL
     @API(help = "Prior probability for y==1. To be used only for logistic regression iff the data has been sampled and" +
             " the mean of response does not reflect reality.", level = API.Level.expert)
     public double prior;
-
-    // dead unused args, formely inherited from supervised model schema
-    /**
-     * For imbalanced data, balance training data class counts via
-     * over/under-sampling. This can result in improved predictive accuracy.
-     */
-    @API(help = "Balance training data class counts via over/under-sampling (for imbalanced data).",
-            level = API.Level.secondary, direction = API.Direction.INOUT)
-    public boolean balance_classes;
-
-    /**
-     * Desired over/under-sampling ratios per class (lexicographic order).
-     * Only when balance_classes is enabled.
-     * If not specified, they will be automatically computed to obtain class balance during training.
-     */
-    @API(help = "Desired over/under-sampling ratios per class (in lexicographic order). If not specified, sampling" +
-            " factors will be automatically computed to obtain class balance during training. Requires " +
-            "balance_classes.", level = API.Level.expert, direction = API.Direction.INOUT)
-    public float[] class_sampling_factors;
-
-    /**
-     * When classes are balanced, limit the resulting dataset size to the
-     * specified multiple of the original dataset size.
-     */
-    @API(help = "Maximum relative size of the training data after balancing class counts (can be less than 1.0). " +
-            "Requires balance_classes.", /* dmin=1e-3, */ level = API.Level.expert, direction = API.Direction.INOUT)
-    public float max_after_balance_size;
 
     @API(help = "Limit the number of interaction terms, if 2 means interaction between 2 columns only, 3 for three" +
             " columns and so on...  Default to 2.", level = API.Level.critical)

--- a/h2o-algos/src/main/java/hex/schemas/GAMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GAMV3.java
@@ -66,9 +66,6 @@ public class GAMV3 extends ModelBuilderSchema<GAM, GAMV3, GAMV3.GAMParametersV3>
             "stopping_metric",
             "stopping_tolerance",
             // dead unused args forced here by backwards compatibility, remove in V4
-            "balance_classes",
-            "class_sampling_factors",
-            "max_after_balance_size",
             "max_confusion_matrix_size",
             "max_runtime_secs",
             "custom_metric_func",
@@ -191,29 +188,6 @@ public class GAMV3 extends ModelBuilderSchema<GAM, GAMV3, GAMV3.GAMParametersV3>
 
     @API(help="A list of pairwise (first order) column interactions.", direction=Direction.INPUT, level=Level.expert)
     public StringPairV3[] interaction_pairs;
-
-    // dead unused args, formely inherited from supervised model schema
-    /**
-     * For imbalanced data, balance training data class counts via
-     * over/under-sampling. This can result in improved predictive accuracy.
-     */
-    @API(help = "Balance training data class counts via over/under-sampling (for imbalanced data).", level = API.Level.secondary, direction = API.Direction.INOUT)
-    public boolean balance_classes;
-
-    /**
-     * Desired over/under-sampling ratios per class (lexicographic order).
-     * Only when balance_classes is enabled.
-     * If not specified, they will be automatically computed to obtain class balance during training.
-     */
-    @API(help = "Desired over/under-sampling ratios per class (in lexicographic order). If not specified, sampling factors will be automatically computed to obtain class balance during training. Requires balance_classes.", level = API.Level.expert, direction = API.Direction.INOUT)
-    public float[] class_sampling_factors;
-
-    /**
-     * When classes are balanced, limit the resulting dataset size to the
-     * specified multiple of the original dataset size.
-     */
-    @API(help = "Maximum relative size of the training data after balancing class counts (can be less than 1.0). Requires balance_classes.", /* dmin=1e-3, */ level = API.Level.expert, direction = API.Direction.INOUT)
-    public float max_after_balance_size;
 
     /** For classification models, the maximum size (in terms of classes) of
      *  the confusion matrix for it to be printed. This option is meant to

--- a/h2o-algos/src/main/java/hex/schemas/GLMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMV3.java
@@ -76,9 +76,6 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
             "stopping_metric",
             "stopping_tolerance",
             // dead unused args forced here by backwards compatibility, remove in V4
-            "balance_classes",
-            "class_sampling_factors",
-            "max_after_balance_size",
             "max_confusion_matrix_size",
             "max_runtime_secs",
             "custom_metric_func",
@@ -215,29 +212,6 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
 
     @API(help="A list of pairwise (first order) column interactions.", direction=Direction.INPUT, level=Level.expert)
     public StringPairV3[] interaction_pairs;
-
-    // dead unused args, formely inherited from supervised model schema
-    /**
-     * For imbalanced data, balance training data class counts via
-     * over/under-sampling. This can result in improved predictive accuracy.
-     */
-    @API(help = "Balance training data class counts via over/under-sampling (for imbalanced data).", level = API.Level.secondary, direction = API.Direction.INOUT)
-    public boolean balance_classes;
-
-    /**
-     * Desired over/under-sampling ratios per class (lexicographic order).
-     * Only when balance_classes is enabled.
-     * If not specified, they will be automatically computed to obtain class balance during training.
-     */
-    @API(help = "Desired over/under-sampling ratios per class (in lexicographic order). If not specified, sampling factors will be automatically computed to obtain class balance during training. Requires balance_classes.", level = API.Level.expert, direction = API.Direction.INOUT)
-    public float[] class_sampling_factors;
-
-    /**
-     * When classes are balanced, limit the resulting dataset size to the
-     * specified multiple of the original dataset size.
-     */
-    @API(help = "Maximum relative size of the training data after balancing class counts (can be less than 1.0). Requires balance_classes.", /* dmin=1e-3, */ level = API.Level.expert, direction = API.Direction.INOUT)
-    public float max_after_balance_size;
 
     /** For classification models, the maximum size (in terms of classes) of
      *  the confusion matrix for it to be printed. This option is meant to

--- a/h2o-algos/src/main/java/hex/schemas/MaxRGLMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/MaxRGLMV3.java
@@ -55,9 +55,6 @@ public class MaxRGLMV3 extends ModelBuilderSchema<MaxRGLM, MaxRGLMV3, MaxRGLMV3.
                 "stopping_metric",
                 "stopping_tolerance",
                 // dead unused args forced here by backwards compatibility, remove in V4
-                "balance_classes",
-                "class_sampling_factors",
-                "max_after_balance_size",
                 "max_confusion_matrix_size",
                 "max_runtime_secs",
                 "custom_metric_func",
@@ -173,34 +170,6 @@ public class MaxRGLMV3 extends ModelBuilderSchema<MaxRGLM, MaxRGLMV3, MaxRGLMV3.
                 " the value of max_active_predictors is set to 5000 otherwise it is set to 100000000.",
                 direction = API.Direction.INPUT, level = API.Level.expert)
         public int max_active_predictors = -1;
-
-        // dead unused args, formely inherited from supervised model schema
-        /**
-         * For imbalanced data, balance training data class counts via
-         * over/under-sampling. This can result in improved predictive accuracy.
-         */
-        @API(help = "Balance training data class counts via over/under-sampling (for imbalanced data).", 
-                level = API.Level.secondary, direction = API.Direction.INOUT)
-        public boolean balance_classes;
-
-        /**
-         * Desired over/under-sampling ratios per class (lexicographic order).
-         * Only when balance_classes is enabled.
-         * If not specified, they will be automatically computed to obtain class balance during training.
-         */
-        @API(help = "Desired over/under-sampling ratios per class (in lexicographic order). If not specified, " +
-                "sampling factors will be automatically computed to obtain class balance during training. Requires" +
-                " balance_classes.", level = API.Level.expert, direction = API.Direction.INOUT)
-        public float[] class_sampling_factors;
-
-        /**
-         * When classes are balanced, limit the resulting dataset size to the
-         * specified multiple of the original dataset size.
-         */
-        @API(help = "Maximum relative size of the training data after balancing class counts (can be less than 1.0)." +
-                " Requires balance_classes.", /* dmin=1e-3, */ level = API.Level.expert, 
-                direction = API.Direction.INOUT)
-        public float max_after_balance_size;
 
         /** For classification models, the maximum size (in terms of classes) of
          *  the confusion matrix for it to be printed. This option is meant to

--- a/h2o-py/h2o/estimators/anovaglm.py
+++ b/h2o-py/h2o/estimators/anovaglm.py
@@ -55,9 +55,6 @@ class H2OANOVAGLMEstimator(H2OEstimator):
                  stopping_metric="auto",  # type: Literal["auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "aucpr", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"]
                  early_stopping=False,  # type: bool
                  stopping_tolerance=0.001,  # type: float
-                 balance_classes=False,  # type: bool
-                 class_sampling_factors=None,  # type: Optional[List[float]]
-                 max_after_balance_size=5.0,  # type: float
                  max_runtime_secs=0.0,  # type: float
                  save_transformed_framekeys=False,  # type: bool
                  highest_interaction_term=0,  # type: int
@@ -176,18 +173,6 @@ class H2OANOVAGLMEstimator(H2OEstimator):
                is not at least this much)
                Defaults to ``0.001``.
         :type stopping_tolerance: float
-        :param balance_classes: Balance training data class counts via over/under-sampling (for imbalanced data).
-               Defaults to ``False``.
-        :type balance_classes: bool
-        :param class_sampling_factors: Desired over/under-sampling ratios per class (in lexicographic order). If not
-               specified, sampling factors will be automatically computed to obtain class balance during training.
-               Requires balance_classes.
-               Defaults to ``None``.
-        :type class_sampling_factors: List[float], optional
-        :param max_after_balance_size: Maximum relative size of the training data after balancing class counts (can be
-               less than 1.0). Requires balance_classes.
-               Defaults to ``5.0``.
-        :type max_after_balance_size: float
         :param max_runtime_secs: Maximum allowed runtime in seconds for model training. Use 0 to disable.
                Defaults to ``0.0``.
         :type max_runtime_secs: float
@@ -236,9 +221,6 @@ class H2OANOVAGLMEstimator(H2OEstimator):
         self.stopping_metric = stopping_metric
         self.early_stopping = early_stopping
         self.stopping_tolerance = stopping_tolerance
-        self.balance_classes = balance_classes
-        self.class_sampling_factors = class_sampling_factors
-        self.max_after_balance_size = max_after_balance_size
         self.max_runtime_secs = max_runtime_secs
         self.save_transformed_framekeys = save_transformed_framekeys
         self.highest_interaction_term = highest_interaction_term
@@ -653,50 +635,6 @@ class H2OANOVAGLMEstimator(H2OEstimator):
     def stopping_tolerance(self, stopping_tolerance):
         assert_is_type(stopping_tolerance, None, numeric)
         self._parms["stopping_tolerance"] = stopping_tolerance
-
-    @property
-    def balance_classes(self):
-        """
-        Balance training data class counts via over/under-sampling (for imbalanced data).
-
-        Type: ``bool``, defaults to ``False``.
-        """
-        return self._parms.get("balance_classes")
-
-    @balance_classes.setter
-    def balance_classes(self, balance_classes):
-        assert_is_type(balance_classes, None, bool)
-        self._parms["balance_classes"] = balance_classes
-
-    @property
-    def class_sampling_factors(self):
-        """
-        Desired over/under-sampling ratios per class (in lexicographic order). If not specified, sampling factors will
-        be automatically computed to obtain class balance during training. Requires balance_classes.
-
-        Type: ``List[float]``.
-        """
-        return self._parms.get("class_sampling_factors")
-
-    @class_sampling_factors.setter
-    def class_sampling_factors(self, class_sampling_factors):
-        assert_is_type(class_sampling_factors, None, [float])
-        self._parms["class_sampling_factors"] = class_sampling_factors
-
-    @property
-    def max_after_balance_size(self):
-        """
-        Maximum relative size of the training data after balancing class counts (can be less than 1.0). Requires
-        balance_classes.
-
-        Type: ``float``, defaults to ``5.0``.
-        """
-        return self._parms.get("max_after_balance_size")
-
-    @max_after_balance_size.setter
-    def max_after_balance_size(self, max_after_balance_size):
-        assert_is_type(max_after_balance_size, None, float)
-        self._parms["max_after_balance_size"] = max_after_balance_size
 
     @property
     def max_runtime_secs(self):

--- a/h2o-py/h2o/estimators/gam.py
+++ b/h2o-py/h2o/estimators/gam.py
@@ -87,9 +87,6 @@ class H2OGeneralizedAdditiveEstimator(H2OEstimator):
                  stopping_rounds=0,  # type: int
                  stopping_metric="auto",  # type: Literal["auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "aucpr", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"]
                  stopping_tolerance=0.001,  # type: float
-                 balance_classes=False,  # type: bool
-                 class_sampling_factors=None,  # type: Optional[List[float]]
-                 max_after_balance_size=5.0,  # type: float
                  max_confusion_matrix_size=20,  # type: int
                  max_runtime_secs=0.0,  # type: float
                  custom_metric_func=None,  # type: Optional[str]
@@ -299,18 +296,6 @@ class H2OGeneralizedAdditiveEstimator(H2OEstimator):
                is not at least this much)
                Defaults to ``0.001``.
         :type stopping_tolerance: float
-        :param balance_classes: Balance training data class counts via over/under-sampling (for imbalanced data).
-               Defaults to ``False``.
-        :type balance_classes: bool
-        :param class_sampling_factors: Desired over/under-sampling ratios per class (in lexicographic order). If not
-               specified, sampling factors will be automatically computed to obtain class balance during training.
-               Requires balance_classes.
-               Defaults to ``None``.
-        :type class_sampling_factors: List[float], optional
-        :param max_after_balance_size: Maximum relative size of the training data after balancing class counts (can be
-               less than 1.0). Requires balance_classes.
-               Defaults to ``5.0``.
-        :type max_after_balance_size: float
         :param max_confusion_matrix_size: [Deprecated] Maximum size (# classes) for confusion matrices to be printed in
                the Logs
                Defaults to ``20``.
@@ -405,9 +390,6 @@ class H2OGeneralizedAdditiveEstimator(H2OEstimator):
         self.stopping_rounds = stopping_rounds
         self.stopping_metric = stopping_metric
         self.stopping_tolerance = stopping_tolerance
-        self.balance_classes = balance_classes
-        self.class_sampling_factors = class_sampling_factors
-        self.max_after_balance_size = max_after_balance_size
         self.max_confusion_matrix_size = max_confusion_matrix_size
         self.max_runtime_secs = max_runtime_secs
         self.custom_metric_func = custom_metric_func
@@ -1150,50 +1132,6 @@ class H2OGeneralizedAdditiveEstimator(H2OEstimator):
     def stopping_tolerance(self, stopping_tolerance):
         assert_is_type(stopping_tolerance, None, numeric)
         self._parms["stopping_tolerance"] = stopping_tolerance
-
-    @property
-    def balance_classes(self):
-        """
-        Balance training data class counts via over/under-sampling (for imbalanced data).
-
-        Type: ``bool``, defaults to ``False``.
-        """
-        return self._parms.get("balance_classes")
-
-    @balance_classes.setter
-    def balance_classes(self, balance_classes):
-        assert_is_type(balance_classes, None, bool)
-        self._parms["balance_classes"] = balance_classes
-
-    @property
-    def class_sampling_factors(self):
-        """
-        Desired over/under-sampling ratios per class (in lexicographic order). If not specified, sampling factors will
-        be automatically computed to obtain class balance during training. Requires balance_classes.
-
-        Type: ``List[float]``.
-        """
-        return self._parms.get("class_sampling_factors")
-
-    @class_sampling_factors.setter
-    def class_sampling_factors(self, class_sampling_factors):
-        assert_is_type(class_sampling_factors, None, [float])
-        self._parms["class_sampling_factors"] = class_sampling_factors
-
-    @property
-    def max_after_balance_size(self):
-        """
-        Maximum relative size of the training data after balancing class counts (can be less than 1.0). Requires
-        balance_classes.
-
-        Type: ``float``, defaults to ``5.0``.
-        """
-        return self._parms.get("max_after_balance_size")
-
-    @max_after_balance_size.setter
-    def max_after_balance_size(self, max_after_balance_size):
-        assert_is_type(max_after_balance_size, None, float)
-        self._parms["max_after_balance_size"] = max_after_balance_size
 
     @property
     def max_confusion_matrix_size(self):

--- a/h2o-py/h2o/estimators/glm.py
+++ b/h2o-py/h2o/estimators/glm.py
@@ -95,9 +95,6 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
                  stopping_rounds=0,  # type: int
                  stopping_metric="auto",  # type: Literal["auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "aucpr", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"]
                  stopping_tolerance=0.001,  # type: float
-                 balance_classes=False,  # type: bool
-                 class_sampling_factors=None,  # type: Optional[List[float]]
-                 max_after_balance_size=5.0,  # type: float
                  max_confusion_matrix_size=20,  # type: int
                  max_runtime_secs=0.0,  # type: float
                  custom_metric_func=None,  # type: Optional[str]
@@ -322,18 +319,6 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
                is not at least this much)
                Defaults to ``0.001``.
         :type stopping_tolerance: float
-        :param balance_classes: Balance training data class counts via over/under-sampling (for imbalanced data).
-               Defaults to ``False``.
-        :type balance_classes: bool
-        :param class_sampling_factors: Desired over/under-sampling ratios per class (in lexicographic order). If not
-               specified, sampling factors will be automatically computed to obtain class balance during training.
-               Requires balance_classes.
-               Defaults to ``None``.
-        :type class_sampling_factors: List[float], optional
-        :param max_after_balance_size: Maximum relative size of the training data after balancing class counts (can be
-               less than 1.0). Requires balance_classes.
-               Defaults to ``5.0``.
-        :type max_after_balance_size: float
         :param max_confusion_matrix_size: [Deprecated] Maximum size (# classes) for confusion matrices to be printed in
                the Logs
                Defaults to ``20``.
@@ -412,9 +397,6 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
         self.stopping_rounds = stopping_rounds
         self.stopping_metric = stopping_metric
         self.stopping_tolerance = stopping_tolerance
-        self.balance_classes = balance_classes
-        self.class_sampling_factors = class_sampling_factors
-        self.max_after_balance_size = max_after_balance_size
         self.max_confusion_matrix_size = max_confusion_matrix_size
         self.max_runtime_secs = max_runtime_secs
         self.custom_metric_func = custom_metric_func
@@ -1941,96 +1923,6 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     def stopping_tolerance(self, stopping_tolerance):
         assert_is_type(stopping_tolerance, None, numeric)
         self._parms["stopping_tolerance"] = stopping_tolerance
-
-    @property
-    def balance_classes(self):
-        """
-        Balance training data class counts via over/under-sampling (for imbalanced data).
-
-        Type: ``bool``, defaults to ``False``.
-
-        :examples:
-
-        >>> cars = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
-        >>> predictors = ["displacement","power","weight","year"]
-        >>> response = "acceleration"
-        >>> train, valid = cars.split_frame(ratios=[.8])
-        >>> cars_glm = H2OGeneralizedLinearEstimator(balance_classes=True,
-        ...                                          seed=1234)
-        >>> cars_glm.train(x=predictors,
-        ...                y=response,
-        ...                training_frame=train,
-        ...                validation_frame=valid)
-        >>> cars_glm.mse()
-        """
-        return self._parms.get("balance_classes")
-
-    @balance_classes.setter
-    def balance_classes(self, balance_classes):
-        assert_is_type(balance_classes, None, bool)
-        self._parms["balance_classes"] = balance_classes
-
-    @property
-    def class_sampling_factors(self):
-        """
-        Desired over/under-sampling ratios per class (in lexicographic order). If not specified, sampling factors will
-        be automatically computed to obtain class balance during training. Requires balance_classes.
-
-        Type: ``List[float]``.
-
-        :examples:
-
-        >>> cars = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
-        >>> predictors = ["displacement","power","weight","year"]
-        >>> response = "acceleration"
-        >>> train, valid = cars.split_frame(ratios=[.8])
-        >>> sample_factors = [1., 0.5, 1., 1., 1., 1., 1.]
-        >>> cars_glm = H2OGeneralizedLinearEstimator(balance_classes=True,
-        ...                                          class_sampling_factors=sample_factors,
-        ...                                          seed=1234)
-        >>> cars_glm.train(x=predictors,
-        ...                y=response,
-        ...                training_frame=train,
-        ...                validation_frame=valid)
-        >>> cars_glm.mse()
-        """
-        return self._parms.get("class_sampling_factors")
-
-    @class_sampling_factors.setter
-    def class_sampling_factors(self, class_sampling_factors):
-        assert_is_type(class_sampling_factors, None, [float])
-        self._parms["class_sampling_factors"] = class_sampling_factors
-
-    @property
-    def max_after_balance_size(self):
-        """
-        Maximum relative size of the training data after balancing class counts (can be less than 1.0). Requires
-        balance_classes.
-
-        Type: ``float``, defaults to ``5.0``.
-
-        :examples:
-
-        >>> cars = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
-        >>> predictors = ["displacement","power","weight","year"]
-        >>> response = "acceleration"
-        >>> train, valid = cars.split_frame(ratios=[.8])
-        >>> max = .85
-        >>> cars_glm = H2OGeneralizedLinearEstimator(balance_classes=True,
-        ...                                          max_after_balance_size=max,
-        ...                                          seed=1234)
-        >>> cars_glm.train(x=predictors,
-        ...                y=response,
-        ...                training_frame=train,
-        ...                validation_frame=valid)
-        >>> cars_glm.mse()
-        """
-        return self._parms.get("max_after_balance_size")
-
-    @max_after_balance_size.setter
-    def max_after_balance_size(self, max_after_balance_size):
-        assert_is_type(max_after_balance_size, None, float)
-        self._parms["max_after_balance_size"] = max_after_balance_size
 
     @property
     def max_confusion_matrix_size(self):

--- a/h2o-py/h2o/estimators/maxrglm.py
+++ b/h2o-py/h2o/estimators/maxrglm.py
@@ -66,9 +66,6 @@ class H2OMaxRGLMEstimator(H2OEstimator):
                  stopping_rounds=0,  # type: int
                  stopping_metric="auto",  # type: Literal["auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "aucpr", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"]
                  stopping_tolerance=0.001,  # type: float
-                 balance_classes=False,  # type: bool
-                 class_sampling_factors=None,  # type: Optional[List[float]]
-                 max_after_balance_size=5.0,  # type: float
                  max_confusion_matrix_size=20,  # type: int
                  max_runtime_secs=0.0,  # type: float
                  custom_metric_func=None,  # type: Optional[str]
@@ -238,18 +235,6 @@ class H2OMaxRGLMEstimator(H2OEstimator):
                is not at least this much)
                Defaults to ``0.001``.
         :type stopping_tolerance: float
-        :param balance_classes: Balance training data class counts via over/under-sampling (for imbalanced data).
-               Defaults to ``False``.
-        :type balance_classes: bool
-        :param class_sampling_factors: Desired over/under-sampling ratios per class (in lexicographic order). If not
-               specified, sampling factors will be automatically computed to obtain class balance during training.
-               Requires balance_classes.
-               Defaults to ``None``.
-        :type class_sampling_factors: List[float], optional
-        :param max_after_balance_size: Maximum relative size of the training data after balancing class counts (can be
-               less than 1.0). Requires balance_classes.
-               Defaults to ``5.0``.
-        :type max_after_balance_size: float
         :param max_confusion_matrix_size: [Deprecated] Maximum size (# classes) for confusion matrices to be printed in
                the Logs
                Defaults to ``20``.
@@ -312,9 +297,6 @@ class H2OMaxRGLMEstimator(H2OEstimator):
         self.stopping_rounds = stopping_rounds
         self.stopping_metric = stopping_metric
         self.stopping_tolerance = stopping_tolerance
-        self.balance_classes = balance_classes
-        self.class_sampling_factors = class_sampling_factors
-        self.max_after_balance_size = max_after_balance_size
         self.max_confusion_matrix_size = max_confusion_matrix_size
         self.max_runtime_secs = max_runtime_secs
         self.custom_metric_func = custom_metric_func
@@ -907,50 +889,6 @@ class H2OMaxRGLMEstimator(H2OEstimator):
     def stopping_tolerance(self, stopping_tolerance):
         assert_is_type(stopping_tolerance, None, numeric)
         self._parms["stopping_tolerance"] = stopping_tolerance
-
-    @property
-    def balance_classes(self):
-        """
-        Balance training data class counts via over/under-sampling (for imbalanced data).
-
-        Type: ``bool``, defaults to ``False``.
-        """
-        return self._parms.get("balance_classes")
-
-    @balance_classes.setter
-    def balance_classes(self, balance_classes):
-        assert_is_type(balance_classes, None, bool)
-        self._parms["balance_classes"] = balance_classes
-
-    @property
-    def class_sampling_factors(self):
-        """
-        Desired over/under-sampling ratios per class (in lexicographic order). If not specified, sampling factors will
-        be automatically computed to obtain class balance during training. Requires balance_classes.
-
-        Type: ``List[float]``.
-        """
-        return self._parms.get("class_sampling_factors")
-
-    @class_sampling_factors.setter
-    def class_sampling_factors(self, class_sampling_factors):
-        assert_is_type(class_sampling_factors, None, [float])
-        self._parms["class_sampling_factors"] = class_sampling_factors
-
-    @property
-    def max_after_balance_size(self):
-        """
-        Maximum relative size of the training data after balancing class counts (can be less than 1.0). Requires
-        balance_classes.
-
-        Type: ``float``, defaults to ``5.0``.
-        """
-        return self._parms.get("max_after_balance_size")
-
-    @max_after_balance_size.setter
-    def max_after_balance_size(self, max_after_balance_size):
-        assert_is_type(max_after_balance_size, None, float)
-        self._parms["max_after_balance_size"] = max_after_balance_size
 
     @property
     def max_confusion_matrix_size(self):

--- a/h2o-r/h2o-package/R/anovaglm.R
+++ b/h2o-r/h2o-package/R/anovaglm.R
@@ -67,12 +67,6 @@
 #'        Defaults to FALSE.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.001.
-#' @param balance_classes \code{Logical}. Balance training data class counts via over/under-sampling (for imbalanced data). Defaults to
-#'        FALSE.
-#' @param class_sampling_factors Desired over/under-sampling ratios per class (in lexicographic order). If not specified, sampling factors will
-#'        be automatically computed to obtain class balance during training. Requires balance_classes.
-#' @param max_after_balance_size Maximum relative size of the training data after balancing class counts (can be less than 1.0). Requires
-#'        balance_classes. Defaults to 5.0.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @param save_transformed_framekeys \code{Logical}. true to save the keys of transformed predictors and interaction column. Defaults to FALSE.
 #' @param highest_interaction_term Limit the number of interaction terms, if 2 means interaction between 2 columns only, 3 for three columns and
@@ -120,9 +114,6 @@ h2o.anovaglm <- function(x,
                          stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "AUCPR", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
                          early_stopping = FALSE,
                          stopping_tolerance = 0.001,
-                         balance_classes = FALSE,
-                         class_sampling_factors = NULL,
-                         max_after_balance_size = 5.0,
                          max_runtime_secs = 0,
                          save_transformed_framekeys = FALSE,
                          highest_interaction_term = 0,
@@ -201,12 +192,6 @@ h2o.anovaglm <- function(x,
     parms$early_stopping <- early_stopping
   if (!missing(stopping_tolerance))
     parms$stopping_tolerance <- stopping_tolerance
-  if (!missing(balance_classes))
-    parms$balance_classes <- balance_classes
-  if (!missing(class_sampling_factors))
-    parms$class_sampling_factors <- class_sampling_factors
-  if (!missing(max_after_balance_size))
-    parms$max_after_balance_size <- max_after_balance_size
   if (!missing(max_runtime_secs))
     parms$max_runtime_secs <- max_runtime_secs
   if (!missing(save_transformed_framekeys))
@@ -250,9 +235,6 @@ h2o.anovaglm <- function(x,
                                          stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "AUCPR", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
                                          early_stopping = FALSE,
                                          stopping_tolerance = 0.001,
-                                         balance_classes = FALSE,
-                                         class_sampling_factors = NULL,
-                                         max_after_balance_size = 5.0,
                                          max_runtime_secs = 0,
                                          save_transformed_framekeys = FALSE,
                                          highest_interaction_term = 0,
@@ -336,12 +318,6 @@ h2o.anovaglm <- function(x,
     parms$early_stopping <- early_stopping
   if (!missing(stopping_tolerance))
     parms$stopping_tolerance <- stopping_tolerance
-  if (!missing(balance_classes))
-    parms$balance_classes <- balance_classes
-  if (!missing(class_sampling_factors))
-    parms$class_sampling_factors <- class_sampling_factors
-  if (!missing(max_after_balance_size))
-    parms$max_after_balance_size <- max_after_balance_size
   if (!missing(max_runtime_secs))
     parms$max_runtime_secs <- max_runtime_secs
   if (!missing(save_transformed_framekeys))

--- a/h2o-r/h2o-package/R/gam.R
+++ b/h2o-r/h2o-package/R/gam.R
@@ -110,12 +110,6 @@
 #'        Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.001.
-#' @param balance_classes \code{Logical}. Balance training data class counts via over/under-sampling (for imbalanced data). Defaults to
-#'        FALSE.
-#' @param class_sampling_factors Desired over/under-sampling ratios per class (in lexicographic order). If not specified, sampling factors will
-#'        be automatically computed to obtain class balance during training. Requires balance_classes.
-#' @param max_after_balance_size Maximum relative size of the training data after balancing class counts (can be less than 1.0). Requires
-#'        balance_classes. Defaults to 5.0.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @param custom_metric_func Reference to custom evaluation function, format: `language:keyName=funcName`
 #' @param num_knots Number of knots for gam predictors
@@ -193,9 +187,6 @@ h2o.gam <- function(x,
                     stopping_rounds = 0,
                     stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "AUCPR", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
                     stopping_tolerance = 0.001,
-                    balance_classes = FALSE,
-                    class_sampling_factors = NULL,
-                    max_after_balance_size = 5.0,
                     max_runtime_secs = 0,
                     custom_metric_func = NULL,
                     num_knots = NULL,
@@ -333,12 +324,6 @@ h2o.gam <- function(x,
     parms$stopping_metric <- stopping_metric
   if (!missing(stopping_tolerance))
     parms$stopping_tolerance <- stopping_tolerance
-  if (!missing(balance_classes))
-    parms$balance_classes <- balance_classes
-  if (!missing(class_sampling_factors))
-    parms$class_sampling_factors <- class_sampling_factors
-  if (!missing(max_after_balance_size))
-    parms$max_after_balance_size <- max_after_balance_size
   if (!missing(max_runtime_secs))
     parms$max_runtime_secs <- max_runtime_secs
   if (!missing(custom_metric_func))
@@ -440,9 +425,6 @@ h2o.gam <- function(x,
                                     stopping_rounds = 0,
                                     stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "AUCPR", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
                                     stopping_tolerance = 0.001,
-                                    balance_classes = FALSE,
-                                    class_sampling_factors = NULL,
-                                    max_after_balance_size = 5.0,
                                     max_runtime_secs = 0,
                                     custom_metric_func = NULL,
                                     num_knots = NULL,
@@ -585,12 +567,6 @@ h2o.gam <- function(x,
     parms$stopping_metric <- stopping_metric
   if (!missing(stopping_tolerance))
     parms$stopping_tolerance <- stopping_tolerance
-  if (!missing(balance_classes))
-    parms$balance_classes <- balance_classes
-  if (!missing(class_sampling_factors))
-    parms$class_sampling_factors <- class_sampling_factors
-  if (!missing(max_after_balance_size))
-    parms$max_after_balance_size <- max_after_balance_size
   if (!missing(max_runtime_secs))
     parms$max_runtime_secs <- max_runtime_secs
   if (!missing(custom_metric_func))

--- a/h2o-r/h2o-package/R/glm.R
+++ b/h2o-r/h2o-package/R/glm.R
@@ -116,12 +116,6 @@
 #'        Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.001.
-#' @param balance_classes \code{Logical}. Balance training data class counts via over/under-sampling (for imbalanced data). Defaults to
-#'        FALSE.
-#' @param class_sampling_factors Desired over/under-sampling ratios per class (in lexicographic order). If not specified, sampling factors will
-#'        be automatically computed to obtain class balance during training. Requires balance_classes.
-#' @param max_after_balance_size Maximum relative size of the training data after balancing class counts (can be less than 1.0). Requires
-#'        balance_classes. Defaults to 5.0.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @param custom_metric_func Reference to custom evaluation function, format: `language:keyName=funcName`
 #' @param generate_scoring_history \code{Logical}. If set to true, will generate scoring history for GLM.  This may significantly slow down the
@@ -231,9 +225,6 @@ h2o.glm <- function(x,
                     stopping_rounds = 0,
                     stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "AUCPR", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
                     stopping_tolerance = 0.001,
-                    balance_classes = FALSE,
-                    class_sampling_factors = NULL,
-                    max_after_balance_size = 5.0,
                     max_runtime_secs = 0,
                     custom_metric_func = NULL,
                     generate_scoring_history = FALSE,
@@ -382,12 +373,6 @@ h2o.glm <- function(x,
     parms$stopping_metric <- stopping_metric
   if (!missing(stopping_tolerance))
     parms$stopping_tolerance <- stopping_tolerance
-  if (!missing(balance_classes))
-    parms$balance_classes <- balance_classes
-  if (!missing(class_sampling_factors))
-    parms$class_sampling_factors <- class_sampling_factors
-  if (!missing(max_after_balance_size))
-    parms$max_after_balance_size <- max_after_balance_size
   if (!missing(max_runtime_secs))
     parms$max_runtime_secs <- max_runtime_secs
   if (!missing(custom_metric_func))
@@ -481,9 +466,6 @@ h2o.glm <- function(x,
                                     stopping_rounds = 0,
                                     stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "AUCPR", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
                                     stopping_tolerance = 0.001,
-                                    balance_classes = FALSE,
-                                    class_sampling_factors = NULL,
-                                    max_after_balance_size = 5.0,
                                     max_runtime_secs = 0,
                                     custom_metric_func = NULL,
                                     generate_scoring_history = FALSE,
@@ -637,12 +619,6 @@ h2o.glm <- function(x,
     parms$stopping_metric <- stopping_metric
   if (!missing(stopping_tolerance))
     parms$stopping_tolerance <- stopping_tolerance
-  if (!missing(balance_classes))
-    parms$balance_classes <- balance_classes
-  if (!missing(class_sampling_factors))
-    parms$class_sampling_factors <- class_sampling_factors
-  if (!missing(max_after_balance_size))
-    parms$max_after_balance_size <- max_after_balance_size
   if (!missing(max_runtime_secs))
     parms$max_runtime_secs <- max_runtime_secs
   if (!missing(custom_metric_func))

--- a/h2o-r/h2o-package/R/maxrglm.R
+++ b/h2o-r/h2o-package/R/maxrglm.R
@@ -92,12 +92,6 @@
 #'        Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.001.
-#' @param balance_classes \code{Logical}. Balance training data class counts via over/under-sampling (for imbalanced data). Defaults to
-#'        FALSE.
-#' @param class_sampling_factors Desired over/under-sampling ratios per class (in lexicographic order). If not specified, sampling factors will
-#'        be automatically computed to obtain class balance during training. Requires balance_classes.
-#' @param max_after_balance_size Maximum relative size of the training data after balancing class counts (can be less than 1.0). Requires
-#'        balance_classes. Defaults to 5.0.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @param custom_metric_func Reference to custom evaluation function, format: `language:keyName=funcName`
 #' @param nparallelism number of models to build in parallel.  Default to 0.0 which is adaptive to the system capability Defaults to
@@ -155,9 +149,6 @@ h2o.maxrglm <- function(x,
                         stopping_rounds = 0,
                         stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "AUCPR", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
                         stopping_tolerance = 0.001,
-                        balance_classes = FALSE,
-                        class_sampling_factors = NULL,
-                        max_after_balance_size = 5.0,
                         max_runtime_secs = 0,
                         custom_metric_func = NULL,
                         nparallelism = 0,
@@ -260,12 +251,6 @@ h2o.maxrglm <- function(x,
     parms$stopping_metric <- stopping_metric
   if (!missing(stopping_tolerance))
     parms$stopping_tolerance <- stopping_tolerance
-  if (!missing(balance_classes))
-    parms$balance_classes <- balance_classes
-  if (!missing(class_sampling_factors))
-    parms$class_sampling_factors <- class_sampling_factors
-  if (!missing(max_after_balance_size))
-    parms$max_after_balance_size <- max_after_balance_size
   if (!missing(max_runtime_secs))
     parms$max_runtime_secs <- max_runtime_secs
   if (!missing(custom_metric_func))
@@ -319,9 +304,6 @@ h2o.maxrglm <- function(x,
                                         stopping_rounds = 0,
                                         stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "AUCPR", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
                                         stopping_tolerance = 0.001,
-                                        balance_classes = FALSE,
-                                        class_sampling_factors = NULL,
-                                        max_after_balance_size = 5.0,
                                         max_runtime_secs = 0,
                                         custom_metric_func = NULL,
                                         nparallelism = 0,
@@ -429,12 +411,6 @@ h2o.maxrglm <- function(x,
     parms$stopping_metric <- stopping_metric
   if (!missing(stopping_tolerance))
     parms$stopping_tolerance <- stopping_tolerance
-  if (!missing(balance_classes))
-    parms$balance_classes <- balance_classes
-  if (!missing(class_sampling_factors))
-    parms$class_sampling_factors <- class_sampling_factors
-  if (!missing(max_after_balance_size))
-    parms$max_after_balance_size <- max_after_balance_size
   if (!missing(max_runtime_secs))
     parms$max_runtime_secs <- max_runtime_secs
   if (!missing(custom_metric_func))


### PR DESCRIPTION
This PR completes task in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8354

Removed balance_classes, class_sampling_factors and max_after_balance_size for GLM, GAM, MaxRGLM and ANOVAGLM