### PR TITLE
PUBDEV-8439: consolidate rules during extraction

### DIFF
--- a/h2o-algos/src/main/java/hex/rulefit/Rule.java
+++ b/h2o-algos/src/main/java/hex/rulefit/Rule.java
@@ -7,6 +7,7 @@ import water.Iced;
 import water.fvec.Chunk;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class Rule extends Iced {
     
@@ -86,43 +87,57 @@ public class Rule extends Iced {
     
     public static Set<Rule> extractRulesFromTree(SharedTreeSubgraph tree, int modelId, String classString) {
         Set<Rule> rules = new HashSet<>();
-        List<Condition> conditions = new ArrayList<>();
-        traverseNodes(tree.rootNode, conditions, rules, null, modelId, classString);
-        return rules;
-    }
-    
-    private static void traverseNodes(SharedTreeNode node, List<Condition> conditions, Set<Rule> rules, Condition conditionToAdd, int modelId, String classString) {
-        if (conditionToAdd != null) {
-            conditions.add(conditionToAdd);
-        }
-        
-        if (node.isLeaf()) {
-            // create Rule
-            String varName = "M" + modelId + "T" + node.getSubgraphNumber() + "N" + node.getNodeNumber();
+        // filter leaves
+        List<SharedTreeNode> leaves = tree.nodesArray.stream().filter(sharedTreeNode -> sharedTreeNode.isLeaf()).collect(Collectors.toList());
+        // traverse paths
+        for (SharedTreeNode leaf : leaves) {
+            List<Condition> conditions = new ArrayList<>();
+            String varName = "M" + modelId + "T" + leaf.getSubgraphNumber() + "N" + leaf.getNodeNumber();
             if (classString != null) {
                 varName += classString;
             }
+            traversePath(leaf, conditions, rules, varName);
+        }
+        return rules;
+    }
+    
+    private static void traversePath(SharedTreeNode node, List<Condition> conditions, Set<Rule> rules, String varName) {
+        SharedTreeNode parent = node.getParent();
+        if (parent == null) {
+            conditions = conditions.stream().sorted(Comparator.comparing(condition -> condition.featureName)).collect(Collectors.toList());
             rules.add(new Rule(conditions.toArray(new Condition[]{}), node.getPredValue(), varName));
         } else {
-            // traverse
-            int colId = node.getColId();
-            String colName = node.getColName();
-            
-            if (node.getDomainValues() == null) {
-                float splitValue = node.getSplitValue();
-                traverseNodes(node.getRightChild(), new ArrayList<>(conditions), rules, 
-                        new Condition(colId, Condition.Type.Numerical, Condition.Operator.GreaterThanOrEqual, splitValue, null, null, colName, node.getRightChild().isInclusiveNa()), modelId, classString);
-                traverseNodes(node.getLeftChild(), new ArrayList<>(conditions), rules,
-                        new Condition(colId, Condition.Type.Numerical, Condition.Operator.LessThan, splitValue, null, null, colName, node.getLeftChild().isInclusiveNa()), modelId, classString);
+            Condition actualCondition;
+            Condition newCondition;
+            String featureName = parent.getColName();
+            int colId = parent.getColId();
+            if (node.getInclusiveLevels() != null && parent.getDomainValues() != null) {
+                // categorical condition
+                actualCondition = getConditionByFeatureNameAndOperator(conditions, parent.getColName(), Condition.Operator.In);
+                CategoricalThreshold categoricalThreshold = extractCategoricalThreshold(node.getInclusiveLevels(), parent.getDomainValues());
+                newCondition = new Condition(colId, Condition.Type.Categorical, Condition.Operator.In, -1, categoricalThreshold.catThreshold, categoricalThreshold.catThresholdNum, featureName, node.isInclusiveNa());
+                
             } else {
-                String[] domainValues = node.getDomainValues();
-                CategoricalThreshold rightCategoricalThreshold = extractCategoricalThreshold(node.getRightChild().getInclusiveLevels(), domainValues);
-                traverseNodes(node.getRightChild(), new ArrayList<>(conditions), rules, 
-                        new Condition(colId, Condition.Type.Categorical, Condition.Operator.In, -1, rightCategoricalThreshold.catThreshold, rightCategoricalThreshold.catThresholdNum, colName, node.getRightChild().isInclusiveNa()), modelId, classString);
-                CategoricalThreshold leftCategoricalThreshold = extractCategoricalThreshold(node.getLeftChild().getInclusiveLevels(), domainValues);
-                traverseNodes(node.getLeftChild(), new ArrayList<>(conditions), rules,
-                        new Condition(colId, Condition.Type.Categorical, Condition.Operator.In, -1, leftCategoricalThreshold.catThreshold, leftCategoricalThreshold.catThresholdNum, colName, node.getLeftChild().isInclusiveNa()), modelId, classString);
+                float splitValue = parent.getSplitValue();
+                Condition.Operator operator = parent.getLeftChild().equals(node) ? Condition.Operator.LessThan : Condition.Operator.GreaterThanOrEqual;
+                actualCondition = getConditionByFeatureNameAndOperator(conditions, parent.getColName(), operator);
+                newCondition = new Condition(colId, Condition.Type.Numerical, operator, splitValue, null, null, featureName, node.isInclusiveNa());
             }
+            if (actualCondition == null ) {
+                conditions.add(newCondition);
+            } else {
+                actualCondition = actualCondition.expandBy(newCondition);
+            }
+            traversePath(node.getParent(), conditions, rules, varName);
+        }
+    }
+    
+    private static Condition getConditionByFeatureNameAndOperator(List<Condition> conditions, String featureName, Condition.Operator operator) {
+        List<Condition> filteredConditions = conditions.stream().filter(condition -> condition.featureName.equals(featureName) && condition.operator.equals(operator)).collect(Collectors.toList());
+        if (filteredConditions.size() != 0) {
+            return filteredConditions.get(0);
+        } else {
+            return null;
         }
     }
     

--- a/h2o-algos/src/main/java/hex/rulefit/Rule.java
+++ b/h2o-algos/src/main/java/hex/rulefit/Rule.java
@@ -91,12 +91,11 @@ public class Rule extends Iced {
         List<SharedTreeNode> leaves = tree.nodesArray.stream().filter(sharedTreeNode -> sharedTreeNode.isLeaf()).collect(Collectors.toList());
         // traverse paths
         for (SharedTreeNode leaf : leaves) {
-            List<Condition> conditions = new ArrayList<>();
             String varName = "M" + modelId + "T" + leaf.getSubgraphNumber() + "N" + leaf.getNodeNumber();
             if (classString != null) {
                 varName += classString;
             }
-            traversePath(leaf, conditions, rules, varName);
+            traversePath(leaf, rules, varName);
         }
         return rules;
     }
@@ -130,6 +129,10 @@ public class Rule extends Iced {
             }
             traversePath(node.getParent(), conditions, rules, varName);
         }
+    }
+
+    private static void traversePath(SharedTreeNode node, Set<Rule> rules, String varName) {
+        traversePath(node, new ArrayList<>(), rules, varName);
     }
     
     private static Condition getConditionByFeatureNameAndOperator(List<Condition> conditions, String featureName, Condition.Operator operator) {

--- a/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
+++ b/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
@@ -26,6 +26,7 @@ import static hex.genmodel.utils.ArrayUtils.difference;
 import static hex.genmodel.utils.ArrayUtils.signum;
 import static hex.rulefit.RuleFitUtils.consolidateRules;
 import static hex.rulefit.RuleFitUtils.sortRules;
+import static hex.rulefit.RuleFitUtils.deduplicateRules;
 
 
 /**
@@ -265,6 +266,7 @@ public class RuleFit extends ModelBuilder<RuleFitModel, RuleFitModel.RuleFitPara
                         glmParameters._lambda = getOptimalLambda();
                 }
 
+                LOG.info("Training GLM...");
                 long startGLMTime = System.nanoTime();
                 GLM job = new GLM(glmParameters);
                 glmModel = job.trainModel().get();
@@ -286,7 +288,7 @@ public class RuleFit extends ModelBuilder<RuleFitModel, RuleFitModel.RuleFitPara
                 model._output._intercept = getIntercept(glmModel);
 
                 // TODO: add here coverage_count and coverage percent
-                model._output._rule_importance = convertRulesToTable(sortRules(consolidateRules(getRules(glmModel.coefficients(), 
+                model._output._rule_importance = convertRulesToTable(sortRules(deduplicateRules(getRules(glmModel.coefficients(), 
                         ruleEnsemble, model._output.classNames()), _parms._remove_duplicates)), isClassifier() && nclasses() > 2);
 
                 model._output._model_summary = generateSummary(glmModel, ruleEnsemble != null ? ruleEnsemble.size() : 0, overallTreeStats, ntrees);

--- a/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
+++ b/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
 
 import static hex.genmodel.utils.ArrayUtils.difference;
 import static hex.genmodel.utils.ArrayUtils.signum;
-import static hex.rulefit.RuleFitUtils.consolidateRules;
 import static hex.rulefit.RuleFitUtils.sortRules;
 import static hex.rulefit.RuleFitUtils.deduplicateRules;
 

--- a/h2o-algos/src/main/java/hex/rulefit/RuleFitUtils.java
+++ b/h2o-algos/src/main/java/hex/rulefit/RuleFitUtils.java
@@ -23,119 +23,34 @@ public class RuleFitUtils {
         }
         return pathNames;
     }
-
-    static Rule[] consolidateRules(Rule[] rules, boolean remove_duplicates) {
-        for (int i = 0; i < rules.length; i++) {
-            if (rules[i].conditions != null) { // linear rules doesn't need to consolidate
-                rules[i] = consolidateRule(rules[i], remove_duplicates);
-            }
-        }
-        
-        if (remove_duplicates)
-            return deduplicateRules(rules);
-        else
-            return rules;
-    }
     
+    static Rule[] deduplicateRules(Rule[] rules, boolean remove_duplicates) {
+        if (remove_duplicates) {
+            List<Rule> list = Arrays.asList(rules);
+    
+            // group by non linear rules
+            List<Rule> transform = list.stream()
+                    .filter(rule -> rule.conditions != null)
+                    .collect(Collectors.groupingBy(rule -> rule.languageRule))
+                    .entrySet().stream()
+                    .map(e -> e.getValue().stream()
+                            .reduce((r1,r2) -> new Rule(r1.conditions, r1.predictionValue, r1.varName + ", " + r2.varName, r1.coefficient + r2.coefficient)))
+                    .map(f -> f.get())
+                    .collect(Collectors.toList());
+    
+            // add linear rules
+            transform.addAll(list.stream().filter(rule -> rule.conditions == null).collect(Collectors.toList()));
+    
+            return transform.toArray(new Rule[0]);
+        } else {
+            return rules;
+        }
+    }
+
     static Rule[] sortRules(Rule[] rules) {
         Comparator<Rule> ruleAbsCoefficientComparator = Comparator.comparingDouble(Rule::getAbsCoefficient).reversed();
         Arrays.sort(rules, ruleAbsCoefficientComparator);
         return rules;
-    }
-
-    static Rule consolidateRule(Rule rule, boolean remove_duplicates) {
-        List<Condition> consolidatedConditions = new ArrayList<>();
-
-        Condition[] conditions = rule.conditions;
-        List<String> varNames = new ArrayList<>();
-        for (int i = 0; i < conditions.length; i++) {
-            if (!varNames.contains(conditions[i].featureName)) {
-                varNames.add(conditions[i].featureName);
-            }
-        }
-        for (int i = 0; i < varNames.size(); i++) {
-            consolidatedConditions.addAll(consolidateConditionsByVar(conditions, varNames.get(i)));
-        }
-        
-        if (remove_duplicates) {
-            // sort by feature name as a preparation for rules deduplication
-            rule.conditions = consolidatedConditions.stream()
-                    .sorted(Comparator.comparing(condition -> condition.featureName))
-                    .collect(Collectors.toList()).toArray(new Condition[0]);
-        } else {
-            rule.conditions = consolidatedConditions.toArray(new Condition[0]);
-        }
-        rule.languageRule = rule.generateLanguageRule();
-        return rule;
-    }
-
-    static List<Condition>  consolidateConditionsByVar(Condition[] conditions, String varname) {
-        List<Condition> currVarConditions = new ArrayList<>();
-        for (int i = 0; i < conditions.length; i++) {
-            if (varname.equals(conditions[i].featureName))
-                currVarConditions.add(conditions[i]);
-        }
-        if (currVarConditions.size() == 1) {
-            return currVarConditions;
-        } else {
-            Condition potentialLessThan = null;
-            Condition potentialGreaterThanOrEqual = null;
-            Condition potentialIn = null;
-            
-            for (int i = 0; i < currVarConditions.size(); i++) {
-                Condition currCondition = currVarConditions.get(i);
-                if (Condition.Operator.LessThan.equals(currCondition.operator)) {
-                    if (potentialLessThan == null) {
-                        potentialLessThan = currCondition;
-                    } else {
-                        potentialLessThan = potentialLessThan.expandBy(currCondition);
-                    }
-                } else if (Condition.Operator.GreaterThanOrEqual.equals(currCondition.operator)) {
-                    if (potentialGreaterThanOrEqual == null) {
-                        potentialGreaterThanOrEqual = currCondition;
-                    } else {
-                        potentialGreaterThanOrEqual = potentialGreaterThanOrEqual.expandBy(currCondition);
-                    }
-                } else {
-                    assert Condition.Operator.In.equals(currCondition.operator);
-                    if (potentialIn == null) {
-                        potentialIn = currCondition;
-                    } else {
-                        potentialIn = potentialIn.expandBy(currCondition);
-                    }
-                }
-            }
-
-            List<Condition> currVarConsolidatedConditions = new ArrayList<>();
-
-            if (potentialLessThan != null)
-                currVarConsolidatedConditions.add(potentialLessThan);
-            if (potentialGreaterThanOrEqual != null)
-                currVarConsolidatedConditions.add(potentialGreaterThanOrEqual);
-            if (potentialIn != null)
-                currVarConsolidatedConditions.add(potentialIn);
-
-            return currVarConsolidatedConditions;
-        }
-    }
-    
-    static Rule[] deduplicateRules(Rule[] rules) {
-        List<Rule> list = Arrays.asList(rules);
-
-        // group by non linear rules
-        List<Rule> transform = list.stream()
-                .filter(rule -> rule.conditions != null)
-                .collect(Collectors.groupingBy(rule -> rule.languageRule))
-                .entrySet().stream()
-                .map(e -> e.getValue().stream()
-                        .reduce((r1,r2) -> new Rule(r1.conditions, r1.predictionValue, r1.varName + ", " + r2.varName, r1.coefficient + r2.coefficient, r1.support)))
-                .map(f -> f.get())
-                .collect(Collectors.toList());
-
-        // add linear rules
-        transform.addAll(list.stream().filter(rule -> rule.conditions == null).collect(Collectors.toList()));
-
-        return transform.toArray(new Rule[0]);
     }
 
     /** 

--- a/h2o-algos/src/main/java/hex/rulefit/RuleFitUtils.java
+++ b/h2o-algos/src/main/java/hex/rulefit/RuleFitUtils.java
@@ -34,7 +34,7 @@ public class RuleFitUtils {
                     .collect(Collectors.groupingBy(rule -> rule.languageRule))
                     .entrySet().stream()
                     .map(e -> e.getValue().stream()
-                            .reduce((r1,r2) -> new Rule(r1.conditions, r1.predictionValue, r1.varName + ", " + r2.varName, r1.coefficient + r2.coefficient)))
+                            .reduce((r1,r2) -> new Rule(r1.conditions, r1.predictionValue, r1.varName + ", " + r2.varName, r1.coefficient + r2.coefficient, r1.support)))
                     .map(f -> f.get())
                     .collect(Collectors.toList());
     

--- a/h2o-algos/src/test/java/hex/rulefit/RuleFitUtilsTest.java
+++ b/h2o-algos/src/test/java/hex/rulefit/RuleFitUtilsTest.java
@@ -150,67 +150,20 @@ public class RuleFitUtilsTest extends TestUtil {
             List<String> languageRules = treeRules.stream().map(it -> it.languageRule).sorted().collect(Collectors.toList());
             // Note: this hard-coded list of expected rules is sensitive to changes in the upstream algo
             List<String> expectedRules = Arrays.asList(
-                    "(fYear in {f1987, f1988, f1989, f1990, f1991}) & (fYear in {f1987, f1988}) & (fYear in {f1987})",
-                    "(fYear in {f1987, f1988, f1989, f1990, f1991}) & (fYear in {f1987, f1988}) & (fYear in {f1988})",
-                    "(fYear in {f1987, f1988, f1989, f1990, f1991}) & (fYear in {f1989, f1990, f1991, f1992, f1993, f1994, f1995, f1996, f1997, f1998, f1999, f2000}) & (fDayOfWeek in {f1, f2, f3, f4} or fDayOfWeek is NA)",
-                    "(fYear in {f1987, f1988, f1989, f1990, f1991}) & (fYear in {f1989, f1990, f1991, f1992, f1993, f1994, f1995, f1996, f1997, f1998, f1999, f2000}) & (fDayOfWeek in {f5, f6, f7})",
-                    "(fYear in {f1992, f1993, f1994, f1995, f1996, f1997, f1998, f1999, f2000} or fYear is NA) & (Distance < 211.5) & (fYear in {f1987, f1988, f1989, f1990, f1991, f1992, f1993} or fYear is NA)",
-                    "(fYear in {f1992, f1993, f1994, f1995, f1996, f1997, f1998, f1999, f2000} or fYear is NA) & (Distance < 211.5) & (fYear in {f1994, f1995, f1996, f1997, f1998, f1999, f2000})",
-                    "(fYear in {f1992, f1993, f1994, f1995, f1996, f1997, f1998, f1999, f2000} or fYear is NA) & (Distance >= 211.5 or Distance is NA) & (Distance < 348.5)",
-                    "(fYear in {f1992, f1993, f1994, f1995, f1996, f1997, f1998, f1999, f2000} or fYear is NA) & (Distance >= 211.5 or Distance is NA) & (Distance >= 348.5 or Distance is NA)"
+                    "(Distance < 211.5) & (fYear in {f1987, f1988, f1989, f1990, f1991, f1992, f1993} or fYear is NA)",
+                    "(Distance < 211.5) & (fYear in {f1994, f1995, f1996, f1997, f1998, f1999, f2000})",
+                    "(Distance < 348.5) & (Distance >= 211.5 or Distance is NA) & (fYear in {f1992, f1993, f1994, f1995, f1996, f1997, f1998, f1999, f2000} or fYear is NA)",
+                    "(Distance >= 348.5 or Distance is NA) & (fYear in {f1992, f1993, f1994, f1995, f1996, f1997, f1998, f1999, f2000} or fYear is NA)",
+                    "(fDayOfWeek in {f1, f2, f3, f4} or fDayOfWeek is NA) & (fYear in {f1989, f1990, f1991, f1992, f1993, f1994, f1995, f1996, f1997, f1998, f1999, f2000})",
+                    "(fDayOfWeek in {f5, f6, f7}) & (fYear in {f1989, f1990, f1991, f1992, f1993, f1994, f1995, f1996, f1997, f1998, f1999, f2000})",
+                    "(fYear in {f1987})",
+                    "(fYear in {f1988})"
             );
             assertEquals(expectedRules, languageRules);
 
             List<Rule> wholeModelRules = Rule.extractRulesListFromModel(isofor, 0, 1);
             assertEquals(wholeModelRules.size(), 8);
 
-        } finally {
-            Scope.exit();
-        }
-    }
-    
-    @Test
-    public void consolidateRulesTest() {
-        try {
-            Scope.enter();
-            Condition condition1 = new Condition(6, Condition.Type.Numerical, Condition.Operator.LessThan, 6.5, null, null,"PSA", true);
-            Condition condition2 = new Condition(6, Condition.Type.Numerical, Condition.Operator.LessThan, 14.730077743530273, null, null, "PSA", false);
-            Condition condition3 = new Condition(2, Condition.Type.Numerical, Condition.Operator.GreaterThanOrEqual, 2.5, null, null,"DPROS", false);
-            Condition[] conditions = new Condition[] {condition1, condition2, condition3};
-
-            Rule rule = new Rule(conditions, 0.032236840575933456, "somevarname");
-            Rule consolidatedRule = RuleFitUtils.consolidateRule(rule, false);
-            assertEquals("(PSA < 14.730077743530273 or PSA is NA) & (DPROS >= 2.5)", consolidatedRule.languageRule);
-            
-            condition1 = new Condition(6, Condition.Type.Categorical, Condition.Operator.In, -1, new String[] {"ABC", "AAA"}, new int[] {2, 6},"PSA", true);
-            condition2 = new Condition(6, Condition.Type.Categorical, Condition.Operator.In, -1,  new String[] { "CCC", "BBB", "AAA"}, new int[] {1, 3, 6}, "PSA", false);
-            condition3 = new Condition(2, Condition.Type.Numerical, Condition.Operator.GreaterThanOrEqual, 2.5, null, null,"DPROS", false);
-            conditions = new Condition[] {condition1, condition2, condition3};
-
-            rule = new Rule(conditions, 0.032236840575933456, "somevarname");
-            consolidatedRule = RuleFitUtils.consolidateRule(rule, false);
-            assertEquals("(PSA in {ABC, AAA, CCC, BBB} or PSA is NA) & (DPROS >= 2.5)", consolidatedRule.languageRule);
-
-            condition1 = new Condition(6, Condition.Type.Numerical, Condition.Operator.GreaterThanOrEqual, 6.5, null, null,"PSA", true);
-            condition2 = new Condition(6, Condition.Type.Numerical, Condition.Operator.GreaterThanOrEqual, 14.730077743530273, null, null, "PSA", false);
-            condition3 = new Condition(2, Condition.Type.Numerical, Condition.Operator.LessThan, 2.5, null, null,"DPROS", false);
-            conditions = new Condition[] {condition1, condition2, condition3};
-
-            rule = new Rule(conditions, 0.032236840575933456, "somevarname");
-            consolidatedRule = RuleFitUtils.consolidateRule(rule, false);
-            assertEquals("(PSA >= 6.5 or PSA is NA) & (DPROS < 2.5)", consolidatedRule.languageRule);
-
-            condition1 = new Condition(6, Condition.Type.Numerical, Condition.Operator.GreaterThanOrEqual, 6.5, null, null,"PSA", true);
-            condition2 = new Condition(6, Condition.Type.Numerical, Condition.Operator.GreaterThanOrEqual, 14.730077743530273, null, null, "PSA", false);
-            condition3 = new Condition(2, Condition.Type.Numerical, Condition.Operator.LessThan, 2.5, null, null,"DPROS", false);
-            Condition condition4 = new Condition(6, Condition.Type.Numerical, Condition.Operator.LessThan, 10.0, null, null, "PSA", false);
-
-            conditions = new Condition[] {condition1, condition2, condition3, condition4};
-
-            rule = new Rule(conditions, 0.032236840575933456, "somevarname");
-            consolidatedRule = RuleFitUtils.consolidateRule(rule, false);
-            assertEquals("(PSA < 10.0) & (PSA >= 6.5 or PSA is NA) & (DPROS < 2.5)", consolidatedRule.languageRule);
-            
         } finally {
             Scope.exit();
         }
@@ -224,7 +177,7 @@ public class RuleFitUtilsTest extends TestUtil {
             Condition conditionr11 = new Condition(6, Condition.Type.Numerical, Condition.Operator.LessThan, 6.5, null, null,"PSA", true);
             Condition conditionr12 = new Condition(6, Condition.Type.Numerical, Condition.Operator.LessThan, 14.730077743530273, null, null, "PSA", false);
             Condition conditionr13 = new Condition(2, Condition.Type.Numerical, Condition.Operator.GreaterThanOrEqual, 2.5, null, null,"DPROS", false);
-            Condition[] conditions1 = new Condition[] {conditionr11, conditionr13, conditionr12};
+            Condition[] conditions1 = new Condition[] {conditionr11, conditionr12, conditionr13};
 
             Rule rule1 = new Rule(conditions1, 0.032236840575933456, "somevarname1");
             rule1.coefficient = 4.0;
@@ -253,7 +206,7 @@ public class RuleFitUtilsTest extends TestUtil {
             
             Rule[] rulesToDeduplicate = new Rule[] {rule1, rule2, rule3, rule4};
 
-            Rule[] deduplicatedRules = RuleFitUtils.consolidateRules(rulesToDeduplicate, true);
+            Rule[] deduplicatedRules = RuleFitUtils.deduplicateRules(rulesToDeduplicate, true);
             
             assertEquals(3, deduplicatedRules.length);
 

--- a/h2o-algos/src/test/java/hex/rulefit/RuleFitUtilsTest.java
+++ b/h2o-algos/src/test/java/hex/rulefit/RuleFitUtilsTest.java
@@ -237,10 +237,6 @@ public class RuleFitUtilsTest extends TestUtil {
 
         ruleId = "M6T10N36_0";
         assertEquals(RuleFitUtils.readRuleId(ruleId), "M6T10N36_0");
-
-        // todo decidde linear beehaviour, but thats not a rule, so maybe return an error
-
-
     }
 
 }


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8439
this is second approach to PUBDEV- 8383:

- tree traversal during rule extraction has changed: it goes from node to root, not from root to node anymore
- it consolidates rules during extraction, before they are passed to GLM, not after GLM as a post-process anymore