### PR TITLE
PUBDEV-8407: Fix GAM weight bug

### DIFF
--- a/h2o-algos/src/main/java/hex/gam/MatrixFrameUtils/GamUtils.java
+++ b/h2o-algos/src/main/java/hex/gam/MatrixFrameUtils/GamUtils.java
@@ -312,7 +312,7 @@ public class GamUtils {
   // grad all predictors to build a smoother
   public static Frame prepareGamVec(int gam_column_index, GAMParameters parms, Frame fr) {
     final Vec weights_column = (parms._weights_column == null) ? Scope.track(Vec.makeOne(fr.numRows()))
-            : Scope.track(fr.vec(parms._weights_column));
+            : fr.vec(parms._weights_column);
     final Frame predictVec = new Frame();
     int numPredictors = parms._gam_columns_sorted[gam_column_index].length;
     for (int colInd = 0; colInd < numPredictors; colInd++)
@@ -368,7 +368,7 @@ public class GamUtils {
     Vec responseVec = train.remove(parms._response_column);
     Vec weightsVec = null;
     if (parms._weights_column != null) // move weight vector to be the last vector before response variable
-      weightsVec = Scope.track(train.remove(parms._weights_column));
+      weightsVec = train.remove(parms._weights_column);
     for (int colIdx = 0; colIdx < parms._gam_columns_sorted.length; colIdx++) {  // append the augmented columns to _train
       Frame gamFrame = Scope.track(gamFrameKeysCenter[colIdx].get());
       train.add(gamFrame.names(), gamFrame.removeAll());

--- a/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_8407_gam_weight.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_8407_gam_weight.py
@@ -1,0 +1,45 @@
+from __future__ import division
+from __future__ import print_function
+import sys, os
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gam import H2OGeneralizedAdditiveEstimator
+import pandas as pd
+import numpy as np
+
+# When GAM is trained with weight columns, scoring on the training frame run into error.
+# I fixed this by not tracking weight columns in Java backend.
+def link_functions_tweedie_vpow():
+    np.random.seed(1234)
+    n_rows = 10
+
+    data = {
+        "X1": np.random.randn(n_rows),
+        "X2": np.random.randn(n_rows),
+        "X3": np.random.randn(n_rows),
+        "W": np.random.choice([10, 20], size=n_rows),
+        "Y": np.random.choice([0, 0, 0, 0, 0, 10, 20, 30], size=n_rows)
+    }
+
+    train = h2o.H2OFrame(pd.DataFrame(data))
+    test = train.drop(3)
+    print(train)
+    h2o_model = H2OGeneralizedAdditiveEstimator(family="tweedie",
+                                                gam_columns=["X3"],
+                                                weights_column="W",
+                                                lambda_=0,
+                                                tweedie_variance_power=1.5,
+                                                tweedie_link_power=0)
+    h2o_model.train(x=["X1", "X2"], y="Y", training_frame=train)
+
+    predict_w = h2o_model.predict(train)
+    predict = h2o_model.predict(test) # scoring without weight column
+    # should produce same frame
+    pyunit_utils.compare_frames_local(predict_w, predict, prob=1, tol=1e-6)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(link_functions_tweedie_vpow)
+else:
+    link_functions_tweedie_vpow()


### PR DESCRIPTION
This PR fixes the problem in : https://h2oai.atlassian.net/browse/PUBDEV-8407

The weight vectors are tracked by Scope and hence when the model building process ends, it will be deleted.
I fixed the error by removing the Scope.track(weight_v).

