### PR TITLE
PUBDEV-8423 : Shorten beta constraints tests

### DIFF
--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7973_beta_constraints_binomial.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7973_beta_constraints_binomial.py
@@ -35,7 +35,6 @@ def test_beta_constraints_binomial():
                                    1.959130413902314*0.8, 0.13139198387980652*0.8, 1.80498551446445*0.8]}
     constraints = h2o.H2OFrame(dictBounds)
     constraints = constraints[["names", "lower_bounds", "upper_bounds"]]
-    run_print_model_performance('binomial', h2o_data, nfolds, constraints, x, y, printText, seed, 'coordinate_descent')
     run_print_model_performance('binomial', h2o_data, nfolds, constraints, x, y, printText, seed, 'irlsm')
 
 def run_print_model_performance(family, train, nfolds, bc_constraints, x, y, printText, seed, solver):
@@ -44,13 +43,9 @@ def run_print_model_performance(family, train, nfolds, bc_constraints, x, y, pri
     h2o_model = H2OGeneralizedLinearEstimator(family=family, nfolds=nfolds, beta_constraints=bc_constraints, seed=seed,
                                               solver = solver)
     h2o_model.train(x=x, y=y, training_frame=train)
-    print("With lambda search and with solver {0}".format(solver))
-    h2o_model2 = H2OGeneralizedLinearEstimator(family=family, nfolds=nfolds, beta_constraints=bc_constraints, seed=seed,
-                                              lambda_search=True, solver = solver)
-    h2o_model2.train(x=x, y=y, training_frame=train)
+
     # check coefficients to be within bounds
     coeff = h2o_model.coef()
-    coeff2 = h2o_model2.coef()
     colNames = bc_constraints["names"]
     lowerB = bc_constraints["lower_bounds"]
     upperB = bc_constraints["upper_bounds"]
@@ -61,13 +56,6 @@ def run_print_model_performance(family, train, nfolds, bc_constraints, x, y, pri
         assert ((coeff[colNames[count,0]] >= lowerB[count,0] or low_diff) and (coeff[colNames[count,0]]
                                                                               <= upperB[count,0] or up_diff)) or coef_inactive, \
             "coef for {0}: {1}, lower bound: {2}, upper bound: {3}".format(colNames[count,0], coeff[colNames[count,0]],
-                                                                           lowerB[count,0], upperB[count,0])
-        low_diff2 =  abs(coeff2[colNames[count,0]]-lowerB[count,0]) < 1e-6
-        up_diff2 = abs(coeff2[colNames[count,0]] <= upperB[count,0]) < 1e-6
-        coef_inactive2 = coeff2[colNames[count,0]]==0
-        assert ((coeff2[colNames[count,0]] >= lowerB[count,0] or low_diff2) and (coeff2[colNames[count,0]]
-                                                                                <= upperB[count,0] or up_diff2)) or coef_inactive2, \
-            "With lambda search: coef for {0}: {1}, lower bound: {2}, upper bound: {3}".format(colNames[count,0], coeff2[colNames[count,0]],
                                                                            lowerB[count,0], upperB[count,0])
 
 if __name__ == "__main__":

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7973_beta_constraints_gaussian.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7973_beta_constraints_gaussian.py
@@ -38,34 +38,20 @@ def test_beta_constraints_gaussian():
                                                  20.130364463336967 * 0.8]})
     constraints = constraints[["names", "lower_bounds", "upper_bounds"]]
     run_print_model_performance('gaussian', h2o_data, nfolds, constraints, x, y, printText, seed, 'coordinate_descent')
-    run_print_model_performance('gaussian', h2o_data, nfolds, constraints, x, y, printText, seed, 'irlsm')
-
 
 def run_print_model_performance(family, train, nfolds, bc_constraints, x, y, printText, seed, solver):
-    print(printText)
-    print("Without lambda search, solver = {0}".format(solver))
-    h2o_model = H2OGeneralizedLinearEstimator(family=family, nfolds=nfolds, beta_constraints=bc_constraints,
-                                              seed=seed,
-                                              solver=solver)
-    h2o_model.train(x=x, y=y, training_frame=train)
     print("With lambda search, solver = {0}".format(solver))
     h2o_model2 = H2OGeneralizedLinearEstimator(family=family, nfolds=nfolds, beta_constraints=bc_constraints,
                                                seed=seed,
                                                lambda_search=True, solver=solver)
     h2o_model2.train(x=x, y=y, training_frame=train)
     # make sure coefficients are within bounds
-    coeff = h2o_model.coef()
     coeff2 = h2o_model2.coef()
     colNames = bc_constraints["names"]
     lowerB = bc_constraints["lower_bounds"]
     upperB = bc_constraints["upper_bounds"]
     for count in range(0, len(colNames)):
         # fix issue due to rounding difference between bounds and coefficients.
-        coef_inactive = coeff[colNames[count,0]]==0
-        assert (round(coeff[colNames[count,0]],6) >= round(lowerB[count,0],6) and round(coeff[colNames[count,0]],6) 
-                <= round(upperB[count,0], 6)) or coef_inactive, \
-            "coef for {0}: {1}, lower bound: {2}, upper bound: {3}".format(colNames[count,0], coeff[colNames[count,0]],
-                                                                           lowerB[count,0], upperB[count,0])
         coef_inactive2 = coeff2[colNames[count,0]]==0
         assert (round(coeff2[colNames[count,0]],6) >= round(lowerB[count,0],6) and round(coeff2[colNames[count,0]],6) 
                 <= round(upperB[count,0], 6)) or coef_inactive2, \


### PR DESCRIPTION
This PR completes the task in: https://h2oai.atlassian.net/browse/PUBDEV-8423.

I was doing some profiling tests and did not remove them after completion.  Hence, the beta constraints tests are taking too long.  Remove the profiling part and it should shorten the test time significantly.