### PR TITLE
Fix pyunit_connect_invalid test

### DIFF
--- a/h2o-hadoop-common/tests/python/pyunit_connect_invalid.py
+++ b/h2o-hadoop-common/tests/python/pyunit_connect_invalid.py
@@ -23,6 +23,9 @@ def connect_invalid():
     # Not invalid yet - first do sanity check that original connection can be used to make a request
     invalid.request("GET /3/About")
 
+    auth_user = invalid._auth[0] if isinstance(invalid._auth, tuple) else "jenkins" # fallback for CI testing
+    invalid._auth = (auth_user, "invalid-password")
+
     # Test with invalid basic auth
     err = None
     try:


### PR DESCRIPTION
We need to only use an invalid password as opposed to also invalid user name.
Invalid user name might be caught by "authentication handler" as opposed
to proper authentication.

The previous version of the test could pass even if there was no authentication in place.