### PR TITLE
Clean-up TypeMap and make sure we get mappings from leader [nocheck]

### DIFF
--- a/h2o-core/src/main/java/water/AutoBuffer.java
+++ b/h2o-core/src/main/java/water/AutoBuffer.java
@@ -782,21 +782,25 @@ public final class AutoBuffer implements AutoCloseable {
   }
 
   public <T extends Freezable> T get() {
-    int id = getInt();
-    if( id == TypeMap.NULL ) return null;
-    if( _is!=null ) {
-      id = remapFrozenId(id);
-    }
-    return (T)TypeMap.newFreezable(id).read(this);
+    return getFreezable(null);
   }
+
   public <T extends Freezable> T get(Class<T> tc) {
+    if (tc == null)
+      throw new IllegalArgumentException("Class argument cannot be null");
+    return getFreezable(tc);
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T extends Freezable> T getFreezable(Class<T> tc) {
     int id = getInt();
     if( id == TypeMap.NULL ) return null;
     if( _is!=null ) {
       id = remapFrozenId(id);
     }
-    assert tc.isInstance(TypeMap.theFreezable(id)):tc.getName() + " != " + TypeMap.theFreezable(id).getClass().getName() + ", id = " + id;
-    return (T)TypeMap.newFreezable(id).read(this);
+    return (T) TypeMap
+            .newFreezable(id, tc)
+            .read(this);
   }
 
   private int remapFrozenId(int id) {

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -2622,5 +2622,18 @@ final public class H2O {
   public static URI downloadLogs(String destinationDir, String logContainer) {
     return LogsHandler.downloadLogs(destinationDir, LogArchiveContainer.valueOf(logContainer));
   }
-  
+
+  /**
+   * Is this H2O cluster running in our continuous integration environment?
+   * 
+   * This information can be used to enable extended error output or force shutdown in case
+   * an error is encountered. Use responsibly.
+   * 
+   * @return true, if running in CI
+   */
+  static boolean isCI() {
+    return AbstractBuildVersion.getBuildVersion().isDevVersion() 
+            && "jenkins".equals(System.getProperty("user.name"));
+  }
+
 }

--- a/h2o-core/src/main/java/water/TCPReceiverThread.java
+++ b/h2o-core/src/main/java/water/TCPReceiverThread.java
@@ -163,6 +163,10 @@ public class TCPReceiverThread extends Thread {
           // On any error from anybody, close everything
           System.err.println("IO error");
           Log.err("IO error on TCP port " + H2O.H2O_PORT + ": ", e);
+          if (e instanceof Error && H2O.isCI()) {
+            // could be AssertionError, OOM...
+            throw H2O.fail("Encountered an error while running in CI - will terminate to prevent deadlocks", e);
+          }
           break;
         }
         // Reuse open sockets for the next task

--- a/h2o-core/src/main/java/water/TypeMap.java
+++ b/h2o-core/src/main/java/water/TypeMap.java
@@ -253,6 +253,13 @@ public class TypeMap {
   }
   static Iced newInstance(int id) { return (Iced) newFreezable(id); }
 
+  static <T extends Freezable> T newFreezable(int id, Class<T> tc) {
+    @SuppressWarnings("unchecked")
+    T iced = (T) newFreezable(id);
+    assert tc == null || tc.isInstance(iced) : tc.getName() + " != " + iced.getClass().getName() + ", id = " + id;
+    return iced;
+  }
+
   /** Create a new freezable object based on its unique ID.
    *
    * @param id  freezable unique id (provided by TypeMap)

--- a/h2o-core/src/main/java/water/TypeMap.java
+++ b/h2o-core/src/main/java/water/TypeMap.java
@@ -271,14 +271,6 @@ public class TypeMap {
       }
     }
   }
-  static void drop(String ice_clz) {
-    Integer I = MAP.get(ice_clz);
-    if( I==null ) return; // no icer, no problem
-    synchronized( TypeMap.class ) {  // install null
-      GOLD[I] = null;
-    }
-
-  }
   static Iced newInstance(int id) { return (Iced) newFreezable(id); }
 
   static <T extends Freezable> T newFreezable(int id, Class<T> tc) {

--- a/h2o-core/src/test/java/water/H2OTest.java
+++ b/h2o-core/src/test/java/water/H2OTest.java
@@ -1,5 +1,6 @@
 package water;
 
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -52,5 +53,11 @@ public class H2OTest {
     public void testLeaderNodeOrNullReturnsNullForEmptyCloud() {
       H2O h2o = new H2O(new H2ONode[0], -1, -1);
       assertNull(h2o.leaderOrNull());
+    }
+
+    @Test
+    public void testIsCI() {
+      Assume.assumeTrue(TestUtil.isCI());
+      assertTrue(H2O.isCI());
     }
 }

--- a/h2o-core/src/test/java/water/TypeMapTest.java
+++ b/h2o-core/src/test/java/water/TypeMapTest.java
@@ -1,0 +1,32 @@
+package water;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.junit.Assert.*;
+
+public class TypeMapTest extends TestUtil {
+
+    @BeforeClass()
+    public static void setup() { stall_till_cloudsize(1); }
+    
+    @Test
+    public void testPrintTypeMap() {
+        TypeMap.printTypeMap(System.out);
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        try (PrintStream ps = new PrintStream(os)) {
+            TypeMap.printTypeMap(ps);
+        }
+        String output = os.toString();
+        String[] lines = output.split("\n");
+        String[] bootstrapClasses = TypeMap.bootstrapClasses();
+        assertTrue(bootstrapClasses.length >= lines.length);
+        for (int i = 0; i < bootstrapClasses.length; i++) {
+            assertEquals(i + " -> " + bootstrapClasses[i] + " (map: " + i + ")", lines[i]);
+        }
+    }
+
+}

--- a/h2o-core/src/test/java/water/TypeMapTest.java
+++ b/h2o-core/src/test/java/water/TypeMapTest.java
@@ -23,7 +23,7 @@ public class TypeMapTest extends TestUtil {
         String output = os.toString();
         String[] lines = output.split("\n");
         String[] bootstrapClasses = TypeMap.bootstrapClasses();
-        assertTrue(bootstrapClasses.length >= lines.length);
+        assertTrue(bootstrapClasses.length <= lines.length);
         for (int i = 0; i < bootstrapClasses.length; i++) {
             assertEquals(i + " -> " + bootstrapClasses[i] + " (map: " + i + ")", lines[i]);
         }


### PR DESCRIPTION
- Remove assert with bad side-effects
- Tests shouldn't hang when there is an AssertionError in h2o-core
- Lock cloud before asking leader for a class type mapping
- Dump TypeMap if a leader node is missing a class mapping
- Remove unused method
