### PR TITLE
PUBDEV-8447: Avoid using Random Stream API - creates differences between Java versionsions

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/isoforextended/ExtendedIsolationForest.java
+++ b/h2o-algos/src/main/java/hex/tree/isoforextended/ExtendedIsolationForest.java
@@ -155,7 +155,7 @@ public class ExtendedIsolationForest extends ModelBuilder<ExtendedIsolationFores
             IsolationTree isolationTree = new IsolationTree(heightLimit, _parms._extension_level);
             for (int tid = 0; tid < _parms._ntrees; tid++) {
                 Timer timer = new Timer();
-                Frame subSample = _train.deepSlice(ArrayUtils.distinctLongs(_parms._sample_size, _train.numRows(), _rand), null);
+                Frame subSample = MRUtils.sampleFrameSmall(_train, _parms._sample_size, _rand);
                 double[][] subSampleArray = FrameUtils.asDoubles(subSample);
                 CompressedIsolationTree compressedIsolationTree = isolationTree.buildTree(subSampleArray, _parms._seed + _rand.nextInt(), tid);
                 if (LOG.isDebugEnabled()) {

--- a/h2o-algos/src/main/java/hex/tree/isoforextended/ExtendedIsolationForest.java
+++ b/h2o-algos/src/main/java/hex/tree/isoforextended/ExtendedIsolationForest.java
@@ -14,7 +14,6 @@ import water.fvec.Frame;
 import water.util.*;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
@@ -156,7 +155,7 @@ public class ExtendedIsolationForest extends ModelBuilder<ExtendedIsolationFores
             IsolationTree isolationTree = new IsolationTree(heightLimit, _parms._extension_level);
             for (int tid = 0; tid < _parms._ntrees; tid++) {
                 Timer timer = new Timer();
-                Frame subSample = _train.deepSlice(_rand.longs(0, _train.numRows()).distinct().limit(_parms._sample_size).toArray(), null);
+                Frame subSample = _train.deepSlice(ArrayUtils.distinctLongs(_parms._sample_size, _train.numRows(), _rand), null);
                 double[][] subSampleArray = FrameUtils.asDoubles(subSample);
                 CompressedIsolationTree compressedIsolationTree = isolationTree.buildTree(subSampleArray, _parms._seed + _rand.nextInt(), tid);
                 if (LOG.isDebugEnabled()) {

--- a/h2o-algos/src/main/java/hex/tree/isoforextended/isolationtree/IsolationTree.java
+++ b/h2o-algos/src/main/java/hex/tree/isoforextended/isolationtree/IsolationTree.java
@@ -251,10 +251,18 @@ public class IsolationTree {
      */
     public static double[] gaussianVector(int n, int zeroNum, long seed) {
         double[] gaussian = ArrayUtils.gaussianVector(n, seed);
-        int[] indexToMakeZero = RandomUtils.getRNG(seed).ints(0, n).distinct().limit(zeroNum).toArray();
+        Random r = RandomUtils.getRNG(seed);
 
-        for (int index: indexToMakeZero) {
-            gaussian[index] = 0.0;
+        while (zeroNum > 0) {
+            int pos = r.nextInt(n);
+            if (!Double.isNaN(gaussian[pos])) {
+                gaussian[pos] = Double.NaN;
+                zeroNum--;
+            }
+        }
+        for (int i = 0; i < gaussian.length; i++) {
+            if (Double.isNaN(gaussian[i]))
+                gaussian[i] = 0;
         }
         return gaussian;
     }

--- a/h2o-core/src/main/java/water/rapids/PermutationVarImp.java
+++ b/h2o-core/src/main/java/water/rapids/PermutationVarImp.java
@@ -111,7 +111,7 @@ public class PermutationVarImp {
 
         final Frame fr;
         if (n_samples > 1) {
-            if (n_samples > 1000) {
+            if (n_samples > 1000 || _model._parms._weights_column != null) {
                 fr = MRUtils.sampleFrame(_inputFrame, n_samples, _model._parms._weights_column, seed);
             } else {
                 Random rand = getRNG(seed);

--- a/h2o-core/src/main/java/water/rapids/PermutationVarImp.java
+++ b/h2o-core/src/main/java/water/rapids/PermutationVarImp.java
@@ -109,13 +109,13 @@ public class PermutationVarImp {
         if (_model._parms._ignored_columns != null)
             featuresToCompute.removeAll(Arrays.asList(_model._parms._ignored_columns));
 
-        Frame fr = null;
+        final Frame fr;
         if (n_samples > 1) {
             if (n_samples > 1000) {
                 fr = MRUtils.sampleFrame(_inputFrame, n_samples, _model._parms._weights_column, seed);
             } else {
                 Random rand = getRNG(seed);
-                fr = _inputFrame.deepSlice(rand.longs(n_samples, 0, _inputFrame.numRows()).toArray(), null);
+                fr = _inputFrame.deepSlice(ArrayUtils.distinctLongs((int) n_samples, _inputFrame.numRows(), rand), null);
             }
         } else {
             fr = _inputFrame;

--- a/h2o-core/src/main/java/water/rapids/PermutationVarImp.java
+++ b/h2o-core/src/main/java/water/rapids/PermutationVarImp.java
@@ -114,8 +114,7 @@ public class PermutationVarImp {
             if (n_samples > 1000 || _model._parms._weights_column != null) {
                 fr = MRUtils.sampleFrame(_inputFrame, n_samples, _model._parms._weights_column, seed);
             } else {
-                Random rand = getRNG(seed);
-                fr = _inputFrame.deepSlice(ArrayUtils.distinctLongs((int) n_samples, _inputFrame.numRows(), rand), null);
+                fr = MRUtils.sampleFrameSmall(_inputFrame, (int) n_samples, seed);
             }
         } else {
             fr = _inputFrame;

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -1103,7 +1103,17 @@ public class ArrayUtils {
     }
   }
 
+  /**
+   * Generates a random array of n distinct non-negative long values. Values are sorted for reproducibility.  
+   * 
+   * @param n desired size of the array
+   * @param bound (exclusive) upper bound of maximum long-value that can be included 
+   * @param rng random generator
+   * @return long array of length n holding values [0, bound)
+   */
   public static long[] distinctLongs(int n, long bound, Random rng) {
+    if (n > bound)
+      throw new IllegalArgumentException("argument bound (=" + bound + ") needs to be lower or equal to n (=" + n + ")");
     if (!(rng instanceof RandomBase))
       throw new IllegalArgumentException("Random implementation needs to be created by RandomUtils and inherit from RandomBase");
     Set<Long> rows = new HashSet<>();

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -1103,6 +1103,16 @@ public class ArrayUtils {
     }
   }
 
+  public static long[] distinctLongs(int n, long bound, Random rng) {
+    if (!(rng instanceof RandomBase))
+      throw new IllegalArgumentException("Random implementation needs to be created by RandomUtils and inherit from RandomBase");
+    Set<Long> rows = new HashSet<>();
+    while (rows.size() < n) {
+      rows.add(((RandomBase) rng).nextLong(bound));
+    }
+    return rows.stream().sorted().mapToLong(Long::longValue).toArray();
+  }
+
   // Generate a n by m array of random numbers drawn from the standard normal distribution
   public static double[][] gaussianArray(int n, int m) { return gaussianArray(n, m, System.currentTimeMillis()); }
   public static double[][] gaussianArray(int n, int m, long seed) {

--- a/h2o-core/src/main/java/water/util/MRUtils.java
+++ b/h2o-core/src/main/java/water/util/MRUtils.java
@@ -446,4 +446,34 @@ public class MRUtils {
     return r;
   }
 
+  /**
+   * Sample small number of rows from a frame. Doesn't support weights.
+   * 
+   * Meaning of "small" is relative, it shouldn't be more that 10k of rows.
+   * 
+   * @param fr Input frame
+   * @param rows Exact number of rows to sample
+   * @param seed Seed for RNG
+   * @return Sampled frame, guaranteed to have exactly specified #rows (as long as the frame is large enough)
+   */
+  public static Frame sampleFrameSmall(Frame fr, final int rows, final long seed) {
+    return sampleFrameSmall(fr, rows, getRNG(seed));
+  }
+
+  /**
+   * Sample small number of rows from a frame. Doesn't support weights.
+   *
+   * Meaning of "small" is relative, it shouldn't be more that 10k of rows.
+   *
+   * @param fr Input frame
+   * @param rows Exact number of rows to sample
+   * @param rand Random Generator
+   * @return Sampled frame, guaranteed to have exactly specified #rows (as long as the frame is large enough)
+   */
+  public static Frame sampleFrameSmall(Frame fr, final int rows, final Random rand) {
+    if (rows >= fr.numRows())
+      return fr;
+    return fr.deepSlice(ArrayUtils.distinctLongs(rows, fr.numRows(), rand), null);
+  }
+
 }

--- a/h2o-core/src/main/java/water/util/RandomBase.java
+++ b/h2o-core/src/main/java/water/util/RandomBase.java
@@ -1,0 +1,108 @@
+package water.util;
+
+import java.util.Random;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+public class RandomBase extends Random {
+
+    protected RandomBase() {
+        super();
+    }
+
+    protected RandomBase(long seed) {
+        super(seed);
+    }
+
+    /**
+     * Returns a pseudorandom, uniformly distributed value
+     * between 0 (inclusive) and the specified value (exclusive).
+     *
+     * @see jsr166y.ThreadLocalRandom#nextLong(long) 
+     * 
+     * @param n the bound on the random number to be returned.  Must be
+     *        positive.
+     * @return the next value
+     * @throws IllegalArgumentException if n is not positive
+     */
+    public long nextLong(long n) {
+        if (n <= 0)
+            throw new IllegalArgumentException("n must be positive");
+        // Divide n by two until small enough for nextInt. On each
+        // iteration (at most 31 of them but usually much less),
+        // randomly choose both whether to include high bit in result
+        // (offset) and whether to continue with the lower vs upper
+        // half (which makes a difference only if odd).
+        long offset = 0;
+        while (n >= Integer.MAX_VALUE) {
+            int bits = next(2);
+            long half = n >>> 1;
+            long nextn = ((bits & 2) == 0) ? half : n - half;
+            if ((bits & 1) == 0)
+                offset += n - nextn;
+            n = nextn;
+        }
+        return offset + nextInt((int) n);
+    }
+
+    @Override
+    public final IntStream ints(long streamSize) {
+        throw new UnsupportedOperationException("Please avoid using Stream API on Random - it introduces different behavior on different Java versions");
+    }
+
+    @Override
+    public final IntStream ints() {
+        throw new UnsupportedOperationException("Please avoid using Stream API on Random - it introduces different behavior on different Java versions");
+    }
+
+    @Override
+    public final IntStream ints(long streamSize, int randomNumberOrigin, int randomNumberBound) {
+        throw new UnsupportedOperationException("Please avoid using Stream API on Random - it introduces different behavior on different Java versions");
+    }
+
+    @Override
+    public final IntStream ints(int randomNumberOrigin, int randomNumberBound) {
+        throw new UnsupportedOperationException("Please avoid using Stream API on Random - it introduces different behavior on different Java versions");
+    }
+
+    @Override
+    public final LongStream longs(long streamSize) {
+        throw new UnsupportedOperationException("Please avoid using Stream API on Random - it introduces different behavior on different Java versions");
+    }
+
+    @Override
+    public final LongStream longs() {
+        throw new UnsupportedOperationException("Please avoid using Stream API on Random - it introduces different behavior on different Java versions");
+    }
+
+    @Override
+    public final LongStream longs(long streamSize, long randomNumberOrigin, long randomNumberBound) {
+        throw new UnsupportedOperationException("Please avoid using Stream API on Random - it introduces different behavior on different Java versions");
+    }
+
+    @Override
+    public final LongStream longs(long randomNumberOrigin, long randomNumberBound) {
+        throw new UnsupportedOperationException("Please avoid using Stream API on Random - it introduces different behavior on different Java versions");
+    }
+
+    @Override
+    public final DoubleStream doubles(long streamSize) {
+        throw new UnsupportedOperationException("Please avoid using Stream API on Random - it introduces different behavior on different Java versions");
+    }
+
+    @Override
+    public final DoubleStream doubles() {
+        throw new UnsupportedOperationException("Please avoid using Stream API on Random - it introduces different behavior on different Java versions");
+    }
+
+    @Override
+    public final DoubleStream doubles(long streamSize, double randomNumberOrigin, double randomNumberBound) {
+        throw new UnsupportedOperationException("Please avoid using Stream API on Random - it introduces different behavior on different Java versions");
+    }
+
+    @Override
+    public final DoubleStream doubles(double randomNumberOrigin, double randomNumberBound) {
+        throw new UnsupportedOperationException("Please avoid using Stream API on Random - it introduces different behavior on different Java versions");
+    }
+}

--- a/h2o-core/src/main/java/water/util/RandomUtils.java
+++ b/h2o-core/src/main/java/water/util/RandomUtils.java
@@ -2,7 +2,6 @@ package water.util;
 
 import water.H2O;
 
-import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -11,7 +10,7 @@ public class RandomUtils {
   private static RNGType _rngType = RNGType.PCGRNG;
 
   /* Returns the configured random generator */
-  public static Random getRNG(long... seed) {
+  public static RandomBase getRNG(long... seed) {
     switch(_rngType) {
     case JavaRNG:      return new H2ORandomRNG(seed[0]);
     case XorShiftRNG:  return new XorShiftRNG (seed[0]);
@@ -24,8 +23,6 @@ public class RandomUtils {
     }
     throw H2O.fail();
   }
-
-
 
   // Converted to Java from the C
   /*
@@ -50,7 +47,7 @@ public class RandomUtils {
    *
    * http://www.pcg-random.org
    */
-  public static class PCGRNG extends Random {
+  public static class PCGRNG extends RandomBase {
     private long _state;        // Random state
     private long _inc;          // Fixed sequence, always odd
     // Seed the rng. Specified in two parts, state initializer and a sequence
@@ -120,7 +117,7 @@ public class RandomUtils {
 
   /** Stock Java RNG, but force the initial seed to have no zeros in either the
    *  low 32 or high 32 bits - leading to well known really bad behavior. */
-  public static class H2ORandomRNG extends Random {
+  public static class H2ORandomRNG extends RandomBase {
     public H2ORandomRNG(long seed) {
       super();
       if ((seed >>> 32) < 0x0000ffffL)         seed |= 0x5b93000000000000L;
@@ -132,7 +129,7 @@ public class RandomUtils {
   /** Simple XorShiftRNG.
    *  Note: According to RF benchmarks it does not provide so accurate results
    *  as {@link java.util.Random}, however it can be used as an alternative. */
-  public static class XorShiftRNG extends Random {
+  public static class XorShiftRNG extends RandomBase {
     private AtomicLong _seed;
     public XorShiftRNG (long seed) { _seed = new AtomicLong(seed); }
     @Override public long nextLong() {
@@ -194,7 +191,7 @@ public class RandomUtils {
    * @author Makoto Matsumoto and Takuji Nishimura (original C version)
    * @author Daniel Dyer (Java port)
    */
-  public static class MersenneTwisterRNG extends Random {
+  public static class MersenneTwisterRNG extends RandomBase {
 
     // Magic numbers from original C version.
     private static final int    N                = 624;

--- a/h2o-core/src/test/java/water/util/ArrayUtilsTest.java
+++ b/h2o-core/src/test/java/water/util/ArrayUtilsTest.java
@@ -545,4 +545,33 @@ public class ArrayUtilsTest {
     interpolateLinear(complex);
     assertArrayEquals("Interpolated array should be"+Arrays.toString(complexExpected)+" but is"+Arrays.toString(complex), complexExpected, complex, 0);
   }
+
+  @Test
+  public void testDistinctLongs() {
+    assertArrayEquals(new long[0], ArrayUtils.distinctLongs(0, 100L, RandomUtils.getRNG(42)));
+    assertArrayEquals(
+            ArrayUtils.toString(ArrayUtils.seq(0, 33)), 
+            ArrayUtils.toString(ArrayUtils.distinctLongs(33, 33L, RandomUtils.getRNG(42)))); // comparing strings to avoid int-long conversion ;)
+    
+    long bound = (long) Integer.MAX_VALUE + 1;
+    long[] vals = ArrayUtils.distinctLongs(33, bound, RandomUtils.getRNG(42));
+    assertEquals(33, vals.length);
+    for (int i = 0; i < vals.length; i++) {
+      assertTrue(vals[i] < bound);
+      assertTrue(i == 0 || vals[i - 1] < vals[i]);
+    }
+    try {
+      ArrayUtils.distinctLongs(11, 10, RandomUtils.getRNG(42));
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals(e.getMessage(), "argument bound (=10) needs to be lower or equal to n (=11)");
+    }
+    try {
+      ArrayUtils.distinctLongs(11, 12, new Random());
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals(e.getMessage(), "Random implementation needs to be created by RandomUtils and inherit from RandomBase");
+    }
+  }
+
 }

--- a/h2o-core/src/test/java/water/util/MRUtilsTest.java
+++ b/h2o-core/src/test/java/water/util/MRUtilsTest.java
@@ -5,6 +5,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import water.DKV;
 import water.Scope;
+import water.TestFrameCatalog;
 import water.TestUtil;
 import water.fvec.Frame;
 import water.fvec.TestFrameBuilder;
@@ -21,11 +22,11 @@ public class MRUtilsTest extends TestUtil {
 
     @Test
     public void testSampleWithWeight() {
-        Frame f = parseTestFile("bigdata/laptop/lending-club/loan.csv");
-        Scope.enter();
-        Scope.track(f);
-        String column = "loan_amnt";
+        final String column = "loan_amnt";
         try {
+            Scope.enter();
+            Frame f = parseTestFile("bigdata/laptop/lending-club/loan.csv");
+            Scope.track(f);
             Frame f1 = MRUtils.sampleFrame(f, 10000, 1);
             Frame f2 = MRUtils.sampleFrame(f, 10000, 2);
             Frame f3 = MRUtils.sampleFrame(f, 10000, 3);
@@ -61,6 +62,19 @@ public class MRUtilsTest extends TestUtil {
             // Sampling when considering the weights should have significantly higher sums of the weights than without considering them.
             assert 0.8 * mean_weight_weighted > mean_weight;
 
+        } finally {
+            Scope.exit();
+        }
+    }
+
+    @Test
+    public void testSampleSmall() {
+        try {
+            Scope.enter();
+            Frame fr = TestFrameCatalog.oneChunkFewRows();
+            Assert.assertSame(fr, MRUtils.sampleFrameSmall(fr, (int) fr.numRows(), 42L));
+            Assert.assertSame(fr, MRUtils.sampleFrameSmall(fr, (int) fr.numRows() + 1, 42L));
+            Assert.assertEquals(2L, MRUtils.sampleFrameSmall(fr, 2, 42L).numRows());
         } finally {
             Scope.exit();
         }


### PR DESCRIPTION
Java 17 brings changes in java Random implementation: https://nipafx.dev/java-random-generator/ - the Stream API changed in a way that produces different results on Java 8 and Java 17.

The goal of H2O's random is to be independent on the Java version - we provide our own implementation, however, we are not immune to changes in Stream API.

We will disable Stream API in this task and rewrite affected pieces of code to use non-Stream alternatives.