### PR TITLE
PUBDEV-8433 glrm model id error

### DIFF
--- a/h2o-algos/src/main/java/hex/glrm/GLRM.java
+++ b/h2o-algos/src/main/java/hex/glrm/GLRM.java
@@ -144,7 +144,7 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
       error("_recover_svd", "_recover_svd and _impute_original cannot both be true if _train" +
               " is transformed");
 
-    if (_train == null) return;
+    if (null == _train) return;
     if (_ncolA < 2)
       error("_train", "_train must have more than one column");
     if (_valid != null && _valid.numRows() != _train.numRows())
@@ -154,31 +154,31 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
       warn("_train", "_train has " + _ncolY + " columns when categoricals are expanded. Algorithm" +
               " may be slow.");
 
-    if (_parms._loading_name != null) {
+    if (null != _parms._loading_name) {
       warn("loading_name", "loading_name is deprecated, use representation_name instead.");
-      if (_parms._representation_name == null)
+      if (null == _parms._representation_name)
         _parms._representation_name = _parms._loading_name;
     }
     
-    if ((_parms._representation_name != null) && (_parms._loading_name != null)) {
+    if ((null != _parms._representation_name) && (null != _parms._loading_name)) {
       if (!(_parms._representation_name.equals(_parms._loading_name)))
         warn("_representation_name and _loading_name", "Are not equal.  _representation_name will" +
                 " be used since _loading_name is deprecated.");
     }
     
-    if (_parms._representation_name != null) {
+    if (null != _parms._representation_name) {
       if (dest().toString().equals(_parms._representation_name))
         error("representation_name", "representation_name and model_id cannot use the same string.");
     }
 
-    if (_parms._loading_name != null) {
+    if (null != _parms._loading_name) {
       if (dest().toString().equals(_parms._loading_name))
         error("loading_name", "loading_name and model_id cannot use the same string.");
     }
     
     if (_parms._k < 1 || _parms._k > _ncolY) error("_k", "_k must be between 1 and " + _ncolY +
             " inclusive");
-    if (_parms._user_y != null) { // Check dimensions of user-specified initial Y
+    if (null != _parms._user_y) { // Check dimensions of user-specified initial Y
       if (_parms._init != GlrmInitialization.User)
         error("_init", "init must be 'User' if providing user-specified points");
 

--- a/h2o-algos/src/main/java/hex/glrm/GLRM.java
+++ b/h2o-algos/src/main/java/hex/glrm/GLRM.java
@@ -159,11 +159,21 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
       if (_parms._representation_name == null)
         _parms._representation_name = _parms._loading_name;
     }
-
+    
     if ((_parms._representation_name != null) && (_parms._loading_name != null)) {
       if (!(_parms._representation_name.equals(_parms._loading_name)))
         warn("_representation_name and _loading_name", "Are not equal.  _representation_name will" +
                 " be used since _loading_name is deprecated.");
+    }
+    
+    if (_parms._representation_name != null) {
+      if (dest().toString().equals(_parms._representation_name))
+        error("representation_name", "representation_name and model_id cannot use the same string.");
+    }
+
+    if (_parms._loading_name != null) {
+      if (dest().toString().equals(_parms._loading_name))
+        error("loading_name", "loading_name and model_id cannot use the same string.");
     }
     
     if (_parms._k < 1 || _parms._k > _ncolY) error("_k", "_k must be between 1 and " + _ncolY +

--- a/h2o-py/tests/testdir_algos/glrm/pyunit_PUBDEV_8433_iris_model_id_name_duplicates.py
+++ b/h2o-py/tests/testdir_algos/glrm/pyunit_PUBDEV_8433_iris_model_id_name_duplicates.py
@@ -1,0 +1,34 @@
+from __future__ import print_function
+from builtins import str
+import sys
+
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glrm import H2OGeneralizedLowRankEstimator
+
+# make sure error was thrown when model_id and representation_name use the same string.
+def glrm_iris_error_message():
+    print("Importing iris_wheader.csv data...")
+    irisH2O = h2o.upload_file(pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+
+    rank = 3
+    gx = 0.5
+    gy = 0.5
+    trans = "STANDARDIZE"
+    print("H2O GLRM with rank k = " + str(rank) + ", gamma_x = " + str(gx) + ", gamma_y = " + str(
+        gy) + ", transform = " + trans)
+    try:
+        glrm_h2o = H2OGeneralizedLowRankEstimator(k=rank, loss="Quadratic", gamma_x=gx, gamma_y=gy, transform=trans,
+                                          model_id="one", representation_name="one")
+        glrm_h2o.train(x=irisH2O.names, training_frame=irisH2O)
+        assert False, "Should have thrown an exception!"
+    except Exception as ex:
+        print(ex)
+        temp = str(ex)
+        assert ("representation_name and model_id cannot use the same string" in temp), "Wrong exception was received."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(glrm_iris_error_message)
+else:
+    glrm_iris_error_message()


### PR DESCRIPTION
This PR solves the issue in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8433.

When the user sets model_id and representation_name to the same string, there is a collision of model and frame using the same key.  To avoid this, we generate a warning if it happens.