### PR TITLE
PUBDEV-8405: follow up after add saving parameter

### DIFF
--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -1584,7 +1584,8 @@ def varimp_heatmap(
         top_n=None,  # type: Option[int]
         figsize=(16, 9),  # type: Tuple[float]
         cluster=True,  # type: bool
-        colormap="RdYlBu_r"  # type: str
+        colormap="RdYlBu_r",  # type: str
+        save_plot_path=None # type: str
 ):
     # type: (...) -> plt.Figure
     """
@@ -1603,7 +1604,8 @@ def varimp_heatmap(
     :param figsize: figsize: figure size; passed directly to matplotlib
     :param cluster: if True, cluster the models and variables
     :param colormap: colormap to use
-    :returns: a matplotlib figure object
+    :param save_plot_path: a path to save the plot via using mathplotlib function savefig
+    :returns: object that contains the resulting figure (can be accessed using result.figure())
 
     :examples:
     >>> import h2o
@@ -1644,7 +1646,9 @@ def varimp_heatmap(
     plt.title("Variable Importance Heatmap")
     plt.grid(False)
     fig = plt.gcf()
-    return fig
+    if save_plot_path is not None:
+        plt.savefig(fname=save_plot_path)
+    return decorate_plot_result(figure=fig)
 
 
 def varimp(
@@ -1697,7 +1701,8 @@ def model_correlation_heatmap(
         cluster_models=True,  # type: bool
         triangular=True,  # type: bool
         figsize=(13, 13),  # type: Tuple[float]
-        colormap="RdYlBu_r"  # type: str
+        colormap="RdYlBu_r",  # type: str
+        save_plot_path=None # type: str
 ):
     # type: (...) -> plt.Figure
     """
@@ -1714,7 +1719,8 @@ def model_correlation_heatmap(
     :param triangular: make the heatmap triangular
     :param figsize: figsize: figure size; passed directly to matplotlib
     :param colormap: colormap to use
-    :returns: a matplotlib figure object
+    :param save_plot_path: a path to save the plot via using mathplotlib function savefig
+    :returns: object that contains the resulting figure (can be accessed using result.figure())
 
     :examples:
     >>> import h2o
@@ -1763,7 +1769,9 @@ def model_correlation_heatmap(
         if _interpretable(t.get_text()):
             t.set_color("red")
     fig = plt.gcf()
-    return fig
+    if save_plot_path is not None:
+        plt.savefig(fname=save_plot_path)
+    return decorate_plot_result(figure=fig)
 
 
 def _check_deprecated_top_n_argument(models, top_n):

--- a/h2o-py/h2o/model/metrics_base.py
+++ b/h2o-py/h2o/model/metrics_base.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from h2o.model.confusion_matrix import ConfusionMatrix
 from h2o.plot import decorate_plot_result, get_matplotlib_pyplot, RAISE_ON_FIGURE_ACCESS
 from h2o.utils.compatibility import *  # NOQA
-from h2o.utils.metaclass import backwards_compatibility, deprecated_fn, h2o_meta
+from h2o.utils.metaclass import backwards_compatibility, deprecated_fn, h2o_meta, deprecated_params
 from h2o.utils.typechecks import assert_is_type, assert_satisfies, is_type, numeric
 
 
@@ -1389,17 +1389,18 @@ class H2OBinomialModelMetrics(MetricsBase):
                 )
         return metrics
 
-    def plot(self, type="roc", server=False, save_to_file=None, plot=True, **kwargs):
+    @deprecated_params({'save_to_file': 'save_plot_path'})
+    def plot(self, type="roc", server=False, save_plot_path=None, plot=True, **kwargs):
         """
         Produce the desired metric plot.
 
         :param type: the type of metric plot (currently, only ROC curve ('roc') and Precision Recall curve ('pr') are supported).
         :param server: if True, generate plot inline using matplotlib's "Agg" backend.
-        :param save_to_file filename to save the plot to
+        :param save_plot_path filename to save the plot to
         :param plot True to plot curve, False to get a tuple of values at axis x and y of the plot 
                 (tprs and fprs for AUC, recall and precision for PR)
         
-        :returns: None or values of x and y axis of the plot 
+        :returns: None or values of x and y axis of the plot + the resulting plot (can be accessed using result.figure())
 
         :examples:
 
@@ -1419,13 +1420,10 @@ class H2OBinomialModelMetrics(MetricsBase):
         
         """
 
-        if save_to_file is None:  # if not supplied by 'real name'
-            save_to_file = kwargs.get('save_plot_path')
-            
         if type == "roc":
-            return self._plot_roc(server, save_to_file, plot)
+            return self._plot_roc(server, save_plot_path, plot)
         elif type == "pr":
-            return self._plot_pr(server, save_to_file, plot)
+            return self._plot_pr(server, save_plot_path, plot)
     
     def _plot_roc(self, server=False, save_to_file=None, plot=True):
         if plot:

--- a/h2o-py/h2o/model/metrics_base.py
+++ b/h2o-py/h2o/model/metrics_base.py
@@ -1389,7 +1389,7 @@ class H2OBinomialModelMetrics(MetricsBase):
                 )
         return metrics
 
-    def plot(self, type="roc", server=False, save_to_file=None, plot=True):
+    def plot(self, type="roc", server=False, save_to_file=None, plot=True, **kwargs):
         """
         Produce the desired metric plot.
 
@@ -1419,6 +1419,9 @@ class H2OBinomialModelMetrics(MetricsBase):
         
         """
 
+        if save_to_file is None:  # if not supplied by 'real name'
+            save_to_file = kwargs.get('save_plot_path')
+            
         if type == "roc":
             return self._plot_roc(server, save_to_file, plot)
         elif type == "pr":

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -1066,7 +1066,7 @@ class ModelBase(h2o_meta(Keyed)):
 
     def partial_plot(self, data, cols=None, destination_key=None, nbins=20, weight_column=None,
                      plot=True, plot_stddev = True, figsize=(7, 10), server=False, include_na=False, user_splits=None,
-                     col_pairs_2dpdp=None, save_to_file=None, row_index=None, targets=None):
+                     col_pairs_2dpdp=None, save_to_file=None, row_index=None, targets=None, **kwargs):
         """
         Create partial dependence plot which gives a graphical depiction of the marginal effect of a variable on the
         response. The effect of a variable is measured in change in the mean response.
@@ -1088,6 +1088,8 @@ class ModelBase(h2o_meta(Keyed)):
         :param targets: Target classes for multiclass model.
         :returns: Plot and list of calculated mean response tables for each feature requested.
         """
+        if save_to_file is None:  # if not supplied by 'real name'
+            save_to_file = kwargs.get('save_plot_path')
         if not isinstance(data, h2o.H2OFrame): raise ValueError("Data must be an instance of H2OFrame.")
         num_1dpdp = 0
         num_2dpdp = 0

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -12,7 +12,7 @@ from h2o.model.extensions import has_extension
 from h2o.plot import decorate_plot_result, get_matplotlib_pyplot, RAISE_ON_FIGURE_ACCESS
 from h2o.utils.compatibility import *  # NOQA
 from h2o.utils.compatibility import viewitems
-from h2o.utils.metaclass import backwards_compatibility, deprecated_fn, h2o_meta
+from h2o.utils.metaclass import backwards_compatibility, deprecated_fn, h2o_meta, deprecated_params
 from h2o.utils.shared_utils import can_use_pandas
 from h2o.utils.typechecks import assert_is_type, assert_satisfies, Enum, is_type
 
@@ -1064,9 +1064,10 @@ class ModelBase(h2o_meta(Keyed)):
             metrics["train"] = output["training_metrics"]
         return metrics
 
+    @deprecated_params({'save_to_file': 'save_plot_path'})
     def partial_plot(self, data, cols=None, destination_key=None, nbins=20, weight_column=None,
                      plot=True, plot_stddev = True, figsize=(7, 10), server=False, include_na=False, user_splits=None,
-                     col_pairs_2dpdp=None, save_to_file=None, row_index=None, targets=None, **kwargs):
+                     col_pairs_2dpdp=None, save_plot_path=None, row_index=None, targets=None):
         """
         Create partial dependence plot which gives a graphical depiction of the marginal effect of a variable on the
         response. The effect of a variable is measured in change in the mean response.
@@ -1083,13 +1084,11 @@ class ModelBase(h2o_meta(Keyed)):
         :param include_na: A boolean specifying whether missing value should be included in the Feature values.
         :param user_splits: a dictionary containing column names as key and user defined split values as value in a list.
         :param col_pairs_2dpdp: list containing pairs of column names for 2D pdp
-        :param save_to_file: Fully qualified name to an image file the resulting plot should be saved to, e.g. '/home/user/pdpplot.png'. The 'png' postfix might be omitted. If the file already exists, it will be overridden. Plot is only saved if plot = True.
+        :param save_plot_path: Fully qualified name to an image file the resulting plot should be saved to, e.g. '/home/user/pdpplot.png'. The 'png' postfix might be omitted. If the file already exists, it will be overridden. Plot is only saved if plot = True.
         :param row_index: Row for which partial dependence will be calculated instead of the whole input frame.
         :param targets: Target classes for multiclass model.
-        :returns: Plot and list of calculated mean response tables for each feature requested.
+        :returns: Plot and list of calculated mean response tables for each feature requested + the resulting plot (can be accessed using result.figure()).
         """
-        if save_to_file is None:  # if not supplied by 'real name'
-            save_to_file = kwargs.get('save_plot_path')
         if not isinstance(data, h2o.H2OFrame): raise ValueError("Data must be an instance of H2OFrame.")
         num_1dpdp = 0
         num_2dpdp = 0
@@ -1166,7 +1165,7 @@ class ModelBase(h2o_meta(Keyed)):
 
         # Plot partial dependence plots using matplotlib
         return self.__generate_partial_plots(num_1dpdp, num_2dpdp, plot, server, pps, figsize, col_pairs_2dpdp, data, nbins,
-                                      kwargs["user_cols"], kwargs["num_user_splits"], plot_stddev, cols, save_to_file, row_index, targets, include_na)
+                                      kwargs["user_cols"], kwargs["num_user_splits"], plot_stddev, cols, save_plot_path, row_index, targets, include_na)
 
     def __generate_user_splits(self, user_splits, data, kwargs):
         # extract user defined split points from dict user_splits into an integer array of column indices

--- a/h2o-py/tests/testdir_algos/glm/pyunit_plot_functions__add_saving_parameter_and_decorate_plot_result.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_plot_functions__add_saving_parameter_and_decorate_plot_result.py
@@ -152,7 +152,7 @@ def partial_plots():
         path1 = "{}/plot1.png".format(tmpdir)
         path2 = "{}/plot2.png".format(tmpdir)
         test_plot_result_saving(gbm_model.partial_plot(data=data, cols=['AGE'], server=True, plot=True, row_index=1), path2,
-                                gbm_model.partial_plot(data=data, cols=['AGE'], server=True, plot=True, row_index=1, save_to_file=path1), path1)
+                                gbm_model.partial_plot(data=data, cols=['AGE'], server=True, plot=True, row_index=1, save_plot_path=path1), path1)
 
 
 def partial_plots_multinomial():
@@ -210,7 +210,7 @@ def roc_pr_curve():
         perf_test = air_gbm.model_performance(air_test)
     
         test_plot_result_saving(perf_test.plot(type="roc", server=False), path2,
-                                perf_test.plot(type="roc", server=False, save_to_file=path1), path1)
+                                perf_test.plot(type="roc", server=False, save_plot_path=path1), path1)
 
 
 def screeplot():
@@ -255,6 +255,21 @@ def std_coef__varimp():
                                 cars_glm.varimp_plot(server=True, save_plot_path=path), path)
 
 
+def test_hist():
+    df = h2o.upload_file(pyunit_utils.locate("smalldata/iris/iris.csv"))
+
+    with TemporaryDirectory() as tmpdir:
+        path1="{}/plot1.png".format(tmpdir)
+        path2="{}/plot2.png".format(tmpdir)
+        test_plot_result_saving( df[0].hist(breaks=5, plot=True), path2,
+                                 df[0].hist(breaks=5, plot=True, save_plot_path=path1), path1)
+
+    h = df[0].hist(breaks=5, plot=True)
+    assert h.nrow == 5
+
+    h = df[0].hist(breaks=[0,0.5,2,3], plot=True)
+    assert h.nrow == 4
+
 pyunit_utils.run_tests([
     binomial_plot_test,
     test_decorate_plot_result,
@@ -264,5 +279,6 @@ pyunit_utils.run_tests([
     partial_plots,
     partial_plots_multinomial,
     roc_pr_curve,
-    screeplot
+    screeplot,
+    test_hist
 ])

--- a/h2o-py/tests/testdir_algos/glm/pyunit_plot_functions__add_saving_parameter_and_decorate_plot_result.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_plot_functions__add_saving_parameter_and_decorate_plot_result.py
@@ -224,7 +224,7 @@ def screeplot():
     with TemporaryDirectory() as tmpdir:
         path="{}/plot1.png".format(tmpdir)
         test_plot_result_saving(screeplot_result, "{}/plot2.png".format(tmpdir),
-                                australia_pca.screeplot(type="barplot", **kwargs, save_plot_path=path), path)
+                                australia_pca.screeplot(type="barplot", save_plot_path=path, **kwargs), path)
     
 
 def std_coef__varimp():    

--- a/h2o-py/tests/testdir_misc/pyunit_explain.py
+++ b/h2o-py/tests/testdir_misc/pyunit_explain.py
@@ -182,11 +182,11 @@ def test_explanation_list_of_models_regression():
     models += [gbm]
 
     # test variable importance heatmap plot
-    assert isinstance(h2o.varimp_heatmap(models), matplotlib.pyplot.Figure)
+    assert isinstance(h2o.varimp_heatmap(models).figure(), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close()
 
     # test model correlation heatmap plot
-    assert isinstance(h2o.model_correlation_heatmap(models, train), matplotlib.pyplot.Figure)
+    assert isinstance(h2o.model_correlation_heatmap(models, train).figure(), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close()
 
     # test partial dependences
@@ -352,11 +352,11 @@ def test_explanation_list_of_models_binomial_classification():
     models += [gbm]
 
     # test variable importance heatmap plot
-    assert isinstance(h2o.varimp_heatmap(models), matplotlib.pyplot.Figure)
+    assert isinstance(h2o.varimp_heatmap(models).figure(), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close()
 
     # test model correlation heatmap plot
-    assert isinstance(h2o.model_correlation_heatmap(models, train), matplotlib.pyplot.Figure)
+    assert isinstance(h2o.model_correlation_heatmap(models, train).figure(), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close()
 
     # test partial dependences
@@ -502,11 +502,11 @@ def test_explanation_list_of_models_multinomial_classification():
     models += [gbm]
 
     # test variable importance heatmap plot
-    assert isinstance(h2o.varimp_heatmap(models), matplotlib.pyplot.Figure)
+    assert isinstance(h2o.varimp_heatmap(models).figure(), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close()
 
     # test model correlation heatmap plot
-    assert isinstance(h2o.model_correlation_heatmap(models, train), matplotlib.pyplot.Figure)
+    assert isinstance(h2o.model_correlation_heatmap(models, train).figure(), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close()
 
     # test partial dependences

--- a/h2o-py/tests/testdir_misc/pyunit_explain.py
+++ b/h2o-py/tests/testdir_misc/pyunit_explain.py
@@ -111,7 +111,7 @@ def test_explanation_automl_regression():
     aml.train(y=y, training_frame=train)
 
     # test variable importance heatmap plot
-    assert isinstance(aml.varimp_heatmap(), matplotlib.pyplot.Figure)
+    assert isinstance(aml.varimp_heatmap().figure(), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close()
 
     assert len(aml.varimp(use_pandas=False)) == 3  # numpy.ndarray, colnames, rownames
@@ -275,7 +275,7 @@ def test_explanation_automl_binomial_classification():
     aml.train(y=y, training_frame=train)
 
     # test variable importance heatmap plot
-    assert isinstance(aml.varimp_heatmap(), matplotlib.pyplot.Figure)
+    assert isinstance(aml.varimp_heatmap().figure(), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close()
 
     assert len(aml.varimp(use_pandas=False)) == 3  # numpy.ndarray, colnames, rownames
@@ -302,7 +302,7 @@ def test_explanation_automl_binomial_classification():
 
     # Leaderboard slices work
     # test variable importance heatmap plot
-    assert isinstance(aml.varimp_heatmap(), matplotlib.pyplot.Figure)
+    assert isinstance(aml.varimp_heatmap().figure(), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close()
 
     leaderboard_without_SE = aml.leaderboard[~aml.leaderboard["model_id"].grep("^Stacked", output_logical=True), :]
@@ -445,7 +445,7 @@ def test_explanation_automl_multinomial_classification():
     aml.train(y=y, training_frame=train)
 
     # test variable importance heatmap plot
-    assert isinstance(aml.varimp_heatmap(), matplotlib.pyplot.Figure)
+    assert isinstance(aml.varimp_heatmap().figure(), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close()
 
     assert len(aml.varimp(use_pandas=False)) == 3  # numpy.ndarray, colnames, rownames


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8405
- added `save_plot_path` parameter also to h2o.frame.H2OFrame.hist since this was not in the list on support ticket, but its also a plot function.
- did alias on functions where there was originally used '`save_to_file'` parameter so that it works also with '`save_plot_path`'

I would not add save_plot_path to varimp_heatmap() and model_correlation_heatmap(), since those already return a plot and there are varimp() and model_correlation() to get data used to build them or do you think it should be added also there?