### PR TITLE
Clean-up IF grid search tests [nocheck]

### DIFF
--- a/h2o-r/tests/testdir_algos/grid/runit_grid_isofor.R
+++ b/h2o-r/tests/testdir_algos/grid/runit_grid_isofor.R
@@ -5,7 +5,7 @@ source("../../../scripts/h2o-r-test-setup.R")
 
 
 
-test.grid.resume <- function() {
+test.grid.isofor <- function() {
   iris.hex <-
     h2o.importFile(path = locate("smalldata/iris/iris.csv"),
                    destination_frame = "iris.hex")
@@ -57,4 +57,4 @@ test.grid.resume <- function() {
     )
 }
 
-doTest("Parallel Grid Search test", test.grid.resume)
+doTest("Isolation Forest Grid Search test", test.grid.isofor)

--- a/h2o-r/tests/testdir_algos/grid/runit_grid_parallel.R
+++ b/h2o-r/tests/testdir_algos/grid/runit_grid_parallel.R
@@ -3,18 +3,16 @@ source("../../../scripts/h2o-r-test-setup.R")
 
 
 
-test.grid.resume <- function() {
-  iris.hex <- h2o.importFile(path = locate("smalldata/iris/iris.csv"), destination_frame="iris.hex")
+test.grid.parallel <- function() {
+  iris.hex <- h2o.importFile(path = locate("smalldata/iris/iris.csv"))
 
   ntrees_opts = c(1, 5)
   learn_rate_opts = c(0.1, 0.01)
   size_of_hyper_space = length(ntrees_opts) * length(learn_rate_opts)
   
   hyper_parameters = list(ntrees = ntrees_opts, learn_rate = learn_rate_opts)
-  baseline_grid <- h2o.grid("gbm", grid_id="gbm_grid_test", x=1:4, y=5, training_frame=iris.hex, hyper_params = hyper_parameters, export_checkpoints_dir = tempdir(), parallelism = 0)
-  grid_id <- baseline_grid@grid_id
+  baseline_grid <- h2o.grid("gbm", grid_id="gbm_grid_test", x=1:4, y=5, training_frame=iris.hex, hyper_params = hyper_parameters, parallelism = 0)
   expect_equal(length(baseline_grid@model_ids), length(ntrees_opts) * length(learn_rate_opts))
-
 }
 
-doTest("Parallel Grid Search test", test.grid.resume)
+doTest("Parallel Grid Search test", test.grid.parallel)

--- a/h2o-r/tests/testdir_algos/isoforextended/runit_isoforextended_grid.R
+++ b/h2o-r/tests/testdir_algos/isoforextended/runit_isoforextended_grid.R
@@ -22,11 +22,10 @@ test.grid.extendedisolationforest <- function() {
       x = c(1, 2),
       training_frame = single_blob.hex,
       hyper_params = hyper_parameters,
-      parallelism = 0
     )
   print(paste("Expected size of hyperparameter space is", length(baseline_grid@model_ids)))
   expect_equal(length(baseline_grid@model_ids), size_of_hyper_space)
 }
 
 
-doTest("Parallel Grid Search test for Extended Isolation Forest", test.grid.extendedisolationforest)
+doTest("Grid Search test for Extended Isolation Forest", test.grid.extendedisolationforest)


### PR DESCRIPTION
- Extended IF: Fix grid search test - the purpose is not to test parallelism
- Clean-up grid search tests - get rid off some redundant copy&paste
