### PR TITLE
[nocheck] Fix pdp dependency plot axes for categoricals

### DIFF
--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -1066,7 +1066,7 @@ class ModelBase(h2o_meta(Keyed)):
 
     @deprecated_params({'save_to_file': 'save_plot_path'})
     def partial_plot(self, data, cols=None, destination_key=None, nbins=20, weight_column=None,
-                     plot=True, plot_stddev = True, figsize=(7, 10), server=False, include_na=False, user_splits=None,
+                     plot=True, plot_stddev=True, figsize=(7, 10), server=False, include_na=False, user_splits=None,
                      col_pairs_2dpdp=None, save_plot_path=None, row_index=None, targets=None):
         """
         Create partial dependence plot which gives a graphical depiction of the marginal effect of a variable on the
@@ -1102,7 +1102,7 @@ class ModelBase(h2o_meta(Keyed)):
         if cols is None and col_pairs_2dpdp is None:
             raise ValueError("Must specify either cols or col_pairs_2dpd to generate partial dependency plots.")
 
-        if col_pairs_2dpdp and targets and len(targets > 1):
+        if col_pairs_2dpdp and targets and len(targets) > 1:
             raise ValueError("Multinomial 2D Partial Dependency is available only for one target.")
             
         assert_is_type(destination_key, None, str)
@@ -1164,8 +1164,10 @@ class ModelBase(h2o_meta(Keyed)):
         pps = json["partial_dependence_data"]
 
         # Plot partial dependence plots using matplotlib
-        return self.__generate_partial_plots(num_1dpdp, num_2dpdp, plot, server, pps, figsize, col_pairs_2dpdp, data, nbins,
-                                      kwargs["user_cols"], kwargs["num_user_splits"], plot_stddev, cols, save_plot_path, row_index, targets, include_na)
+        return self.__generate_partial_plots(num_1dpdp, num_2dpdp, plot, server, pps, figsize, 
+                                             col_pairs_2dpdp, data, nbins,
+                                             kwargs["user_cols"], kwargs["num_user_splits"], 
+                                             plot_stddev, cols, save_plot_path, row_index, targets, include_na)
 
     def __generate_user_splits(self, user_splits, data, kwargs):
         # extract user defined split points from dict user_splits into an integer array of column indices
@@ -1360,7 +1362,10 @@ class ModelBase(h2o_meta(Keyed)):
             fmt = 'o'
         else:
             fmt = '-'
-            axs.set_xlim(min(x), max(x))
+            if isinstance(x[0], str):
+                axs.set_xlim(0, len(x)-1)
+            else:
+                axs.set_xlim(min(x), max(x))
         if cat:
             labels = x  # 1d pdp, this is 0
             x = range(len(labels))

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -25,6 +25,7 @@ import string
 import subprocess
 from subprocess import STDOUT,PIPE
 import sys
+import tempfile
 import time # needed to randomly generate time
 import threading
 import urllib.request, urllib.error, urllib.parse
@@ -35,25 +36,6 @@ try:
 except:
     from io import StringIO  # py3
     
-
-try:
-    from tempfile import TemporaryDirectory
-except ImportError:
-    import tempfile
-    
-    class TemporaryDirectory:
-
-        def __init__(self):
-            self.tmp_dir = None
-
-        def __enter__(self):
-            self.tmp_dir = tempfile.mkdtemp()
-            return self.tmp_dir
-
-        def __exit__(self, *args):
-            shutil.rmtree(self.tmp_dir)
-
-
 # 3rd parties
 import numpy as np
 import pandas as pd
@@ -74,6 +56,24 @@ from h2o.estimators import H2OGradientBoostingEstimator, H2ODeepLearningEstimato
     H2OPrincipalComponentAnalysisEstimator
 from h2o.utils.typechecks import is_type
 from h2o.utils.shared_utils import temp_ctr  # unused in this file  but exposed here for symmetry with rest_ctr
+
+
+class TemporaryDirectory:
+
+    def __init__(self, keep=False):
+        """
+        :param keep: set to True for debugging, to look at generated content.
+        """
+        self.tmp_dir = None
+        self._keep = keep
+
+    def __enter__(self):
+        self.tmp_dir = tempfile.mkdtemp(prefix='h2o_pyunit_')
+        return self.tmp_dir
+
+    def __exit__(self, *args):
+        if not self._keep:
+            shutil.rmtree(self.tmp_dir)
 
 
 class Timeout:

--- a/h2o-py/tests/testdir_misc/pyunit_pubdev_5706_usersplits_pdp.py
+++ b/h2o-py/tests/testdir_misc/pyunit_pubdev_5706_usersplits_pdp.py
@@ -34,10 +34,10 @@ def partial_plot_test_with_user_splits():
     # pdp without weight or NA
     with pyunit_utils.TemporaryDirectory() as tmpdir:
         file, filename = tempfile.mkstemp(suffix=".png", dir=tmpdir)
-        pdpOrig = gbm_model.partial_plot(data=data,cols=['AGE', 'RACE', 'DCAPS'],server=True, plot=True, save_to_file=filename)
+        pdpOrig = gbm_model.partial_plot(data=data,cols=['AGE', 'RACE', 'DPROS'],server=True, plot=True, save_to_file=filename)
         assert os.path.getsize(filename) > 0
 
-    pdpUserSplit = gbm_model.partial_plot(data=data,cols=['AGE', 'RACE', 'DCAPS'],server=True, plot=True,
+    pdpUserSplit = gbm_model.partial_plot(data=data,cols=['AGE', 'RACE', 'DPROS'],server=True, plot=True,
                                           user_splits=user_splits)
 
     # compare results

--- a/h2o-py/tests/testdir_misc/pyunit_pubdev_5706_usersplits_pdp.py
+++ b/h2o-py/tests/testdir_misc/pyunit_pubdev_5706_usersplits_pdp.py
@@ -32,12 +32,10 @@ def partial_plot_test_with_user_splits():
                           75.21052631578948, 77.10526315789474]
     user_splits['RACE'] = ["Black"]
     # pdp without weight or NA
-    file, filename = tempfile.mkstemp(suffix=".png")
-    pdpOrig = gbm_model.partial_plot(data=data,cols=['AGE', 'RACE', 'DCAPS'],server=True, plot=True, save_to_file=filename)
-    assert os.path.getsize(filename) > 0
-    os.unlink(filename)
-    if os.path.isfile(filename):
-        os.remove(filename)
+    with pyunit_utils.TemporaryDirectory(keep=True) as tmpdir:
+        file, filename = tempfile.mkstemp(suffix=".png", dir=tmpdir)
+        pdpOrig = gbm_model.partial_plot(data=data,cols=['AGE', 'RACE', 'DCAPS'],server=True, plot=True, save_to_file=filename)
+        assert os.path.getsize(filename) > 0
 
     pdpUserSplit = gbm_model.partial_plot(data=data,cols=['AGE', 'RACE', 'DCAPS'],server=True, plot=True,
                                           user_splits=user_splits)

--- a/h2o-py/tests/testdir_misc/pyunit_pubdev_5706_usersplits_pdp.py
+++ b/h2o-py/tests/testdir_misc/pyunit_pubdev_5706_usersplits_pdp.py
@@ -32,7 +32,7 @@ def partial_plot_test_with_user_splits():
                           75.21052631578948, 77.10526315789474]
     user_splits['RACE'] = ["Black"]
     # pdp without weight or NA
-    with pyunit_utils.TemporaryDirectory(keep=True) as tmpdir:
+    with pyunit_utils.TemporaryDirectory() as tmpdir:
         file, filename = tempfile.mkstemp(suffix=".png", dir=tmpdir)
         pdpOrig = gbm_model.partial_plot(data=data,cols=['AGE', 'RACE', 'DCAPS'],server=True, plot=True, save_to_file=filename)
         assert os.path.getsize(filename) > 0


### PR DESCRIPTION
Without the fix, the PDP plots don't work with most versions of `matplotlib`