### PR TITLE
[nocheck] avoid use of deprecated imp standard library

### DIFF
--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -66,7 +66,7 @@ def temp_ctr():
 
 
 def is_module_available(mod):
-    if mod in sys.modules:  # fast track + safer in unusual environments 
+    if mod in sys.modules and sys.modules[mod] is not None:  # fast track + safer in unusual environments 
         return True
     if PY2:
         import imp

--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -89,16 +89,20 @@ def can_use_numpy():
 _url_safe_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~"
 _url_chars_map = [chr(i) if chr(i) in _url_safe_chars else "%%%02X" % i for i in range(256)]
 
+
 def url_encode(s):
     # Note: type cast str(s) will not be needed once all code is made compatible
     return "".join(_url_chars_map[c] for c in bytes_iterator(s))
 
+
 def quote(s):
     return url_encode(s)
+
 
 def clamp(x, xmin, xmax):
     """Return the value of x, clamped from below by `xmin` and from above by `xmax`."""
     return max(xmin, min(x, xmax))
+
 
 def _gen_header(cols):
     return ["C" + str(c) for c in range(1, cols + 1, 1)]
@@ -194,6 +198,7 @@ def _handle_numpy_array(python_obj, header):
 def _handle_pandas_data_frame(python_obj, header):
     data = _handle_python_lists(python_obj.values.tolist(), -1)[1]
     return list(str(c) for c in python_obj.columns), data
+
 
 def _handle_python_dicts(python_obj, check_header):
     header = list(python_obj.keys()) if python_obj else _gen_header(1)

--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -11,7 +11,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from .compatibility import *  # NOQA
 
 import csv
-import imp  # keeping this deprecated module as soon as we keep supporting Py2.7
 import io
 import itertools
 import os
@@ -66,20 +65,25 @@ def temp_ctr():
     return _id_ctr
 
 
+def is_module_available(mod):
+    if PY2:
+        import imp
+        try:
+            imp.find_module(mod)
+            return True
+        except ImportError:
+            return False
+        
+    import importlib.util
+    return importlib.util.find_spec(mod) is not None
+
+
 def can_use_pandas():
-    try:
-        imp.find_module('pandas')
-        return True
-    except ImportError:
-        return False
+    return is_module_available('pandas')
 
 
 def can_use_numpy():
-    try:
-        imp.find_module('numpy')
-        return True
-    except ImportError:
-        return False
+    return is_module_available('numpy')
 
 
 _url_safe_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~"

--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -66,6 +66,8 @@ def temp_ctr():
 
 
 def is_module_available(mod):
+    if mod in sys.modules:  # fast track + safer in unusual environments 
+        return True
     if PY2:
         import imp
         try:

--- a/h2o-py/tests/testdir_utils/pyunit_shared_utils.py
+++ b/h2o-py/tests/testdir_utils/pyunit_shared_utils.py
@@ -1,0 +1,19 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+
+from h2o.utils.shared_utils import is_module_available, can_use_pandas, can_use_numpy
+from tests import pyunit_utils as pu
+
+
+def test_external_libraries_detection():
+    assert can_use_pandas(), "pandas should be detected in test environment"
+    assert can_use_numpy(), "numpy should be detected in test environment"
+    assert is_module_available('matplotlib'), "matplotlib should be detected in test environment"
+    assert is_module_available('sklearn'), "sklearn should be detected in test environment"
+    assert not is_module_available('foobar'), "please don't"
+    
+
+pu.run_tests([
+    test_external_libraries_detection
+])


### PR DESCRIPTION
I checked in the entire project: the `imp` module was used only in those `shared_utils` functions.