### PR TITLE
GH-7325 Prediction consistency check for constrained models

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/DTree.java
+++ b/h2o-algos/src/main/java/hex/tree/DTree.java
@@ -712,10 +712,12 @@ public class DTree extends Iced {
         Arrays.fill(_nids, ScoreBuildHistogram.UNDECIDED_CHILD_NODE_ID);
         return;
       }
-      if(cs != null){
+      if(cs != null) {
         int constr = cs.getColumnConstraint(_split._col);
-        if(nid() != 0 && constr != 0) {
-          assert constr * _split._tree_p0 <= constr* parentPred() &&  constr * parentPred() <= constr * _split._tree_p1;
+        if (!cs._dist._family.equals(DistributionFamily.quantile) && nid() != 0 && constr != 0) {
+            assert constr * _split._tree_p0 <= constr * parentPred() && constr * parentPred() <= constr * _split._tree_p1 :
+                    "Parent prediction and children prediction is not consistent. Parent prediction " + constr * parentPred() +
+                            " should be in interval of the children: " + constr * _split._tree_p0 + " " + constr * _split._tree_p1;
         }
       }
       _splat = _split.splat(hs);

--- a/h2o-algos/src/main/java/hex/tree/DTree.java
+++ b/h2o-algos/src/main/java/hex/tree/DTree.java
@@ -126,6 +126,7 @@ public class DTree extends Iced {
     _leaves = tree._leaves;
     _len = tree._len;
     _depth = tree._depth;
+    _checkConstraintConsistency = tree._checkConstraintConsistency;
   }
 
   public final Node root() { return _ns[0]; }

--- a/h2o-algos/src/main/java/hex/tree/DTree.java
+++ b/h2o-algos/src/main/java/hex/tree/DTree.java
@@ -955,15 +955,13 @@ public class DTree extends Iced {
     
     private boolean isLeftChild(){
       int[] parentNids = ((DecidedNode) _tree.node(pid()))._nids;
-      int index = ArrayUtils.indexOf(ArrayUtils.toIntegers(parentNids, 0, 2), _nid);
-      return index == 0;
+      return parentNids[0] == _nid;
     }
     
     public double parentPred(){
       Split parentSplit = ((DecidedNode) _tree.node(pid()))._split;
       return isLeftChild() ? parentSplit._tree_p0 : parentSplit._tree_p1;
     }
-    
   }
 
   public final static class LeafNode extends Node {

--- a/h2o-algos/src/main/java/hex/tree/DTree.java
+++ b/h2o-algos/src/main/java/hex/tree/DTree.java
@@ -709,8 +709,14 @@ public class DTree extends Iced {
         // which might be because all predictor columns are now constant, or
         // because all responses are now constant.
         _splat = Float.NaN;
-        Arrays.fill(_nids,ScoreBuildHistogram.UNDECIDED_CHILD_NODE_ID);
+        Arrays.fill(_nids, ScoreBuildHistogram.UNDECIDED_CHILD_NODE_ID);
         return;
+      }
+      if(cs != null){
+        int constr = cs.getColumnConstraint(_split._col);
+        if(nid() != 0 && constr != 0) {
+          assert constr * _split._tree_p0 <= constr* parentPred() &&  constr * parentPred() <= constr * _split._tree_p1;
+        }
       }
       _splat = _split.splat(hs);
       for(int way = 0; way <2; way++ ) { // left / right
@@ -931,6 +937,18 @@ public class DTree extends Iced {
       assert _size == ab.position()-pos:"reported size = " + _size + " , real size = " + (ab.position()-pos);
       return ab;
     }
+    
+    private boolean isLeftChild(){
+      int[] parentNids = ((DecidedNode) _tree.node(pid()))._nids;
+      int index = ArrayUtils.indexOf(ArrayUtils.toIntegers(parentNids, 0, 2), _nid);
+      return index == 0;
+    }
+    
+    public double parentPred(){
+      Split parentSplit = ((DecidedNode) _tree.node(pid()))._split;
+      return isLeftChild() ? parentSplit._tree_p0 : parentSplit._tree_p1;
+    }
+    
   }
 
   public final static class LeafNode extends Node {

--- a/h2o-docs/src/product/data-science/algo-params/monotone_constraints.rst
+++ b/h2o-docs/src/product/data-science/algo-params/monotone_constraints.rst
@@ -11,6 +11,8 @@ A mapping that represents monotonic constraints. Use +1 to enforce an increasing
 
 **Note**: In GBM and XGBoost, this option can only be used when the distribution is ``gaussian``, ``bernoulli``, ``tweedie``. In GBM also ``quantile`` distribution is supported.
 
+You can enable consistency check using the system property: ``sys.ai.h2o.tree.constraintConsistencyCheck=true``. It is disabled by default.
+
 Related Parameters
 ~~~~~~~~~~~~~~~~~~
 

--- a/h2o-docs/src/product/data-science/algo-params/monotone_constraints.rst
+++ b/h2o-docs/src/product/data-science/algo-params/monotone_constraints.rst
@@ -11,7 +11,7 @@ A mapping that represents monotonic constraints. Use +1 to enforce an increasing
 
 **Note**: In GBM and XGBoost, this option can only be used when the distribution is ``gaussian``, ``bernoulli``, ``tweedie``. In GBM also ``quantile`` distribution is supported.
 
-You can enable consistency check using the system property: ``sys.ai.h2o.tree.constraintConsistencyCheck=true``. It is disabled by default.
+You can enable monotone constraints consistency check using the system property: ``sys.ai.h2o.tree.constraintConsistencyCheck=true``. It checks the parent prediction is in interval of the children predictions. It is disabled by default.
 
 Related Parameters
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Issue: https://github.com/h2oai/h2o-3/issues/7325

The first idea is to implement assert, which checks the parent prediction is in the interval of children's predictions. 

Quantile distribution is excluded, other monotone constraints tests should pass. 