### PR TITLE
Fix: Disable integer optimized histograms for uplift [nocheck]

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/DHistogram.java
+++ b/h2o-algos/src/main/java/hex/tree/DHistogram.java
@@ -517,18 +517,19 @@ public final class DHistogram extends Iced<DHistogram> {
     }
     return hs;
   }
-  
+
   public static DHistogram make(String name, final int nbins, byte isInt, double min, double maxEx, boolean intOpt, boolean hasNAs, 
                                 long seed, SharedTreeModel.SharedTreeParameters parms, Key globalQuantilesKey, 
                                 Constraints cs, boolean checkFloatSplits) {
-    UpliftDRFModel.UpliftDRFParameters.UpliftMetricType upliftMetricType = null;
-    boolean useUplift = false;
-    if (parms instanceof UpliftDRFModel.UpliftDRFParameters) {
-      upliftMetricType = ((UpliftDRFModel.UpliftDRFParameters) parms)._uplift_metric;
-      useUplift = true;
-    }
+    boolean useUplift = isUplift(parms);
+    UpliftDRFModel.UpliftDRFParameters.UpliftMetricType upliftMetricType = useUplift ?
+            ((UpliftDRFModel.UpliftDRFParameters) parms)._uplift_metric : null;
     return new DHistogram(name, nbins, parms._nbins_cats, isInt, min, maxEx, intOpt, hasNAs,
             parms._min_split_improvement, parms._histogram_type, seed, globalQuantilesKey, cs, checkFloatSplits, useUplift, upliftMetricType);
+  }
+
+  private static boolean isUplift(SharedTreeModel.SharedTreeParameters parms) {
+    return parms instanceof UpliftDRFModel.UpliftDRFParameters;
   }
 
   /**
@@ -540,6 +541,10 @@ public final class DHistogram extends Iced<DHistogram> {
    * @return can we use integer representation for extracted data? 
    */
   public static boolean useIntOpt(Vec v, SharedTreeModel.SharedTreeParameters parms, Constraints cs) {
+    if (isUplift(parms)) {
+      // Uplift modelling doesn't support integer optimization (different code path)
+      return false;
+    }
     if (cs != null) {
       // if constraints are not handled on the optimized path to avoid higher code complexity
       // (the benefit of this optimization would be small anyway as constraints introduce overhead)
@@ -594,9 +599,10 @@ public final class DHistogram extends Iced<DHistogram> {
   }
 
   void updateHisto(double[] ws, double[] resp, Object cs, double[] ys, double[] preds, int[] rows, int hi, int lo, double[] treatment){
-    if (_intOpt)
-      updateHistoInt(ws, (int[])cs, ys, rows, hi, lo);
-    else
+    if (_intOpt) {
+      assert treatment == null : "Integer-optimized histograms cannot be used when treatment is provided";
+      updateHistoInt(ws, (int[]) cs, ys, rows, hi, lo);
+    } else
       updateHisto(ws, resp, (double[]) cs, ys, preds, rows, hi, lo, treatment);
   }
 

--- a/h2o-algos/src/main/java/hex/tree/DHistogram.java
+++ b/h2o-algos/src/main/java/hex/tree/DHistogram.java
@@ -606,13 +606,6 @@ public final class DHistogram extends Iced<DHistogram> {
       updateHisto(ws, resp, (double[]) cs, ys, preds, rows, hi, lo, treatment);
   }
 
-  void updateHisto(double[] ws, double[] resp, Object cs, double[] ys, double[] preds, int[] rows, int hi, int lo){
-    if (_intOpt)
-      updateHistoInt(ws, (int[])cs, ys, rows, hi, lo);
-    else
-      updateHisto(ws, resp, (double[]) cs, ys, preds, rows, hi, lo, null);
-  }
-
   /**
    * Update counts in appropriate bins. Not thread safe, assumed to have private copy.
    * 

--- a/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram2.java
+++ b/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram2.java
@@ -399,14 +399,13 @@ public class ScoreBuildHistogram2 extends ScoreBuildHistogram {
       double[] treatment = null;
       final int maxWorkId = _allocator.getMaxId(id);
       for(int i = _allocator.allocateWork(id); i < maxWorkId; i = _allocator.allocateWork(id)) {
-        if (cs == null) {
+        if (cs == null) { // chunk data cache doesn't exist yet
           if (_respIdx >= 0)
             resp = MemoryManager.malloc8d(_maxChunkSz);
           if (_predsIdx >= 0)
             preds = MemoryManager.malloc8d(_maxChunkSz);
-        }
-        if(_treatmentIdx >= 0){
-          treatment = MemoryManager.malloc8d(_maxChunkSz);
+          if (_treatmentIdx >= 0)
+            treatment = MemoryManager.malloc8d(_maxChunkSz);
         }
         cs = computeChunk(i, cs, _ws[i], resp, preds, treatment);
       }

--- a/h2o-algos/src/test/java/hex/tree/DHistogramTest.java
+++ b/h2o-algos/src/test/java/hex/tree/DHistogramTest.java
@@ -192,14 +192,14 @@ public class DHistogramTest extends TestUtil {
             SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, false);
     histoOpt.init();
 
-    histoOpt.updateHisto(weights, null, dataInt, ys, null, rows, N, 0);
+    histoOpt.updateHisto(weights, null, dataInt, ys, null, rows, N, 0, null);
 
     // optimization OFF
     DHistogram histo = new DHistogram("intOpt-off", 1000, 1024, (byte) 1, 0, 1000, false, false, -0.001,
             SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, false);
     histo.init();
 
-    histo.updateHisto(weights, null, data, ys, null, rows, N, 0);
+    histo.updateHisto(weights, null, data, ys, null, rows, N, 0, null);
 
     assertEquals(histo._min2, histoOpt._min2, 0);
     assertEquals(histo._maxIn, histoOpt._maxIn, 0);

--- a/h2o-algos/src/test/java/hex/tree/DHistogramTest.java
+++ b/h2o-algos/src/test/java/hex/tree/DHistogramTest.java
@@ -1,5 +1,7 @@
 package hex.tree;
 
+import hex.tree.uplift.UpliftDRF;
+import hex.tree.uplift.UpliftDRFModel;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import water.*;
@@ -213,6 +215,9 @@ public class DHistogramTest extends TestUtil {
       DKV.put(f);
 
       TreeParameters defaultTP = new TreeParameters();
+
+      // disabled for Uplift
+      assertFalse(DHistogram.useIntOpt(null, new UpliftDRFModel.UpliftDRFParameters(), null));
       
       // disabled when constraints are used
       assertFalse(DHistogram.useIntOpt(null, null, new Constraints(new int[0], null, false)));


### PR DESCRIPTION
- Uplift - refactor: unify constructors in DHistogram
- Fix: Disable integer optimized histograms for uplift
- Uplift clean-up: removed method only called from tests
- Clean-up: unify extra array allocation in ScoreBuildHistogram
