### PR TITLE
Remove constructor only used in tests [nocheck]

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/DHistogram.java
+++ b/h2o-algos/src/main/java/hex/tree/DHistogram.java
@@ -181,75 +181,7 @@ public final class DHistogram extends Iced<DHistogram> {
       super("column=" + name + " leads to invalid histogram(check numeric range) -> [max=" + maxEx + ", min = " + min + "], step= " + step + ", xbin= " + xbins);
     }
   }
-
-  DHistogram(String name, final int nbins, int nbins_cats, byte isInt, double min, double maxEx, boolean intOpt, boolean initNA,
-             double minSplitImprovement, SharedTreeModel.SharedTreeParameters.HistogramType histogramType, long seed, Key globalQuantilesKey,
-             Constraints cs, boolean checkFloatSplits) {
-    assert nbins >= 1;
-    assert nbins_cats >= 1;
-    assert maxEx > min : "Caller ensures "+maxEx+">"+min+", since if max==min== the column "+name+" is all constants";
-    if (cs != null) {
-      _pred1 = cs._min;
-      _pred2 = cs._max;
-      if (!cs.needsGammaDenom() && !cs.needsGammaNom()) {
-        _vals_dim = Double.isNaN(_pred1) && Double.isNaN(_pred2) ? 3 : 5;
-        _dist = cs._dist;
-      } else if (!cs.needsGammaNom()) {
-        _vals_dim = 6;
-        _dist = cs._dist;
-      } else {
-        _vals_dim = 7;
-        _dist = cs._dist;
-      }
-    } else {
-      _pred1 = Double.NaN;
-      _pred2 = Double.NaN;
-      _vals_dim = 3;
-      _dist = null;
-    }
-    _isInt = isInt;
-    _name = name;
-    _min = min;
-    _minInt = (int) min;
-    _maxEx = maxEx;             // Set Exclusive max
-    _min2 = Double.MAX_VALUE;   // Set min/max to outer bounds
-    _maxIn= -Double.MAX_VALUE;
-    _intOpt = intOpt;
-    _initNA = initNA;
-    _minSplitImprovement = minSplitImprovement;
-    _histoType = histogramType;
-    _useUplift = false;
-    _upliftMetric = null;
-    _seed = seed;
-    while (_histoType == HistogramType.RoundRobin) {
-      HistogramType[] h = HistogramType.values();
-      _histoType = h[(int)Math.abs(seed++ % h.length)];
-    }
-    if (_histoType== HistogramType.AUTO)
-      _histoType= HistogramType.UniformAdaptive;
-    assert(_histoType!= HistogramType.RoundRobin);
-    _globalQuantilesKey = globalQuantilesKey;
-    // See if we can show there are fewer unique elements than nbins.
-    // Common for e.g. boolean columns, or near leaves.
-    int xbins = isInt == 2 ? nbins_cats : nbins;
-    if (isInt > 0 && maxEx - min <= xbins) {
-      assert ((long) min) == min : "Overflow for integer/categorical histogram: minimum value cannot be cast to long without loss: (long)" + min + " != " + min + "!";                // No overflow
-      xbins = (char) ((long) maxEx - (long) min);  // Shrink bins
-      _step = 1.0f;                           // Fixed step size
-    } else {
-      _step = xbins / (maxEx - min);              // Step size for linear interpolation, using mul instead of div
-      if(_step <= 0 || Double.isInfinite(_step) || Double.isNaN(_step))
-        throw new StepOutOfRangeException(name,_step, xbins, maxEx, min);
-    }
-    _nbin = (char) xbins;
-    assert(_nbin>0);
-    assert(_vals == null);
-    _checkFloatSplits = checkFloatSplits;
-
-    if (LOG.isTraceEnabled()) LOG.trace("Histogram: " + this);
-    // Do not allocate the big arrays here; wait for scoreCols to pick which cols will be used.
-  }
-
+  
   DHistogram(String name, final int nbins, int nbins_cats, byte isInt, double min, double maxEx, boolean intOpt, boolean initNA,
              double minSplitImprovement, SharedTreeModel.SharedTreeParameters.HistogramType histogramType, long seed, Key globalQuantilesKey,
              Constraints cs, boolean checkFloatSplits, boolean useUplift, UpliftDRFModel.UpliftDRFParameters.UpliftMetricType upliftMetricType) {

--- a/h2o-algos/src/test/java/hex/tree/DHistogramTest.java
+++ b/h2o-algos/src/test/java/hex/tree/DHistogramTest.java
@@ -1,6 +1,5 @@
 package hex.tree;
 
-import hex.tree.uplift.UpliftDRF;
 import hex.tree.uplift.UpliftDRFModel;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -42,7 +41,7 @@ public class DHistogramTest extends TestUtil {
       Scope.track_generic(hq);
 
       DHistogram histo = new DHistogram("test", 20, 1024, (byte) 1, -1, 2, false, false, -0.001,
-              SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesGlobal, 42L, hq._key, null, false);
+              SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesGlobal, 42L, hq._key, null, false, false, null);
       histo.init();
 
       // check that -0.0 was converted to 0.0 by the init method
@@ -64,7 +63,7 @@ public class DHistogramTest extends TestUtil {
       Scope.track_generic(hq);
 
       DHistogram histo = new DHistogram("test", 20, 1024, (byte) 1, -1, 2, false, false, -0.001,
-              SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesGlobal, 42L, hq._key, null, false);
+              SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesGlobal, 42L, hq._key, null, false, false, null);
       histo.init();
 
       // check that negative zero can be found
@@ -91,7 +90,7 @@ public class DHistogramTest extends TestUtil {
       values[values.length - 1] = maxEx - 1e-8;
 
       DHistogram histoRand = new DHistogram("rand", 20, 1024, (byte) 0, min, maxEx, false, false, -0.001,
-              SharedTreeModel.SharedTreeParameters.HistogramType.Random, 42L, null, null, false);
+              SharedTreeModel.SharedTreeParameters.HistogramType.Random, 42L, null, null, false, false, null);
       histoRand.init();
 
       // project the random split points into regular space (original values of the column)
@@ -104,7 +103,7 @@ public class DHistogramTest extends TestUtil {
       DKV.put(hq);
       Scope.track_generic(hq);
       DHistogram histoQuant = new DHistogram("quant", 20, 1024, (byte) 0, min, maxEx, false, false, -0.001,
-              SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesGlobal, 42L, hq._key, null, false);
+              SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesGlobal, 42L, hq._key, null, false, false, null);
       histoQuant.init();
 
       int[] bins_rand = new int[values.length];
@@ -122,7 +121,7 @@ public class DHistogramTest extends TestUtil {
   @Test
   public void testExtractData_double() {
     DHistogram histo = new DHistogram("test", 20, 1024, (byte) 1, -1, 2, false, false, -0.001,
-            SharedTreeModel.SharedTreeParameters.HistogramType.AUTO, 42L, null, null, false);
+            SharedTreeModel.SharedTreeParameters.HistogramType.AUTO, 42L, null, null, false, false, null);
     histo.init();
 
     // init with c1
@@ -148,7 +147,7 @@ public class DHistogramTest extends TestUtil {
   @Test
   public void testExtractData_int() {
     DHistogram histo = new DHistogram("test", 20, 1024, (byte) 1, -1, 2, true, false, -0.001,
-            SharedTreeModel.SharedTreeParameters.HistogramType.AUTO, 42L, null, null, false);
+            SharedTreeModel.SharedTreeParameters.HistogramType.AUTO, 42L, null, null, false, false, null);
     histo.init();
 
     // init with c1
@@ -189,14 +188,14 @@ public class DHistogramTest extends TestUtil {
 
     // optimization enabled
     DHistogram histoOpt = new DHistogram("intOpt-on", 1000, 1024, (byte) 1, 0, 1000, true, false, -0.001,
-            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, false);
+            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, false, false, null);
     histoOpt.init();
 
     histoOpt.updateHisto(weights, null, dataInt, ys, null, rows, N, 0, null);
 
     // optimization OFF
     DHistogram histo = new DHistogram("intOpt-off", 1000, 1024, (byte) 1, 0, 1000, false, false, -0.001,
-            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, false);
+            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, false, false, null);
     histo.init();
 
     histo.updateHisto(weights, null, data, ys, null, rows, N, 0, null);
@@ -262,6 +261,9 @@ public class DHistogramTest extends TestUtil {
   }
 
   private static class TreeParameters extends SharedTreeModel.SharedTreeParameters {
+    public TreeParameters() {
+    }
+
     @Override
     public String algoName() {
       return null;

--- a/h2o-algos/src/test/java/hex/tree/DTreeSplitTest.java
+++ b/h2o-algos/src/test/java/hex/tree/DTreeSplitTest.java
@@ -44,7 +44,7 @@ public class DTreeSplitTest {
         double max = ArrayUtils.maxValue(data);
         double maxEx = DHistogram.find_maxEx(max, 0);
         DHistogram histo = new DHistogram("histo" + nbins, nbins, 2, (byte) 0, min, maxEx, false, false, 0,
-                SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, checkFloatSplits);
+                SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, checkFloatSplits, false, null);
         histo.init();
         histo.updateHisto(
                 ArrayUtils.constAry(data.length, 1.0), 

--- a/h2o-algos/src/test/java/hex/tree/DTreeTest.java
+++ b/h2o-algos/src/test/java/hex/tree/DTreeTest.java
@@ -18,7 +18,7 @@ public class DTreeTest {
     int[] rows  = new int[]   {0,          1,          2,   3  };
 
     DHistogram hs = new DHistogram("test_hs", 2, 2, (byte) 0, 0, 2, false, true, 0.01,
-            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 123, null, null, false);
+            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 123, null, null, false, false, null);
     hs.init();
     hs.updateHisto(ws, null, cs, ys, null, rows, rows.length, 0, null);
 
@@ -32,7 +32,7 @@ public class DTreeTest {
 
     // 3. allow negative (!!!) split improvement, min_rows = #NAs + 1
     DHistogram hsN = new DHistogram("test_hs", 2, 2, (byte) 0, 0, 2, false, true, -9,
-            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 123, null, null, false);
+            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 123, null, null, false, false, null);
     hsN.init();
     hsN.updateHisto(ws, null, cs, ys, null, rows, rows.length, 0, null);
     DTree.Split s3 = DTree.findBestSplitPoint(hsN, 0, 21, 0, Double.NaN, Double.NaN, false, null);
@@ -75,7 +75,7 @@ public class DTreeTest {
     assertEquals(min_pred, c._min, 0);
     assertEquals(max_pred, c._max, 0);
     return new DHistogram("test_hs", nbins, 2, (byte) 0, 0, 10, false, false, 0.01,
-            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 123, null, c, false);
+            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 123, null, c, false, false, null);
   }
   
   private static ExpectedSplitInfo updateHisto(DHistogram hs, final double min_pred, final double max_pred, double na_percent) {

--- a/h2o-algos/src/test/java/hex/tree/HistogramTest.java
+++ b/h2o-algos/src/test/java/hex/tree/HistogramTest.java
@@ -126,7 +126,7 @@ public class HistogramTest extends TestUtil {
       }
       DHistogram.HistoQuantiles hq = new DHistogram.HistoQuantiles(Key.make(), splitPts);
       DKV.put(hq);
-      DHistogram hist = new DHistogram("myhisto",nbins,nbins_cats,isInt,min,maxEx,false,false,0,histoType,seed,hq._key,null, false);
+      DHistogram hist = new DHistogram("myhisto",nbins,nbins_cats,isInt,min,maxEx,false,false,0,histoType,seed,hq._key,null, false, false, null);
       hist.init();
       int N=10000000;
       int bin=-1;
@@ -163,7 +163,7 @@ public class HistogramTest extends TestUtil {
     double maxEx = 6.900000000000001;
     long seed = 1234;
     SharedTreeModel.SharedTreeParameters.HistogramType histoType = SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive;
-    DHistogram hist = new DHistogram("myhisto", nbins, nbins_cats, isInt, min, maxEx, false,false, 0, histoType, seed, null, null, false);
+    DHistogram hist = new DHistogram("myhisto", nbins, nbins_cats, isInt, min, maxEx, false,false, 0, histoType, seed, null, null, false, false, null);
     hist.init();
     assert(hist.binAt(0)==min);
     assert(hist.binAt(nbins-1)<maxEx);
@@ -179,7 +179,7 @@ public class HistogramTest extends TestUtil {
     double maxEx = 6.900000000000001;
     long seed = 1234;
     SharedTreeModel.SharedTreeParameters.HistogramType histoType = SharedTreeModel.SharedTreeParameters.HistogramType.Random;
-    DHistogram hist = new DHistogram("myhisto", nbins, nbins_cats, isInt, min, maxEx, false, false,0, histoType, seed, null, null, false);
+    DHistogram hist = new DHistogram("myhisto", nbins, nbins_cats, isInt, min, maxEx, false, false,0, histoType, seed, null, null, false, false, null);
     hist.init();
     assert(hist.binAt(0)==min);
     assert(hist.binAt(nbins-1)<maxEx);
@@ -196,15 +196,15 @@ public class HistogramTest extends TestUtil {
     long seed = 1234;
     SharedTreeModel.SharedTreeParameters.HistogramType histoType = SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesGlobal;
     double[] splitPts = new double[]{1,1.5,2,2.5,3,4,5,6.1,6.2,6.3,6.7,6.8,6.85};
-    Key k = Key.make();
+    Key<DHistogram.HistoQuantiles> k = Key.make();
     DKV.put(new DHistogram.HistoQuantiles(k,splitPts));
-    DHistogram hist = new DHistogram("myhisto",nbins,nbins_cats,isInt,min,maxEx,false,false,0,histoType,seed,k,null, false);
+    DHistogram hist = new DHistogram("myhisto",nbins,nbins_cats,isInt,min,maxEx,false,false,0,histoType,seed,k,null, false, false, null);
     hist.init();
     assert(hist.binAt(0)==min);
     assert(hist.binAt(nbins-1)<maxEx);
     assert(hist.bin(min) == 0);
     assert(hist.bin(maxEx-1e-15) == nbins-1);
-    k.remove();
+    Keyed.remove(k);
   }
 
   @Test public void testShrinking() {


### PR DESCRIPTION
This constructor was only used in JUnit tests - the Uplift-aware copy of the constructor was thus not tested at all in these tests.

This PR makes sure the constructor used in production code is actually tested.