### PR TITLE
rulefit: importances for linear & rule predictors + total variable importance

### DIFF
--- a/h2o-algos/src/main/java/hex/rulefit/Rule.java
+++ b/h2o-algos/src/main/java/hex/rulefit/Rule.java
@@ -17,7 +17,7 @@ public class Rule extends Iced {
     double coefficient;
     String varName;
     double support;
-    double importance;
+    double globalImportance;
 
     public Rule(Condition[] conditions, double predictionValue, String varName) {
         this.conditions = conditions;
@@ -26,14 +26,14 @@ public class Rule extends Iced {
         this.languageRule = generateLanguageRule();
     }
 
-    public Rule(Condition[] conditions, double predictionValue, String varName,  double coefficient, double support, double importance) {
+    public Rule(Condition[] conditions, double predictionValue, String varName,  double coefficient, double support, double globalImportance) {
         this.conditions = conditions;
         this.predictionValue = predictionValue;
         this.varName = varName; 
         this.coefficient = coefficient;
         this.languageRule = generateLanguageRule();
         this.support = support;
-        this.importance = importance;
+        this.globalImportance = globalImportance;
     }
 
     public void setCoefficient(double coefficient) {

--- a/h2o-algos/src/main/java/hex/rulefit/Rule.java
+++ b/h2o-algos/src/main/java/hex/rulefit/Rule.java
@@ -7,6 +7,7 @@ import water.Iced;
 import water.fvec.Chunk;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class Rule extends Iced {
     
@@ -16,6 +17,7 @@ public class Rule extends Iced {
     double coefficient;
     String varName;
     double support;
+    double importance;
 
     public Rule(Condition[] conditions, double predictionValue, String varName) {
         this.conditions = conditions;
@@ -24,13 +26,14 @@ public class Rule extends Iced {
         this.languageRule = generateLanguageRule();
     }
 
-    public Rule(Condition[] conditions, double predictionValue, String varName,  double coefficient, double support) {
+    public Rule(Condition[] conditions, double predictionValue, String varName,  double coefficient, double support, double importance) {
         this.conditions = conditions;
         this.predictionValue = predictionValue;
         this.varName = varName; 
         this.coefficient = coefficient;
         this.languageRule = generateLanguageRule();
         this.support = support;
+        this.importance = importance;
     }
 
     public void setCoefficient(double coefficient) {
@@ -152,6 +155,11 @@ public class Rule extends Iced {
 
     double getAbsCoefficient() {
         return Math.abs(coefficient);
+    }
+    
+    boolean hasFeaturePresent(String feature) {
+        List<Condition> featureConditions = Arrays.asList(conditions).stream().filter(condition -> condition.featureName.equals(feature)).collect(Collectors.toList());
+        return featureConditions.size() > 0 ? true : false;
     }
 
 }

--- a/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
+++ b/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
@@ -450,13 +450,15 @@ public class RuleFit extends ModelBuilder<RuleFitModel, RuleFitModel.RuleFitPara
                 String featureName = entry.getKey();
                 if (!entry.getKey().startsWith("linear.")) {
                     rule = ruleEnsemble.getRuleByVarName(getVarName(featureName, classNames));
-                    rule.globalImportance = ruleImportance(lassoWeight, rule.support);
+                    // global importance for rule feature:
+                    rule.globalImportance = ruleGlobalImportance(lassoWeight, rule.support);
                 } else {
                     rule = new Rule(null, lassoWeight, featureName);
                     // linear rule applies to all the rows:
                     rule.support = 1.0;
-                    // compute importance for linear feature:
-                    rule.globalImportance = Math.abs(lassoWeight) * train().vec(featureName).sigma();
+                    // global importance for linear feature:
+                    String name =  Arrays.asList(train()._names).stream().filter(currName -> featureName.contains(currName)).collect(Collectors.toList()).get(0);
+                    rule.globalImportance = Math.abs(lassoWeight) * train().vec(name).sigma();
                 }
                 rule.setCoefficient(lassoWeight);
                 rules.add(rule);

--- a/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
+++ b/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
@@ -290,7 +290,7 @@ public class RuleFit extends ModelBuilder<RuleFitModel, RuleFitModel.RuleFitPara
                         ruleEnsemble, model._output.classNames()), _parms._remove_duplicates)), isClassifier() && nclasses() > 2);
                
                 // total feature importance:
-                model._output._varimp = model.calculateVarimp(ArrayUtils.remove(train().names(), _parms._response_column));
+                model._output._varimp = model.calculateTotalVarimp(ArrayUtils.remove(train().names(), _parms._response_column));
                 model._output._variable_importance = calcVarImp(model._output._varimp);
 
                 model._output._model_summary = generateSummary(glmModel, ruleEnsemble != null ? ruleEnsemble.size() : 0, overallTreeStats, ntrees);

--- a/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
+++ b/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
@@ -450,13 +450,13 @@ public class RuleFit extends ModelBuilder<RuleFitModel, RuleFitModel.RuleFitPara
                 String featureName = entry.getKey();
                 if (!entry.getKey().startsWith("linear.")) {
                     rule = ruleEnsemble.getRuleByVarName(getVarName(featureName, classNames));
-                    rule.importance = ruleImportance(lassoWeight, rule.support);
+                    rule.globalImportance = ruleImportance(lassoWeight, rule.support);
                 } else {
                     rule = new Rule(null, lassoWeight, featureName);
                     // linear rule applies to all the rows:
                     rule.support = 1.0;
                     // compute importance for linear feature:
-                    rule.importance = Math.abs(lassoWeight) * train().vec(featureName).sigma();
+                    rule.globalImportance = Math.abs(lassoWeight) * train().vec(featureName).sigma();
                 }
                 rule.setCoefficient(lassoWeight);
                 rules.add(rule);
@@ -524,7 +524,7 @@ public class RuleFit extends ModelBuilder<RuleFitModel, RuleFitModel.RuleFitPara
             }
             table.set(row, col++, (rules[row]).coefficient);
             table.set(row, col++, (rules[row]).support);
-            table.set(row, col++, (rules[row]).importance);
+            table.set(row, col++, (rules[row]).globalImportance);
             table.set(row, col, (rules[row]).languageRule);
         }
 

--- a/h2o-algos/src/main/java/hex/rulefit/RuleFitModel.java
+++ b/h2o-algos/src/main/java/hex/rulefit/RuleFitModel.java
@@ -225,9 +225,9 @@ public class RuleFitModel extends Model<RuleFitModel, RuleFitModel.RuleFitParame
         double totalFeatureImportance = 0;
         for (Rule currRule : rulesWithFeature) {
             if (currRule.varName.startsWith("linear.")) {
-                totalFeatureImportance += currRule.importance;
+                totalFeatureImportance += currRule.globalImportance;
             } else {
-                totalFeatureImportance += currRule.importance / currRule.conditions.length;
+                totalFeatureImportance += currRule.globalImportance / currRule.conditions.length;
             }
         }
         return totalFeatureImportance;

--- a/h2o-algos/src/main/java/hex/rulefit/RuleFitUtils.java
+++ b/h2o-algos/src/main/java/hex/rulefit/RuleFitUtils.java
@@ -133,7 +133,7 @@ public class RuleFitUtils {
                 .map(e -> e.getValue().stream()
                         .reduce((r1,r2) -> new Rule(r1.conditions, r1.predictionValue, r1.varName + ", " + r2.varName,
                                 r1.coefficient + r2.coefficient, r1.support, 
-                                 ruleImportance(r1.coefficient + r2.coefficient, r1.support))))
+                                 ruleGlobalImportance(r1.coefficient + r2.coefficient, r1.support))))
                 .map(f -> f.get())
                 .collect(Collectors.toList());
 
@@ -156,7 +156,7 @@ public class RuleFitUtils {
         }
     }
 
-    static double ruleImportance(double lassoWeight, double support) {
+    static double ruleGlobalImportance(double lassoWeight, double support) {
         return abs(lassoWeight) * sqrt(support * (1 - support));
     }
 }

--- a/h2o-algos/src/main/java/hex/rulefit/RuleFitUtils.java
+++ b/h2o-algos/src/main/java/hex/rulefit/RuleFitUtils.java
@@ -6,6 +6,9 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.lang.Math.abs;
+import static java.lang.Math.sqrt;
+
 public class RuleFitUtils {
 
     public static String[] getPathNames(int modelId, int numCols, String[] names) {
@@ -128,7 +131,9 @@ public class RuleFitUtils {
                 .collect(Collectors.groupingBy(rule -> rule.languageRule))
                 .entrySet().stream()
                 .map(e -> e.getValue().stream()
-                        .reduce((r1,r2) -> new Rule(r1.conditions, r1.predictionValue, r1.varName + ", " + r2.varName, r1.coefficient + r2.coefficient, r1.support)))
+                        .reduce((r1,r2) -> new Rule(r1.conditions, r1.predictionValue, r1.varName + ", " + r2.varName,
+                                r1.coefficient + r2.coefficient, r1.support, 
+                                 ruleImportance(r1.coefficient + r2.coefficient, r1.support))))
                 .map(f -> f.get())
                 .collect(Collectors.toList());
 
@@ -137,8 +142,8 @@ public class RuleFitUtils {
 
         return transform.toArray(new Rule[0]);
     }
-
-    /** 
+    
+    /**
      * Returns a ruleId. 
      * If the ruleId is in form after deduplication:  "M0T0N1, M0T9N56, M9T34N56", meaning contains ", "
      * finds only first rule (other are equivalents)
@@ -149,5 +154,9 @@ public class RuleFitUtils {
         } else {
             return ruleId;
         }
+    }
+
+    static double ruleImportance(double lassoWeight, double support) {
+        return abs(lassoWeight) * sqrt(support * (1 - support));
     }
 }

--- a/h2o-algos/src/main/java/hex/schemas/RuleFitModelV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/RuleFitModelV3.java
@@ -14,6 +14,9 @@ public class RuleFitModelV3 extends ModelSchemaV3<RuleFitModel, RuleFitModelV3, 
     @API(help = "The estimated coefficients and language representations (in case it is a rule) for each of the significant baselearners.")
     public TwoDimTableV3 rule_importance;
 
+    @API(help = "Variable importance. Total importance of a feature that occurs as a linear term and possibly within many decision rules")
+    public TwoDimTableV3 variable_importance;
+
     @API(help = "Intercept.")
     public double[] intercept;
   }

--- a/h2o-algos/src/test/java/hex/rulefit/RuleFitTest.java
+++ b/h2o-algos/src/test/java/hex/rulefit/RuleFitTest.java
@@ -2,6 +2,7 @@ package hex.rulefit;
 
 import hex.ConfusionMatrix;
 import hex.ScoringInfo;
+import hex.VarImp;
 import hex.genmodel.utils.DistributionFamily;
 import hex.glm.GLM;
 import hex.glm.GLMModel;
@@ -66,6 +67,14 @@ public class RuleFitTest extends TestUtil {
             System.out.println(rfModel._output._rule_importance);
 
             fr2 = rfModel.score(fr);
+
+            //todo: make reading of " M0T44N20, M0T16N22" rules
+            String[] features = new String[] {"M0T6N17", "M0T44N20", "M0T34N20"};
+            double[] probs = new double[] {0.0, 1.0};
+            // on categorical response isnot possible to calculate quantiles -> localVarimp is globalVarimp now
+            // -> todo: should it be possible to calculate local on certain classes predictions?
+            VarImp localVarimp = rfModel.calculateLocalVarimp(features, fr, probs);
+            
 
             Assert.assertTrue(rfModel.testJavaScoring(fr,fr2,1e-4));
 

--- a/h2o-py/tests/testdir_algos/rulefit/pyunit_titanic_rulefit.py
+++ b/h2o-py/tests/testdir_algos/rulefit/pyunit_titanic_rulefit.py
@@ -38,6 +38,7 @@ def titanic():
     
     assert rfit._model_json["output"]["model_summary"] is not None, "model_summary should be present"
     assert len(rfit._model_json["output"]["model_summary"]._cell_values) > 0, "model_summary's content should be present"
+    assert rfit._model_json["output"]["variable_importance"] is not None, "variable_importance should be present"
 
     rfit_predictions = rfit.predict(test)
 


### PR DESCRIPTION
this is currently based on zuzana/PUBDEV-8414/rulefit_support

1.
each rule will have also "importance" field in rule importance table:
<img width="1549" alt="Screenshot 2021-12-06 at 15 29 18" src="https://user-images.githubusercontent.com/18303397/144863949-46e24658-39c6-4d75-b33a-087ec4ed6ddd.png">

calculated based on:
(done) --linear feature =abs( lasso weight) * std 
(done) --rule feature = abs(lasso weight) * sqrt(support * (1 - support))
(https://jerryfriedman.su.domains/ftp/RuleFit.pdf pt 8 Rule based interpretation eq (28) and (29))

apart of this, in model output there will be variable_importance:
(done) -- total importance of a feature = its_linear_importance + sum ( rule_where_the_feature_is_present_importance / num_of_features_in_that_rule  ) 
(https://jerryfriedman.su.domains/ftp/RuleFit.pdf pt 7 Input variable importance eq (35))  over the whole space using (28) and (29) what is valid based on the last paragraph of 7.



Documentation to add about importance in separate PR:


```

Rule based interpretation
~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Common measure of importance of any predictor in a linear model is the absolute value of the coefficient of the corresponding predictor.
For rule predictors this becomes

I_k = abs(c_k) * sqrt(s_k * (1 - s_k))

where c_k is the coefficient of the rule k, s_k is the support of the rule k (which is the percentage of data points to which the decision rule applies).

For the linear predictors, the corresponding quantity is

I_j = abs(c_k) * std(x_j)

where c_k is the coefficient of the linear predictor, std(xj) is the standard deviation over the data.


These measures reflect the average influence of each predictor over the distribution of all joint input variable values and 
can be found in model.rule_importance() table in 'importance' column.




Input variable importance
~~~~~~~~~~~~~~~~~~~~~~~~~~~~

The most relevant input variables are those that define the most influential predictors appearing in the model.
Input variables that appear frequently in important predictors are considered to be more relevant than those that appear only in less influential predictors.
The measure of importance of input variable x_l over the whole space is
		
		J_l  = I_l + sum {x_l /in r_k} I_k  / m_k

where I_l is the importance of the linear term, I_k is the importance of the decision rules in which x_j is present, m_k is the number of features constituting the rule r_k.


Input variable importance values can be found in model.variable_importance() table.


```


reference is already there



TODO: 

-local importances over for example 25% highest or 25% lowest predictions or for the single prediction point.


