### PR TITLE
PUBDEV-8427 add maxrglm coeffs function

### DIFF
--- a/h2o-algos/src/main/java/hex/maxrglm/MaxRGLM.java
+++ b/h2o-algos/src/main/java/hex/maxrglm/MaxRGLM.java
@@ -131,6 +131,7 @@ public class MaxRGLM extends ModelBuilder<MaxRGLMModel, MaxRGLMModel.MaxRGLMPara
                 model._output._best_model_ids = new Key[_parms._max_predictor_number];
                 model._output._best_r2_values = new double[_parms._max_predictor_number];
                 model._output._best_model_predictors = new String[_parms._max_predictor_number][];
+                model._output._coefficient_names = new String[_parms._max_predictor_number][];
                 // build glm model with num_predictors and find one with best R2
                 for (int predNum=1; predNum <= _parms._max_predictor_number; predNum++) { 
                     int numModels = combinatorial(_numPredictors, predNum);

--- a/h2o-algos/src/main/java/hex/schemas/MaxRGLMModelV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/MaxRGLMModelV3.java
@@ -21,7 +21,8 @@ public class MaxRGLMModelV3 extends ModelSchemaV3<MaxRGLMModel, MaxRGLMModelV3, 
         
         @API(help="Key of models containing best 1-predictor model, best 2-predictors model, ....")
         KeyV3.ModelKeyV3[] best_model_ids;
-        
+
+        @API(help="arrays of string arrays containing coefficient names of best 1-predictor model, best 2-predictors model, ....")        
         String[][] coefficient_names;
         
         @Override

--- a/h2o-algos/src/main/java/hex/schemas/MaxRGLMModelV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/MaxRGLMModelV3.java
@@ -22,6 +22,8 @@ public class MaxRGLMModelV3 extends ModelSchemaV3<MaxRGLMModel, MaxRGLMModelV3, 
         @API(help="Key of models containing best 1-predictor model, best 2-predictors model, ....")
         KeyV3.ModelKeyV3[] best_model_ids;
         
+        String[][] coefficient_names;
+        
         @Override
         public MaxRGLMModelOutputV3 fillFromImpl(MaxRGLMModel.MaxRGLMModelOutput impl) {
             super.fillFromImpl(impl);   // fill in the best_model_predictors_r2 table here when done

--- a/h2o-bindings/bin/custom/R/gen_maxrglm.py
+++ b/h2o-bindings/bin/custom/R/gen_maxrglm.py
@@ -22,7 +22,8 @@ h2o.get_best_r2_values<- function(model) {
 h2o.get_best_model_predictors<-function(model) {
   if ( is(model, "H2OModel") && (model@algorithm=='maxrglm'))
     return(model@model$best_model_predictors)
-} 
+}
+
     """
 )
 

--- a/h2o-bindings/bin/custom/python/gen_maxrglm.py
+++ b/h2o-bindings/bin/custom/python/gen_maxrglm.py
@@ -1,4 +1,66 @@
 def class_extensions():
+    def coef_norm(self, predictor_size=None):
+        """
+        Get the normalized coefficients for all models built with different number of predictors.
+        
+        :param self:
+        :param predictor_size: predictor subset size, will only return model coefficients of that subset size.
+        :return: list of Python Dicts of coefficients for all models built with different predictor numbers
+        """
+        model_ids = self._model_json["output"]["best_model_ids"]
+        if model_ids is None:
+            return None
+        else:
+            model_numbers = len(model_ids)
+            if predictor_size==None:
+                coefs = [None]*model_numbers
+                for index in range(0, model_numbers):
+                    one_model = h2o.get_model(model_ids[index]['name'])
+                    tbl = one_model._model_json["output"]["coefficients_table"]
+                    if tbl is not None:
+                        coefs[index] =  {name: coef for name, coef in zip(tbl["names"], tbl["standardized_coefficients"])}
+                return coefs
+            if predictor_size > model_numbers:
+                raise H2OValueError("predictor_size (predictor subset size) cannot exceed the total number of predictors used.")
+            if predictor_size == 0:
+                raise H2OValueError("predictor_size (predictor subset size) must be between 0 and the total number of predictors used.")
+
+            one_model = h2o.get_model(model_ids[predictor_size-1]['name'])
+            tbl = one_model._model_json["output"]["coefficients_table"]
+            if tbl is not None:
+                return {name: coef for name, coef in zip(tbl["names"], tbl["standardized_coefficients"])}
+
+    def coef(self, predictor_size=None):
+        """
+        Get the coefficients for all models built with different number of predictors.
+        
+        :param self: 
+        :param predictor_size: predictor subset size, will only return model coefficients of that subset size.
+        :return: list of Python Dicts of coefficients for all models built with different predictor numbers
+        """
+        model_ids = self._model_json["output"]["best_model_ids"]
+        if model_ids is None:
+            return None
+        else:
+            model_numbers = len(model_ids)
+            if predictor_size==None:
+                coefs = [None]*model_numbers
+                for index in range(0, model_numbers):
+                    one_model = h2o.get_model(model_ids[index]['name'])
+                    tbl = one_model._model_json["output"]["coefficients_table"]
+                    if tbl is not None:
+                        coefs[index] =  {name: coef for name, coef in zip(tbl["names"], tbl["coefficients"])}
+                return coefs
+            if predictor_size > model_numbers:
+                raise H2OValueError("predictor_size (predictor subset size) cannot exceed the total number of predictors used.")
+            if predictor_size == 0:
+                raise H2OValueError("predictor_size (predictor subset size) must be between 0 and the total number of predictors used.")
+
+            one_model = h2o.get_model(model_ids[predictor_size-1]['name'])
+            tbl = one_model._model_json["output"]["coefficients_table"]
+            if tbl is not None:
+                return {name: coef for name, coef in zip(tbl["names"], tbl["coefficients"])}
+
     def result(self):
         """
         Get result frame that contains information about the model building process like for maxrglm and anovaglm.
@@ -40,6 +102,7 @@ extensions = dict(
     from h2o.frame import H2OFrame
     from h2o.expr import ExprNode
     from h2o.expr import ASTId
+    from h2o.exceptions import H2OValueError
     """,
     __class__=class_extensions,
     __init__validation="""

--- a/h2o-py/h2o/estimators/maxrglm.py
+++ b/h2o-py/h2o/estimators/maxrglm.py
@@ -11,6 +11,7 @@ from h2o.base import Keyed
 from h2o.frame import H2OFrame
 from h2o.expr import ExprNode
 from h2o.expr import ASTId
+from h2o.exceptions import H2OValueError
 from h2o.estimators.estimator_base import H2OEstimator
 from h2o.exceptions import H2OValueError
 from h2o.frame import H2OFrame
@@ -1026,6 +1027,68 @@ class H2OMaxRGLMEstimator(H2OEstimator):
         assert_is_type(max_predictor_number, None, int)
         self._parms["max_predictor_number"] = max_predictor_number
 
+
+    def coef_norm(self, predictor_size=None):
+        """
+        Get the normalized coefficients for all models built with different number of predictors.
+
+        :param self:
+        :param predictor_size: predictor subset size, will only return model coefficients of that subset size.
+        :return: list of Python Dicts of coefficients for all models built with different predictor numbers
+        """
+        model_ids = self._model_json["output"]["best_model_ids"]
+        if model_ids is None:
+            return None
+        else:
+            model_numbers = len(model_ids)
+            if predictor_size==None:
+                coefs = [None]*model_numbers
+                for index in range(0, model_numbers):
+                    one_model = h2o.get_model(model_ids[index]['name'])
+                    tbl = one_model._model_json["output"]["coefficients_table"]
+                    if tbl is not None:
+                        coefs[index] =  {name: coef for name, coef in zip(tbl["names"], tbl["standardized_coefficients"])}
+                return coefs
+            if predictor_size > model_numbers:
+                raise H2OValueError("predictor_size (predictor subset size) cannot exceed the total number of predictors used.")
+            if predictor_size == 0:
+                raise H2OValueError("predictor_size (predictor subset size) must be between 0 and the total number of predictors used.")
+
+            one_model = h2o.get_model(model_ids[predictor_size-1]['name'])
+            tbl = one_model._model_json["output"]["coefficients_table"]
+            if tbl is not None:
+                return {name: coef for name, coef in zip(tbl["names"], tbl["standardized_coefficients"])}
+
+    def coef(self, predictor_size=None):
+        """
+        Get the coefficients for all models built with different number of predictors.
+
+        :param self: 
+        :param predictor_size: predictor subset size, will only return model coefficients of that subset size.
+        :return: list of Python Dicts of coefficients for all models built with different predictor numbers
+        """
+        model_ids = self._model_json["output"]["best_model_ids"]
+        if model_ids is None:
+            return None
+        else:
+            model_numbers = len(model_ids)
+            if predictor_size==None:
+                coefs = [None]*model_numbers
+                for index in range(0, model_numbers):
+                    one_model = h2o.get_model(model_ids[index]['name'])
+                    tbl = one_model._model_json["output"]["coefficients_table"]
+                    if tbl is not None:
+                        coefs[index] =  {name: coef for name, coef in zip(tbl["names"], tbl["coefficients"])}
+                return coefs
+            if predictor_size > model_numbers:
+                raise H2OValueError("predictor_size (predictor subset size) cannot exceed the total number of predictors used.")
+            if predictor_size == 0:
+                raise H2OValueError("predictor_size (predictor subset size) must be between 0 and the total number of predictors used.")
+
+            one_model = h2o.get_model(model_ids[predictor_size-1]['name'])
+            tbl = one_model._model_json["output"]["coefficients_table"]
+            if tbl is not None:
+                return {name: coef for name, coef in zip(tbl["names"], tbl["coefficients"])}
 
     def result(self):
         """

--- a/h2o-py/tests/testdir_algos/maxrglm/pyunit_PUBDEV_8427_maxrglm_coefs.py
+++ b/h2o-py/tests/testdir_algos/maxrglm/pyunit_PUBDEV_8427_maxrglm_coefs.py
@@ -1,0 +1,39 @@
+from __future__ import print_function
+from __future__ import division
+import sys
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.maxrglm import H2OMaxRGLMEstimator as maxrglm
+
+# test the maxrglm coef() and coef_norm() work properly.
+def test_maxrglm_gaussian_coefs():
+    d = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    my_y = "GLEASON"
+    my_x = ["AGE","RACE","CAPSULE","DCAPS","PSA","VOL","DPROS"]
+    maxrglm_model = maxrglm(seed=12345, max_predictor_number=7)
+    maxrglm_model.train(training_frame=d, x=my_x, y=my_y)
+    coefs = maxrglm_model.coef()
+    coefs_norm = maxrglm_model.coef_norm()
+    for ind in list(range(len(coefs))):
+        one_coef = coefs[ind]
+        one_coef_norm = coefs_norm[ind]
+        # coefficients obtained from accessing model_id, generate model and access the model coeffs
+        one_model = h2o.get_model(maxrglm_model._model_json["output"]["best_model_ids"][ind]['name'])
+        model_coef = one_model.coef()
+        model_coef_norm = one_model.coef_norm()
+        # get coefficients of individual predictor subset size
+        subset_size = ind+1
+        one_model_coef = maxrglm_model.coef(subset_size)
+        one_model_coef_norm = maxrglm_model.coef_norm(subset_size)
+        
+        # check coefficient dicts are equal
+        pyunit_utils.assertCoefDictEqual(one_coef, model_coef, 1e-6)
+        pyunit_utils.assertCoefDictEqual(one_coef_norm, model_coef_norm, 1e-6)
+        pyunit_utils.assertCoefDictEqual(one_model_coef, model_coef, 1e-6)
+        pyunit_utils.assertCoefDictEqual(one_model_coef_norm, model_coef_norm, 1e-6)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_maxrglm_gaussian_coefs)
+else:
+    test_maxrglm_gaussian_coefs()

--- a/h2o-r/h2o-package/R/maxrglm.R
+++ b/h2o-r/h2o-package/R/maxrglm.R
@@ -474,5 +474,6 @@ h2o.get_best_r2_values<- function(model) {
 h2o.get_best_model_predictors<-function(model) {
   if ( is(model, "H2OModel") && (model@algorithm=='maxrglm'))
     return(model@model$best_model_predictors)
-} 
+}
+
     

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -1786,9 +1786,9 @@ h2o.coef <- function(object, predictorSize=-1) {
 grabOneModelCoef <- function(modelIDs, index, standardized) {
   oneModel <- h2o.getModel(modelIDs[[index]]$name)
   if (standardized) {
-    return(h2o.coef(oneModel))
-  } else {
     return(h2o.coef_norm(oneModel))
+  } else {
+      return(h2o.coef(oneModel))
   }
 }
 

--- a/h2o-r/tests/testdir_algos/maxrglm/runit_PUBDEV_8427_maxrglm_coeffs.R
+++ b/h2o-r/tests/testdir_algos/maxrglm/runit_PUBDEV_8427_maxrglm_coeffs.R
@@ -20,6 +20,7 @@ testMaxRGLMCoeffs <- function() {
     expect_equal(coeffsTemp, coeffsModel, tolerance=1e-6)
     expect_equal(coeffsNormTemp, coeffsNormModel, tolerance=1e-6)
   }
+  print("Test success and completed!")
 }
 
 doTest("MaxRGLM: test h2o.coef() and h2o.coef_norm()", testMaxRGLMCoeffs)

--- a/h2o-r/tests/testdir_algos/maxrglm/runit_PUBDEV_8427_maxrglm_coeffs.R
+++ b/h2o-r/tests/testdir_algos/maxrglm/runit_PUBDEV_8427_maxrglm_coeffs.R
@@ -1,0 +1,25 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+testMaxRGLMCoeffs <- function() {
+  bhexFV <- h2o.uploadFile(locate("smalldata/logreg/prostate.csv"))
+  Y <- "GLEASON"
+  X <- c("AGE","RACE","CAPSULE","DCAPS","PSA","VOL","DPROS")
+  Log.info("Build the MaxRGLM model")
+  numModel <- 7
+  maxrglmModel <- h2o.maxrglm(y=Y, x=X, seed=12345, training_frame = bhexFV, max_predictor_number=numModel)
+  coeffs <- h2o.coef(maxrglmModel)
+  coeffsNorm <- h2o.coef_norm(maxrglmModel)
+  numModel = length(coeffs)
+  # check coefficients obtained in different ways are the same.
+  for (ind in c(1:numModel)) {
+    coeffsModel <- coeffs[[ind]]
+    coeffsNormModel <- coeffsNorm[[ind]]
+    coeffsTemp <- h2o.coef(h2o.getModel(maxrglmModel@model$best_model_ids[[ind]]$name))
+    coeffsNormTemp <- h2o.coef_norm(h2o.getModel(maxrglmModel@model$best_model_ids[[ind]]$name))
+    expect_equal(coeffsTemp, coeffsModel, tolerance=1e-6)
+    expect_equal(coeffsNormTemp, coeffsNormModel, tolerance=1e-6)
+  }
+}
+
+doTest("MaxRGLM: test h2o.coef() and h2o.coef_norm()", testMaxRGLMCoeffs)

--- a/h2o-r/tests/testdir_algos/maxrglm/runit_PUBDEV_8427_maxrglm_coeffs_demo.R
+++ b/h2o-r/tests/testdir_algos/maxrglm/runit_PUBDEV_8427_maxrglm_coeffs_demo.R
@@ -1,0 +1,25 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+testMaxRGLMCoeffs <- function() {
+  bhexFV <- h2o.uploadFile(locate("smalldata/logreg/prostate.csv"))
+  Y <- "GLEASON"
+  X <- c("AGE","RACE","CAPSULE","DCAPS","PSA","VOL","DPROS")
+  Log.info("Build the MaxRGLM model")
+  numModel <- 7
+  maxrglmModel <- h2o.maxrglm(y=Y, x=X, seed=12345, training_frame = bhexFV, max_predictor_number=numModel)
+  result <- h2o.result(maxrglmModel) # H2OFrame containing best model_ids, best_r2_value, predictor subsets
+  print(result)
+  coeffs <- h2o.coef(maxrglmModel) # list of coefficients from model built from each predictor size
+  print(coeffs)
+  coeffsNorm <- h2o.coef_norm(maxrglmModel) # list of standardized coefficients from model built from each predictor size
+  print(coeffsNorm)
+  for (index in seq(1,length(coeffsNorm))) {
+    oneModelCoeff <- h2o.coef(maxrglmModel, index)
+    oneModelCoeffNorm <- h2o.coef_norm(maxrglmModel, index)
+    expect_equal(coeffs[[index]], oneModelCoeff, tolerance=1e-6)
+    expect_equal(coeffsNorm[[index]], oneModelCoeffNorm, tolerance=1e-6)
+  }
+}
+
+doTest("MaxRGLM: test h2o.coef() and h2o.coef_norm()", testMaxRGLMCoeffs)


### PR DESCRIPTION
This PR completes the task in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8427

I have completed the following functions:
1.  add to coef(), coef_norm() in python to return coefficients and normalized coefficients for maxrglm;
2. add to h2o.coef(), h2o.coef_norm() in R  to return coefficients and normalized coefficients for maxrglm;
3. beta(), getNormBeta(), coefficients(), coefficients(boolean standardize) in Java.

Unit tests in R, Python and Java are added to check correct implementation.