### PR TITLE
PUBDEV-8451: Added change log to user guide

### DIFF
--- a/h2o-docs/src/product/index.rst
+++ b/h2o-docs/src/product/index.rst
@@ -16,7 +16,7 @@ Additional Resources:
 - See how are customers are using H2O at https://www.h2o.ai/customers/.
 - Keep up to date with the latest H2O blogs at https://www.h2o.ai/blog/.
 - Review projects, applications, research papers, tutorials, courses, and books that use H2O at https://github.com/h2oai/awesome-h2o.
-- `Change log <https://github.com/h2oai/h2o-3/blob/master/Changes.md>`__
+- `Change Log <https://github.com/h2oai/h2o-3/blob/master/Changes.md>`__
 
 .. toctree::
    :maxdepth: 2

--- a/h2o-docs/src/product/index.rst
+++ b/h2o-docs/src/product/index.rst
@@ -16,6 +16,7 @@ Additional Resources:
 - See how are customers are using H2O at https://www.h2o.ai/customers/.
 - Keep up to date with the latest H2O blogs at https://www.h2o.ai/blog/.
 - Review projects, applications, research papers, tutorials, courses, and books that use H2O at https://github.com/h2oai/awesome-h2o.
+- `Change log <https://github.com/h2oai/h2o-3/blob/master/Changes.md>`__
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
For: [PUBDEV-8451](https://h2oai.atlassian.net/browse/PUBDEV-8451)

I placed the link on the index page under the "Additional Resources" section.

I currently have the link titled as "Change Log", but would you rather me title the link as "Release Notes"?