### PR TITLE
Fix pyunit_cacert_conf.py [nocheck]

### DIFF
--- a/h2o-py/tests/testdir_misc/pyunit_cacert_conf.py
+++ b/h2o-py/tests/testdir_misc/pyunit_cacert_conf.py
@@ -3,6 +3,7 @@ sys.path.insert(1,"../../")
 import h2o
 from tests import pyunit_utils
 from h2o.exceptions import H2OConnectionError
+import os
 
 # Note: this test is relies on external service (badssl.com)
 #       badssl.com provides a public endpoint with a self-signed certificate
@@ -19,7 +20,12 @@ def test_cacert_in_config():
     except H2OConnectionError as e:
         assert "CERTIFICATE_VERIFY_FAILED" in str(e)
 
-    cfg["cacert"] = pyunit_utils.locate("smalldata/certs/badssl-cacert-2020.pem")
+    path = pyunit_utils.locate("results")
+    cert_file = os.path.join(path, "badssl-cacert.pem")
+
+    # Download self-signed certificate
+    os.system("openssl s_client -showcerts -verify 0 -connect self-signed.badssl.com:443 -servername self-signed.badssl.com < /dev/null > {0}".format(cert_file))
+    cfg["cacert"] = cert_file
     try:
         h2o.connect(config=cfg)
         assert False


### PR DESCRIPTION
The current certificate from s3 is expired. Download it each time and avoid any future problems