### PR TITLE
Speed-up AutoML tests [nocheck]

### DIFF
--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -97,7 +97,7 @@ test-pyunit-xgboost-stress:
 	export NO_GCE_CHECK=True && cd h2o-py/tests/ && ../../scripts/run.py --wipeall --geterrs --testsize s --numclouds 1 --numnodes 5 --jvm.xmx 4g --testlist ../../tests/pyunitXGBoostStressTestList
 
 test-pyunit-automl: lookup-automl-tests
-	export NO_GCE_CHECK=True && cd h2o-py/tests/ && ../../scripts/run.py --wipeall --geterrs --numclouds 6 --jvm.xmx 4g --testlist .lookup.txt
+	export NO_GCE_CHECK=True && cd h2o-py/tests/ && ../../scripts/run.py --wipeall --geterrs --numclouds 2 --jvm.xmx 4g --testlist .lookup.txt
 
 test-pyunit-automl-smoke-noxgb: lookup-automl-smoke-tests
 	export NO_GCE_CHECK=True && cd h2o-py/tests/ && ../../scripts/run.py --wipeall --geterrs --numclouds 1 --jvm.xmx 4g --jvm.opts '-Dsys.ai.h2o.ext.core.toggle.XGBoost=false' --testlist .lookup.txt


### PR DESCRIPTION
This is the first iteration. The next, step is to derive # clouds from # available CPU cores on a specific Jenkins machine.


Many AutoML tests are working on small datasets - eg. prostate - that is a single chunk, so there is no parallelism in model building except for parallelism of CV itself - if you have 5 fold cv for prostate you are running all of them independently in 5 threads, this is followed by the main model which is running 1 thread => having just one cloud would therefore waste time.

Having 2 clouds should help with utilizing more cores.

