### PR TITLE
Resolve merge conflict after changes in Jetty idleTime config [nocheck]

### DIFF
--- a/h2o-algos/src/main/java/hex/gam/MatrixFrameUtils/GamUtils.java
+++ b/h2o-algos/src/main/java/hex/gam/MatrixFrameUtils/GamUtils.java
@@ -312,7 +312,7 @@ public class GamUtils {
   // grad all predictors to build a smoother
   public static Frame prepareGamVec(int gam_column_index, GAMParameters parms, Frame fr) {
     final Vec weights_column = (parms._weights_column == null) ? Scope.track(Vec.makeOne(fr.numRows()))
-            : Scope.track(fr.vec(parms._weights_column));
+            : fr.vec(parms._weights_column);
     final Frame predictVec = new Frame();
     int numPredictors = parms._gam_columns_sorted[gam_column_index].length;
     for (int colInd = 0; colInd < numPredictors; colInd++)
@@ -368,7 +368,7 @@ public class GamUtils {
     Vec responseVec = train.remove(parms._response_column);
     Vec weightsVec = null;
     if (parms._weights_column != null) // move weight vector to be the last vector before response variable
-      weightsVec = Scope.track(train.remove(parms._weights_column));
+      weightsVec = train.remove(parms._weights_column);
     for (int colIdx = 0; colIdx < parms._gam_columns_sorted.length; colIdx++) {  // append the augmented columns to _train
       Frame gamFrame = Scope.track(gamFrameKeysCenter[colIdx].get());
       train.add(gamFrame.names(), gamFrame.removeAll());

--- a/h2o-jetty-8/src/main/java/water/webserver/jetty8/Jetty8Helper.java
+++ b/h2o-jetty-8/src/main/java/water/webserver/jetty8/Jetty8Helper.java
@@ -84,6 +84,7 @@ class Jetty8Helper {
       //        something else at assembly time
       Response.RELATIVE_REDIRECT_ALLOWED = false;
     }
+    connector.setMaxIdleTime(cfg.getIdleTimeout());
   }
 
   HandlerWrapper authWrapper(Server jettyServer) {

--- a/h2o-jetty-8/src/test/java/water/webserver/jetty8/Jetty8HelperTest.java
+++ b/h2o-jetty-8/src/test/java/water/webserver/jetty8/Jetty8HelperTest.java
@@ -77,6 +77,7 @@ public class Jetty8HelperTest {
 
       verify(defaultConnectorMock).setRequestHeaderSize(32 * 1024);
       verify(defaultConnectorMock).setRequestBufferSize(32 * 1024);
+      verify(defaultConnectorMock).setMaxIdleTime(5 * 60 * 1000);
       assertFalse(Response.RELATIVE_REDIRECT_ALLOWED);
     } finally {
       Response.RELATIVE_REDIRECT_ALLOWED = origRedirects;

--- a/h2o-jetty-9-minimal/src/main/java/water/webserver/jetty9/Jetty9Helper.java
+++ b/h2o-jetty-9-minimal/src/main/java/water/webserver/jetty9/Jetty9Helper.java
@@ -73,6 +73,7 @@ class Jetty9Helper {
         httpConfiguration.setResponseHeaderSize(cfg.getResponseHeaderSize());
         httpConfiguration.setOutputBufferSize(cfg.getOutputBufferSize(httpConfiguration.getOutputBufferSize()));
         httpConfiguration.setRelativeRedirectAllowed(cfg.isRelativeRedirectAllowed());
+        httpConfiguration.setIdleTimeout(cfg.getIdleTimeout());
         return httpConfiguration;
     }
 

--- a/h2o-jetty-9-minimal/src/test/java/water/webserver/jetty9/Jetty9HelperTest.java
+++ b/h2o-jetty-9-minimal/src/test/java/water/webserver/jetty9/Jetty9HelperTest.java
@@ -78,6 +78,7 @@ public class Jetty9HelperTest {
     when(ccMock.getRequestHeaderSize()).thenReturn(42);
     when(ccMock.getResponseHeaderSize()).thenReturn(43);
     when(ccMock.getOutputBufferSize(anyInt())).thenReturn(44);
+    when(ccMock.getIdleTimeout()).thenReturn(45);
     when(ccMock.isRelativeRedirectAllowed()).thenReturn(false);
 
     HttpConfiguration customCfg = Jetty9Helper.makeHttpConfiguration(ccMock);
@@ -85,6 +86,7 @@ public class Jetty9HelperTest {
     assertEquals(customCfg.getRequestHeaderSize(), 42);
     assertEquals(customCfg.getResponseHeaderSize(), 43);
     assertEquals(customCfg.getOutputBufferSize(), 44);
+    assertEquals(customCfg.getIdleTimeout(), 45);
     assertFalse(customCfg.isRelativeRedirectAllowed());
   }
 

--- a/h2o-jetty-9/src/main/java/water/webserver/jetty9/Jetty9Helper.java
+++ b/h2o-jetty-9/src/main/java/water/webserver/jetty9/Jetty9Helper.java
@@ -89,6 +89,7 @@ class Jetty9Helper {
         httpConfiguration.setResponseHeaderSize(cfg.getResponseHeaderSize());
         httpConfiguration.setOutputBufferSize(cfg.getOutputBufferSize(httpConfiguration.getOutputBufferSize()));
         httpConfiguration.setRelativeRedirectAllowed(cfg.isRelativeRedirectAllowed());
+        httpConfiguration.setIdleTimeout(cfg.getIdleTimeout());
         return httpConfiguration;
     }
 

--- a/h2o-jetty-9/src/test/java/water/webserver/jetty9/Jetty9HelperTest.java
+++ b/h2o-jetty-9/src/test/java/water/webserver/jetty9/Jetty9HelperTest.java
@@ -79,6 +79,7 @@ public class Jetty9HelperTest {
     when(ccMock.getRequestHeaderSize()).thenReturn(42);
     when(ccMock.getResponseHeaderSize()).thenReturn(43);
     when(ccMock.getOutputBufferSize(anyInt())).thenReturn(44);
+    when(ccMock.getIdleTimeout()).thenReturn(45);
     when(ccMock.isRelativeRedirectAllowed()).thenReturn(false);
 
     H2OHttpConfiguration customCfg = (H2OHttpConfiguration) Jetty9Helper.makeHttpConfiguration(ccMock);
@@ -86,6 +87,7 @@ public class Jetty9HelperTest {
     assertEquals(customCfg.getRequestHeaderSize(), 42);
     assertEquals(customCfg.getResponseHeaderSize(), 43);
     assertEquals(customCfg.getOutputBufferSize(), 44);
+    assertEquals(customCfg.getIdleTimeout(), 45);
     assertFalse(customCfg.isRelativeRedirectAllowed());
   }
 

--- a/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_8407_gam_weight.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_8407_gam_weight.py
@@ -1,0 +1,45 @@
+from __future__ import division
+from __future__ import print_function
+import sys, os
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gam import H2OGeneralizedAdditiveEstimator
+import pandas as pd
+import numpy as np
+
+# When GAM is trained with weight columns, scoring on the training frame run into error.
+# I fixed this by not tracking weight columns in Java backend.
+def link_functions_tweedie_vpow():
+    np.random.seed(1234)
+    n_rows = 10
+
+    data = {
+        "X1": np.random.randn(n_rows),
+        "X2": np.random.randn(n_rows),
+        "X3": np.random.randn(n_rows),
+        "W": np.random.choice([10, 20], size=n_rows),
+        "Y": np.random.choice([0, 0, 0, 0, 0, 10, 20, 30], size=n_rows)
+    }
+
+    train = h2o.H2OFrame(pd.DataFrame(data))
+    test = train.drop(3)
+    print(train)
+    h2o_model = H2OGeneralizedAdditiveEstimator(family="tweedie",
+                                                gam_columns=["X3"],
+                                                weights_column="W",
+                                                lambda_=0,
+                                                tweedie_variance_power=1.5,
+                                                tweedie_link_power=0)
+    h2o_model.train(x=["X1", "X2"], y="Y", training_frame=train)
+
+    predict_w = h2o_model.predict(train)
+    predict = h2o_model.predict(test) # scoring without weight column
+    # should produce same frame
+    pyunit_utils.compare_frames_local(predict_w, predict, prob=1, tol=1e-6)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(link_functions_tweedie_vpow)
+else:
+    link_functions_tweedie_vpow()

--- a/h2o-webserver-iface/src/main/java/water/webserver/config/ConnectionConfiguration.java
+++ b/h2o-webserver-iface/src/main/java/water/webserver/config/ConnectionConfiguration.java
@@ -26,6 +26,10 @@ public class ConnectionConfiguration {
         return getSysPropInt("responseBufferSize", defaultOutputBufferSize);
     }
 
+    public int getIdleTimeout() {
+        return getSysPropInt("jetty.idleTimeout", 5 * 60 * 1000);
+    }
+
     public boolean isRelativeRedirectAllowed() {
         return getSysPropBool("relativeRedirectAllowed", true);
     }

--- a/h2o-webserver-iface/src/test/java/water/webserver/config/ConnectionConfigurationTest.java
+++ b/h2o-webserver-iface/src/test/java/water/webserver/config/ConnectionConfigurationTest.java
@@ -16,6 +16,7 @@ public class ConnectionConfigurationTest {
         assertEquals(32 * 1024, cfg.getRequestBufferSize());
         assertEquals(32 * 1024, cfg.getResponseHeaderSize());
         assertEquals(17, cfg.getOutputBufferSize(17));
+        assertEquals(5 * 60 * 1000, cfg.getIdleTimeout());
         assertTrue(cfg.isRelativeRedirectAllowed());
     }
 
@@ -28,6 +29,7 @@ public class ConnectionConfigurationTest {
             props.put(prefix + "requestBufferSize", "43");
             props.put(prefix + "responseHeaderSize", "44");
             props.put(prefix + "responseBufferSize", "45");
+            props.put(prefix + "jetty.idleTimeout", "46");
             props.put(prefix + "relativeRedirectAllowed", "false");
 
             ConnectionConfiguration cfg = new MyConnectionConfiguration(props, isSecured);
@@ -35,6 +37,7 @@ public class ConnectionConfigurationTest {
             assertEquals(43, cfg.getRequestBufferSize());
             assertEquals(44, cfg.getResponseHeaderSize());
             assertEquals(45, cfg.getOutputBufferSize(17));
+            assertEquals(46, cfg.getIdleTimeout());
             assertFalse(cfg.isRelativeRedirectAllowed());
         }
     }


### PR DESCRIPTION
- [PUBDEV-8377] Increase Jetty Idle Timeout to 5 minutes and Make It Configurable
- remove weight vector to Scope (#5882)
- Jetty: Add test for setIdleTimeout


[PUBDEV-8377]: https://h2oai.atlassian.net/browse/PUBDEV-8377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ