### PR TITLE
Fix incorrect use of indexOf in FriedmanPopescusH [nocheck]

### DIFF
--- a/h2o-algos/src/main/java/hex/gram/Gram.java
+++ b/h2o-algos/src/main/java/hex/gram/Gram.java
@@ -103,14 +103,14 @@ public final class Gram extends Iced<Gram> {
       for (int betaInd = 0; betaInd < numKnots; betaInd++) {
         Integer betaIndex = gamIndices[gamInd][betaInd]; // for multinomial
         if (activeColumns != null) {  // column indices in gamIndices need to be translated due to columns deleted
-          betaIndex = ArrayUtils.indexOfSorted(activeColumns, betaIndex);
+          betaIndex = Arrays.binarySearch(activeColumns, betaIndex);
           if (betaIndex < 0)
             continue;
         }
         for (int betaIndj = 0; betaIndj <= betaInd; betaIndj++) {
           Integer betaIndexJ = gamIndices[gamInd][betaIndj];
           if (activeColumns != null) {  // column indices in gamIndices need to be translated due to columns deleted
-            betaIndexJ = ArrayUtils.indexOfSorted(activeColumns, betaIndexJ);
+            betaIndexJ = Arrays.binarySearch(activeColumns, betaIndexJ);
             if (betaIndexJ < 0)
               continue;
           }

--- a/h2o-algos/src/main/java/hex/gram/Gram.java
+++ b/h2o-algos/src/main/java/hex/gram/Gram.java
@@ -103,14 +103,14 @@ public final class Gram extends Iced<Gram> {
       for (int betaInd = 0; betaInd < numKnots; betaInd++) {
         Integer betaIndex = gamIndices[gamInd][betaInd]; // for multinomial
         if (activeColumns != null) {  // column indices in gamIndices need to be translated due to columns deleted
-          betaIndex = ArrayUtils.indexOf(activeColumns, betaIndex);
+          betaIndex = ArrayUtils.indexOfSorted(activeColumns, betaIndex);
           if (betaIndex < 0)
             continue;
         }
         for (int betaIndj = 0; betaIndj <= betaInd; betaIndj++) {
           Integer betaIndexJ = gamIndices[gamInd][betaIndj];
           if (activeColumns != null) {  // column indices in gamIndices need to be translated due to columns deleted
-            betaIndexJ = ArrayUtils.indexOf(activeColumns, betaIndexJ);
+            betaIndexJ = ArrayUtils.indexOfSorted(activeColumns, betaIndexJ);
             if (betaIndexJ < 0)
               continue;
           }

--- a/h2o-algos/src/main/java/hex/tree/FriedmanPopescusH.java
+++ b/h2o-algos/src/main/java/hex/tree/FriedmanPopescusH.java
@@ -338,7 +338,7 @@ public class FriedmanPopescusH {
                     totalWeight += weightStackAr[stackSize];
                 } else {
                     // non-terminal node:
-                    int featureId = ArrayUtils.indexOf(targetFeature, currNode.getColId());
+                    int featureId = ArrayUtils.indexOfSorted(targetFeature, currNode.getColId());
                     if (featureId != -1) {
                         // split feature in target set
                         // push left or right child on stack

--- a/h2o-algos/src/main/java/hex/tree/FriedmanPopescusH.java
+++ b/h2o-algos/src/main/java/hex/tree/FriedmanPopescusH.java
@@ -44,7 +44,7 @@ public class FriedmanPopescusH {
             for (int j = 0; j < currCombinations.size(); j++) {
                 int[] currCombination = currCombinations.get(j);
                 String[] cols = getCurrCombinationCols(currCombination, vars);
-                Integer[] currModelIds = getCurrentCombinationModelIds(currCombination, modelIds);
+                int[] currModelIds = getCurrentCombinationModelIds(currCombination, modelIds);
                 fValues.put(Arrays.toString(currCombination), computeFValues(currModelIds, filteredFrame, cols, learnRate, sharedTreeSubgraphs));
             }
         }
@@ -52,8 +52,8 @@ public class FriedmanPopescusH {
         
     }
 
-    static Integer[] getCurrentCombinationModelIds(int[] currCombination, int[] modelIds) {
-        Integer[] currCombinationCols = new Integer[currCombination.length];
+    static int[] getCurrentCombinationModelIds(int[] currCombination, int[] modelIds) {
+        int[] currCombinationCols = new int[currCombination.length];
         for (int i = 0; i < currCombination.length; i++) {
             currCombinationCols[i] = modelIds[currCombination[i]];
         }
@@ -205,7 +205,7 @@ public class FriedmanPopescusH {
     }
     
     
-    static Frame computeFValues(Integer[] modelIds, Frame filteredFrame, String[] cols, double learnRate, SharedTreeSubgraph[][] sharedTreeSubgraphs) {
+    static Frame computeFValues(int[] modelIds, Frame filteredFrame, String[] cols, double learnRate, SharedTreeSubgraph[][] sharedTreeSubgraphs) {
         // filter frame -> only curr combination cols will be used
         filteredFrame = filterFrame(filteredFrame, cols);
         filteredFrame = new Frame(Key.make(), filteredFrame.names(), filteredFrame.vecs());
@@ -221,7 +221,7 @@ public class FriedmanPopescusH {
     
     
     
-    static Frame partialDependence(Integer[] modelIds, Frame uniqueWithCounts, double learnRate, SharedTreeSubgraph[][] sharedTreeSubgraphs) {
+    static Frame partialDependence(int[] modelIds, Frame uniqueWithCounts, double learnRate, SharedTreeSubgraph[][] sharedTreeSubgraphs) {
         Frame result = new Frame();
         int nclasses = sharedTreeSubgraphs[0].length;
         int ntrees = sharedTreeSubgraphs.length;
@@ -240,7 +240,7 @@ public class FriedmanPopescusH {
     }
 
     public static double[] add(double[] first, double[] second) { 
-        int length = first.length < second.length ? first.length : second.length;
+        int length = Math.min(first.length, second.length);
         double[] result = new double[length]; 
         for (int i = 0; i < length; i++) { 
             result[i] = first[i] + second[i]; 
@@ -311,7 +311,7 @@ public class FriedmanPopescusH {
      *             
      * @return Vec with the resulting partial dependence values for each point of the input grid         
      */
-    public static Vec partialDependenceTree(SharedTreeSubgraph tree, Integer[] targetFeature, double learnRate, Frame grid) {
+    static Vec partialDependenceTree(SharedTreeSubgraph tree, int[] targetFeature, double learnRate, Frame grid) {
         Vec outVec = Vec.makeZero(grid.numRows());
         
         int stackSize;
@@ -338,8 +338,8 @@ public class FriedmanPopescusH {
                     totalWeight += weightStackAr[stackSize];
                 } else {
                     // non-terminal node:
-                    int featureId = ArrayUtils.indexOfSorted(targetFeature, currNode.getColId());
-                    if (featureId != -1) {
+                    int featureId = ArrayUtils.find(targetFeature, currNode.getColId());
+                    if (featureId >= 0) {
                         // split feature in target set
                         // push left or right child on stack
                         if (grid.vec(featureId).at(i) <= currNode.getSplitValue()) {

--- a/h2o-algos/src/test/java/hex/gam/GamTestPiping.java
+++ b/h2o-algos/src/test/java/hex/gam/GamTestPiping.java
@@ -503,13 +503,13 @@ public class GamTestPiping extends TestUtil {
         for (int beta1 = 0; beta1 < numKnots; beta1++) {
           Integer betaIndex = gamCoeffIndices[gamColInd][beta1]; // for multinomial
           if (activeCols != null)
-            betaIndex = ArrayUtils.indexOfSorted(activeCols, betaIndex);
+            betaIndex = ArrayUtils.find(activeCols, betaIndex);
           if (betaIndex < 0)
             continue;
           for (int beta2 = 0; beta2 < numKnots; beta2++) {
             Integer betaIndex2 = gamCoeffIndices[gamColInd][beta2]; // for multinomial
             if (activeCols != null)
-              betaIndex2 = ArrayUtils.indexOfSorted(activeCols, betaIndex2);
+              betaIndex2 = ArrayUtils.find(activeCols, betaIndex2);
             if (betaIndex2 < 0)
               continue;
             gramGLM[betaIndex][betaIndex2] += penalty_mat[gamColInd][beta1][beta2] + penalty_mat[gamColInd][beta2][beta1];

--- a/h2o-algos/src/test/java/hex/gam/GamTestPiping.java
+++ b/h2o-algos/src/test/java/hex/gam/GamTestPiping.java
@@ -503,13 +503,13 @@ public class GamTestPiping extends TestUtil {
         for (int beta1 = 0; beta1 < numKnots; beta1++) {
           Integer betaIndex = gamCoeffIndices[gamColInd][beta1]; // for multinomial
           if (activeCols != null)
-            betaIndex = ArrayUtils.indexOf(activeCols, betaIndex);
+            betaIndex = ArrayUtils.indexOfSorted(activeCols, betaIndex);
           if (betaIndex < 0)
             continue;
           for (int beta2 = 0; beta2 < numKnots; beta2++) {
             Integer betaIndex2 = gamCoeffIndices[gamColInd][beta2]; // for multinomial
             if (activeCols != null)
-              betaIndex2 = ArrayUtils.indexOf(activeCols, betaIndex2);
+              betaIndex2 = ArrayUtils.indexOfSorted(activeCols, betaIndex2);
             if (betaIndex2 < 0)
               continue;
             gramGLM[betaIndex][betaIndex2] += penalty_mat[gamColInd][beta1][beta2] + penalty_mat[gamColInd][beta2][beta1];

--- a/h2o-algos/src/test/java/hex/tree/FriedmanPopescusHTest.java
+++ b/h2o-algos/src/test/java/hex/tree/FriedmanPopescusHTest.java
@@ -1221,7 +1221,7 @@ public class FriedmanPopescusHTest extends TestUtil {
 
         SharedTreeGraph tree = createSharedTreeGraphForTest();
 
-        Vec result = FriedmanPopescusH.partialDependenceTree(tree.subgraphArray.get(0), new Integer[] {0,1,2}, 0.1, frame);
+        Vec result = FriedmanPopescusH.partialDependenceTree(tree.subgraphArray.get(0), new int[] {0,1,2}, 0.1, frame);
         scope.track(result);
         assertEquals(result.length(), res.length);
         for (int i = 0; i < res.length; i++) {
@@ -1247,7 +1247,7 @@ public class FriedmanPopescusHTest extends TestUtil {
         
         Frame frame1 = new Frame();
         frame1.add(new String[] {"feature0", "feature2"}, new Vec[] {frame.vec(0), frame.vec(2)});
-        result = FriedmanPopescusH.partialDependenceTree(tree.subgraphArray.get(0), new Integer[] {0,2}, 0.1, frame1);
+        result = FriedmanPopescusH.partialDependenceTree(tree.subgraphArray.get(0), new int[] {0,2}, 0.1, frame1);
         scope.track(result);
         assertEquals(result.length(), res.length);
         for (int i = 0; i < res.length; i++) {
@@ -1272,7 +1272,7 @@ public class FriedmanPopescusHTest extends TestUtil {
         
         Frame frame2 = new Frame();
         frame2.add(new String[] {"feature0", "feature1"}, new Vec[] {frame.vec(0), frame.vec(1)});
-        result = FriedmanPopescusH.partialDependenceTree(tree.subgraphArray.get(0), new Integer[] {0,1}, 0.1, frame2);
+        result = FriedmanPopescusH.partialDependenceTree(tree.subgraphArray.get(0), new int[] {0,1}, 0.1, frame2);
         scope.track(result);
         assertEquals(result.length(), res.length);
         for (int i = 0; i < res.length; i++) {
@@ -1385,7 +1385,7 @@ public class FriedmanPopescusHTest extends TestUtil {
                 -1.382180013617986813e-02, 3.244345671239585310e-02, -9.702081839312389107e-04, -1.382180013617986813e-02, -1.382180013617986813e-02, 3.244345671239585310e-02,
                 -1.382180013617986813e-02, -1.382180013617986813e-02, -1.382180013617986813e-02, -9.702081839312389107e-04, 1.615156143003408304e-02, 6.192571362039934330e-02,
                 -1.382180013617986813e-02};
-        checkFValues(new Integer[] {0,1}, frame, new String[]{"feature0", "feature1"}, 4, sharedTreeSubgraphs, params._learn_rate, expectedResult);
+        checkFValues(new int[] {0,1}, frame, new String[]{"feature0", "feature1"}, 4, sharedTreeSubgraphs, params._learn_rate, expectedResult);
         
         expectedResult = new double[] {4.768910591425756795e-03, 4.768910591425756795e-03, 4.768910591425756795e-03, 4.768910591425756795e-03, 4.768910591425756795e-03,
                 -2.188878791803407567e-02, 4.768910591425756795e-03, 4.768910591425756795e-03, -2.188878791803407567e-02, 4.768910591425756795e-03, 4.768910591425756795e-03,
@@ -1405,7 +1405,7 @@ public class FriedmanPopescusHTest extends TestUtil {
                 7.798772619952633323e-02,
 
         };
-        checkFValues(new Integer[] {1,2}, frame, new String[]{"feature1", "feature2"}, 4, sharedTreeSubgraphs, params._learn_rate, expectedResult);
+        checkFValues(new int[] {1,2}, frame, new String[]{"feature1", "feature2"}, 4, sharedTreeSubgraphs, params._learn_rate, expectedResult);
         
         expectedResult = new double[] {-2.188878791803407567e-02, -6.741245150466762537e-02, 4.768910591425757663e-03, 3.297972219392274890e-02, -2.188878791803407567e-02,
                 3.297972219392274890e-02, -2.188878791803407567e-02, 4.768910591425757663e-03, -6.741245150466762537e-02, -6.741245150466762537e-02, -2.188878791803407567e-02,
@@ -1424,7 +1424,7 @@ public class FriedmanPopescusHTest extends TestUtil {
                 -2.188878791803407567e-02, 4.768910591425757663e-03, 4.768910591425757663e-03, 3.297972219392274890e-02, 2.213861966073389642e-02, 1.334595684654562298e-01,
                 -2.188878791803407567e-02,
         };
-        checkFValues(new Integer[] {0,1,2}, frame, frame.names(), 5,  sharedTreeSubgraphs, params._learn_rate, expectedResult);
+        checkFValues(new int[] {0,1,2}, frame, frame.names(), 5,  sharedTreeSubgraphs, params._learn_rate, expectedResult);
         
         expectedResult = new double[] {-1.600119057756334978e-02, -1.600119057756334978e-02, -1.600119057756334978e-02, -1.600119057756334978e-02, -1.600119057756334978e-02,
                 -1.600119057756334978e-02, -1.600119057756334978e-02, -1.600119057756334978e-02, -1.600119057756334978e-02, -1.600119057756334978e-02, -1.600119057756334978e-02,
@@ -1442,7 +1442,7 @@ public class FriedmanPopescusHTest extends TestUtil {
                 3.447581725787000895e-02, 3.447581725787000895e-02, 3.447581725787000895e-02, 3.447581725787000895e-02, 3.447581725787000895e-02, 3.447581725787000895e-02, 
                 3.447581725787000895e-02, 3.447581725787000895e-02, 3.447581725787000895e-02, 3.447581725787000895e-02, 3.447581725787000895e-02, 3.447581725787000895e-02, 
                 3.447581725787000895e-02};
-        checkFValues(new Integer[] {1}, frame, new String[]{"feature1"}, 3,  sharedTreeSubgraphs, params._learn_rate, expectedResult);
+        checkFValues(new int[] {1}, frame, new String[]{"feature1"}, 3,  sharedTreeSubgraphs, params._learn_rate, expectedResult);
         
         double h = FriedmanPopescusH.h(frame, new String[] {"feature0","feature1","feature2"}, params._learn_rate, sharedTreeSubgraphs);
         assertEquals(h, 0.08603547308125703, 1e-8);
@@ -1456,7 +1456,7 @@ public class FriedmanPopescusHTest extends TestUtil {
         assertEquals(h, 0.2508738347652033, 1e-8);
     }
     
-    void checkFValues(Integer[] modelIds, Frame filteredFrame, String[] cols, int expectedNumCols, SharedTreeSubgraph[][] sharedTreeSubgraphs, double learn_rate, double[] result) {
+    void checkFValues(int[] modelIds, Frame filteredFrame, String[] cols, int expectedNumCols, SharedTreeSubgraph[][] sharedTreeSubgraphs, double learn_rate, double[] result) {
         Frame res = FriedmanPopescusH.computeFValues(modelIds, filteredFrame, cols, learn_rate, sharedTreeSubgraphs);
         scope.track(res);
         assertEquals(res.numCols(),expectedNumCols);
@@ -1519,13 +1519,13 @@ public class FriedmanPopescusHTest extends TestUtil {
                 0.000000000000000000e+00, 0.000000000000000000e+00, 0.000000000000000000e+00, 0.000000000000000000e+00, 0.000000000000000000e+00, 0.000000000000000000e+00,
                 0.000000000000000000e+00, 0.000000000000000000e+00, 0.000000000000000000e+00, 0.000000000000000000e+00, 0.000000000000000000e+00, 0.000000000000000000e+00,
                 0.000000000000000000e+00, 0.000000000000000000e+00, 0.000000000000000000e+00, 0.000000000000000000e+00, 0.000000000000000000e+00, 0.000000000000000000e+00};
-        checkFValues(new Integer[] {0}, frame, new String[]{"sepal_len"}, 3, sharedTreeSubgraphs, params._learn_rate, expectedResult);
+        checkFValues(new int[] {0}, frame, new String[]{"sepal_len"}, 3, sharedTreeSubgraphs, params._learn_rate, expectedResult);
 
         expectedResult = new double[] {-1.598199002489364418e-05, -1.598199002489364418e-05, -1.598199002489364418e-05, -1.598199002489364418e-05, -1.598199002489364418e-05,
                 -1.598199002489364418e-05, -1.598199002489364418e-05, -1.598199002489364418e-05, 7.292752730092555424e-06, 7.292752730092555424e-06, 7.292752730092555424e-06,
                 7.292752730092555424e-06, 7.292752730092555424e-06, 7.292752729981533122e-06, 7.292752729981533122e-06, 7.292752729981533122e-06, 7.292752729981533122e-06,
                 7.292752729981533122e-06, 7.292752729981533122e-06, 7.292752729981533122e-06, 7.292752729981533122e-06, 7.292752729981533122e-06, 7.292752729981533122e-06};
-        checkFValues(new Integer[] {1}, frame, new String[]{"sepal_wid"}, 3, sharedTreeSubgraphs, params._learn_rate, expectedResult);
+        checkFValues(new int[] {1}, frame, new String[]{"sepal_wid"}, 3, sharedTreeSubgraphs, params._learn_rate, expectedResult);
         
         expectedResult = new double[] {1.860171545473183308e+00, 1.860171545473183308e+00, 1.860171545473183308e+00, 1.860171545473183308e+00, 1.860171545473183308e+00, 1.860171545473183308e+00,
                 1.860171545473183308e+00, 1.860171545473183308e+00, 1.860171545473183308e+00, -9.284181247164067230e-01, -9.284181247164067230e-01, -9.284181247164067230e-01,
@@ -1535,13 +1535,13 @@ public class FriedmanPopescusHTest extends TestUtil {
                 -9.309887451596334795e-01, -9.309887451596334795e-01, -9.309887451596334795e-01, -9.309887451596334795e-01, -9.309887451596334795e-01, -9.309887451596334795e-01,
                 -9.309887451596334795e-01, -9.309887451596334795e-01, -9.309887451596334795e-01, -9.309887451596334795e-01, -9.309887451596334795e-01, -9.309887451596334795e-01,
                 -9.309887451596334795e-01};
-        checkFValues(new Integer[] {2}, frame, new String[]{"petal_len"}, 3, sharedTreeSubgraphs, params._learn_rate, expectedResult);
+        checkFValues(new int[] {2}, frame, new String[]{"petal_len"}, 3, sharedTreeSubgraphs, params._learn_rate, expectedResult);
 
         expectedResult = new double[] {1.998372945075835405e+00, 1.998372945075835405e+00, 1.998372945075835405e+00, 1.998372945075835405e+00, 1.998372945075835405e+00, 1.998372945075835405e+00,
                 -1.001627054924164151e+00, -1.001627054924164151e+00, -1.001627054924164151e+00, -1.001627054924164151e+00, -1.001627054924164151e+00, -1.001627054924164151e+00,
                 -1.001627054924164151e+00, -1.011312200166400332e+00, -9.959003477696179996e-01, -9.959003477696179996e-01, -9.959003477696179996e-01, -9.959003477696179996e-01,
                 -9.959003477696179996e-01, -9.959003477696179996e-01, -9.959003477696179996e-01, -9.959003477696179996e-01};
-        checkFValues(new Integer[] {3}, frame, new String[]{"petal_wid"}, 3, sharedTreeSubgraphs, params._learn_rate, expectedResult);
+        checkFValues(new int[] {3}, frame, new String[]{"petal_wid"}, 3, sharedTreeSubgraphs, params._learn_rate, expectedResult);
         
         expectedResult = new double[] {7.292752729981533122e-06, 7.292752729981533122e-06, 7.292752729981533122e-06, 7.292752729981533122e-06, -1.598199002500466648e-05, 7.292752729981533122e-06,
                 7.292752729981533122e-06, 7.292752729981533122e-06, 7.292752729981533122e-06, 7.292752729981533122e-06, 7.292752729981533122e-06, 7.292752729981533122e-06,
@@ -1563,7 +1563,7 @@ public class FriedmanPopescusHTest extends TestUtil {
                 7.292752730092555424e-06, 7.292752730092555424e-06, 7.292752729981533122e-06, 7.292752729981533122e-06, 7.292752729981533122e-06, 7.292752729981533122e-06,
                 7.292752729981533122e-06, -1.598199002500466648e-05, 7.292752729981533122e-06, -1.598199002500466648e-05, -1.598199002500466648e-05, 7.292752729981533122e-06, 
                 7.292752729981533122e-06, 7.292752729981533122e-06};
-        checkFValues(new Integer[] {0, 1}, frame, new String[]{"sepal_len", "sepal_wid"}, 4,  sharedTreeSubgraphs, params._learn_rate, expectedResult);
+        checkFValues(new int[] {0, 1}, frame, new String[]{"sepal_len", "sepal_wid"}, 4,  sharedTreeSubgraphs, params._learn_rate, expectedResult);
         
         expectedResult = new double[] {1.860171545473183308e+00, 1.860171545473183308e+00, 1.860171545473183308e+00, 1.860171545473183308e+00, 1.860171545473183308e+00, 1.860171545473183308e+00,
                 1.860171545473183308e+00, 1.860171545473183308e+00, 1.860171545473183308e+00, 1.860171545473183308e+00, 1.860171545473183308e+00, 1.860171545473183308e+00,
@@ -1586,7 +1586,7 @@ public class FriedmanPopescusHTest extends TestUtil {
                 -9.350317669621380778e-01, -9.309887451596335906e-01, -9.309887451596335906e-01, -9.284181247164066120e-01, -9.309887451596335906e-01, -9.309887451596335906e-01,
                 -9.309887451596335906e-01, -9.309887451596335906e-01, -9.309887451596335906e-01, -9.309887451596335906e-01, -9.309887451596335906e-01, -9.309887451596335906e-01,
                 -9.309887451596335906e-01, -9.309887451596335906e-01, -9.309887451596335906e-01};
-        checkFValues(new Integer[] {0, 2}, frame, new String[]{"sepal_len", "petal_len"}, 4, sharedTreeSubgraphs, params._learn_rate, expectedResult);
+        checkFValues(new int[] {0, 2}, frame, new String[]{"sepal_len", "petal_len"}, 4, sharedTreeSubgraphs, params._learn_rate, expectedResult);
         
         expectedResult = new double[] {-9.284242856777238373e-01, -9.284242856777238373e-01, -9.284242856777238373e-01, -9.350379279234550811e-01, 1.860165384511866193e+00,
                 -9.284242856777238373e-01, -9.284242856777238373e-01, -9.284242856777238373e-01, -9.284242856777238373e-01, -9.284242856777238373e-01, -9.284242856777238373e-01,
@@ -1609,7 +1609,7 @@ public class FriedmanPopescusHTest extends TestUtil {
                 1.860165384511866193e+00, -9.309435647766381994e-01, 1.860165384511866193e+00, 1.860165384511866193e+00, 1.860165384511866193e+00, 1.860165384511866193e+00,
                 1.860165384511866193e+00, -9.309435647766381994e-01, -9.309435647766381994e-01, 1.860165384511866193e+00, 1.860165384511866193e+00, 1.860165384511866193e+00,
                 1.860165384511866193e+00, 1.860165384511866193e+00, 1.860165384511866193e+00};
-        checkFValues(new Integer[] {1, 2}, frame, new String[]{"sepal_wid", "petal_len"}, 4, sharedTreeSubgraphs, params._learn_rate, expectedResult);
+        checkFValues(new int[] {1, 2}, frame, new String[]{"sepal_wid", "petal_len"}, 4, sharedTreeSubgraphs, params._learn_rate, expectedResult);
         
         expectedResult = new double[] {3.860171545473182864e+00, 3.860171545473182864e+00, 3.860171545473182864e+00, 3.860171545473182864e+00, 3.860171545473182864e+00,
                 3.860171545473182864e+00, 3.860171545473182864e+00, 3.860171545473182864e+00, 3.860171545473182864e+00, 3.860171545473182864e+00, 3.860171545473182864e+00,
@@ -1636,7 +1636,7 @@ public class FriedmanPopescusHTest extends TestUtil {
                 -1.929110513867624555e+00, -1.928199081351590571e+00, -1.928199081351590571e+00, -1.928459326023855169e+00, -1.928199081351590571e+00, -1.942961105380160980e+00,
                 -1.928199081351590571e+00, -1.928199081351590571e+00, -1.928199081351590571e+00, -1.928199081351590571e+00, -1.928199081351590571e+00, -1.928199081351590571e+00,
                 -1.928199081351590571e+00, -1.928199081351590571e+00, -1.928199081351590571e+00, -1.928199081351590571e+00};
-        checkFValues(new Integer[] {0, 1, 2, 3}, frame, new String[]{"sepal_len","sepal_wid","petal_len","petal_wid"}, 6, sharedTreeSubgraphs, params._learn_rate, expectedResult);
+        checkFValues(new int[] {0, 1, 2, 3}, frame, new String[]{"sepal_len","sepal_wid","petal_len","petal_wid"}, 6, sharedTreeSubgraphs, params._learn_rate, expectedResult);
         
         double h = FriedmanPopescusH.h(frame, new String[] {"sepal_len","sepal_wid","petal_len","petal_wid"}, params._learn_rate, sharedTreeSubgraphs);
         assertEquals(1.7358501914626407e-16, h , 1e-15);

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -109,7 +109,7 @@ public class ArrayUtils {
    * @param <T>: data type
    * @return index of element val or -1 if not found
    */
-  public static<T extends Comparable<T>> int indexOf(T[] arr, T val) {
+  public static<T extends Comparable<T>> int indexOfSorted(T[] arr, T val) {
     int highIndex = arr.length-1;
     int compare0 = val.compareTo(arr[0]); // small shortcut
     if (compare0 == 0)

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -101,44 +101,6 @@ public class ArrayUtils {
     return result;
   }
 
-  /***
-   * Find the index of an element val in the sorted array arr.
-   * 
-   * @param arr: sorted array
-   * @param val: value of element we are interested in
-   * @param <T>: data type
-   * @return index of element val or -1 if not found
-   */
-  public static<T extends Comparable<T>> int indexOfSorted(T[] arr, T val) {
-    int highIndex = arr.length-1;
-    int compare0 = val.compareTo(arr[0]); // small shortcut
-    if (compare0 == 0)
-      return 0;
-    int compareLast = val.compareTo(arr[highIndex]);
-    if (compareLast==0)
-      return highIndex;
-    if (val.compareTo(arr[0])<0 || val.compareTo(arr[highIndex])>0) // end shortcut
-      return -1;
-    
-    int count = 0;
-    int numBins = arr.length;
-    int lowIndex = 0;
-
-    while (count < numBins) {
-      int tryBin = (int) Math.floor((highIndex+lowIndex)*0.5);
-      double compareVal = val.compareTo(arr[tryBin]);
-      if (compareVal==0)
-        return tryBin;
-      else if (compareVal>0)
-        lowIndex = tryBin;
-      else
-        highIndex = tryBin;
-
-      count++;
-    }
-    return -1;
-  }
-  
   // return the sqrt of each element of the array.  Will overwrite the original array in this case
   public static double[] sqrtArr(double [] x){
     assert (x != null);


### PR DESCRIPTION
This PR removes method ArrayUtils#indexOf - this method was responsible for 2 bugs:

- https://github.com/h2oai/h2o-3/pull/5929/files#diff-97ab26585a59e421d722a6ddd915c83f9253545352911b44b43e210a0b459590L405
- and the one in H-statistic in this PR

The issue is that the general contract of `indexOf` is to not have any assumptions about the input being sorted.
However, our version does require a sorted method and hence creates confusion and when used on unsorted
data produces bugs (like the 2 above).

In this PR I completely removed the method in favor of `Arrays.binarySearch` and in H-statistic ArrayUtils#find (the input was not sorted)