### PR TITLE
PUBDEV-8357: Improve error messages in Explain module

### DIFF
--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -471,7 +471,7 @@ def _get_algorithm(model,  treat_xrt_as_algorithm=False):
     return model.algo
 
 
-def _first_of_family(models, all_stackedensembles=True):
+def _first_of_family(models, all_stackedensembles=False):
     # type: (Union[str, h2o.model.ModelBase], bool) -> Union[str, h2o.model.ModelBase]
     """
     Get first of family models

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -428,7 +428,6 @@ class NumpyFrame:
             yield col, self.get(col, with_categorical_names)
 
 
-
 def _get_domain_mapping(model):
     """
     Get a mapping between columns and their domains.
@@ -998,6 +997,9 @@ def pd_plot(
     if target is not None and not isinstance(target, list):
         target = [target]
 
+    if frame.type(column) == "string":
+        raise ValueError("String columns are not supported!")
+
     color = plt.get_cmap(colormap)(0)
     with no_progress():
         plt.figure(figsize=figsize)
@@ -1114,6 +1116,10 @@ def pd_multi_plot(
                 raise ValueError("Only one target can be specified!")
             target = target[0]
         target = [target]
+
+    if frame.type(column) == "string":
+        raise ValueError("String columns are not supported!")
+
     if _is_automl_or_leaderboard(models):
         all_models = _get_model_ids_from_automl_or_leaderboard(models)
     else:
@@ -1249,6 +1255,10 @@ def ice_plot(
                 raise ValueError("Only one target can be specified!")
             target = target[0]
         target = [target]
+
+    if frame.type(column) == "string":
+        raise ValueError("String columns are not supported!")
+
     with no_progress():
         frame = frame.sort(model.actual_params["response_column"])
         is_factor = frame[column].isfactor()[0]
@@ -2535,6 +2545,13 @@ def explain(
     else:
         if columns_of_interest is None:
             columns_of_interest = _get_xy(models_to_show[0])[0]
+    # Make sure that there are no string columns to explain as they are not supported by pdp
+    # Usually those columns would not be used by algos so this just makes sure to exclude them
+    # if user specifies top_n=float('inf') or columns_of_interest=x etc.
+    dropped_string_columns = [col for col in columns_of_interest if frame.type(col) == "string"]
+    if len(dropped_string_columns) > 0:
+        warnings.warn("Dropping string columns as they are not supported: {}".format(dropped_string_columns))
+        columns_of_interest = [col for col in columns_of_interest if frame.type(col) != "string"]
 
     if is_aml or len(models_to_show) > 1:
         if "varimp_heatmap" in explanations:
@@ -2721,6 +2738,14 @@ def explain_row(
             import warnings
             warnings.warn("No model with variable importance. Selecting all features to explain.")
             columns_of_interest = _get_xy(models_to_show[0])[0]
+
+    # Make sure that there are no string columns to explain as they are not supported by pdp
+    # Usually those columns would not be used by algos so this just makes sure to exclude them
+    # if user specifies top_n=float('inf') or columns_of_interest=x etc.
+    dropped_string_columns = [col for col in columns_of_interest if frame.type(col) == "string"]
+    if len(dropped_string_columns) > 0:
+        warnings.warn("Dropping string columns as they are not supported: {}".format(dropped_string_columns))
+        columns_of_interest = [col for col in columns_of_interest if frame.type(col) != "string"]
 
     possible_explanations = ["leaderboard", "shap_explain_row", "ice"]
 

--- a/h2o-py/tests/testdir_misc/pyunit_explain.py
+++ b/h2o-py/tests/testdir_misc/pyunit_explain.py
@@ -35,8 +35,9 @@ def test_get_xy():
 
 
 def test_explanation_single_model_regression():
-    train = h2o.upload_file(pyunit_utils.locate("smalldata/wine/winequality-redwhite-no-BOM.csv"))
-    y = "quality"
+    train = h2o.upload_file(pyunit_utils.locate("smalldata/titanic/titanic_expanded.csv"))
+    y = "fare"
+
     # get at most one column from each type
     cols_to_test = []
     for col, typ in train.types.items():
@@ -63,11 +64,17 @@ def test_explanation_single_model_regression():
 
     # test pd_plot
     for col in cols_to_test:
-        assert isinstance(gbm.pd_plot(train, col), matplotlib.pyplot.Figure)
+        try:
+            assert isinstance(gbm.pd_plot(train, col), matplotlib.pyplot.Figure)
+        except ValueError:
+            assert col == "name", "'name' is a string column which is not supported."
 
     # test ICE plot
     for col in cols_to_test:
-        assert isinstance(gbm.ice_plot(train, col), matplotlib.pyplot.Figure)
+        try:
+            assert isinstance(gbm.ice_plot(train, col), matplotlib.pyplot.Figure)
+        except ValueError:
+            assert col == "name", "'name' is a string column which is not supported."
     matplotlib.pyplot.close("all")
 
     # test learning curve
@@ -85,8 +92,10 @@ def test_explanation_single_model_regression():
 
 
 def test_explanation_automl_regression():
-    train = h2o.upload_file(pyunit_utils.locate("smalldata/wine/winequality-redwhite-no-BOM.csv"))
-    y = "quality"
+    train = h2o.upload_file(pyunit_utils.locate("smalldata/titanic/titanic_expanded.csv"))
+    train["name"] = train["name"].asfactor()
+    y = "fare"
+
     # get at most one column from each type
     cols_to_test = []
     for col, typ in train.types.items():
@@ -116,7 +125,10 @@ def test_explanation_automl_regression():
 
     # test partial dependences
     for col in cols_to_test:
-        assert isinstance(aml.pd_multi_plot(train, col), matplotlib.pyplot.Figure)
+        try:
+            assert isinstance(aml.pd_multi_plot(train, col), matplotlib.pyplot.Figure)
+        except ValueError:
+            assert col == "name", "'name' is a string column which is not supported."
     matplotlib.pyplot.close("all")
 
     # test explain
@@ -142,8 +154,10 @@ def test_explanation_automl_regression():
 
 
 def test_explanation_list_of_models_regression():
-    train = h2o.upload_file(pyunit_utils.locate("smalldata/wine/winequality-redwhite-no-BOM.csv"))
-    y = "quality"
+    train = h2o.upload_file(pyunit_utils.locate("smalldata/titanic/titanic_expanded.csv"))
+    train["name"] = train["name"].asfactor()
+    y = "fare"
+
     # get at most one column from each type
     cols_to_test = []
     for col, typ in train.types.items():
@@ -174,7 +188,10 @@ def test_explanation_list_of_models_regression():
 
     # test partial dependences
     for col in cols_to_test:
-        assert isinstance(h2o.pd_multi_plot(models, train, col), matplotlib.pyplot.Figure)
+        try:
+            assert isinstance(h2o.pd_multi_plot(models, train, col), matplotlib.pyplot.Figure)
+        except ValueError:
+            assert col == "name", "'name' is a string column which is not supported."
     matplotlib.pyplot.close("all")
 
     # test learning curve

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -56,7 +56,7 @@ with_no_h2o_progress <- function(expr) {
 #'
 #' @param models models or model ids
 #' @param all_stackedensembles if TRUE, select all stacked ensembles
-.get_first_of_family <- function(models, all_stackedensembles = TRUE) {
+.get_first_of_family <- function(models, all_stackedensembles = FALSE) {
   selected_models <- character()
   included_families <- character()
   for (model in models) {

--- a/h2o-r/tests/testdir_misc/runit_explain.R
+++ b/h2o-r/tests/testdir_misc/runit_explain.R
@@ -10,8 +10,8 @@ expect_ggplot <- function(gg) {
 }
 
 explanation_test_single_model_regression <- function() {
-  train <- h2o.uploadFile(locate("smalldata/wine/winequality-redwhite-no-BOM.csv"))
-  y <- "quality"
+  train <- h2o.uploadFile(locate("smalldata/titanic/titanic_expanded.csv"))
+  y <- "fare"
 
   col_types <- setNames(unlist(h2o.getTypes(train)), names(train))
   col_types <- col_types[names(col_types) != y]
@@ -33,12 +33,18 @@ explanation_test_single_model_regression <- function() {
 
   # test partial dependences
   for (col in cols_to_test) {
-    expect_ggplot(h2o.pd_plot(gbm, train, col))
+    if (col == "name")  # a string column
+      expect_error(expect_ggplot(h2o.pd_multi_plot(models, train, col)))
+    else
+      expect_ggplot(h2o.pd_plot(gbm, train, col))
   }
 
   # test ice plot
   for (col in cols_to_test) {
-    expect_ggplot(h2o.ice_plot(gbm, train, col))
+    if (col == "name")  # a string column
+      expect_error(expect_ggplot(h2o.pd_multi_plot(models, train, col)))
+    else
+      expect_ggplot(h2o.ice_plot(gbm, train, col))
   }
 
   # test learning curve plot
@@ -56,8 +62,8 @@ explanation_test_single_model_regression <- function() {
 }
 
 explanation_test_automl_regression <- function() {
-  train <- h2o.uploadFile(locate("smalldata/wine/winequality-redwhite-no-BOM.csv"))
-  y <- "quality"
+  train <- h2o.uploadFile(locate("smalldata/titanic/titanic_expanded.csv"))
+  y <- "fare"
 
   col_types <- setNames(unlist(h2o.getTypes(train)), names(train))
   col_types <- col_types[names(col_types) != y]
@@ -85,7 +91,10 @@ explanation_test_automl_regression <- function() {
 
   # test partial dependences
   for (col in cols_to_test) {
-    expect_ggplot(h2o.pd_multi_plot(aml, train, col))
+    if (col == "name")  # a string column
+      expect_error(expect_ggplot(h2o.pd_multi_plot(models, train, col)))
+    else
+      expect_ggplot(h2o.pd_multi_plot(aml, train, col))
   }
   # test ice plot
   expect_error(h2o.ice_plot(aml, train, cols_to_test[[1]]), "Only one model is allowed!")
@@ -105,8 +114,8 @@ explanation_test_automl_regression <- function() {
 }
 
 explanation_test_list_of_models_regression <- function() {
-  train <- h2o.uploadFile(locate("smalldata/wine/winequality-redwhite-no-BOM.csv"))
-  y <- "quality"
+  train <- h2o.uploadFile(locate("smalldata/titanic/titanic_expanded.csv"))
+  y <- "fare"
 
   col_types <- setNames(unlist(h2o.getTypes(train)), names(train))
   col_types <- col_types[names(col_types) != y]
@@ -137,7 +146,10 @@ explanation_test_list_of_models_regression <- function() {
 
   # test partial dependences
   for (col in cols_to_test) {
-    expect_ggplot(h2o.pd_multi_plot(models, train, col))
+    if (col == "name")  # a string column
+      expect_error(expect_ggplot(h2o.pd_multi_plot(models, train, col)))
+    else
+      expect_ggplot(h2o.pd_multi_plot(models, train, col))
   }
   # test ice plot
   expect_error(h2o.ice_plot(models, train, cols_to_test[[1]]), "Only one model is allowed!")


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8357

**Includes:**
 - Add error message in R when no model with varimp is found and only
   models with varimp are required
 - Speed up Explain tests: use titanic dataset for regression tests in explain
 - Use only the top SE in best of family plots (default value of `all_stackedensembles` changed to `False`)
 - Add error message when user uses string column in pdp related plots (not
   supported by partialPlot)
   
>**NOTE:** String columns are ignored by most models (those that we support in explain) so the models don't use them   (ModelBuilder drops them), but the user can specify to explain all columns even those that are dropped so I added a check to ensure that we provide some error rather then plotting NaNs.