### PR TITLE
[nocheck] Add python 3.7 to prerequisites

### DIFF
--- a/h2o-dist/index.html
+++ b/h2o-dist/index.html
@@ -554,7 +554,7 @@
             <div id="quickstart-py" style="display:none">
                 <h2>Use H<sub>2</sub>O directly from Python</h2>
 
-                <p>1. Prerequisite:    Python 2.7.x, 3.5.x, or 3.6.x</p>
+                <p>1. Prerequisite:    Python 2.7.x, 3.5.x, 3.6.x, or 3.7.x</p>
                 <p>2. Install dependencies (prepending with `sudo` if needed):</p>
                  <button class="btn copy_button" id="btnCopy8" data-copied-hint="Copied!" data-clipboard-target='to_copy8'>
               <span class="octicon octicon-clippy"></span>

--- a/h2o-dist/index.html
+++ b/h2o-dist/index.html
@@ -554,7 +554,7 @@
             <div id="quickstart-py" style="display:none">
                 <h2>Use H<sub>2</sub>O directly from Python</h2>
 
-                <p>1. Prerequisite:    Python 2.7.x, 3.5.x, 3.6.x, or 3.7.x</p>
+                <p>1. Prerequisite:    Python 2.7.x, 3.5.x to 3.7.x</p>
                 <p>2. Install dependencies (prepending with `sudo` if needed):</p>
                  <button class="btn copy_button" id="btnCopy8" data-copied-hint="Copied!" data-clipboard-target='to_copy8'>
               <span class="octicon octicon-clippy"></span>


### PR DESCRIPTION
We are using python 3.7 in automated tests in jenkins (for about 17 months[1]) so I think we should update the prerequisites.

[1] https://github.com/h2oai/h2o-3/blame/rel-zizler/scripts/jenkins/groovy/defineTestStages.groovy#L45