### PR TITLE
AbstractBuildVersion should not be defined in both h2o-core and h2o-genmodel [nocheck]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ h2o-r/h2o-package/DESCRIPTION
 gradle-app.setting
 .gradle
 src/main/java/water/BuildVersion.java
+h2o-genmodel/src/main/java/water/genmodel/BuildVersion.java
 .Rproj.user
 .RData
 .Rhistory

--- a/buildSrc/src/main/java/H2OBuildVersion.java
+++ b/buildSrc/src/main/java/H2OBuildVersion.java
@@ -19,6 +19,7 @@ public class H2OBuildVersion {
   // Passed in by caller.
   File _rootDir;
   String _versionFromGradle;
+  String _targetPackage;
 
   // Calculated.
   String _branch;
@@ -39,8 +40,13 @@ public class H2OBuildVersion {
   }
 
   H2OBuildVersion(File rootDir, String versionFromGradle) {
+    this(rootDir, versionFromGradle, "water.init");
+  }
+
+  H2OBuildVersion(File rootDir, String versionFromGradle, String targetPackage) {
     _rootDir = rootDir;
     _versionFromGradle = versionFromGradle;
+    _targetPackage = targetPackage;
     calc();
   }
 
@@ -249,7 +255,7 @@ public class H2OBuildVersion {
       }
 
       PrintWriter writer = new PrintWriter(fileName);
-      writer.println("package water.init;");
+      writer.print("package "); writer.print(_targetPackage); writer.println(";");
       writer.println("");
       writer.println("public class BuildVersion extends AbstractBuildVersion {");
       writer.println("    public String branchName()     { return \"" + branchName     + "\"; }");

--- a/h2o-genmodel/build.gradle
+++ b/h2o-genmodel/build.gradle
@@ -35,11 +35,11 @@ dependencies {
   compile "ai.h2o:h2o-tree-api:0.3.17"
 }
 
-def buildVersionFile = new File(projectDir, "/src/main/java/water/init/BuildVersion.java")
+def buildVersionFile = new File(projectDir, "/src/main/java/water/genmodel/BuildVersion.java")
 
 task generateBuildVersionJava {
   doLast {
-    H2OBuildVersion bv = new H2OBuildVersion(rootDir, version)
+    H2OBuildVersion bv = new H2OBuildVersion(rootDir, version, "water.genmodel")
     bv.emitBuildVersionJavaFileIfNecessary(buildVersionFile)
   }
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/tools/PrintMojo.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/tools/PrintMojo.java
@@ -8,7 +8,7 @@ import hex.genmodel.algos.gbm.GbmMojoModel;
 import hex.genmodel.algos.tree.SharedTreeGraph;
 import hex.genmodel.algos.tree.SharedTreeGraphConverter;
 import hex.genmodel.algos.tree.TreeBackedMojoModel;
-import water.init.AbstractBuildVersion;
+import water.genmodel.AbstractBuildVersion;
 
 import java.io.FileOutputStream;
 import java.io.IOException;

--- a/h2o-genmodel/src/main/java/water/genmodel/AbstractBuildVersion.java
+++ b/h2o-genmodel/src/main/java/water/genmodel/AbstractBuildVersion.java
@@ -1,4 +1,4 @@
-package water.init;
+package water.genmodel;
 
 abstract public class AbstractBuildVersion {
 
@@ -56,7 +56,7 @@ abstract public class AbstractBuildVersion {
   public static AbstractBuildVersion getBuildVersion() {
     AbstractBuildVersion abv = AbstractBuildVersion.UNKNOWN_VERSION;
     try {
-      Class klass = Class.forName("water.init.BuildVersion");
+      Class klass = Class.forName("water.genmodel.BuildVersion");
       java.lang.reflect.Constructor constructor = klass.getConstructor();
       abv = (AbstractBuildVersion) constructor.newInstance();
     } catch (Exception ignore) { }


### PR DESCRIPTION
h2o-core depends on h2o-genmodel, when the independent jars are on classpath
this results in a classpath clash
