### PR TITLE
Fix explain tests [nocheck]

### DIFF
--- a/h2o-py/tests/testdir_misc/pyunit_explain.py
+++ b/h2o-py/tests/testdir_misc/pyunit_explain.py
@@ -147,15 +147,16 @@ def test_explanation_automl_regression():
 
     # Leaderboard slices work
     # test explain
-    assert isinstance(h2o.explain(aml.leaderboard[:8, :], train, render=False), H2OExplanation)
+    assert isinstance(h2o.explain(aml.leaderboard[~aml.leaderboard["model_id"].grep("^Stacked", output_logical=True), :],
+                                  train, render=False), H2OExplanation)
 
     # test explain row
-    assert isinstance(h2o.explain_row(aml.leaderboard[:8, :], train, 1, render=False), H2OExplanation)
+    assert isinstance(h2o.explain_row(aml.leaderboard[~aml.leaderboard["model_id"].grep("^Stacked", output_logical=True), :],
+                                      train, 1, render=False), H2OExplanation)
 
 
 def test_explanation_list_of_models_regression():
     train = h2o.upload_file(pyunit_utils.locate("smalldata/titanic/titanic_expanded.csv"))
-    train["name"] = train["name"].asfactor()
     y = "fare"
 
     # get at most one column from each type
@@ -303,25 +304,26 @@ def test_explanation_automl_binomial_classification():
     assert isinstance(aml.varimp_heatmap(), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close()
 
-    assert len(h2o.explanation.varimp(aml.leaderboard[:8, :], use_pandas=False)) == 3  # numpy.ndarray, colnames, rownames
-    assert isinstance(h2o.explanation.varimp(aml.leaderboard[:8, :], use_pandas=True), pandas.DataFrame)
+    leaderboard_without_SE = aml.leaderboard[~aml.leaderboard["model_id"].grep("^Stacked", output_logical=True), :]
+    assert len(h2o.explanation.varimp(leaderboard_without_SE, use_pandas=False)) == 3  # numpy.ndarray, colnames, rownames
+    assert isinstance(h2o.explanation.varimp(leaderboard_without_SE, use_pandas=True), pandas.DataFrame)
 
     # test model correlation heatmap plot
-    assert isinstance(h2o.model_correlation_heatmap(aml.leaderboard[:8, :], train), matplotlib.pyplot.Figure)
+    assert isinstance(h2o.model_correlation_heatmap(leaderboard_without_SE, train), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close()
 
-    assert len(h2o.explanation.model_correlation(aml.leaderboard[:8, :], train, use_pandas=False)) == 2  # numpy.ndarray, colnames and rownames both in the same order => represented by just one vector
-    assert isinstance(h2o.explanation.model_correlation(aml.leaderboard[:8, :], train, use_pandas=True), pandas.DataFrame)
+    assert len(h2o.explanation.model_correlation(leaderboard_without_SE, train, use_pandas=False)) == 2  # numpy.ndarray, colnames and rownames both in the same order => represented by just one vector
+    assert isinstance(h2o.explanation.model_correlation(leaderboard_without_SE, train, use_pandas=True), pandas.DataFrame)
 
     # test partial dependences
-    assert isinstance(h2o.pd_multi_plot(aml.leaderboard[:8, :], train, cols_to_test[0]), matplotlib.pyplot.Figure)
+    assert isinstance(h2o.pd_multi_plot(leaderboard_without_SE, train, cols_to_test[0]), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close()
 
     # test explain
-    assert isinstance(h2o.explain(aml.leaderboard[:8, :], train, render=False), H2OExplanation)
+    assert isinstance(h2o.explain(leaderboard_without_SE, train, render=False), H2OExplanation)
 
     # test explain row
-    assert isinstance(h2o.explain_row(aml.leaderboard[:8, :], train, 1, render=False), H2OExplanation)
+    assert isinstance(h2o.explain_row(leaderboard_without_SE, train, 1, render=False), H2OExplanation)
 
 
 def test_explanation_list_of_models_binomial_classification():
@@ -468,10 +470,10 @@ def test_explanation_automl_multinomial_classification():
 
     # Leaderboard slices work
     # test explain
-    assert isinstance(h2o.explain(aml.leaderboard[:8, :], train, render=False), H2OExplanation)
+    assert isinstance(h2o.explain(aml.leaderboard[~aml.leaderboard["model_id"].grep("^Stacked", output_logical=True), :], train, render=False), H2OExplanation)
 
     # test explain row
-    assert isinstance(h2o.explain_row(aml.leaderboard[:8, :], train, 1, render=False), H2OExplanation)
+    assert isinstance(h2o.explain_row(aml.leaderboard[~aml.leaderboard["model_id"].grep("^Stacked", output_logical=True), :], train, 1, render=False), H2OExplanation)
 
 
 def test_explanation_list_of_models_multinomial_classification():

--- a/h2o-r/tests/testdir_misc/runit_explain.R
+++ b/h2o-r/tests/testdir_misc/runit_explain.R
@@ -107,10 +107,10 @@ explanation_test_automl_regression <- function() {
 
   # Leaderboard slice works
   # test explanation
-  expect_true("H2OExplanation" %in% class(h2o.explain(aml@leaderboard[1:4,], train)))
+  expect_true("H2OExplanation" %in% class(h2o.explain(aml@leaderboard[-1,], train)))
 
   # test explanation
-  expect_true("H2OExplanation" %in% class(h2o.explain_row(aml@leaderboard[1:4,], train, 1)))
+  expect_true("H2OExplanation" %in% class(h2o.explain_row(aml@leaderboard[-1,], train, 1)))
 }
 
 explanation_test_list_of_models_regression <- function() {
@@ -260,28 +260,28 @@ explanation_test_automl_binomial_classification <- function() {
 
   # Leaderboard slice works
   # test model correlation
-  expect_ggplot(h2o.model_correlation_heatmap(aml@leaderboard[1:8,], train))
+  expect_ggplot(h2o.model_correlation_heatmap(aml@leaderboard[-1,], train))
 
   # test variable importance heatmap
-  expect_ggplot(h2o.varimp_heatmap(aml@leaderboard[1:8,]))
+  expect_ggplot(h2o.varimp_heatmap(aml@leaderboard[-1,]))
 
   # test shap summary
-  expect_error(h2o.shap_summary_plot(aml@leaderboard[1:8,], train), "SHAP summary plot requires a tree-based model!")
+  expect_error(h2o.shap_summary_plot(aml@leaderboard[-1,], train), "SHAP summary plot requires a tree-based model!")
 
   # test shap explain row
-  expect_error(h2o.shap_explain_row_plot(aml@leaderboard[1:8,], train, 1), "SHAP explain_row plot requires a tree-based model!")
+  expect_error(h2o.shap_explain_row_plot(aml@leaderboard[-1,], train, 1), "SHAP explain_row plot requires a tree-based model!")
 
   # test partial dependences
-  expect_ggplot(h2o.pd_multi_plot(aml@leaderboard[1:8,], train, cols_to_test[[1]]))
+  expect_ggplot(h2o.pd_multi_plot(aml@leaderboard[-1,], train, cols_to_test[[1]]))
 
   # test ice plot
-  expect_error(h2o.ice_plot(aml@leaderboard[1:8,], train, cols_to_test[[1]]), "Only one model is allowed!")
+  expect_error(h2o.ice_plot(aml@leaderboard[-1,], train, cols_to_test[[1]]), "Only one model is allowed!")
 
   # test explanation
-  expect_true("H2OExplanation" %in% class(h2o.explain(aml@leaderboard[1:8,], train)))
+  expect_true("H2OExplanation" %in% class(h2o.explain(aml@leaderboard[-1,], train)))
 
   # test explanation
-  expect_true("H2OExplanation" %in% class(h2o.explain_row(aml@leaderboard[1:8,], train, 1)))
+  expect_true("H2OExplanation" %in% class(h2o.explain_row(aml@leaderboard[-1,], train, 1)))
 }
 
 explanation_test_list_of_models_binomial_classification <- function() {


### PR DESCRIPTION
I was unable to reproduce the behavior locally so I made it more robust, most likely it will solve the issues `explain` currently has - sometimes there is no model in top N that is not a stacked ensemble and it fails on not having an "explainable" model in that leaderboard slice.