### PR TITLE
Make JavaVersionSupportTest independent from external debug.allowJava versions settings [nocheck]

### DIFF
--- a/h2o-core/src/test/java/water/JavaVersionSupportTest.java
+++ b/h2o-core/src/test/java/water/JavaVersionSupportTest.java
@@ -1,5 +1,6 @@
 package water;
 
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -18,6 +19,11 @@ import static org.junit.Assert.*;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({JavaVersionSupportTest.SupportedJavasTest.class, JavaVersionSupportTest.UnsupportedJavasTest.class})
 public class JavaVersionSupportTest {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        Assume.assumeTrue(System.getProperty(H2O.OptArgs.SYSTEM_PROP_PREFIX + "debug.allowJavaVersions") == null);
+    }
 
     @RunWith(Parameterized.class)
     public static class SupportedJavasTest {


### PR DESCRIPTION
I found that when I set debug.allowJavaVersions to 16 externally. Then I get failed test in 
`assertFalse(JavaVersionSupport.runningOnSupportedVersion());`

I made this test independent from external set of this property.

Second option would be to change:

```
        @Parameterized.Parameters
        public static Collection<Object[]> data() {
            return Arrays.asList(new Object[][]{
                    {7}, {16}
            });
        }
```

to `{7}, {256}` and avoid conflict between temporally unsupported java version.