### PR TITLE
PUBDEV-8396: fixing AutoML XGBoost learn_rate search step

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -83,6 +83,14 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
                 .setNamedValue("start_"+_provider+"_"+_id, new Date(), EventLogEntry.epochFormat.get());
         try {
             builder.init(false);          // validate parameters
+            if (builder._messages.length > 0) {
+                for (ModelBuilder.ValidationMessage vm : builder._messages) {
+                    if (vm.log_level() == Log.WARN || vm.log_level() == Log.ERRR) {
+                        String label = vm.log_level() == Log.ERRR ? " [error]" : "";
+                        aml().eventLog().warn(Stage.ModelTraining, resultKey+label+": "+vm.field()+" param, "+vm.message());
+                    }
+                }
+            }
             return builder.trainModelOnH2ONode();
         } catch (H2OIllegalArgumentException exception) {
             aml().eventLog().warn(Stage.ModelTraining, "Skipping training of model "+resultKey+" due to exception: "+exception);

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/GBMStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/GBMStepsProvider.java
@@ -177,8 +177,7 @@ public class GBMStepsProvider
                         resultKey = result;
                         GBMModel bestGBM = getBestGBM();
                         aml().eventLog().info(EventLogEntry.Stage.ModelSelection, "Retraining best GBM with learning rate annealing: "+bestGBM._key);
-                        GBMParameters params = (GBMParameters) bestGBM._parms.clone();
-                        params._ntrees = 10000; // reset ntrees (we'll need more for this fine tuning)
+                        GBMParameters params = (GBMParameters) bestGBM._input_parms.clone();
                         params._max_runtime_secs = 0; // reset max runtime
                         params._learn_rate_annealing = 0.99;
                         initTimeConstraints(params, maxRuntimeSecs);

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/XGBoostSteps.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/XGBoostSteps.java
@@ -232,6 +232,7 @@ public class XGBoostSteps extends ModelingSteps {
                     aml().eventLog().info(EventLogEntry.Stage.ModelSelection, "Retraining best XGBoost with learning rate annealing: "+bestXGB._key);
                     XGBoostParameters params = (XGBoostParameters) bestXGB._parms.clone();
                     params._ntrees = 10000; // reset ntrees (we'll need more for this fine tuning)
+                    params._n_estimators = params._ntrees; // during training, XGBoost model was set with n_estimators=n_trees, and now we have to sync this old alias!
                     params._max_runtime_secs = 0; // reset max runtime
                     params._learn_rate_annealing = 0.99;
                     initTimeConstraints(params, maxRuntimeSecs);
@@ -271,6 +272,8 @@ public class XGBoostSteps extends ModelingSteps {
                     setStoppingCriteria(params, defaults); // keep the same seed as the bestXGB
                     // reset _eta to defaults, otherwise it ignores the _learn_rate hyperparam: this is very annoying!
                     params._eta = defaults._eta;
+                    // during training, XGBoost model was set with n_estimators=n_trees, and now we have to sync or reset this old alias, also annoying!
+                    params._n_estimators = defaults._n_estimators; 
 //                    params._learn_rate = defaults._learn_rate;
 
                     // keep stopping_rounds fixed, but increases score_tree_interval when lowering learn rate

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/XGBoostSteps.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/XGBoostSteps.java
@@ -230,9 +230,7 @@ public class XGBoostSteps extends ModelingSteps {
                     resultKey = result;
                     XGBoostModel bestXGB = getBestXGB();
                     aml().eventLog().info(EventLogEntry.Stage.ModelSelection, "Retraining best XGBoost with learning rate annealing: "+bestXGB._key);
-                    XGBoostParameters params = (XGBoostParameters) bestXGB._parms.clone();
-                    params._ntrees = 10000; // reset ntrees (we'll need more for this fine tuning)
-                    params._n_estimators = params._ntrees; // during training, XGBoost model was set with n_estimators=n_trees, and now we have to sync this old alias!
+                    XGBoostParameters params = (XGBoostParameters) bestXGB._input_parms.clone();
                     params._max_runtime_secs = 0; // reset max runtime
                     params._learn_rate_annealing = 0.99;
                     initTimeConstraints(params, maxRuntimeSecs);
@@ -264,17 +262,11 @@ public class XGBoostSteps extends ModelingSteps {
                     resultKey = result;
                     XGBoostModel bestXGB = getBestXGBs(1).get(0);
                     aml().eventLog().info(EventLogEntry.Stage.ModelSelection, "Applying learning rate search on best XGBoost: "+bestXGB._key);
-                    XGBoostParameters params = (XGBoostParameters) bestXGB._parms.clone();
+                    XGBoostParameters params = (XGBoostParameters) bestXGB._input_parms.clone();
                     XGBoostParameters defaults = new XGBoostParameters();
-                    params._ntrees = 10000; // reset ntrees (we'll need more for this fine tuning)
                     params._max_runtime_secs = 0; // reset max runtime
                     initTimeConstraints(params, 0); // ensure we have a max runtime per model in the grid
                     setStoppingCriteria(params, defaults); // keep the same seed as the bestXGB
-                    // reset _eta to defaults, otherwise it ignores the _learn_rate hyperparam: this is very annoying!
-                    params._eta = defaults._eta;
-                    // during training, XGBoost model was set with n_estimators=n_trees, and now we have to sync or reset this old alias, also annoying!
-                    params._n_estimators = defaults._n_estimators; 
-//                    params._learn_rate = defaults._learn_rate;
 
                     // keep stopping_rounds fixed, but increases score_tree_interval when lowering learn rate
                     int sti = params._score_tree_interval;

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -1297,6 +1297,8 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
       Log.log(log_level,field_name + ": " + message);
     }
     public int log_level() { return _log_level; }
+    public String field() { return _field_name; }
+    public String message() { return _message; }
     @Override public String toString() { return Log.LVLS[_log_level] + " on field: " + _field_name + ": " + _message; }
   }
 

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
@@ -234,7 +234,7 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
     checkColumnAlias("col_sample_rate", _parms._col_sample_rate, "colsample_bylevel", _parms._colsample_bylevel, 1);
     checkColumnAlias("col_sample_rate_per_tree", _parms._col_sample_rate_per_tree, "colsample_bytree", _parms._colsample_bytree, 1);
     checkColumnAlias("sample_rate", _parms._sample_rate, "subsample", _parms._subsample, 1);
-    checkColumnAlias("learn_rate", _parms._learn_rate, "subsample", _parms._eta, 0.3);
+    checkColumnAlias("learn_rate", _parms._learn_rate, "eta", _parms._eta, 0.3);
     checkColumnAlias("max_abs_leafnode_pred", _parms._max_abs_leafnode_pred, "max_delta_step", _parms._max_delta_step,0);
     checkColumnAlias("ntrees", _parms._ntrees, "n_estimators", _parms._n_estimators, 0);
     

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
@@ -281,8 +281,7 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
   private void checkColumnAlias(String paramName, double paramValue, String aliasName, double aliasValue, double defaultValue) {
     if (paramValue != defaultValue && aliasValue != defaultValue && paramValue != aliasValue) {
       error("_" + paramName, paramName + " and its alias " + aliasName + " are both set to different value than default value. Set " + aliasName + " to default value (" + defaultValue + "), to use " + paramName + " actual value.");
-    }
-    if (aliasValue != defaultValue){
+    } else if (aliasValue != defaultValue){
       warn("_"+paramName, "Using user-provided parameter "+aliasName+" instead of "+paramName+".\"");
     }
   }


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8396

also propagating model builder validation errors/warnings as warnings (https://h2oai.atlassian.net/browse/PUBDEV-8389): for now for single models only, can't figure a simple way to do the same with grids yet.