### PR TITLE
PUBDEV-7973 glm beta constraints not working

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/ComputationState.java
+++ b/h2o-algos/src/main/java/hex/glm/ComputationState.java
@@ -724,7 +724,7 @@ public final class ComputationState {
       }
     }
     ADMM.subgrad(_alpha * _lambda, beta, grad);
-    for (int c : activeCols) // set the error tolerance to the highest error og included columns
+    for (int c : activeCols) // set the error tolerance to the highest error of included columns
       if (grad[c] > err) err = grad[c];
       else if (grad[c] < -err) err = -grad[c];
     _gradientErr = err;

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -2764,7 +2764,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
     private void checkCoeffsBounds() {
       BetaConstraint bc = _parms._beta_constraints != null ? new BetaConstraint(_parms._beta_constraints.get())
               : new BetaConstraint(); // bounds for columns _dinfo.fullN()+1 only
-      double[] coeffs = _model._output.getNormBeta();
+      double[] coeffs = _model._output.beta();
       if (bc._betaLB == null || bc._betaUB == null || coeffs == null)
         return;
       int coeffsLen = bc._betaLB.length;

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -2763,6 +2763,8 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
      */
     private void checkCoeffsBounds() {
       double[] coeffs = _model._output.getNormBeta();
+      if (_bc._betaLB == null)
+        return;
       int coeffsLen = _bc._betaLB.length;
       for (int index=0; index < coeffsLen; index++) {
         if (!(coeffs[index] == 0 || (coeffs[index] >= _bc._betaLB[index] && coeffs[index] <= _bc._betaUB[index])))

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -2764,7 +2764,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
     private void checkCoeffsBounds() {
       BetaConstraint bc = _parms._beta_constraints != null ? new BetaConstraint(_parms._beta_constraints.get())
               : new BetaConstraint(); // bounds for columns _dinfo.fullN()+1 only
-      double[] coeffs = _model._output.beta();
+      double[] coeffs = _parms._standardize ? _model._output.getNormBeta() :_model._output.beta();
       if (bc._betaLB == null || bc._betaUB == null || coeffs == null)
         return;
       int coeffsLen = bc._betaLB.length;

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -2753,7 +2753,8 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
     }
 
     private boolean betaConstraintsCheckEnabled() {
-      return Boolean.parseBoolean(getSysProperty("glm.beta.constraints.checkEnabled", "true"));
+      return Boolean.parseBoolean(getSysProperty("glm.beta.constraints.checkEnabled", "true")) &&
+              !multinomial.equals(_parms._family) && !ordinal.equals(_parms._family);
     }
 
     /***
@@ -2761,9 +2762,10 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
      * beta constraints bounds.  This check only applies when the beta constraints has a lower and upper bound.
      */
     private void checkCoeffsBounds() {
+      BetaConstraint bc = _parms._beta_constraints != null ? new BetaConstraint(_parms._beta_constraints.get())
+              : new BetaConstraint(); // bounds for columns _dinfo.fullN()+1 only
       double[] coeffs = _model._output.getNormBeta();
-      BetaConstraint bc = new BetaConstraint(_parms._beta_constraints.get());
-      if (bc._betaLB == null || bc._betaUB == null)
+      if (bc._betaLB == null || bc._betaUB == null || coeffs == null)
         return;
       int coeffsLen = bc._betaLB.length;
       for (int index=0; index < coeffsLen; index++) {

--- a/h2o-bindings/bin/custom/python/gen_glm.py
+++ b/h2o-bindings/bin/custom/python/gen_glm.py
@@ -206,6 +206,26 @@ assert_is_type({pname}, None, numeric, [numeric])
 self._parms["{sname}"] = {pname}
 """
     ),
+    beta_constraints=dict(
+        setter="""
+# beta_constraints can be specified as a H2OFrame or python dict
+assert_is_type({pname}, None, dict, H2OFrame)
+if type({pname}) is H2OFrame:
+    self._parms["{sname}"]={pname}
+if type({pname}) is dict:
+    colnames = {pname}.keys()
+    col_names = []
+    upper_bounds = []
+    lower_bounds = []
+    for key in colnames:
+        one_col_bounds = {pname}.get(key)
+        col_names.append(key)
+        upper_bounds.append(one_col_bounds.get('upper_bound'))
+        lower_bounds.append(one_col_bounds.get('lower_bound'))
+    constraints = h2o.H2OFrame(dict([("names",col_names), ("lower_bounds", lower_bounds), ("upper_bounds", upper_bounds)]))
+    self._parms["{sname}"] = constraints[["names", "lower_bounds", "upper_bounds"]]
+"""
+    )
 )
 
 doc = dict(

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7973_beta_constraints_binomial.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7973_beta_constraints_binomial.py
@@ -1,0 +1,76 @@
+from builtins import range
+import sys
+
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+
+# simple test to set beta constraints tests with various number of predictors.  Make sure the coefficient bounds are
+# within the beta constraints bounds.
+def test_beta_constraints_binomial():
+    h2o_data = h2o.import_file(pyunit_utils.locate("smalldata/glm_test/binomial_20_cols_10KRows.csv"))
+    h2o_data["C1"] = h2o_data["C1"].asfactor()
+    h2o_data["C2"] = h2o_data["C2"].asfactor()
+    h2o_data["C3"] = h2o_data["C3"].asfactor()
+    h2o_data["C4"] = h2o_data["C4"].asfactor()
+    h2o_data["C5"] = h2o_data["C5"].asfactor()
+    h2o_data["C6"] = h2o_data["C6"].asfactor()
+    h2o_data["C7"] = h2o_data["C7"].asfactor()
+    h2o_data["C8"] = h2o_data["C8"].asfactor()
+    h2o_data["C9"] = h2o_data["C9"].asfactor()
+    h2o_data["C10"] = h2o_data["C10"].asfactor()
+    y = "C21"
+    x = h2o_data.names
+    x.remove(y)
+    nfolds = 4
+    seed = 12345
+    h2o_data["C21"] = h2o_data["C21"].asfactor()
+
+    printText = "running model with beta constrains on C1, C2, C3, C11, C12, C13"
+    dictBounds = {'names': ["C1.0", "C2.0", "C3.0", "C11", "C12", "C13"],
+                  'lower_bounds': [1.3498144060671078*0.1, 0.8892709168416222*0.1, 2.5406690227893254*0.1,
+                                   1.959130413902314*0.1, 0.13139198387980652*0.1, 1.80498551446445*0.1],
+                  'upper_bounds': [1.3498144060671078*0.8, 0.8892709168416222*0.8, 2.5406690227893254*0.8,
+                                   1.959130413902314*0.8, 0.13139198387980652*0.8, 1.80498551446445*0.8]}
+    constraints = h2o.H2OFrame(dictBounds)
+    constraints = constraints[["names", "lower_bounds", "upper_bounds"]]
+    run_print_model_performance('binomial', h2o_data, nfolds, constraints, x, y, printText, seed, 'coordinate_descent')
+    run_print_model_performance('binomial', h2o_data, nfolds, constraints, x, y, printText, seed, 'irlsm')
+
+def run_print_model_performance(family, train, nfolds, bc_constraints, x, y, printText, seed, solver):
+    print(printText)
+    print("Without lambda search and with solver {0}".format(solver))
+    h2o_model = H2OGeneralizedLinearEstimator(family=family, nfolds=nfolds, beta_constraints=bc_constraints, seed=seed,
+                                              solver = solver)
+    h2o_model.train(x=x, y=y, training_frame=train)
+    print("With lambda search and with solver {0}".format(solver))
+    h2o_model2 = H2OGeneralizedLinearEstimator(family=family, nfolds=nfolds, beta_constraints=bc_constraints, seed=seed,
+                                              lambda_search=True, solver = solver)
+    h2o_model2.train(x=x, y=y, training_frame=train)
+    # check coefficients to be within bounds
+    coeff = h2o_model.coef()
+    coeff2 = h2o_model2.coef()
+    colNames = bc_constraints["names"]
+    lowerB = bc_constraints["lower_bounds"]
+    upperB = bc_constraints["upper_bounds"]
+    for count in range(0, len(colNames)):
+        low_diff = abs(coeff[colNames[count,0]]-lowerB[count,0]) < 1e-6
+        up_diff = abs(coeff[colNames[count,0]] <= upperB[count,0]) < 1e-6
+        coef_inactive = coeff[colNames[count,0]]==0
+        assert ((coeff[colNames[count,0]] >= lowerB[count,0] or low_diff) and (coeff[colNames[count,0]]
+                                                                              <= upperB[count,0] or up_diff)) or coef_inactive, \
+            "coef for {0}: {1}, lower bound: {2}, upper bound: {3}".format(colNames[count,0], coeff[colNames[count,0]],
+                                                                           lowerB[count,0], upperB[count,0])
+        low_diff2 =  abs(coeff2[colNames[count,0]]-lowerB[count,0]) < 1e-6
+        up_diff2 = abs(coeff2[colNames[count,0]] <= upperB[count,0]) < 1e-6
+        coef_inactive2 = coeff2[colNames[count,0]]==0
+        assert ((coeff2[colNames[count,0]] >= lowerB[count,0] or low_diff2) and (coeff2[colNames[count,0]]
+                                                                                <= upperB[count,0] or up_diff2)) or coef_inactive2, \
+            "With lambda search: coef for {0}: {1}, lower bound: {2}, upper bound: {3}".format(colNames[count,0], coeff2[colNames[count,0]],
+                                                                           lowerB[count,0], upperB[count,0])
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_beta_constraints_binomial)
+else:
+    test_beta_constraints_binomial()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7973_beta_constraints_gaussian.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7973_beta_constraints_gaussian.py
@@ -1,0 +1,78 @@
+from builtins import range
+import sys
+
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+
+# simple test to set beta constraints tests with various number of predictors.  Make sure the coefficient bounds are
+# within the beta constraints bounds.
+def test_beta_constraints_gaussian():
+    h2o_data = h2o.import_file(pyunit_utils.locate("smalldata/glm_test/gaussian_20cols_10000Rows.csv"))
+    h2o_data["C1"] = h2o_data["C1"].asfactor()
+    h2o_data["C2"] = h2o_data["C2"].asfactor()
+    h2o_data["C3"] = h2o_data["C3"].asfactor()
+    h2o_data["C4"] = h2o_data["C4"].asfactor()
+    h2o_data["C5"] = h2o_data["C5"].asfactor()
+    h2o_data["C6"] = h2o_data["C6"].asfactor()
+    h2o_data["C7"] = h2o_data["C7"].asfactor()
+    h2o_data["C8"] = h2o_data["C8"].asfactor()
+    h2o_data["C9"] = h2o_data["C9"].asfactor()
+    h2o_data["C10"] = h2o_data["C10"].asfactor()
+    y = "C21"
+    x = h2o_data.names
+    x.remove(y)
+    nfolds = 4
+    seed = 12345
+
+    printText = "running model with beta constrains on C1, C2, C3, C11, C12, C13"
+    constraints = h2o.H2OFrame({'names': ["C1.1", "C2.0", "C3.0", "C11", "C12", "C13"],
+                                'lower_bounds': [0.3696965402743819 * 0.1, 3.8273867830358252 * 0.1,
+                                                 2.2831399185698835 * 0.1,
+                                                 10.20086488314071 * 0.1, 2.9111423805443195 * 0.1,
+                                                 20.130364463336967 * 0.1],
+                                'upper_bounds': [0.3696965402743819 * 0.8, 3.8273867830358252 * 0.8,
+                                                 2.2831399185698835 * 0.8,
+                                                 10.20086488314071 * 0.8, 2.9111423805443195 * 0.8,
+                                                 20.130364463336967 * 0.8]})
+    constraints = constraints[["names", "lower_bounds", "upper_bounds"]]
+    run_print_model_performance('gaussian', h2o_data, nfolds, constraints, x, y, printText, seed, 'coordinate_descent')
+    run_print_model_performance('gaussian', h2o_data, nfolds, constraints, x, y, printText, seed, 'irlsm')
+
+
+def run_print_model_performance(family, train, nfolds, bc_constraints, x, y, printText, seed, solver):
+    print(printText)
+    print("Without lambda search, solver = {0}".format(solver))
+    h2o_model = H2OGeneralizedLinearEstimator(family=family, nfolds=nfolds, beta_constraints=bc_constraints,
+                                              seed=seed,
+                                              solver=solver)
+    h2o_model.train(x=x, y=y, training_frame=train)
+    print("With lambda search, solver = {0}".format(solver))
+    h2o_model2 = H2OGeneralizedLinearEstimator(family=family, nfolds=nfolds, beta_constraints=bc_constraints,
+                                               seed=seed,
+                                               lambda_search=True, solver=solver)
+    h2o_model2.train(x=x, y=y, training_frame=train)
+    # make sure coefficients are within bounds
+    coeff = h2o_model.coef()
+    coeff2 = h2o_model2.coef()
+    colNames = bc_constraints["names"]
+    lowerB = bc_constraints["lower_bounds"]
+    upperB = bc_constraints["upper_bounds"]
+    for count in range(0, len(colNames)):
+        # fix issue due to rounding difference between bounds and coefficients.
+        coef_inactive = coeff[colNames[count,0]]==0
+        assert (round(coeff[colNames[count,0]],6) >= round(lowerB[count,0],6) and round(coeff[colNames[count,0]],6) 
+                <= round(upperB[count,0], 6)) or coef_inactive, \
+            "coef for {0}: {1}, lower bound: {2}, upper bound: {3}".format(colNames[count,0], coeff[colNames[count,0]],
+                                                                           lowerB[count,0], upperB[count,0])
+        coef_inactive2 = coeff2[colNames[count,0]]==0
+        assert (round(coeff2[colNames[count,0]],6) >= round(lowerB[count,0],6) and round(coeff2[colNames[count,0]],6) 
+                <= round(upperB[count,0], 6)) or coef_inactive2, \
+            "With lambda search: coef for {0}: {1}, lower bound: {2}, upper bound: " \
+            "{3}".format(colNames[count,0], coeff2[colNames[count,0]], lowerB[count,0], upperB[count,0])
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_beta_constraints_gaussian)
+else:
+    test_beta_constraints_gaussian()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7973_glm_beta_constrains_dict_megan.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7973_glm_beta_constrains_dict_megan.py
@@ -1,0 +1,36 @@
+from __future__ import print_function
+from builtins import range
+import sys, os
+sys.path.insert(1,"../../../")
+import h2o
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+from tests import pyunit_utils
+
+# This test is to test our implementation of allowing users to specify beta constraints using python dicts instead of
+# H2O frame.  The user will specify a lower and upper bound for each variable she wants to impose bounds on using 
+# python dicts and using H2OFrame.  Model built with both ways should generate the same coefficients.
+def test_glm_beta_constraints_dict_megan():
+    df = h2o.import_file(pyunit_utils.locate("smalldata/kaggle/CreditCard/creditcard_train_cat.csv"),
+                         col_types={"DEFAULT_PAYMENT_NEXT_MONTH": "enum"})
+    lb_limit_bal = 0.0001
+    constraints = h2o.H2OFrame({'names':["LIMIT_BAL", "AGE"], 'lower_bounds': [lb_limit_bal, lb_limit_bal], 
+                                'upper_bounds': [1e6, 1e6]})
+    # make sure we have the column names in expected order, the backend does weird things when the order is different    
+    constraints = constraints[["names", "lower_bounds", "upper_bounds"]]
+    glm_beta = H2OGeneralizedLinearEstimator(model_id="beta_glm", beta_constraints=constraints, seed=42)
+    glm_beta.train(y="DEFAULT_PAYMENT_NEXT_MONTH", training_frame=df)
+    glm_coeff = glm_beta.coef()
+    assert glm_coeff["LIMIT_BAL"] >= lb_limit_bal or glm_coeff["LIMIT_BAL"]==0
+    # using dict for beta_constraints
+    constraints2 = {"LIMIT_BAL":{"lower_bound":lb_limit_bal, "upper_bound":1e6}, "AGE":{"lower_bound":lb_limit_bal,
+                                                                                        "upper_bound":1e6}}
+    glm_beta_dict = H2OGeneralizedLinearEstimator(model_id="beta_glm", beta_constraints=constraints2, seed=42)
+    glm_beta_dict.train(y="DEFAULT_PAYMENT_NEXT_MONTH", training_frame=df)
+    glm_coeff_dict = glm_beta_dict.coef()
+    pyunit_utils.assertCoefDictEqual(glm_coeff, glm_coeff_dict, tol=1e-6) # coefficients should be the same from both runs
+    print("test complete!")
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_glm_beta_constraints_dict_megan)
+else:
+    test_glm_beta_constraints_dict_megan()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7973_glm_beta_constrains_mk.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7973_glm_beta_constrains_mk.py
@@ -1,0 +1,25 @@
+from __future__ import print_function
+from builtins import range
+import sys, os
+sys.path.insert(1,"../../../")
+import h2o
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+from tests import pyunit_utils
+
+# Michalk has caught problems with glm beta constrains.
+def test_glm_beta_constraints_mk():
+    df = h2o.import_file(pyunit_utils.locate("smalldata/kaggle/CreditCard/creditcard_train_cat.csv"),
+                         col_types={"DEFAULT_PAYMENT_NEXT_MONTH": "enum"})
+    lb_limit_bal = 0.0001
+    constraints = h2o.H2OFrame({'names':["LIMIT_BAL"], 'lower_bounds': [lb_limit_bal], 'upper_bounds': [1e6]})
+    # make sure we have the column names in expected order, the backend does weird things when the order is different    
+    constraints = constraints[["names", "lower_bounds", "upper_bounds"]]
+    glm_beta = H2OGeneralizedLinearEstimator(model_id="beta_glm", beta_constraints=constraints, seed=42)
+    glm_beta.train(y="DEFAULT_PAYMENT_NEXT_MONTH", training_frame=df)
+    glm_coeff = glm_beta.coef()
+    assert glm_coeff["LIMIT_BAL"] >= lb_limit_bal or glm_coeff["LIMIT_BAL"]==0
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_glm_beta_constraints_mk)
+else:
+    test_glm_beta_constraints_mk()

--- a/h2o-r/tests/testdir_algos/glm/runit_pubdev_4641_glm_beta_constraints_bad_results.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_pubdev_4641_glm_beta_constraints_bad_results.R
@@ -1,0 +1,61 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# add test from Erin Ledell
+glmBetaConstraints <- function() {
+  df <- h2o.importFile("https://s3.amazonaws.com/erin-data/higgs/higgs_train_10k.csv")
+  test <- h2o.importFile("https://s3.amazonaws.com/erin-data/higgs/higgs_test_5k.csv")
+
+  y <- "response"
+  x <- setdiff(names(df), y)
+  df[,y] <- as.factor(df[,y])
+  test[,y] <- as.factor(test[,y])
+  
+  # Split off a validation_frame
+  ss <- h2o.splitFrame(df, seed = 1)
+  train <- ss[[1]]
+  valid <- ss[[2]]
+  
+  # Some comparisons
+  m4 <- h2o.glm(x = x, y = y, training_frame = train, validation_frame = valid, family = "binomial", non_negative = TRUE, solver="COORDINATE_DESCENT")
+  m5 <- h2o.glm(x = x, y = y, training_frame = train, validation_frame = valid, family = "binomial", non_negative = TRUE, lambda_search = TRUE, solver="COORDINATE_DESCENT")
+  m6 <- h2o.glm(x = x, y = y, training_frame = train, validation_frame = valid, family = "binomial", non_negative = TRUE, lambda_search = TRUE, solver="COORDINATE_DESCENT", cold_start=TRUE)
+  m10 <- h2o.glm(x = x, y = y, training_frame = train, validation_frame = valid, family = "binomial", solver="irlsm", non_negative=TRUE)
+  m11 <- h2o.glm(x = x, y = y, training_frame = train, validation_frame = valid, family = "binomial", solver="irlsm", non_negative=TRUE, lambda_search=TRUE)
+  m12 <- h2o.glm(x = x, y = y, training_frame = train, validation_frame = valid, family = "binomial", solver="irlsm", non_negative=TRUE, lambda_search=TRUE, cold_start=TRUE)
+  m16 <- h2o.glm(x = x, y = y, training_frame = train, family = "binomial", non_negative = TRUE, solver="COORDINATE_DESCENT")
+  m17 <- h2o.glm(x = x, y = y, training_frame = train, family = "binomial", non_negative = TRUE, lambda_search = TRUE, solver="COORDINATE_DESCENT")
+  m18 <- h2o.glm(x = x, y = y, training_frame = train, family = "binomial", non_negative = TRUE, lambda_search = TRUE, solver="COORDINATE_DESCENT", cold_start=TRUE)
+  m22 <- h2o.glm(x = x, y = y, training_frame = train, family = "binomial", solver="irlsm", non_negative=TRUE)
+  m23 <- h2o.glm(x = x, y = y, training_frame = train, family = "binomial", solver="irlsm", non_negative=TRUE, lambda_search=TRUE)
+  m24 <- h2o.glm(x = x, y = y, training_frame = train, family = "binomial", solver="irlsm", non_negative=TRUE, lambda_search=TRUE, cold_start=TRUE)
+  
+  
+  models <- c(m4, m5, m6, m10, m11, m12, m16, m17, m18, m22, m23, m24)
+  
+  for (m in models) {
+    cat(sprintf("validation_frame: %s\n", m@parameters$validation_frame))
+    cat(sprintf("lambda_search: %s\n", m@parameters$lambda_search))
+    cat(sprintf("non_negative: %s\n", m@parameters$non_negative))
+    cat(sprintf("solver: %s\n", m@parameters$solver))
+    cat(sprintf("coldstart: %s\n", m@parameters$cold_start))    
+    cat("-------------------------\n")
+    cat(sprintf("Test AUC: %f\n", h2o.auc(h2o.performance(m, test))))
+    cat(sprintf("Test Logloss: %f\n", h2o.logloss(h2o.performance(m, test))))
+    cat(sprintf(
+      "Test Res Deviance: %f\n\n",
+      h2o.residual_deviance(h2o.performance(m, test))
+    ))
+    # check coefficients are non-negative
+    coeff <- m@model$coefficients
+    count <- 1
+    for (oneCoeff in coeff) {
+      if (count > 1) {
+        expect_true(oneCoeff >= 0)
+      }
+      count <- count+1
+    }
+  } 
+}
+
+doTest("GLM: Compare GLM with and without beta constraints for irlsm and coordinate_descent", glmBetaConstraints)

--- a/pyunit_PUBDEV_7973_beta_constraints_binomial.py
+++ b/pyunit_PUBDEV_7973_beta_constraints_binomial.py
@@ -1,0 +1,104 @@
+from builtins import range
+import sys
+
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+
+
+def test_beta_constraints_binomial():
+    # binomial
+    h2o_data = h2o.import_file(pyunit_utils.locate("smalldata/glm_test/binomial_20_cols_10KRows.csv"))
+    h2o_data["C1"] = h2o_data["C1"].asfactor()
+    h2o_data["C2"] = h2o_data["C2"].asfactor()
+    h2o_data["C3"] = h2o_data["C3"].asfactor()
+    h2o_data["C4"] = h2o_data["C4"].asfactor()
+    h2o_data["C5"] = h2o_data["C5"].asfactor()
+    h2o_data["C6"] = h2o_data["C6"].asfactor()
+    h2o_data["C7"] = h2o_data["C7"].asfactor()
+    h2o_data["C8"] = h2o_data["C8"].asfactor()
+    h2o_data["C9"] = h2o_data["C9"].asfactor()
+    h2o_data["C10"] = h2o_data["C10"].asfactor()
+    y = "C21"
+    x = h2o_data.names
+    x.remove(y)
+    nfolds = 4
+    seed = 12345
+    h2o_data["C21"] = h2o_data["C21"].asfactor()
+
+    run_print_model_performance('binomial', h2o_data, nfolds, None, x, y, "No beta constraints", seed, 
+                                "coordinate_descent")
+    run_print_model_performance('binomial', h2o_data, nfolds, None, x, y, "No beat constraints", seed, "irlsm")
+    printText = "running model with beta constrains on C1, C11"
+    dictBounds = {'names': ["C1.0", "C11"], 'lower_bounds': [1.3498144060671078*0.1, 1.959130413902314*0.1],
+                  'upper_bounds': [1.3498144060671078*0.8, 1.959130413902314*0.8]}
+    constraints = h2o.H2OFrame(dictBounds)
+    constraints = constraints[["names", "lower_bounds", "upper_bounds"]]
+    run_print_model_performance('binomial', h2o_data, nfolds, constraints, x, y, printText, seed, "coordinate_descent")
+    run_print_model_performance('binomial', h2o_data, nfolds, constraints, x, y, printText, seed, "irlsm")
+    
+    printText = "running model with beta constrains on C1, C2, C11, C12"
+    dictBounds = {'names': ["C1.0", "C2.0", "C11", "C12"], 
+                  'lower_bounds': [1.3498144060671078*0.1, 0.8892709168416222*0.1, 1.959130413902314*0.1, 0.13139198387980652*0.1],
+                  'upper_bounds': [1.3498144060671078*0.8, 0.8892709168416222*0.8, 1.959130413902314*0.8, 0.13139198387980652*0.8]}
+    constraints = h2o.H2OFrame(dictBounds)
+    constraints = constraints[["names", "lower_bounds", "upper_bounds"]]
+    run_print_model_performance('binomial', h2o_data, nfolds, constraints, x, y, printText, seed, 'coordinate_descent')
+    run_print_model_performance('binomial', h2o_data, nfolds, constraints, x, y, printText, seed, 'irlsm')
+
+    printText = "running model with beta constrains on C1, C2, C3, C11, C12, C13"
+    dictBounds = {'names': ["C1.0", "C2.0", "C3.0", "C11", "C12", "C13"],
+                  'lower_bounds': [1.3498144060671078*0.1, 0.8892709168416222*0.1, 2.5406690227893254*0.1,
+                                   1.959130413902314*0.1, 0.13139198387980652*0.1, 1.80498551446445*0.1],
+                  'upper_bounds': [1.3498144060671078*0.8, 0.8892709168416222*0.8, 2.5406690227893254*0.8,
+                                   1.959130413902314*0.8, 0.13139198387980652*0.8, 1.80498551446445*0.8]}
+    constraints = h2o.H2OFrame(dictBounds)
+    constraints = constraints[["names", "lower_bounds", "upper_bounds"]]
+    run_print_model_performance('binomial', h2o_data, nfolds, constraints, x, y, printText, seed, 'coordinate_descent')
+    run_print_model_performance('binomial', h2o_data, nfolds, constraints, x, y, printText, seed, 'irlsm')
+
+def run_print_model_performance(family, train, nfolds, bc_constraints, x, y, printText, seed, solver):
+    print(printText)
+    if bc_constraints is None:
+        print("No beta constraints: Without lambda search and with solver {0}".format(solver))
+        h2o_model = H2OGeneralizedLinearEstimator(family=family, nfolds=nfolds, beta_constraints=bc_constraints, seed=seed,
+                                              solver = solver)
+        h2o_model.train(x=x, y=y, training_frame=train)
+        print(h2o_model.model_performance(xval=True))
+        print("No beta constraints: With lambda search and with solver {0}".format(solver))
+        h2o_model2 = H2OGeneralizedLinearEstimator(family=family, nfolds=nfolds, beta_constraints=bc_constraints, seed=seed,
+                                               lambda_search=True, solver = solver)
+        h2o_model2.train(x=x, y=y, training_frame=train)
+        print(h2o_model.model_performance(xval=True))
+    else:
+        print("Without lambda search and with solver {0}".format(solver))
+        h2o_model = H2OGeneralizedLinearEstimator(family=family, nfolds=nfolds, beta_constraints=bc_constraints, seed=seed,
+                                              solver = solver)
+        h2o_model.train(x=x, y=y, training_frame=train)
+        print(h2o_model.model_performance(xval=True))
+        print("With lambda search and with solver {0}".format(solver))
+        h2o_model2 = H2OGeneralizedLinearEstimator(family=family, nfolds=nfolds, beta_constraints=bc_constraints, seed=seed,
+                                              lambda_search=True, solver = solver)
+        h2o_model2.train(x=x, y=y, training_frame=train)
+        print(h2o_model.model_performance(xval=True))
+        coeff = h2o_model.coef()
+        coeff2 = h2o_model2.coef()
+        colNames = bc_constraints["names"]
+        lowerB = bc_constraints["lower_bounds"]
+        upperB = bc_constraints["upper_bounds"]
+        for count in range(0, len(colNames)):
+            assert (coeff[colNames[count,0]] >= lowerB[count,0] and coeff[colNames[count,0]] <= upperB[count,0]) or \
+                   coeff[colNames[count,0]]==0,\
+                "coefficient exceed limits"
+            assert (coeff2[colNames[count,0]] >= lowerB[count,0] and coeff2[colNames[count,0]] <= upperB[count,0]) or\
+                   coeff2[colNames[count,0]]==0, \
+                "coefficient exceed limits"
+        #assert h2o_model.logloss() >= h2o_model2.logloss(), "Logloss without lambda_search {0} should exceed logloss with" \
+        #                                                " lambda_saerch {1}".format(h2o_model.logloss(), h2o_model2.logloss())
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_beta_constraints_binomial)
+else:
+    test_beta_constraints_binomial()

--- a/pyunit_PUBDEV_7973_beta_constraints_gaussian.py
+++ b/pyunit_PUBDEV_7973_beta_constraints_gaussian.py
@@ -1,0 +1,113 @@
+from builtins import range
+import sys
+
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+import numpy as np
+
+
+def test_beta_constraints_gaussian():
+    # binomial
+    h2o_data = h2o.import_file(pyunit_utils.locate("smalldata/glm_test/gaussian_20cols_10000Rows.csv"))
+    h2o_data["C1"] = h2o_data["C1"].asfactor()
+    h2o_data["C2"] = h2o_data["C2"].asfactor()
+    h2o_data["C3"] = h2o_data["C3"].asfactor()
+    h2o_data["C4"] = h2o_data["C4"].asfactor()
+    h2o_data["C5"] = h2o_data["C5"].asfactor()
+    h2o_data["C6"] = h2o_data["C6"].asfactor()
+    h2o_data["C7"] = h2o_data["C7"].asfactor()
+    h2o_data["C8"] = h2o_data["C8"].asfactor()
+    h2o_data["C9"] = h2o_data["C9"].asfactor()
+    h2o_data["C10"] = h2o_data["C10"].asfactor()
+    y = "C21"
+    x = h2o_data.names
+    x.remove(y)
+    nfolds = 4
+    seed = 12345
+
+    run_print_model_performance('gaussian', h2o_data, nfolds, None, x, y, "no beta constraints", seed,
+                                'coordinate_descent')
+    run_print_model_performance('gaussian', h2o_data, nfolds, None, x, y, "no beta constraints", seed, 'irlsm')
+    printText = "running model with beta constrains on C1, C11"
+    constraints = h2o.H2OFrame(
+        {'names': ["C1.1", "C11"], 'lower_bounds': [0.3696965402743819 * 0.1, 10.20086488314071 * 0.1],
+         'upper_bounds': [0.3696965402743819 * 0.8, 10.20086488314071 * 0.8]})
+    constraints = constraints[["names", "lower_bounds", "upper_bounds"]]
+    run_print_model_performance('gaussian', h2o_data, nfolds, constraints, x, y, printText, seed, 'coordinate_descent')
+    run_print_model_performance('gaussian', h2o_data, nfolds, constraints, x, y, printText, seed, 'irlsm')
+
+    printText = "running model with beta constrains on C1, C2, C11, C12"
+    constraints = h2o.H2OFrame({'names': ["C1.1", "C2.0", "C11", "C12"],
+                                'lower_bounds': [0.3696965402743819 * 0.1, 3.8273867830358252 * 0.1,
+                                                 10.20086488314071 * 0.1, 2.9111423805443195 * 0.1],
+                                'upper_bounds': [0.3696965402743819 * 0.8, 3.8273867830358252 * 0.8,
+                                                 10.20086488314071 * 0.8, 2.9111423805443195 * 0.8]})
+    constraints = constraints[["names", "lower_bounds", "upper_bounds"]]
+    run_print_model_performance('gaussian', h2o_data, nfolds, constraints, x, y, printText, seed, 'coordinate_descent')
+    run_print_model_performance('gaussian', h2o_data, nfolds, constraints, x, y, printText, seed, 'irlsm')
+
+    printText = "running model with beta constrains on C1, C2, C3, C11, C12, C13"
+    constraints = h2o.H2OFrame({'names': ["C1.1", "C2.0", "C3.0", "C11", "C12", "C13"],
+                                'lower_bounds': [0.3696965402743819 * 0.1, 3.8273867830358252 * 0.1,
+                                                 2.2831399185698835 * 0.1,
+                                                 10.20086488314071 * 0.1, 2.9111423805443195 * 0.1,
+                                                 20.130364463336967 * 0.1],
+                                'upper_bounds': [0.3696965402743819 * 0.8, 3.8273867830358252 * 0.8,
+                                                 2.2831399185698835 * 0.8,
+                                                 10.20086488314071 * 0.8, 2.9111423805443195 * 0.8,
+                                                 20.130364463336967 * 0.8]})
+    constraints = constraints[["names", "lower_bounds", "upper_bounds"]]
+    run_print_model_performance('gaussian', h2o_data, nfolds, constraints, x, y, printText, seed, 'coordinate_descent')
+    run_print_model_performance('gaussian', h2o_data, nfolds, constraints, x, y, printText, seed, 'irlsm')
+
+
+def run_print_model_performance(family, train, nfolds, bc_constraints, x, y, printText, seed, solver):
+    print(printText)
+    if bc_constraints is None:
+        print("Without lambda search, solver = {0}".format(solver))
+        h2o_model = H2OGeneralizedLinearEstimator(family=family, nfolds=nfolds, seed=seed, solver=solver)
+        h2o_model.train(x=x, y=y, training_frame=train)
+        print(h2o_model.model_performance(xval=True))
+        print("With lambda search, solver = {0}".format(solver))
+        h2o_model2 = H2OGeneralizedLinearEstimator(family=family, nfolds=nfolds, seed=seed, lambda_search=True,
+                                                   solver=solver)
+        h2o_model2.train(x=x, y=y, training_frame=train)
+        print(h2o_model2.model_performance(xval=True))
+    else:
+        print("Without lambda search, solver = {0}".format(solver))
+        h2o_model = H2OGeneralizedLinearEstimator(family=family, nfolds=nfolds, beta_constraints=bc_constraints,
+                                                  seed=seed,
+                                                  solver=solver)
+        h2o_model.train(x=x, y=y, training_frame=train)
+        print(h2o_model.model_performance(xval=True))
+        print("With lambda search, solver = {0}".format(solver))
+        h2o_model2 = H2OGeneralizedLinearEstimator(family=family, nfolds=nfolds, beta_constraints=bc_constraints,
+                                                   seed=seed,
+                                                   lambda_search=True, solver=solver)
+        h2o_model2.train(x=x, y=y, training_frame=train)
+        print(h2o_model2.model_performance(xval=True))
+        coeff = h2o_model.coef()
+        coeff2 = h2o_model2.coef()
+        colNames = bc_constraints["names"]
+        lowerB = bc_constraints["lower_bounds"]
+        upperB = bc_constraints["upper_bounds"]
+        for count in range(0, len(colNames)):
+            assert (coeff[colNames[count, 0]] >= lowerB[count, 0] and
+                    (coeff[colNames[count, 0]] < upperB[count, 0] or (
+                            coeff[colNames[count, 0]] - upperB[count, 0]) < 1e-6)) \
+                   or coeff[colNames[count, 0]] == 0, "coeff: {0}, lower limit: {1}, upper limit: " \
+                                                      "{2}".format(coeff[colNames[count, 0]], lowerB[count, 0], upperB[count, 0])
+            assert (coeff2[colNames[count, 0]] >= lowerB[count, 0] and
+                    (coeff2[colNames[count, 0]] < upperB[count, 0] or (
+                    coeff2[colNames[count, 0]] - upperB[count, 0]) < 1e-6)) or coeff2[colNames[count, 0]] == 0, \
+                "coeff: {0}, lower limit: {1}, upper limit: " \
+                                                         "{2}".format(coeff2[colNames[count, 0]], lowerB[count, 0], upperB[count, 0])
+                    # assert h2o_model.rmse() >= h2o_model2.rmse(), "RMSE without lambda_search {0} should exceed RMSE with" \
+                    #                                                 " lambda_saerch {1}".format(h2o_model.rmse(), h2o_model2.rmse())
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_beta_constraints_gaussian)
+else:
+    test_beta_constraints_gaussian()


### PR DESCRIPTION
This PR fixes the problems in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-7973.

This is a two part JIRA.  One is to fix the problem with beta constraints not working and the other one is to add additional ways to specify beta constraints per Megan Kurka suggestion

Done:
1. Fixed bugs associated with beta constraints.  I added additional application of beta constraints to the end of LS if it exists, else, it will be applied after the new beta is calculated;
2. I extended beta constraints to be applicable to IRLSM as well as COORDINATE_DESCENT and LBFGS.
3. Added tests to make sure that the coefficients are constraints are limited as desired.
4. I enabled that python users can now specify beta_constraints using a python dict per Megan Kurka suggestions.
5. Added tests to make sure the new way of specifying beta constraints using python dict works.

