### PR TITLE
[PUBDEV-8377] Increase Jetty Idle Timeout to 5 minutes and Make It Configurable

### DIFF
--- a/h2o-jetty-8/src/main/java/water/webserver/jetty8/Jetty8Helper.java
+++ b/h2o-jetty-8/src/main/java/water/webserver/jetty8/Jetty8Helper.java
@@ -82,6 +82,7 @@ class Jetty8Helper {
     connector.setRequestBufferSize(getSysPropInt(proto+".requestBufferSize", 32*1024));
     connector.setResponseHeaderSize(getSysPropInt(proto+".responseHeaderSize", connector.getResponseHeaderSize()));
     connector.setResponseBufferSize(getSysPropInt(proto+".responseBufferSize", connector.getResponseBufferSize()));
+    connector.setMaxIdleTime(getSysPropInt(proto + ".jetty.idleTimeout", 5 * 60 * 1000));
   }
 
   private static int getSysPropInt(String suffix, int defaultValue) {

--- a/h2o-jetty-9/src/main/java/water/webserver/jetty9/Jetty9Helper.java
+++ b/h2o-jetty-9/src/main/java/water/webserver/jetty9/Jetty9Helper.java
@@ -87,6 +87,7 @@ class Jetty9Helper {
         httpConfiguration.setRequestHeaderSize(getSysPropInt(proto + ".requestHeaderSize", 32 * 1024));
         httpConfiguration.setResponseHeaderSize(getSysPropInt(proto + ".responseHeaderSize", 32 * 1024));
         httpConfiguration.setOutputBufferSize(getSysPropInt(proto + ".responseBufferSize", httpConfiguration.getOutputBufferSize()));
+        httpConfiguration.setIdleTimeout(getSysPropInt(proto + ".jetty.idleTimeout", 5 * 60 * 1000));
 
         return new HttpConnectionFactory(httpConfiguration);
     }


### PR DESCRIPTION
Default limit is 30s on Jetty 9 and 200s on Jetty8.

Sparkling Water conversions fails on this timeout when partitions are big and if the source of the data is slow (JDBC connections).

Problem description: https://github.com/h2oai/sparkling-water/issues/2552