### PR TITLE
PUBDEV-8429 shorten GLM tests

### DIFF
--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8077_binomial_alpha.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8077_binomial_alpha.py
@@ -11,40 +11,40 @@ def test_binomial_alpha():
     X = [0, 1, 2, 4, 5, 6, 7, 8, 9, 10]
 
     # test with lambda search on, generate_scoring_history on and off
-    model1 = H2OGeneralizedLinearEstimator(family="binomial", alpha=[0,0.2,0.5,0.8,1], lambda_search=True, 
-                                           generate_scoring_history=True)
+    model1 = H2OGeneralizedLinearEstimator(family="binomial", alpha=[0,0.2,1], lambda_search=True, 
+                                           generate_scoring_history=True, nlambdas=5)
     model1.train(x=X, y=Y, training_frame=training_data)
-    model2 = H2OGeneralizedLinearEstimator(family="binomial", alpha=[0,0.2,0.5,0.8,1], lambda_search=True,
-                                           generate_scoring_history=True)
+    model2 = H2OGeneralizedLinearEstimator(family="binomial", alpha=[0,0.2,1], lambda_search=True,
+                                           generate_scoring_history=True, nlambdas=5)
     model2.train(x=X, y=Y, training_frame=training_data)
     pyunit_utils.assertCoefDictEqual(model1.coef(), model2.coef())
 
     # test with lambda search off, generate_scoring_history on and off
-    model1 = H2OGeneralizedLinearEstimator(family="binomial", alpha=[0,0.2,0.5,0.8,1], lambda_search=False,
-                                           generate_scoring_history=True, Lambda=[0, 0.1, 0.01, 0.001])
+    model1 = H2OGeneralizedLinearEstimator(family="binomial", alpha=[0,0.8,1], lambda_search=False,
+                                           generate_scoring_history=True, Lambda=[0, 0.1])
     model1.train(x=X, y=Y, training_frame=training_data)
-    model2 = H2OGeneralizedLinearEstimator(family="binomial", alpha=[0,0.2,0.5,0.8,1], lambda_search=False,
-                                           generate_scoring_history=True, Lambda=[0, 0.1, 0.01, 0.001])
+    model2 = H2OGeneralizedLinearEstimator(family="binomial", alpha=[0,0.8,1], lambda_search=False,
+                                           generate_scoring_history=True, Lambda=[0, 0.1])
     model2.train(x=X, y=Y, training_frame=training_data)
     pyunit_utils.assertCoefDictEqual(model1.coef(), model2.coef())
 
     # test with lambda search on, generate_scoring_history on and off, cv on
-    model1 = H2OGeneralizedLinearEstimator(family="binomial", alpha=[0,0.2,0.5,0.8,1], lambda_search=True,
-                                           generate_scoring_history=True, nfolds=2, seed=12345)
+    model1 = H2OGeneralizedLinearEstimator(family="binomial", alpha=[0,0.8,1], lambda_search=True,
+                                           generate_scoring_history=True, nfolds=2, seed=12345, nlambdas=5)
     model1.train(x=X, y=Y, training_frame=training_data)
-    model2 = H2OGeneralizedLinearEstimator(family="binomial", alpha=[0,0.2,0.5,0.8,1], lambda_search=True,
-                                           generate_scoring_history=True, nfolds=2, seed=12345)
+    model2 = H2OGeneralizedLinearEstimator(family="binomial", alpha=[0,0.8,1], lambda_search=True,
+                                           generate_scoring_history=True, nfolds=2, seed=12345, nlambdas=5)
     model2.train(x=X, y=Y, training_frame=training_data)
     pyunit_utils.assertCoefDictEqual(model1.coef(), model2.coef())
 
     # test with lambda search off, generate_scoring_history on and off, cv on
-    model1 = H2OGeneralizedLinearEstimator(family="binomial", alpha=[0,0.2,0.5,0.8,1], lambda_search=False,
+    model1 = H2OGeneralizedLinearEstimator(family="binomial", alpha=[0,0.2,1], lambda_search=False,
                                            generate_scoring_history=True, nfolds=2, seed=12345, 
-                                           Lambda=[0, 0.1, 0.01, 0.001])
+                                           Lambda=[0, 0.001])
     model1.train(x=X, y=Y, training_frame=training_data)
-    model2 = H2OGeneralizedLinearEstimator(family="binomial", alpha=[0,0.2,0.5,0.8,1], lambda_search=False,
+    model2 = H2OGeneralizedLinearEstimator(family="binomial", alpha=[0,0.2,1], lambda_search=False,
                                            generate_scoring_history=True, nfolds=2, seed=12345, 
-                                           Lambda=[0, 0.1, 0.01, 0.001])
+                                           Lambda=[0,  0.001])
     model2.train(x=X, y=Y, training_frame=training_data)
     pyunit_utils.assertCoefDictEqual(model1.coef(), model2.coef())
 

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8077_gaussian_alpha.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8077_gaussian_alpha.py
@@ -21,36 +21,36 @@ def test_gaussian_alpha():
     test_data = data_frames[1]
 
     # test with lambda search on, generate_scoring_history on and off
-    model1 = glm(family="gaussian", lambda_search=True, alpha=[0,0.2,0.5,0.8,1], generate_scoring_history=True)
+    model1 = glm(family="gaussian", lambda_search=True, alpha=[0,0.2,1], generate_scoring_history=True, nlambdas=5)
     model1.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
-    model2 = glm(family="gaussian", lambda_search=True, alpha=[0,0.2,0.5,0.8,1], generate_scoring_history=False)
+    model2 = glm(family="gaussian", lambda_search=True, alpha=[0,0.2,1], generate_scoring_history=False, nlambdas=5)
     model2.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
     pyunit_utils.assertCoefDictEqual(model1.coef(), model2.coef())
 
     # test with lambda search off, generate_scoring_history on and off
-    model1 = glm(family="gaussian", lambda_search=False, alpha=[0,0.2,0.5,0.8,1], generate_scoring_history=True, 
-                 Lambda=[0,0.1,0.001,0.004])
+    model1 = glm(family="gaussian", lambda_search=False, alpha=[0,0.8,1], generate_scoring_history=True, 
+                 Lambda=[0,0.004])
     model1.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
-    model2 = glm(family="gaussian", lambda_search=False, alpha=[0,0.2,0.5,0.8,1], generate_scoring_history=False,
-                 Lambda=[0,0.1,0.001,0.004])
+    model2 = glm(family="gaussian", lambda_search=False, alpha=[0,0.8,1], generate_scoring_history=False,
+                 Lambda=[0,0.004])
     model2.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
     pyunit_utils.assertCoefDictEqual(model1.coef(), model2.coef())
 
     # test with lambda search on, generate_scoring_history on and off, cv on
-    model1 = glm(family="gaussian", lambda_search=True, alpha=[0,0.2,0.5,0.8,1], generate_scoring_history=True, 
-                 nfolds=2, seed=12345)
+    model1 = glm(family="gaussian", lambda_search=True, alpha=[0,0.8,1], generate_scoring_history=True, 
+                 nfolds=2, seed=12345, nlambdas=5)
     model1.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
-    model2 = glm(family="gaussian", lambda_search=True, alpha=[0,0.2,0.5,0.8,1], generate_scoring_history=False,
-                 nfolds=2, seed=12345)
+    model2 = glm(family="gaussian", lambda_search=True, alpha=[0,0.8,1], generate_scoring_history=False,
+                 nfolds=2, seed=12345, nlambdas=5)
     model2.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
     pyunit_utils.assertCoefDictEqual(model1.coef(), model2.coef())
 
     # test with lambda search off, generate_scoring_history on and off, cv on
-    model1 = glm(family="gaussian", lambda_search=False, alpha=[0,0.2,0.5,0.8,1], generate_scoring_history=True,
-                 Lambda=[0,0.1,0.001,0.004], nfolds=2, seed=12345)
+    model1 = glm(family="gaussian", lambda_search=False, alpha=[0,0.2,1], generate_scoring_history=True,
+                 Lambda=[0,0.1], nfolds=2, seed=12345)
     model1.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
-    model2 = glm(family="gaussian", lambda_search=False, alpha=[0,0.2,0.5,0.8,1], generate_scoring_history=False,
-                 Lambda=[0,0.1,0.001,0.004], nfolds=2, seed=12345)
+    model2 = glm(family="gaussian", lambda_search=False, alpha=[0,0.2], generate_scoring_history=False,
+                 Lambda=[0,0.1], nfolds=2, seed=12345)
     model2.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
     pyunit_utils.assertCoefDictEqual(model1.coef(), model2.coef())
 

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8077_multinomial_alpha.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8077_multinomial_alpha.py
@@ -9,8 +9,6 @@ from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
 
 # Test GLM multinomial works with alpha array
 def test_multinomial_alpha():
-    col_list_compare = ["iterations", "objective", "negative_log_likelihood", "training_logloss", "validation_logloss",
-                        "training_classification_error", "validation_classification_error"]
     print("Preparing dataset....")
     h2o_data = h2o.import_file(
         pyunit_utils.locate("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"))
@@ -28,11 +26,11 @@ def test_multinomial_alpha():
 
     print("Building model with score_each_iteration turned on.")
     # test with lambda search on, generate_scoring_history on and off
-    model1 = glm(family="multinomial", alpha=[0,0.2,0.5,0.8,1], lambda_search=True,
-                                           generate_scoring_history=True)
+    model1 = glm(family="multinomial", alpha=[0,0.8,1], lambda_search=True,
+                                           generate_scoring_history=True, nlambdas=5)
     model1.train(x=X, y=Y, training_frame=training_data, validation_frame=test_data)
-    model2 = glm(family="multinomial", alpha=[0,0.2,0.5,0.8,1], lambda_search=True,
-                                           generate_scoring_history=True)
+    model2 = glm(family="multinomial", alpha=[0,0.8,1], lambda_search=True,
+                                           generate_scoring_history=True, nlambdas=5)
     model2.train(x=X, y=Y, training_frame=training_data, validation_frame=test_data)
     coef1 = model1.coef()
     coef2 = model2.coef()
@@ -40,11 +38,11 @@ def test_multinomial_alpha():
         pyunit_utils.assertEqualCoeffDicts(coef1[key], coef2[key], tol=1e-6)
 
     # test with lambda search off, generate_scoring_history on and off
-    model1 = glm(family="multinomial", alpha=[0,0.2,0.5,0.8,1], lambda_search=False,
-                                           generate_scoring_history=True, Lambda=[0, 0.1, 0.01, 0.001])
+    model1 = glm(family="multinomial", alpha=[0,0.2,1], lambda_search=False,
+                                           generate_scoring_history=True, Lambda=[0,0.001])
     model1.train(x=X, y=Y, training_frame=training_data, validation_frame=test_data)
-    model2 = glm(family="multinomial", alpha=[0,0.2,0.5,0.8,1], lambda_search=False,
-                                           generate_scoring_history=True, Lambda=[0, 0.1, 0.01, 0.001])
+    model2 = glm(family="multinomial", alpha=[0,0.2,1], lambda_search=False,
+                                           generate_scoring_history=True, Lambda=[0,0.001])
     model2.train(x=X, y=Y, training_frame=training_data, validation_frame=test_data)
     coef1 = model1.coef()
     coef2 = model2.coef()
@@ -52,11 +50,11 @@ def test_multinomial_alpha():
         pyunit_utils.assertEqualCoeffDicts(coef1[key], coef2[key], tol=1e-6)
 
     # test with lambda search on, generate_scoring_history on and off, cv on
-    model1 = glm(family="multinomial", alpha=[0,0.2,0.5,0.8,1], lambda_search=True,
-                                           generate_scoring_history=True, nfolds=2, seed=12345)
+    model1 = glm(family="multinomial", alpha=[0,0.8,1], lambda_search=True,
+                                           generate_scoring_history=True, nfolds=2, seed=12345, nlambdas=5)
     model1.train(x=X, y=Y, training_frame=training_data, validation_frame=test_data)
-    model2 = glm(family="multinomial", alpha=[0,0.2,0.5,0.8,1], lambda_search=True,
-                                           generate_scoring_history=True, nfolds=2, seed=12345)
+    model2 = glm(family="multinomial", alpha=[0,0.8,1], lambda_search=True,
+                                           generate_scoring_history=True, nfolds=2, seed=12345, nlambdas=5)
     model2.train(x=X, y=Y, training_frame=training_data, validation_frame=test_data)
     coef1 = model1.coef()
     coef2 = model2.coef()
@@ -64,13 +62,13 @@ def test_multinomial_alpha():
         pyunit_utils.assertEqualCoeffDicts(coef1[key], coef2[key], tol=1e-6)
 
     # test with lambda search off, generate_scoring_history on and off, cv on
-    model1 = glm(family="multinomial", alpha=[0,0.2,0.5,0.8,1], lambda_search=False,
+    model1 = glm(family="multinomial", alpha=[0,0.2,1], lambda_search=False,
                                            generate_scoring_history=True, nfolds=2, seed=12345,
-                                           Lambda=[0, 0.1, 0.01, 0.001])
+                                           Lambda=[0, 0.001])
     model1.train(x=X, y=Y, training_frame=training_data, validation_frame=test_data)
-    model2 = glm(family="multinomial", alpha=[0,0.2,0.5,0.8,1], lambda_search=False,
+    model2 = glm(family="multinomial", alpha=[0,0.2,1], lambda_search=False,
                                            generate_scoring_history=True, nfolds=2, seed=12345,
-                                           Lambda=[0, 0.1, 0.01, 0.001])
+                                           Lambda=[0, 0.001])
     model2.train(x=X, y=Y, training_frame=training_data, validation_frame=test_data)
     coef1 = model1.coef()
     coef2 = model2.coef()

--- a/h2o-py/tests/testdir_generic_model/pyunit_generic_model_mojo_glm.py
+++ b/h2o-py/tests/testdir_generic_model/pyunit_generic_model_mojo_glm.py
@@ -12,7 +12,7 @@ def test(x, y, output_test, strip_part, algo_name, generic_algo_name, family):
 
     # GLM
     airlines = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/airlines_train.csv"))
-    glm = H2OGeneralizedLinearEstimator(nfolds = 3, family = family, max_iterations=5) # alpha = 1, lambda_ = 1, bad values, use default
+    glm = H2OGeneralizedLinearEstimator(nfolds = 2, family = family, max_iterations=2) # alpha = 1, lambda_ = 1, bad values, use default
     glm.train(x = x, y = y, training_frame=airlines, validation_frame=airlines, )
     print(glm)
     with Capturing() as original_output:


### PR DESCRIPTION
This PR fixes the issue in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8429

The following tests run for quite a long time:

395 pass 40002 1314s pyunit_PUBDEV_8077_multinomial_alpha.py
774 pass 40000 836s pyunit_generic_model_mojo_glm.py

I reduced the run time by reducing:
- maximum iterations;
- nfold;
- length of alpha and lambda arrays;
- if lambda_search=True, set nlambdas = 5 instead of nlambdas=100.