### PR TITLE
diagnose bug origin

### DIFF
--- a/h2o-algos/src/test/java/hex/tree/PrintMojoTreeTest.java
+++ b/h2o-algos/src/test/java/hex/tree/PrintMojoTreeTest.java
@@ -219,6 +219,7 @@ public class PrintMojoTreeTest {
             assertTrue(fileNames.get(i).endsWith(expectedFileNames[i]));
         } 
       } else {
+        assertTrue(Files.size(treeOutputPath) > 0);
         assertTrue(treeOutputPath.endsWith(expectedFileNames[0]));
       }
   }


### PR DESCRIPTION
this should help diagnose test failures in https://github.com/h2oai/h2o-3/pull/5768, since it is not well locally reproducible. 
with this line, also `testMojoCategoricalPng` should fail if there is a problem with ServiceLoader not loading JgraphtPrintMojo. If not, there will be a problem in sth else.



