### PR TITLE
PUBDEV-8388: Add a plot function for gains/lift in R and Python

### DIFF
--- a/h2o-docs/src/product/performance-and-prediction.rst
+++ b/h2o-docs/src/product/performance-and-prediction.rst
@@ -2120,7 +2120,7 @@ Example:
                          gainslift_bins = 20)
 
         # Plot the Gains/Lift chart:
-        h2o.plot_gainslift(model)
+        h2o.plot_gains_lift(model)
 
     .. code-tab:: python
 
@@ -2138,7 +2138,7 @@ Example:
                     training_frame=airlines)
 
         # Plot the Gains/Lift chart:
-        model.plot_gainslift()
+        model.plot_gains_lift()
 
 .. figure:: images/gainslift_plot.png
     :alt: Gains/Lift Plot

--- a/h2o-docs/src/product/performance-and-prediction.rst
+++ b/h2o-docs/src/product/performance-and-prediction.rst
@@ -2120,7 +2120,7 @@ Example:
                          gainslift_bins = 20)
 
         # Plot the Gains/Lift chart:
-        h2o.plot_gains_lift(model)
+        h2o.gains_lift_plot(model)
 
     .. code-tab:: python
 
@@ -2138,7 +2138,7 @@ Example:
                     training_frame=airlines)
 
         # Plot the Gains/Lift chart:
-        model.plot_gains_lift()
+        model.gains_lift_plot()
 
 .. figure:: images/gainslift_plot.png
     :alt: Gains/Lift Plot

--- a/h2o-docs/src/product/performance-and-prediction.rst
+++ b/h2o-docs/src/product/performance-and-prediction.rst
@@ -2120,15 +2120,7 @@ Example:
                          gainslift_bins = 20)
 
         # Plot the Gains/Lift chart:
-        gain_table <- model@model$training_metrics@metrics$gains_lift_table
-        plot(gain_table$cumulative_data_fraction,
-             gain_table$cumulative_capture_rate,'l', 
-             ylim = c(0,1.5), col = "dodgerblue3",
-             xlab = "cumulative data fraction",
-             ylab = "cumulative capture rate, cumulative lift",
-             main = "Gains/Lift")
-        lines(gain_table$cumulative_data_fraction,
-              gain_table$cumulative_lift, col = "orange")
+        h2o.plot_gainslift(model)
 
     .. code-tab:: python
 
@@ -2146,24 +2138,7 @@ Example:
                     training_frame=airlines)
 
         # Plot the Gains/Lift chart:
-        gl = model.gains_lift()
-        X = gl['cumulative_data_fraction']
-        Y = gl['cumulative_capture_rate']
-        YC = gl['cumulative_lift']
-
-        plt = get_matplotlib_pyplot(server=False, raise_if_not_available=True)
-        plt.figure(figsize=(10,10))
-        plt.grid(True)
-        plt.plot(X, Y, zorder=10, label='cumulative capture rate')
-        plt.plot(X, YC, zorder=10, label='cumulative lift')
-        plt.legend(loc=4, fancybox=True, framealpha=0.5)
-        plt.xlim(0, 1)
-        plt.ylim(0, 1.5)
-        plt.xlabel('cumulative data fraction')
-        plt.ylabel('cumulative capture rate, cumulative lift')
-        plt.title('Gains/Lift')
-        fig = plt.gcf()
-        plt.show()
+        model.plot_gainslift()
 
 .. figure:: images/gainslift_plot.png
     :alt: Gains/Lift Plot

--- a/h2o-py/h2o/model/binomial.py
+++ b/h2o-py/h2o/model/binomial.py
@@ -6,6 +6,7 @@ from h2o.exceptions import H2OValueError
 from h2o.utils.typechecks import assert_is_type
 from .extensions import has_extension
 from .model_base import ModelBase
+from ..utils.metaclass import deprecated_params
 
 
 class H2OBinomialModel(ModelBase):
@@ -851,6 +852,20 @@ class H2OBinomialModel(ModelBase):
         >>> gbm.gains_lift(train=True, valid=True, xval=True)
         """
         return self._delegate_to_metrics('gains_lift', train, valid, xval)
+
+    @deprecated_params({'save_to_file': 'save_plot_path'})
+    def plot_gainslift(self, xval=False, server=False, save_plot_path=None, plot=True, **kwargs):
+        """
+        Plot Gains/Lift curves.
+
+        :param xval: if True, use cross-validation metrics
+        :param server: if True, generate plot inline using matplotlib's "Agg" backend.
+        :param save_plot_path: filename to save the plot to
+        :param plot: True to plot curve, False to get a gains lift table
+
+        :returns: Gains lift table + the resulting plot (can be accessed using result.figure())
+        """
+        return self._delegate_to_metrics('plot_gainslift', xval=xval, server=server, save_plot_path=save_plot_path, plot=plot)
 
     def kolmogorov_smirnov(self):
         """

--- a/h2o-py/h2o/model/binomial.py
+++ b/h2o-py/h2o/model/binomial.py
@@ -854,10 +854,11 @@ class H2OBinomialModel(ModelBase):
         return self._delegate_to_metrics('gains_lift', train, valid, xval)
 
     @deprecated_params({'save_to_file': 'save_plot_path'})
-    def plot_gainslift(self, xval=False, server=False, save_plot_path=None, plot=True, **kwargs):
+    def plot_gains_lift(self, type="both", xval=False, server=False, save_plot_path=None, plot=True, **kwargs):
         """
         Plot Gains/Lift curves.
 
+        :param type: one of "both", "gains", "lift". Defaults to "both".
         :param xval: if True, use cross-validation metrics
         :param server: if True, generate plot inline using matplotlib's "Agg" backend.
         :param save_plot_path: filename to save the plot to
@@ -865,7 +866,7 @@ class H2OBinomialModel(ModelBase):
 
         :returns: Gains lift table + the resulting plot (can be accessed using result.figure())
         """
-        return self._delegate_to_metrics('plot_gainslift', xval=xval, server=server, save_plot_path=save_plot_path, plot=plot)
+        return self._delegate_to_metrics('plot_gains_lift', type=type, xval=xval, server=server, save_plot_path=save_plot_path, plot=plot)
 
     def kolmogorov_smirnov(self):
         """

--- a/h2o-py/h2o/model/binomial.py
+++ b/h2o-py/h2o/model/binomial.py
@@ -854,7 +854,7 @@ class H2OBinomialModel(ModelBase):
         return self._delegate_to_metrics('gains_lift', train, valid, xval)
 
     @deprecated_params({'save_to_file': 'save_plot_path'})
-    def plot_gains_lift(self, type="both", xval=False, server=False, save_plot_path=None, plot=True, **kwargs):
+    def plot_gains_lift(self, type="both", xval=False, server=False, save_plot_path=None, plot=True):
         """
         Plot Gains/Lift curves.
 

--- a/h2o-py/h2o/model/binomial.py
+++ b/h2o-py/h2o/model/binomial.py
@@ -854,7 +854,7 @@ class H2OBinomialModel(ModelBase):
         return self._delegate_to_metrics('gains_lift', train, valid, xval)
 
     @deprecated_params({'save_to_file': 'save_plot_path'})
-    def plot_gains_lift(self, type="both", xval=False, server=False, save_plot_path=None, plot=True):
+    def gains_lift_plot(self, type="both", xval=False, server=False, save_plot_path=None, plot=True):
         """
         Plot Gains/Lift curves.
 
@@ -866,7 +866,7 @@ class H2OBinomialModel(ModelBase):
 
         :returns: Gains lift table + the resulting plot (can be accessed using result.figure())
         """
-        return self._delegate_to_metrics('plot_gains_lift', type=type, xval=xval, server=server, save_plot_path=save_plot_path, plot=plot)
+        return self._delegate_to_metrics('gains_lift_plot', type=type, xval=xval, server=server, save_plot_path=save_plot_path, plot=plot)
 
     def kolmogorov_smirnov(self):
         """

--- a/h2o-py/h2o/model/metrics_base.py
+++ b/h2o-py/h2o/model/metrics_base.py
@@ -1433,13 +1433,13 @@ class H2OBinomialModelMetrics(MetricsBase):
         >>> cars_gbm.plot(type="pr")
         
         """
-
+        assert type in ["roc", "pr", "gains_lift"]
         if type == "roc":
             return self._plot_roc(server, save_plot_path, plot)
         elif type == "pr":
             return self._plot_pr(server, save_plot_path, plot)
-        elif type == "gainslift":
-            return self.plot_gainslift(server=server, save_plot_path=save_plot_path, plot=plot)
+        elif type == "gains_lift":
+            return self.plot_gains_lift(server=server, save_plot_path=save_plot_path, plot=plot)
     
     def _plot_roc(self, server=False, save_to_file=None, plot=True):
         if plot:
@@ -1774,36 +1774,46 @@ class H2OBinomialModelMetrics(MetricsBase):
         return None
 
     @deprecated_params({'save_to_file': 'save_plot_path'})
-    def plot_gainslift(self, server=False, save_plot_path=None, plot=True, **kwargs):
+    def plot_gains_lift(self, type="both", server=False, save_plot_path=None, plot=True, **kwargs):
         """
         Plot Gains/Lift curves.
 
+        :param type: one of "both", "gains", "lift". Defaults to "both".
         :param server: if True, generate plot inline using matplotlib's "Agg" backend.
         :param save_plot_path: filename to save the plot to
         :param plot: True to plot curve, False to get a gains lift table
 
         :returns: Gains lift table + the resulting plot (can be accessed using result.figure())
         """
+        type = type.lower()
+        assert type in ["both", "gains", "lift"]
         gl = self.gains_lift()
         if plot:
             plt = get_matplotlib_pyplot(server)
             if plt is None:
                 return decorate_plot_result(figure=RAISE_ON_FIGURE_ACCESS)
-
+            title = []
+            ylab = []
             x = gl['cumulative_data_fraction']
             yccr = gl['cumulative_capture_rate']
             ycl = gl['cumulative_lift']
             plt = get_matplotlib_pyplot(server=False, raise_if_not_available=True)
             fig = plt.figure(figsize=(10, 10))
             plt.grid(True)
-            plt.plot(x, yccr, zorder=10, label='cumulative capture rate')
-            plt.plot(x, ycl, zorder=10, label='cumulative lift')
+            if type in ["both", "gains"]:
+                plt.plot(x, yccr, zorder=10, label='cumulative capture rate')
+                title.append("Gains")
+                ylab.append('cumulative capture rate')
+            if type in ["both", "lift"]:
+                plt.plot(x, ycl, zorder=10, label='cumulative lift')
+                title.append("Lift")
+                ylab.append('cumulative lift')
             plt.legend(loc=4, fancybox=True, framealpha=0.5)
             plt.xlim(0, None)
             plt.ylim(0, None)
             plt.xlabel('cumulative data fraction')
-            plt.ylabel('cumulative capture rate, cumulative lift')
-            plt.title('Gains/Lift')
+            plt.ylabel(", ".join(ylab))
+            plt.title(" / ".join(title))
             if not server:
                 plt.show()
             if save_plot_path is not None:  # only save when a figure is actually plotted

--- a/h2o-py/h2o/model/metrics_base.py
+++ b/h2o-py/h2o/model/metrics_base.py
@@ -1404,7 +1404,7 @@ class H2OBinomialModelMetrics(MetricsBase):
         return metrics
 
     @deprecated_params({'save_to_file': 'save_plot_path'})
-    def plot(self, type="roc", server=False, save_plot_path=None, plot=True, **kwargs):
+    def plot(self, type="roc", server=False, save_plot_path=None, plot=True):
         """
         Produce the desired metric plot.
 
@@ -1774,7 +1774,7 @@ class H2OBinomialModelMetrics(MetricsBase):
         return None
 
     @deprecated_params({'save_to_file': 'save_plot_path'})
-    def plot_gains_lift(self, type="both", server=False, save_plot_path=None, plot=True, **kwargs):
+    def plot_gains_lift(self, type="both", server=False, save_plot_path=None, plot=True):
         """
         Plot Gains/Lift curves.
 

--- a/h2o-py/h2o/model/metrics_base.py
+++ b/h2o-py/h2o/model/metrics_base.py
@@ -1439,7 +1439,7 @@ class H2OBinomialModelMetrics(MetricsBase):
         elif type == "pr":
             return self._plot_pr(server, save_plot_path, plot)
         elif type == "gains_lift":
-            return self.plot_gains_lift(server=server, save_plot_path=save_plot_path, plot=plot)
+            return self.gains_lift_plot(server=server, save_plot_path=save_plot_path, plot=plot)
     
     def _plot_roc(self, server=False, save_to_file=None, plot=True):
         if plot:
@@ -1774,7 +1774,7 @@ class H2OBinomialModelMetrics(MetricsBase):
         return None
 
     @deprecated_params({'save_to_file': 'save_plot_path'})
-    def plot_gains_lift(self, type="both", server=False, save_plot_path=None, plot=True):
+    def gains_lift_plot(self, type="both", server=False, save_plot_path=None, plot=True):
         """
         Plot Gains/Lift curves.
 

--- a/h2o-py/tests/testdir_misc/pyunit_plot_gains_lift.py
+++ b/h2o-py/tests/testdir_misc/pyunit_plot_gains_lift.py
@@ -1,0 +1,41 @@
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+
+
+def plot_test():
+    air = h2o.import_file(pyunit_utils.locate("smalldata/airlines/AirlinesTrain.csv.zip"))
+
+    # Constructing test and train sets by sampling (20/80)
+    s = air[0].runif()
+    air_train = air[s <= 0.8]
+    air_valid = air[s > 0.8]
+
+    myX = ["Origin", "Dest", "Distance", "UniqueCarrier", "fMonth", "fDayofMonth", "fDayOfWeek"]
+    myY = "IsDepDelayed"
+
+    air_gbm = H2OGradientBoostingEstimator(distribution="bernoulli", ntrees=100, max_depth=3, learn_rate=0.01)
+    air_gbm.train(x=myX, y=myY, training_frame=air_train, validation_frame=air_valid)
+
+    air_gbm.plot_gains_lift(server=True)
+    air_gbm.plot_gains_lift(type="gains", server=True)
+    air_gbm.plot_gains_lift(type="lift", server=True)
+
+    # Plot for train set
+    perf_train = air_gbm.model_performance(train=True)
+    perf_train.plot(type="gains_lift", server=True)
+    perf_train.plot_gains_lift(server=True)
+    perf_train.plot_gains_lift(type="gains", server=True)
+    perf_train.plot_gains_lift(type="lift", server=True)
+
+    # Plot for valid set
+    perf_valid = air_gbm.model_performance(valid=True)
+    perf_valid.plot(type="gains_lift", server=True)
+    perf_valid.plot_gains_lift(server=True)
+    perf_valid.plot_gains_lift(type="gains", server=True)
+    perf_valid.plot_gains_lift(type="lift", server=True)
+
+
+pyunit_utils.standalone_test(plot_test)

--- a/h2o-py/tests/testdir_misc/pyunit_plot_gains_lift.py
+++ b/h2o-py/tests/testdir_misc/pyunit_plot_gains_lift.py
@@ -19,23 +19,23 @@ def plot_test():
     air_gbm = H2OGradientBoostingEstimator(distribution="bernoulli", ntrees=100, max_depth=3, learn_rate=0.01)
     air_gbm.train(x=myX, y=myY, training_frame=air_train, validation_frame=air_valid)
 
-    air_gbm.plot_gains_lift(server=True)
-    air_gbm.plot_gains_lift(type="gains", server=True)
-    air_gbm.plot_gains_lift(type="lift", server=True)
+    air_gbm.gains_lift_plot(server=True)
+    air_gbm.gains_lift_plot(type="gains", server=True)
+    air_gbm.gains_lift_plot(type="lift", server=True)
 
     # Plot for train set
     perf_train = air_gbm.model_performance(train=True)
     perf_train.plot(type="gains_lift", server=True)
-    perf_train.plot_gains_lift(server=True)
-    perf_train.plot_gains_lift(type="gains", server=True)
-    perf_train.plot_gains_lift(type="lift", server=True)
+    perf_train.gains_lift_plot(server=True)
+    perf_train.gains_lift_plot(type="gains", server=True)
+    perf_train.gains_lift_plot(type="lift", server=True)
 
     # Plot for valid set
     perf_valid = air_gbm.model_performance(valid=True)
     perf_valid.plot(type="gains_lift", server=True)
-    perf_valid.plot_gains_lift(server=True)
-    perf_valid.plot_gains_lift(type="gains", server=True)
-    perf_valid.plot_gains_lift(type="lift", server=True)
+    perf_valid.gains_lift_plot(server=True)
+    perf_valid.gains_lift_plot(type="gains", server=True)
+    perf_valid.gains_lift_plot(type="lift", server=True)
 
 
 pyunit_utils.standalone_test(plot_test)

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -4377,10 +4377,10 @@ h2o.std_coef_plot <- function(model, num_of_features = NULL){
 #' data <- h2o.importFile(
 #' path = "https://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/allyears2k_headers.zip")
 #' model <- h2o.gbm(x = c("Origin", "Distance"), y = "IsDepDelayed", training_frame = data, ntrees = 1)
-#' h2o.plot_gains_lift(model)
+#' h2o.gains_lift_plot(model)
 #' }
 #' @export
-setGeneric("h2o.plot_gains_lift", function(object, type = c("both", "gains", "lift"), ...) {})
+setGeneric("h2o.gains_lift_plot", function(object, type = c("both", "gains", "lift"), ...) {})
 
 .gains_lift_plot <- function(gain_table, type) {
   labels <- character()
@@ -4434,7 +4434,7 @@ setGeneric("h2o.plot_gains_lift", function(object, type = c("both", "gains", "li
 #' @param object H2OModelMetrics object
 #' @param type What curve to plot. One of "both", "gains", "lift".
 #' @export
-setMethod("h2o.plot_gains_lift", "H2OModelMetrics", function(object, type = c("both", "gains", "lift")) {
+setMethod("h2o.gains_lift_plot", "H2OModelMetrics", function(object, type = c("both", "gains", "lift")) {
   gain_table <- h2o.gainsLift(object)
   .gains_lift_plot(gain_table, type = match.arg(type))
 })
@@ -4444,7 +4444,7 @@ setMethod("h2o.plot_gains_lift", "H2OModelMetrics", function(object, type = c("b
 #' @param type What curve to plot. One of "both", "gains", "lift".
 #' @param xval if TRUE, use cross-validation metrics
 #' @export
-setMethod("h2o.plot_gains_lift", "H2OModel", function(object, type = c("both", "gains", "lift"), xval = FALSE) {
+setMethod("h2o.gains_lift_plot", "H2OModel", function(object, type = c("both", "gains", "lift"), xval = FALSE) {
   gain_table <- h2o.gainsLift(object, xval = xval)
   .gains_lift_plot(gain_table, type = match.arg(type))
 })
@@ -4481,7 +4481,7 @@ plot.H2OBinomialMetrics <- function(x, type = "roc", main, ...) {
     ydata <- rev(x@metrics$thresholds_and_metric_scores$precision)
     graphics::plot(xdata, ydata, main = main, xlab = xaxis, ylab = yaxis, ylim=c(0,1), xlim=c(0,1), type='l', lty=2, col='blue', lwd=2, panel.first = grid())
   } else if (type == "gains_lift") {
-    h2o.plot_gains_lift(x, ...)
+    h2o.gains_lift_plot(x, ...)
   }
 }
 

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -3799,13 +3799,13 @@ setMethod("h2o.gainsLift", "H2OModel", function(object, newdata, valid=FALSE, xv
   if( missing(newdata) ) {
     if( valid ) {
       if( is.null(model.parts$vm) ) return( invisible(.warn.no.validation()) )
-      else                          return( h2o.gainsLift(model.parts$vm) )
+      else                          return( h2o.gainsLift(model.parts$vm, ...) )
     }
     if ( xval ) {
       if( is.null(model.parts$xm) ) return( invisible(.warn.no.cross.validation()))
-      else                          return( h2o.gainsLift(model.parts$xm) )
+      else                          return( h2o.gainsLift(model.parts$xm, ...) )
     }
-    return( h2o.gainsLift(model.parts$tm) )
+    return( h2o.gainsLift(model.parts$tm, ...) )
   } else {
     if( valid ) stop("Cannot have both `newdata` and `valid=TRUE`", call.=FALSE)
     if( xval )  stop("Cannot have both `newdata` and `xval=TRUE`", call.=FALSE)

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -3767,6 +3767,7 @@ h2o.null_dof <- function(object, train=FALSE, valid=FALSE, xval=FALSE) {
 #' @seealso \code{\link{predict}} for generating prediction frames,
 #'          \code{\link{h2o.performance}} for creating
 #'          \linkS4class{H2OModelMetrics}.
+#' @alias h2o.gains_lift
 #' @examples
 #' \dontrun{
 #' library(h2o)
@@ -3786,6 +3787,10 @@ h2o.null_dof <- function(object, train=FALSE, valid=FALSE, xval=FALSE) {
 #' }
 #' @export
 setGeneric("h2o.gainsLift", function(object, ...) {})
+
+#' @rdname h2o.gainsLift
+#' @export
+h2o.gains_lift <- function(object, ...) h2o.gainsLift(object, ...)
 
 #' @rdname h2o.gainsLift
 #' @export

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -4362,44 +4362,92 @@ h2o.std_coef_plot <- function(model, num_of_features = NULL){
 
 #' Plot Gains/Lift curves
 #' @param object Either an H2OModel or H2OModelMetrics
+#' @param type What curve to plot. One of "both", "gains", "lift".
 #' @param ... Optional arguments
+#'
+#' @examples
+#' \dontrun{
+#' library(h2o)
+#' h2o.init()
+#' data <- h2o.importFile(
+#' path = "https://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/allyears2k_headers.zip")
+#' model <- h2o.gbm(x = c("Origin", "Distance"), y = "IsDepDelayed", training_frame = data, ntrees = 1)
+#' h2o.plot_gains_lift(model)
+#' }
 #' @export
-setGeneric("h2o.plot_gainslift", function(object, ...) {})
+setGeneric("h2o.plot_gains_lift", function(object, type = c("both", "gains", "lift"), ...) {})
 
-.gainslift_plot <- function(gain_table) {
-  graphics::plot(gain_table$cumulative_data_fraction,
-                 gain_table$cumulative_capture_rate, 'l',
-                 ylim = c(0, max(gain_table$cumulative_capture_rate, gain_table$cumulative_lift)), col = "blue",
-                 xlab = "cumulative data fraction",
-                 ylab = "cumulative capture rate, cumulative lift",
-                 main = "Gains/Lift",
-                 panel.first = grid())
-  graphics::lines(gain_table$cumulative_data_fraction,
-                  gain_table$cumulative_lift, col = "orange")
-  legend("topright", c("cummulative capture rate", "cummulative lift"), lty = 1, col = c("blue", "orange"))
+.gains_lift_plot <- function(gain_table, type) {
+  labels <- character()
+  colors <- character()
+
+  if (type == "both") {
+    ylim <- c(0, max(gain_table$cumulative_capture_rate, gain_table$cumulative_lift))
+    ylab <- "cumulative capture rate, cumulative lift"
+    title <- "Gains / Lift"
+  } else if (type == "gains") {
+    ylim <- c(0, max(gain_table$cumulative_capture_rate))
+    ylab <- "cumulative capture rate"
+    title <- "Gains"
+  } else if (type == "lift") {
+    ylim <- c(0, max(gain_table$cumulative_lift))
+    ylab <- "cumulative lift"
+    title <- "Lift"
+  }
+  if (type %in% c("both", "gains")) {
+    graphics::plot(gain_table$cumulative_data_fraction,
+                   gain_table$cumulative_capture_rate,
+                   type='l',
+                   ylim = ylim,
+                   col = "blue",
+                   xlab = "cumulative data fraction",
+                   ylab = ylab,
+                   main = title,
+                   panel.first = grid())
+    labels <- c("cummulative capture rate")
+    colors <- c("blue")
+  }
+  if (type %in% c("both", "lift")) {
+    opar <- par(new = type == "both")  # if new == T => don't clean the plot
+    on.exit(par(opar))
+    graphics::plot(gain_table$cumulative_data_fraction,
+                   gain_table$cumulative_lift,
+                   type = "l",
+                   ylim = ylim,
+                   col = "orange",
+                   xlab = "cumulative data fraction",
+                   ylab = ylab,
+                   main = title,
+                   panel.first = grid())
+    labels <- c(labels, "cummulative lift")
+    colors <- c(colors, "orange")
+  }
+  legend("topright", labels, lty = 1, col = colors)
 }
 
 #' Plot Gains/Lift curves
 #' @param object H2OModelMetrics object
+#' @param type What curve to plot. One of "both", "gains", "lift".
 #' @export
-setMethod("h2o.plot_gainslift", "H2OModelMetrics", function(object) {
+setMethod("h2o.plot_gains_lift", "H2OModelMetrics", function(object, type = c("both", "gains", "lift")) {
   gain_table <- h2o.gainsLift(object)
-  .gainslift_plot(gain_table)
+  .gains_lift_plot(gain_table, type = match.arg(type))
 })
 
 #' Plot Gains/Lift curves
 #' @param object H2OModel object
+#' @param type What curve to plot. One of "both", "gains", "lift".
 #' @param xval if TRUE, use cross-validation metrics
 #' @export
-setMethod("h2o.plot_gainslift", "H2OModel", function(object, xval = FALSE) {
+setMethod("h2o.plot_gains_lift", "H2OModel", function(object, type = c("both", "gains", "lift"), xval = FALSE) {
   gain_table <- h2o.gainsLift(object, xval = xval)
-  .gainslift_plot(gain_table)
+  .gains_lift_plot(gain_table, type = match.arg(type))
 })
 
 #' @export
 plot.H2OBinomialMetrics <- function(x, type = "roc", main, ...) {
   # TODO: add more types (i.e. cutoffs)
-  if(!type %in% c("roc", "pr", "gainslift")) stop("type must be 'roc', 'pr', or 'gainslift'")
+  if(!type %in% c("roc", "pr", "gains_lift")) stop("type must be 'roc', 'pr', or 'gains_lift'")
   if(type == "roc") {
     xaxis <- "False Positive Rate (TPR)"; yaxis = "True Positive Rate (FPR)"
     if(missing(main)) {
@@ -4427,8 +4475,8 @@ plot.H2OBinomialMetrics <- function(x, type = "roc", main, ...) {
     xdata <- rev(x@metrics$thresholds_and_metric_scores$recall)
     ydata <- rev(x@metrics$thresholds_and_metric_scores$precision)
     graphics::plot(xdata, ydata, main = main, xlab = xaxis, ylab = yaxis, ylim=c(0,1), xlim=c(0,1), type='l', lty=2, col='blue', lwd=2, panel.first = grid())
-  } else if (type == "gainslift") {
-    h2o.plot_gainslift(x)
+  } else if (type == "gains_lift") {
+    h2o.plot_gains_lift(x, ...)
   }
 }
 

--- a/h2o-r/h2o-package/pkgdown/_pkgdown.yml
+++ b/h2o-r/h2o-package/pkgdown/_pkgdown.yml
@@ -122,6 +122,7 @@ reference:
       - h2o.floor
       - h2o.flow
       - h2o.gainsLift
+      - h2o.gains_lift
       - h2o.gains_lift_plot
       - h2o.gbm
       - h2o.generic

--- a/h2o-r/h2o-package/pkgdown/_pkgdown.yml
+++ b/h2o-r/h2o-package/pkgdown/_pkgdown.yml
@@ -123,7 +123,6 @@ reference:
       - h2o.flow
       - h2o.gainsLift
       - h2o.gains_lift
-      - h2o.gains_lift_plot
       - h2o.gbm
       - h2o.generic
       - h2o.genericModel

--- a/h2o-r/h2o-package/pkgdown/_pkgdown.yml
+++ b/h2o-r/h2o-package/pkgdown/_pkgdown.yml
@@ -244,6 +244,7 @@ reference:
       - h2o.permutation_importance
       - h2o.permutation_importance_plot
       - h2o.pivot
+      - h2o.plot_gainslift
       - h2o.prcomp
       - h2o.predict
       - h2o.predict_json

--- a/h2o-r/h2o-package/pkgdown/_pkgdown.yml
+++ b/h2o-r/h2o-package/pkgdown/_pkgdown.yml
@@ -123,6 +123,7 @@ reference:
       - h2o.flow
       - h2o.gainsLift
       - h2o.gains_lift
+      - h2o.gains_lift_plot
       - h2o.gbm
       - h2o.generic
       - h2o.genericModel
@@ -245,7 +246,6 @@ reference:
       - h2o.permutation_importance
       - h2o.permutation_importance_plot
       - h2o.pivot
-      - h2o.plot_gains_lift
       - h2o.prcomp
       - h2o.predict
       - h2o.predict_json

--- a/h2o-r/h2o-package/pkgdown/_pkgdown.yml
+++ b/h2o-r/h2o-package/pkgdown/_pkgdown.yml
@@ -122,6 +122,7 @@ reference:
       - h2o.floor
       - h2o.flow
       - h2o.gainsLift
+      - h2o.gains_lift_plot
       - h2o.gbm
       - h2o.generic
       - h2o.genericModel
@@ -244,7 +245,7 @@ reference:
       - h2o.permutation_importance
       - h2o.permutation_importance_plot
       - h2o.pivot
-      - h2o.plot_gainslift
+      - h2o.plot_gains_lift
       - h2o.prcomp
       - h2o.predict
       - h2o.predict_json

--- a/h2o-r/tests/testdir_misc/runit_plot_gains_lift.R
+++ b/h2o-r/tests/testdir_misc/runit_plot_gains_lift.R
@@ -1,0 +1,33 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+
+# test that plot(performance) generates a curve plot
+test.plot_gains_lift <- function() {
+    # Importing prostate.csv data
+    prostate.hex <- h2o.uploadFile(locate("smalldata/logreg/prostate.csv"), destination_frame="prostate.hex")
+    # Converting CAPSULE and RACE columns to factors
+    prostate.hex$CAPSULE <- as.factor(prostate.hex$CAPSULE)
+    prostate.hex$RACE <- as.factor(prostate.hex$RACE)
+
+    # Train H2O GBM Model:
+    prostate.gbm <- h2o.gbm(x = 3:9, y = "CAPSULE", training_frame = prostate.hex, distribution = "bernoulli")
+    
+    # Get performance object
+    perf <- h2o.performance(prostate.gbm)
+
+    # Plot using metrics
+    plot(perf, type='gains_lift')
+    h2o.plot_gains_lift(perf) # type = "both" (default)
+    h2o.plot_gains_lift(perf, type = "gains")
+    h2o.plot_gains_lift(perf, type = "lift")
+
+    # Plot using model
+    plot(prostate.gbm, type='gains_lift')
+    h2o.plot_gains_lift(prostate.gbm)
+    h2o.plot_gains_lift(prostate.gbm, type = "gains")
+    h2o.plot_gains_lift(prostate.gbm, type = "lift")
+}
+
+doTest("Plot Gains Lift", test.plot_gains_lift)
+

--- a/h2o-r/tests/testdir_misc/runit_plot_gains_lift.R
+++ b/h2o-r/tests/testdir_misc/runit_plot_gains_lift.R
@@ -3,7 +3,7 @@ source("../../scripts/h2o-r-test-setup.R")
 
 
 # test that plot(performance) generates a curve plot
-test.plot_gains_lift <- function() {
+test.gains_lift_plot <- function() {
     # Importing prostate.csv data
     prostate.hex <- h2o.uploadFile(locate("smalldata/logreg/prostate.csv"), destination_frame="prostate.hex")
     # Converting CAPSULE and RACE columns to factors
@@ -18,16 +18,16 @@ test.plot_gains_lift <- function() {
 
     # Plot using metrics
     plot(perf, type='gains_lift')
-    h2o.plot_gains_lift(perf) # type = "both" (default)
-    h2o.plot_gains_lift(perf, type = "gains")
-    h2o.plot_gains_lift(perf, type = "lift")
+    h2o.gains_lift_plot(perf) # type = "both" (default)
+    h2o.gains_lift_plot(perf, type = "gains")
+    h2o.gains_lift_plot(perf, type = "lift")
 
     # Plot using model
     plot(prostate.gbm, type='gains_lift')
-    h2o.plot_gains_lift(prostate.gbm)
-    h2o.plot_gains_lift(prostate.gbm, type = "gains")
-    h2o.plot_gains_lift(prostate.gbm, type = "lift")
+    h2o.gains_lift_plot(prostate.gbm)
+    h2o.gains_lift_plot(prostate.gbm, type = "gains")
+    h2o.gains_lift_plot(prostate.gbm, type = "lift")
 }
 
-doTest("Plot Gains Lift", test.plot_gains_lift)
+doTest("Plot Gains Lift", test.gains_lift_plot)
 


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8388

@ledell After looking at https://github.com/h2oai/h2o-3/pull/5845, I still have several API related questions:
* Should the user be able to plot just one of the curves? If so what should be the API, `type = "both" | "gains" | "lift"` or `plot_gains = TRUE`. I am also wondering about the usage of "gains" since in the plot we are using "cummulative capture rate".
* The name `h2o.plot_gainslift` looks inconsistent next to the `h2o.gainsLift`. Should we deprecate the `h2o.gainsLift` and add `h2o.gainslift`?


The plots are basically the same as in JIRA but Y axis doesn't have upper bound since it cutoff some values and I added grid and legend to R. This can be seen here:
![glr](https://user-images.githubusercontent.com/61695433/143254459-2a43c5b4-3cb6-41f7-b967-05647774ed4d.png)
