### PR TITLE
PUBDEV-8420: AutoML & Grids, rethink+improve exception handling

### DIFF
--- a/h2o-algos/src/test/java/hex/grid/GridTest.java
+++ b/h2o-algos/src/test/java/hex/grid/GridTest.java
@@ -14,6 +14,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import water.*;
+import water.exceptions.H2OGridException;
 import water.fvec.Frame;
 import water.fvec.Vec;
 import water.parser.BufferedString;
@@ -68,16 +69,16 @@ public class GridTest extends TestUtil {
       searchCriteria.set_max_runtime_secs(1d);
 
       Job<Grid> gridSearch = GridSearch.startGridSearch(
-          null, params, hyperParms,
-            new GridSearch.SimpleParametersBuilderFactory(),
-            searchCriteria, 2
+              null, params, hyperParms,
+              new GridSearch.SimpleParametersBuilderFactory(),
+              searchCriteria, 2
       );
 
       Scope.track_generic(gridSearch);
       final Grid grid = gridSearch.get();
       Scope.track_generic(grid);
 
-     assertNotEquals(ntreesArr.length * maxDepthArr.length, grid.getModelCount());
+      assertNotEquals(ntreesArr.length * maxDepthArr.length, grid.getModelCount());
     } finally {
       Scope.exit();
     }
@@ -105,11 +106,11 @@ public class GridTest extends TestUtil {
       params._response_column = "IsDepDelayed";
       params._seed = 42;
 
-      Job<Grid> gridSearch = GridSearch.startGridSearch(           
-          dest, params, hyperParms,
-          new GridSearch.SimpleParametersBuilderFactory(),
-          new HyperSpaceSearchCriteria.CartesianSearchCriteria(), 
-          2
+      Job<Grid> gridSearch = GridSearch.startGridSearch(
+              dest, params, hyperParms,
+              new GridSearch.SimpleParametersBuilderFactory(),
+              new HyperSpaceSearchCriteria.CartesianSearchCriteria(),
+              2
       );
       Scope.track_generic(gridSearch);
       gridSearch.stop();
@@ -122,11 +123,11 @@ public class GridTest extends TestUtil {
 
       final Grid grid = DKV.getGet(dest);
       Scope.track_generic(grid);
-      
-      for(Model m : grid.getModels()){
+
+      for (Model m : grid.getModels()) {
         Scope.track_generic(m);
       }
-    
+
       assertNotEquals(ntreesArr.length * maxDepthArr.length, grid.getModelCount());
 
     } finally {
@@ -165,7 +166,7 @@ public class GridTest extends TestUtil {
       Scope.exit();
     }
   }
-  
+
   @Test
   public void testCoxPHGridSearch() {
     try {
@@ -177,9 +178,9 @@ public class GridTest extends TestUtil {
       trainingFrame.add("w3", Vec.makeRepSeq(trainingFrame.numRows(), 11));
       DKV.put(trainingFrame);
       Scope.track(trainingFrame);
-      
+
       HashMap<String, Object[]> hyperParms = new HashMap<String, Object[]>() {{
-        put("_weights_column", new String[] {"w1", "w2", "w3"});
+        put("_weights_column", new String[]{"w1", "w2", "w3"});
       }};
 
       CoxPHModel.CoxPHParameters params = new CoxPHModel.CoxPHParameters();
@@ -231,7 +232,7 @@ public class GridTest extends TestUtil {
   }
 
   @Test
-  public void testFaileH2OdParamsCleanup() {
+  public void testFailedH2OParamsCleanup() {
     try {
       Scope.enter();
       final Frame trainingFrame = parseTestFile("smalldata/iris/iris_train.csv");
@@ -320,7 +321,7 @@ public class GridTest extends TestUtil {
       final File serializedGridFile = new File(params._export_checkpoints_dir, originalGrid._key.toString());
       assertTrue(serializedGridFile.exists());
       assertTrue(serializedGridFile.isFile());
-      
+
       final Grid grid = loadGridFromFile(serializedGridFile);
       assertArrayEquals(originalGrid.getModelKeys(), grid.getModelKeys());
       Scope.track_generic(grid);
@@ -328,7 +329,7 @@ public class GridTest extends TestUtil {
       Scope.exit();
     }
   }
-  
+
   private static Grid waitForModelsToTrain(Job<Grid> gs, Key<Grid> gridKey, int numModels) throws InterruptedException {
     while (gs.isRunning()) {
       Thread.sleep(1000);
@@ -366,15 +367,15 @@ public class GridTest extends TestUtil {
       final Frame trainingFrame = parseTestFile(trainKey, "smalldata/iris/iris_train.csv");
       Scope.track(trainingFrame);
       Job<Grid> gs = GridSearch.startGridSearch(
-          null, gridKey, params, hyperParms,             
-          new GridSearch.SimpleParametersBuilderFactory(),
-          new HyperSpaceSearchCriteria.CartesianSearchCriteria(),
-          recovery1, 1
+              null, gridKey, params, hyperParms,
+              new GridSearch.SimpleParametersBuilderFactory(),
+              new HyperSpaceSearchCriteria.CartesianSearchCriteria(),
+              recovery1, 1
       );
       Scope.track_generic(gs);
       Grid grid1 = waitForModelsToTrain(gs, gridKey, 1);
       grid1ModelKeys = grid1.getModelKeys();
-      assertTrue("full grid should not have finished", grid1ModelKeys.length < 4*3*3);
+      assertTrue("full grid should not have finished", grid1ModelKeys.length < 4 * 3 * 3);
     } finally {
       Scope.exit();
     }
@@ -394,18 +395,18 @@ public class GridTest extends TestUtil {
         assertNotNull(DKV.getGet(originalModelKey));
       }
       Job<Grid> gs2 = GridSearch.startGridSearch(
-          null, gridKey,
-          loadedGrid1.getParams(),
-          loadedGrid1.getHyperParams(),
-          new GridSearch.SimpleParametersBuilderFactory(),
-          loadedGrid1.getSearchCriteria(),
-          recovery2,
-          loadedGrid1.getParallelism()
+              null, gridKey,
+              loadedGrid1.getParams(),
+              loadedGrid1.getHyperParams(),
+              new GridSearch.SimpleParametersBuilderFactory(),
+              loadedGrid1.getSearchCriteria(),
+              recovery2,
+              loadedGrid1.getParallelism()
       );
       Scope.track_generic(gs2);
       Grid resumedGrid = waitForModelsToTrain(gs2, gridKey, grid1ModelKeys.length);
       resumedModelKeys = resumedGrid.getModelKeys();
-      assertTrue("full grid should not have finished", resumedModelKeys.length < 4*3*3);
+      assertTrue("full grid should not have finished", resumedModelKeys.length < 4 * 3 * 3);
     } finally {
       Scope.exit();
     }
@@ -453,40 +454,40 @@ public class GridTest extends TestUtil {
       Recovery<Grid> recovery = new Recovery<>(recoveryDir);
       Key gridKey = Key.make("gridSearchWithRecovery_GRID");
       Job<Grid> gs = GridSearch.startGridSearch(
-          null, gridKey, params, hyperParms,
-          new GridSearch.SimpleParametersBuilderFactory<>(),
-          new HyperSpaceSearchCriteria.CartesianSearchCriteria(),
-          recovery, GridSearch.SEQUENTIAL_MODEL_BUILDING
+              null, gridKey, params, hyperParms,
+              new GridSearch.SimpleParametersBuilderFactory<>(),
+              new HyperSpaceSearchCriteria.CartesianSearchCriteria(),
+              recovery, GridSearch.SEQUENTIAL_MODEL_BUILDING
       );
       Scope.track_generic(gs);
       Grid gridInProgress = DKV.getGet(gridKey);
       Scope.track_generic(gridInProgress);
-      while (gs.isRunning() && gridInProgress.getModelKeys().length == 0) {
+      while (gs.isRunning() && gridInProgress.getModelKeys().length==0) {
         System.out.println("sleeping...");
         Thread.sleep(100);
         gridInProgress = DKV.getGet(gridKey);
       }
       assertTrue(
-          "Some files should be in the recovery directory (grid in progress)", 
-          new File(recoveryDir).listFiles().length > 0
+              "Some files should be in the recovery directory (grid in progress)",
+              new File(recoveryDir).listFiles().length > 0
       );
-          
+
       // wait for grid to finish and check cleanup was done
       gs.get();
       assertEquals(
-          "Recovery directory should be empty after successful grid. " +
-              Arrays.toString(new File(recoveryDir).list()), 
-          new File(recoveryDir).listFiles().length, 0
+              "Recovery directory should be empty after successful grid. " +
+                      Arrays.toString(new File(recoveryDir).list()),
+              new File(recoveryDir).listFiles().length, 0
       );
     } finally {
       Scope.exit();
     }
   }
-  
+
   private void testGridRecovery(Key gridKey, Job gs, Frame train, String recoveryDir) throws IOException, InterruptedException {
     Grid originalGrid = DKV.getGet(gridKey);
     Scope.track_generic(originalGrid);
-    while (gs.isRunning() && originalGrid.getModelKeys().length == 0) {
+    while (gs.isRunning() && originalGrid.getModelKeys().length==0) {
       Thread.sleep(100);
     }
     assertTrue("Some files should be in the recovery directory", new File(recoveryDir).listFiles().length > 0);
@@ -497,10 +498,10 @@ public class GridTest extends TestUtil {
       Thread.sleep(100);
     }
     assertNotEquals(
-        "Recovery directory should not be empty after canceled grid.",
-        new File(recoveryDir).listFiles().length, 0
+            "Recovery directory should not be empty after canceled grid.",
+            new File(recoveryDir).listFiles().length, 0
     );
-    
+
     Key<Model>[] originalKeys = originalGrid.getModelKeys();
     originalGrid.remove();
     train.remove();
@@ -539,10 +540,10 @@ public class GridTest extends TestUtil {
       Recovery<Grid> recovery = new Recovery<>(recoveryDir);
       Key gridKey = Key.make("gridSearchWithRecovery_GRID");
       Job<Grid> gs = GridSearch.startGridSearch(
-          null, gridKey, params, hyperParms,
-          new GridSearch.SimpleParametersBuilderFactory<>(),
-          new HyperSpaceSearchCriteria.CartesianSearchCriteria(),
-          recovery, GridSearch.SEQUENTIAL_MODEL_BUILDING
+              null, gridKey, params, hyperParms,
+              new GridSearch.SimpleParametersBuilderFactory<>(),
+              new HyperSpaceSearchCriteria.CartesianSearchCriteria(),
+              recovery, GridSearch.SEQUENTIAL_MODEL_BUILDING
       );
       Scope.track_generic(gs);
       testGridRecovery(gridKey, gs, trainingFrame, recoveryDir);
@@ -551,11 +552,11 @@ public class GridTest extends TestUtil {
       Scope.exit();
     }
   }
-  
+
   private Object[] toArrayOfArrays(double[] arr) {
     Object[] res = new Object[arr.length];
     for (int i = 0; i < arr.length; i++) {
-      res[i] = new double[] { arr[i] };
+      res[i] = new double[]{arr[i]};
     }
     return res;
   }
@@ -571,8 +572,8 @@ public class GridTest extends TestUtil {
       trainingFrame.remove(0);
 
       HashMap<String, Object[]> hyperParms = new HashMap<String, Object[]>() {{
-        put("_alpha", toArrayOfArrays(new double[]{ 0.01, 0.3, 0.5, 0.7, 0.9}));
-        put("_lambda", toArrayOfArrays(new double[]{ 1e-5, 1e-6, 1e-7, 1e-8, 5e-5, 5e-6, 5e-7, 5e-8}));
+        put("_alpha", toArrayOfArrays(new double[]{0.01, 0.3, 0.5, 0.7, 0.9}));
+        put("_lambda", toArrayOfArrays(new double[]{1e-5, 1e-6, 1e-7, 1e-8, 5e-5, 5e-6, 5e-7, 5e-8}));
       }};
 
       GLMModel.GLMParameters params = new GLMModel.GLMParameters();
@@ -582,10 +583,10 @@ public class GridTest extends TestUtil {
       Recovery<Grid> recovery = new Recovery<>(recoveryDir);
       Key gridKey = Key.make("gridSearchWithRecoveryGlm");
       Job<Grid> gs = GridSearch.startGridSearch(
-          null, gridKey, params, hyperParms,
-          new GridSearch.SimpleParametersBuilderFactory<>(),
-          new HyperSpaceSearchCriteria.CartesianSearchCriteria(),
-          recovery, GridSearch.SEQUENTIAL_MODEL_BUILDING
+              null, gridKey, params, hyperParms,
+              new GridSearch.SimpleParametersBuilderFactory<>(),
+              new HyperSpaceSearchCriteria.CartesianSearchCriteria(),
+              recovery, GridSearch.SEQUENTIAL_MODEL_BUILDING
       );
       Scope.track_generic(gs);
       testGridRecovery(gridKey, gs, trainingFrame, recoveryDir);
@@ -619,12 +620,12 @@ public class GridTest extends TestUtil {
       Scope.track_generic(gs);
       final Grid originalGrid = gs.get();
       Scope.track_generic(originalGrid);
-      
+
       final String originalGridPath = exportDir + "/" + originalGrid._key.toString();
       originalGrid.exportBinary(exportDir, true);
       assertTrue(Files.exists(Paths.get(originalGridPath)));
-      for(Model model : originalGrid.getModels()){
-        assertTrue(Files.exists(Paths.get(exportDir, model._key.toString())));  
+      for (Model model : originalGrid.getModels()) {
+        assertTrue(Files.exists(Paths.get(exportDir, model._key.toString())));
       }
     } finally {
       Scope.exit();
@@ -642,7 +643,7 @@ public class GridTest extends TestUtil {
       HashMap<String, Object[]> hyperParms = new HashMap<String, Object[]>() {{
         put("_distribution", new DistributionFamily[]{DistributionFamily.multinomial});
         put("_ntrees", new Integer[]{5, 10, 50});
-        put("_max_depth", new Integer[]{2,3});
+        put("_max_depth", new Integer[]{2, 3});
         put("_learn_rate", new Double[]{.7});
       }};
 
@@ -674,7 +675,7 @@ public class GridTest extends TestUtil {
       final Freezable possibleGrid = autoBuffer.get();
       assertTrue(possibleGrid instanceof Grid);
       return (Grid) possibleGrid;
-      
+
     }
   }
 
@@ -713,7 +714,7 @@ public class GridTest extends TestUtil {
       assertEquals(0, failures.getFailureCount());
 
       errGrid.appendFailedModelParameters(errGrid.getModels()[0]._key, params, new RuntimeException("Test exception"));
-      
+
       failures = errGrid.getFailures();
       assertEquals(1, failures.getFailureCount());
 
@@ -773,7 +774,7 @@ public class GridTest extends TestUtil {
       Scope.track_generic(gridSearch);
       final Grid grid = gridSearch.get();
       Scope.track_generic(grid);
-      
+
       for (Model m : grid.getModels()) {
         Model foundModel = grid.getModel(m._input_parms);
         assertNotNull("Expected to find the model in model cache.", foundModel);
@@ -784,7 +785,8 @@ public class GridTest extends TestUtil {
     }
   }
 
-  @Test // this test is fine as with Cartesian we don't really have early stopping based on max_models ( always train whole hyper space)
+  @Test
+  // this test is fine as with Cartesian we don't really have early stopping based on max_models ( always train whole hyper space)
   public void testParallelCartesian() {
     try {
       Scope.enter();
@@ -796,7 +798,7 @@ public class GridTest extends TestUtil {
         put("_distribution", new DistributionFamily[]{DistributionFamily.multinomial});
         put("_ntrees", new Integer[]{5});
         put("_max_depth", new Integer[]{2});
-        put("_min_rows", new Integer[]{10,11,12,13,14});
+        put("_min_rows", new Integer[]{10, 11, 12, 13, 14});
         put("_learn_rate", new Double[]{.7});
       }};
 
@@ -838,7 +840,7 @@ public class GridTest extends TestUtil {
         put("_distribution", new DistributionFamily[]{DistributionFamily.multinomial});
         put("_ntrees", new Integer[]{5});
         put("_max_depth", new Integer[]{2});
-        put("_min_rows", new Integer[]{10,11,12,13,14});
+        put("_min_rows", new Integer[]{10, 11, 12, 13, 14});
         put("_learn_rate", new Double[]{.7});
       }};
 
@@ -874,7 +876,7 @@ public class GridTest extends TestUtil {
         put("_distribution", new DistributionFamily[]{DistributionFamily.multinomial});
         put("_ntrees", new Integer[]{5});
         put("_max_depth", new Integer[]{2});
-        put("_min_rows", new Integer[]{10,11,12,13,14});
+        put("_min_rows", new Integer[]{10, 11, 12, 13, 14});
         put("_learn_rate", new Double[]{.7});
       }};
 
@@ -906,12 +908,12 @@ public class GridTest extends TestUtil {
       Frame trainingFrame = TestFrameCatalog.oneChunkFewRows();
 
       Map<String, Object[]> hyperParms = Collections.singletonMap(
-        "_cancel_job", new Boolean[]{true}
+              "_cancel_job", new Boolean[]{true}
       );
 
       DummyModelParameters params = new DummyModelParameters();
       params._train = trainingFrame._key;
-      
+
       Grid grid = GridSearch.startGridSearch(null, params, hyperParms).get();
       Scope.track_generic(grid);
 
@@ -932,19 +934,53 @@ public class GridTest extends TestUtil {
       Map<String, Object[]> hyperParms = Collections.singletonMap(
               "_cancel_job", new Boolean[]{true}
       );
-      
+
       DummyModelParameters params = new DummyModelParameters();
       params._train = trainingFrame._key;
       params._on_exception_action = new MessageInstallAction(proofKey, "onExceptionalCompletionCalled");
 
       Grid grid = GridSearch.startGridSearch(null, params, hyperParms).get();
       Scope.track_generic(grid);
-      
+
       assertEquals("Computed onExceptionalCompletionCalled", DKV.getGet(proofKey).toString());
     } finally {
       Scope.exit();
       DKV.remove(proofKey);
     }
+  }
+
+  @Test(expected = H2OGridException.class)
+  public void test_grid_cancelled_on_consecutive_model_failures() {
+    try {
+      Scope.enter();
+      final Frame trainingFrame = parseTestFile("smalldata/iris/iris_train.csv");
+      Scope.track(trainingFrame);
+      String target = "species";
+
+      HashMap<String, Object[]> hyperParms = new HashMap<String, Object[]>() {{
+        put("_distribution", new DistributionFamily[]{DistributionFamily.bernoulli});  // incompatible with iris
+        put("_ntrees", new Integer[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+        put("_max_depth", new Integer[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+//        put("_min_rows", new Integer[]{5000000}); // Invalid hyperparameter, causes model training to fail
+      }};
+
+      GBMModel.GBMParameters params = new GBMModel.GBMParameters();
+      params._train = trainingFrame._key;
+      params._response_column = target;
+
+      Job<Grid> gs = GridSearch.startGridSearch(null, params, hyperParms);
+      Scope.track_generic(gs);
+      final Grid grid = gs.get();
+      Scope.track_generic(grid);
+
+    } finally {
+      Scope.exit();
+    }
+  }
+  
+  @Test
+  public void test_parallel_grid_cancelled_on_consecutive_model_failures() {
+
   }
 
 }

--- a/h2o-algos/src/test/java/hex/grid/GridTest.java
+++ b/h2o-algos/src/test/java/hex/grid/GridTest.java
@@ -6,6 +6,7 @@ import hex.ModelMetrics;
 import hex.faulttolerance.Recovery;
 import hex.genmodel.utils.DistributionFamily;
 import hex.glm.GLMModel;
+import hex.grid.HyperSpaceWalker.BaseWalker.WalkerFactory;
 import hex.tree.CompressedTree;
 import hex.tree.gbm.GBMModel;
 import org.junit.Before;
@@ -968,7 +969,9 @@ public class GridTest extends TestUtil {
       params._train = trainingFrame._key;
       params._response_column = target;
 
-      Job<Grid> gs = GridSearch.startGridSearch(null, params, hyperParms);
+      Job<Grid> gs = GridSearch.create(null, params, hyperParms)
+              .withMaxConsecutiveFailures(10)
+              .start();
       try {
         Scope.track_generic(gs);
         final Grid grid = gs.get();
@@ -1003,7 +1006,10 @@ public class GridTest extends TestUtil {
       params._train = trainingFrame._key;
       params._response_column = target;
 
-      Job<Grid> gs = GridSearch.startGridSearch(null, params, hyperParms, 3);
+      Job<Grid> gs = GridSearch.create(null, params, hyperParms)
+              .withMaxConsecutiveFailures(10)
+              .withParallelism(3)
+              .start();
       try {
         Scope.track_generic(gs);
         final Grid grid = gs.get();

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -17,7 +17,6 @@ import hex.splitframe.ShuffleSplitFrame;
 import water.*;
 import water.automl.api.schemas3.AutoMLV99;
 import water.exceptions.H2OAutoMLException;
-import water.exceptions.H2OGridException;
 import water.exceptions.H2OIllegalArgumentException;
 import water.fvec.Frame;
 import water.fvec.Vec;

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -661,7 +661,6 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
           _consecutiveModelFailures.set(0);
           completed.add(step);
         } else if (state.is(ResultStatus.failed)) {
-          _consecutiveModelFailures.incrementAndGet();
           if (_consecutiveModelFailures.incrementAndGet() >= _maxConsecutiveModelFailures) {
             throw new H2OAutoMLException("Aborting AutoML after too many consecutive model failures", state.error());
           }

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -154,6 +154,10 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
     public boolean isResumable() {
         return false;
     }
+    
+    public boolean ignores(AutoML.Constraint constraint) {
+        return ArrayUtils.contains(_ignoredConstraints, constraint);
+    }
 
     /**
      * @return true iff we can call {@link #run()} on this modeling step to start a new job.
@@ -475,7 +479,7 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
             setCustomParams(parms);
 
             // override model's max_runtime_secs to ensure that the total max_runtime doesn't exceed expectations
-            if (ArrayUtils.contains(_ignoredConstraints, AutoML.Constraint.TIMEOUT)) {
+            if (ignores(AutoML.Constraint.TIMEOUT)) {
                 parms._max_runtime_secs = 0;
             } else {
                 Work work = getAllocatedWork();
@@ -584,7 +588,7 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
         protected void setSearchCriteria(RandomDiscreteValueSearchCriteria searchCriteria, Model.Parameters baseParms) {
             Work work = getAllocatedWork();
             // for time limit, this is allocated in proportion of the entire work budget.
-            double maxAssignedTimeSecs = ArrayUtils.contains(_ignoredConstraints, AutoML.Constraint.TIMEOUT)
+            double maxAssignedTimeSecs = ignores(AutoML.Constraint.TIMEOUT)
                     ? 0
                     : aml().timeRemainingMs() * getWorkAllocations().remainingWorkRatio(work, _isSamePriorityGroup) / 1e3;
             // SE predicate can be removed if/when we decide to include SEs in the max_models limit
@@ -672,7 +676,7 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
             Job<Models> job = new Job<>(key, Models.class.getName(), _description);
             Work work = getAllocatedWork();
 
-            double maxAssignedTimeSecs = ArrayUtils.contains(_ignoredConstraints, AutoML.Constraint.TIMEOUT)
+            double maxAssignedTimeSecs = ignores(AutoML.Constraint.TIMEOUT)
                     ? 0
                     : aml().timeRemainingMs() * getWorkAllocations().remainingWorkRatio(work) / 1e3;
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -552,7 +552,7 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
             try {
                 defaults = baseParms.getClass().newInstance();
             } catch (Exception e) {
-                aml().eventLog().warn(Stage.ModelTraining, "Internal error doing hyperparameter search");
+                aml().eventLog().error(Stage.ModelTraining, "Internal error doing hyperparameter search");
                 throw new H2OIllegalArgumentException("Hyperparameter search can't create a new instance of Model.Parameters subclass: " + baseParms.getClass());
             }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -24,7 +24,6 @@ import hex.grid.HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria;
 import jsr166y.CountedCompleter;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import water.*;
-import water.exceptions.H2OAbstractRuntimeException;
 import water.exceptions.H2OIllegalArgumentException;
 import water.util.ArrayUtils;
 import water.util.Countdown;

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStepsExecutor.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStepsExecutor.java
@@ -101,8 +101,7 @@ class ModelingStepsExecutor extends Iced<ModelingStepsExecutor> {
             try {
                 job = step.run();
                 if (job == null) {
-                    skip(step, parentJob);
-                    resultState.addState(new StepResultState(step.getId(), ResultStatus.skipped));
+                    resultState.addState(skip(step, parentJob));
                 } else {
                     resultState.addState(monitor(job, step, parentJob));
                 }
@@ -121,13 +120,14 @@ class ModelingStepsExecutor extends Iced<ModelingStepsExecutor> {
         return resultState;
     }
 
-    private void skip(ModelingStep step, Job parentJob) {
+    private StepResultState skip(ModelingStep step, Job parentJob) {
         if (null != parentJob) {
             String desc = step._description;
             Work work = step.getAllocatedWork();
             parentJob.update(work.consume(), "SKIPPED: "+desc);
             Log.info("AutoML; skipping "+desc);
         }
+        return new StepResultState(step.getId(), ResultStatus.skipped);
     }
 
     StepResultState monitor(Job job, ModelingStep step, Job parentJob) {

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStepsExecutor.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStepsExecutor.java
@@ -136,7 +136,7 @@ class ModelingStepsExecutor extends Iced<ModelingStepsExecutor> {
         eventLog.debug(Stage.ModelTraining, jobDescription + " started");
         _jobs.add(job);
 
-        boolean ignoreTimeout = ArrayUtils.contains(step._ignoredConstraints, Constraint.TIMEOUT);
+        boolean ignoreTimeout = step.ignores(Constraint.TIMEOUT);
         Work work = step.getAllocatedWork();
         long lastWorkedSoFar = 0;
         long lastTotalModelsBuilt = 0;
@@ -224,8 +224,7 @@ class ModelingStepsExecutor extends Iced<ModelingStepsExecutor> {
         int before = leaderboard.getModelCount();
         leaderboard.addModel(model._key);
         int after = leaderboard.getModelCount();
-        boolean ignoreModelCount = ArrayUtils.contains(step._ignoredConstraints, Constraint.MODEL_COUNT);
-        if (!ignoreModelCount)
+        if (!step.ignores(Constraint.MODEL_COUNT))
             _modelCount.addAndGet(after - before);
     }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStepsExecutor.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStepsExecutor.java
@@ -178,7 +178,7 @@ class ModelingStepsExecutor extends Iced<ModelingStepsExecutor> {
             }
 
             if (job.isCrashed()) {
-                eventLog.warn(Stage.ModelTraining, jobDescription+" failed: "+job.ex());
+                eventLog.error(Stage.ModelTraining, jobDescription+" failed: "+job.ex());
                 return new StepResultState(step._description, job.ex());
             } else if (job.get() == null) {
                 eventLog.info(Stage.ModelTraining, jobDescription+" cancelled");

--- a/h2o-automl/src/main/java/ai/h2o/automl/StepResultState.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/StepResultState.java
@@ -1,0 +1,139 @@
+package ai.h2o.automl;
+
+import water.util.IcedHashMap;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static ai.h2o.automl.StepResultState.ResultStatus.*;
+
+final class StepResultState {
+
+    enum ResultStatus {
+        skipped,
+        cancelled,
+        failed,
+        success,
+    }
+
+    enum Resolution {
+        sameAsMain,  // 
+        optimistic,  // success if any success, otherwise cancelled if any cancelled, otherwise failed if any failure, otherwise skipped.
+        pessimistic, // failures if any failure, otherwise cancelled if any cancelled, otherwise success it any success, otherwise skipped.
+    }
+
+    private final String _id;
+    private final IcedHashMap<String, StepResultState> _subStates = new IcedHashMap<>();
+    private ResultStatus _status;
+    private Throwable _error;
+
+    StepResultState(String id) {
+        this(id, (ResultStatus) null);
+    }
+
+    StepResultState(String id, ResultStatus status) {
+        this(id, status, null);
+    }
+
+    StepResultState(String id, Throwable error) {
+        this(id, failed, error);
+    }
+    
+    private StepResultState(String id, ResultStatus status, Throwable error) {
+        _id = id;
+        _status = status;
+        _error = error;
+    }
+
+    void setStatus(ResultStatus status) {
+        assert _status == null;
+        _status = status;
+    }
+
+    void setStatus(Throwable error) {
+        setStatus(failed);
+        _error = error;
+    }
+
+    void addState(StepResultState state) {
+        _subStates.put(state.id(), state);
+    }
+
+    boolean is(ResultStatus status) {
+        return _status==status;
+    }
+
+    String id() {
+        return _id;
+    }
+
+    ResultStatus status() {
+        return _status;
+    }
+
+    Throwable error() {
+        return _error;
+    }
+
+    StepResultState subState(String id) {
+        return _subStates.get(id);
+    }
+
+    Map<String, StepResultState> subStates() {
+        return Collections.unmodifiableMap(_subStates);
+    }
+
+    void resolveState(Resolution strategy) {
+        if (_status != null) return;
+        if (_subStates.size() == 0) {
+            setStatus(skipped);
+        } else if (_subStates.size() == 1 && _subStates.containsKey(id())) {
+            StepResultState state = subState(id());
+            _status = state.status();
+            _error = state.error();
+            _subStates.clear();
+            _subStates.putAll(state.subStates());
+        } else {
+            switch (strategy) {
+                case sameAsMain:
+                    StepResultState state = subState(id());
+                    if (state != null) {
+                        _status = state.status();
+                        _error = state.error();
+                    } else {
+                        _status = cancelled;
+                    }
+                    break;
+                case optimistic:
+                    if (_subStates.values().stream().anyMatch(s -> s.is(success)))
+                        _status = success;
+                    else if (_subStates.values().stream().anyMatch(s -> s.is(cancelled)))
+                        _status = cancelled;
+                    else if (_subStates.values().stream().anyMatch(s -> s.is(failed)))
+                        _subStates.values().stream().filter(s -> s.is(failed)).limit(1).findFirst().ifPresent(s -> setStatus(s.error()));
+                    else _status = skipped;
+                    break;
+                case pessimistic:
+                    if (_subStates.values().stream().anyMatch(s -> s.is(failed)))
+                        _subStates.values().stream().filter(s -> s.is(failed)).limit(1).findFirst().ifPresent(s -> setStatus(s.error()));
+                    else if (_subStates.values().stream().anyMatch(s -> s.is(cancelled)))
+                        _status = cancelled;
+                    else if (_subStates.values().stream().anyMatch(s -> s.is(success)))
+                        _status = success;
+                    else _status = skipped;
+                    break;
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("StepResultState{");
+        sb.append("_id='").append(_id).append('\'');
+        sb.append(", _status=").append(_status);
+        if (_error != null) sb.append(", _error=").append(_error);
+        if (_subStates.size() > 0) sb.append(", _subStates=").append(_subStates);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/h2o-automl/src/main/java/ai/h2o/automl/StepResultState.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/StepResultState.java
@@ -17,7 +17,7 @@ final class StepResultState {
     }
 
     enum Resolution {
-        sameAsMain,  // 
+        sameAsMain,  // resolves to the same state as the main step (ignoring other sub-step states).
         optimistic,  // success if any success, otherwise cancelled if any cancelled, otherwise failed if any failure, otherwise skipped.
         pessimistic, // failures if any failure, otherwise cancelled if any cancelled, otherwise success it any success, otherwise skipped.
     }

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/StackedEnsembleStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/StackedEnsembleStepsProvider.java
@@ -36,7 +36,10 @@ public class StackedEnsembleStepsProvider
             StackedEnsembleModelStep(String id, Metalearner.Algorithm algo, int priorityGroup, int weight, AutoML autoML) {
                 super(NAME, Algo.StackedEnsemble, id, priorityGroup, weight, autoML);
                 _metalearnerAlgo = algo;
-                _ignoredConstraints = new AutoML.Constraint[] {AutoML.Constraint.MODEL_COUNT};
+                _ignoredConstraints = new AutoML.Constraint[] {
+                        AutoML.Constraint.MODEL_COUNT,    // do not include SEs in model count (current contract: max_models = max_base_models).
+                        AutoML.Constraint.FAILURE_COUNT   // do not increment failures on SEs (several issues can occur with SEs during reruns, we should still add the error to event log, but not fail AutoML).
+                };
             }
 
             @Override

--- a/h2o-automl/src/main/java/water/exceptions/H2OAutoMLException.java
+++ b/h2o-automl/src/main/java/water/exceptions/H2OAutoMLException.java
@@ -1,0 +1,49 @@
+package water.exceptions;
+
+import water.H2OError;
+
+public class H2OAutoMLException extends H2OAbstractRuntimeException {
+    
+    private final Throwable _rootCause;
+    private final int _httpResponse;
+    
+    public H2OAutoMLException(String msg) {
+        this(msg, null);
+    }
+    
+    public H2OAutoMLException(String msg, Throwable rootException) {
+        this(msg, rootException, 0);
+    }
+    
+    public H2OAutoMLException(String msg, Throwable rootException, int httpResponse) {
+        super(msg, msg);
+        _rootCause = rootException;
+        _httpResponse = httpResponse > 0 ? httpResponse : super.HTTP_RESPONSE_CODE();
+    }
+
+    @Override
+    protected int HTTP_RESPONSE_CODE() {
+        return _httpResponse;
+    }
+
+    @Override
+    public H2OError toH2OError(String error_url) {
+        H2OError err;
+        String rootMessage = _rootCause== null ? null : _rootCause.getMessage().trim();
+        if (_rootCause instanceof H2OAbstractRuntimeException) {
+            err = ((H2OAbstractRuntimeException) _rootCause).toH2OError(error_url);
+        } else {
+            err = new H2OError(timestamp, error_url, getMessage(), dev_message, HTTP_RESPONSE_CODE(), values, _rootCause);
+        }
+        StringBuilder msg = new StringBuilder(getMessage().trim());
+        if (msg.charAt(msg.length()-1) != '.') msg.append('.');
+        if (rootMessage != null) {
+            msg.append(' ');
+            msg.append("Root cause: ");
+            msg.append(rootMessage);
+            err._exception_msg = msg.toString();
+        }
+        return err;
+    }
+    
+}

--- a/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
@@ -236,10 +236,9 @@ public class AutoMLTest extends water.TestUtil {
       fr = parseTestFile("./smalldata/logreg/prostate_train.csv");
       autoMLBuildSpec.input_spec.training_frame = fr._key;
       autoMLBuildSpec.input_spec.response_column = "CAPSULE";
-      autoMLBuildSpec.build_models.exclude_algos = new Algo[] {Algo.DeepLearning, Algo.DRF, Algo.GLM};
+      autoMLBuildSpec.build_models.exclude_algos = new Algo[] {Algo.XGBoost, Algo.DeepLearning, Algo.DRF, Algo.GLM};
 
-      autoMLBuildSpec.build_control.stopping_criteria.set_max_runtime_secs(8);
-//      autoMLBuildSpec.build_control.stopping_criteria.set_max_runtime_secs(new Random().nextInt(30));
+      autoMLBuildSpec.build_control.stopping_criteria.set_max_runtime_secs(15);
       autoMLBuildSpec.build_control.keep_cross_validation_models = false; //Prevent leaked keys from CV models
       autoMLBuildSpec.build_control.keep_cross_validation_predictions = false; //Prevent leaked keys from CV predictions
       autoMLBuildSpec.build_models.modeling_plan = ModelingPlans.TWO_LAYERED;

--- a/h2o-automl/src/test/java/ai/h2o/automl/ModelingStepTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/ModelingStepTest.java
@@ -15,6 +15,7 @@ import water.DKV;
 import water.Job;
 import water.Key;
 import water.Keyed;
+import water.exceptions.H2OIllegalArgumentException;
 import water.fvec.Frame;
 import water.fvec.Vec;
 import water.runner.CloudSize;
@@ -80,13 +81,13 @@ public class ModelingStepTest {
         assertEquals(aml.getBuildSpec().build_control.stopping_criteria.stopping_metric(), model._parms._stopping_metric);
     }
 
-    @Test public void testFailingModelStep() {
+    @Test(expected = H2OIllegalArgumentException.class)
+    public void test_failing_ModelStep_propagates_error() {
         ModelingStep step = Arrays.stream(aml.getExecutionPlan()).filter(s -> "dummy_model_failing".equals(s._id)).findFirst().get();
-        Job<DummyModel> job = step.run();
-        assertNull(job);
+        step.run();
     }
 
-    @Test public void testGridStep() {
+    @Test public void test_GridStep() {
         ModelingStep step = Arrays.stream(aml.getExecutionPlan()).filter(s -> "dummy_grid".equals(s._id)).findFirst().get();
         Job<Grid> job = step.run();
         Grid grid = job.get(); toDelete.add(grid);
@@ -99,7 +100,7 @@ public class ModelingStepTest {
         }
     }
 
-    @Test public void testSelectionStepSingleModel() {
+    @Test public void test_SelectionStep_with_single_model() {
         ModelingStep step = Arrays.stream(aml.getExecutionPlan()).filter(s -> "dummy_exploitation_single".equals(s._id)).findFirst().get();
         Job<Models> job = step.run();
         Models models = job.get(); toDelete.add(models);
@@ -112,7 +113,7 @@ public class ModelingStepTest {
         }
     }
 
-    @Test public void testSelectionStepMultipleModels() {
+    @Test public void test_SelectionStep_with_multiple_models() {
         ModelingStep step = Arrays.stream(aml.getExecutionPlan()).filter(s -> "dummy_exploitation_multi".equals(s._id)).findFirst().get();
         Job<Models> job = step.run();
         Models models = job.get(); toDelete.add(models);
@@ -125,14 +126,14 @@ public class ModelingStepTest {
         }
     }
     
-    public void testDynamicStepNoSubStepsNoMain() {
+    public void test_DynamicStep_with_no_substeps_and_no_main_step() {
         ModelingStep step = Arrays.stream(aml.getExecutionPlan()).filter(s -> "dummy_dynamic_nothing".equals(s._id)).findFirst().get();
         assertFalse(step.canRun());
         assertNull(step.run());
         assertFalse(step.iterateSubSteps().hasNext());
     }
     
-    @Test public void testDynamicStepWithSubStepsNoMain() {
+    @Test public void test_DynamicStep_with_substeps_but_no_main_step() {
         ModelingStep step = Arrays.stream(aml.getExecutionPlan()).filter(s -> "dummy_dynamic_no_main".equals(s._id)).findFirst().get();
         assertFalse(step.canRun());
         assertNull(step.run());
@@ -152,7 +153,7 @@ public class ModelingStepTest {
         }
     }
     
-    @Test public void testDynamicStepWithSubStepsWithMain() {
+    @Test public void test_DynamicStep_with_substeps_and_main_step() {
         ModelingStep step = Arrays.stream(aml.getExecutionPlan()).filter(s -> "dummy_dynamic_substeps_and_main".equals(s._id)).findFirst().get();
         assertTrue(step.canRun());
         assertTrue(step.iterateSubSteps().hasNext());

--- a/h2o-automl/src/test/java/ai/h2o/automl/ModelingStepsExecutorTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/ModelingStepsExecutorTest.java
@@ -216,8 +216,8 @@ public class ModelingStepsExecutorTest {
         StepResultState state = executor.submit(aml.session().getModelingStep(NAME, "job_with_1_cancelled_substep"), parentJob);
         assertEquals(ResultStatus.success, state.status());
         assertEquals(3, state.subStates().size());
-        assertEquals(ResultStatus.success, state.subState("sub_step_1").status());
-        assertEquals(ResultStatus.cancelled, state.subState("sub_step_2").status());
+        assertEquals(ResultStatus.success, state.subState(NAME+" sub_step_1").status());
+        assertEquals(ResultStatus.cancelled, state.subState(NAME+" sub_step_2").status());
         executor.stop();
         assertEquals(1, aml.leaderboard().getModelCount());
     }
@@ -231,9 +231,9 @@ public class ModelingStepsExecutorTest {
         StepResultState state = executor.submit(aml.session().getModelingStep(NAME, "job_with_1_failed_substep"), parentJob);
         assertEquals(ResultStatus.success, state.status());
         assertEquals(4, state.subStates().size());
-        assertEquals(ResultStatus.success, state.subState("sub_step_1").status());
-        assertEquals(ResultStatus.failed, state.subState("sub_step_2").status());
-        assertEquals(ResultStatus.cancelled, state.subState("sub_step_3").status());
+        assertEquals(ResultStatus.success, state.subState(NAME+" sub_step_1").status());
+        assertEquals(ResultStatus.failed, state.subState(NAME+" sub_step_2").status());
+        assertEquals(ResultStatus.cancelled, state.subState(NAME+" sub_step_3").status());
         executor.stop();
         assertEquals(1, aml.leaderboard().getModelCount());
     }
@@ -247,10 +247,10 @@ public class ModelingStepsExecutorTest {
         StepResultState state = executor.submit(aml.session().getModelingStep(NAME, "job_with_all_failed_substeps"), parentJob);
         assertEquals(ResultStatus.cancelled, state.status());
         assertEquals(5, state.subStates().size());
-        assertEquals(ResultStatus.failed, state.subState("sub_step_1").status());
-        assertEquals(ResultStatus.skipped, state.subState("sub_step_2").status());
-        assertEquals(ResultStatus.cancelled, state.subState("sub_step_3").status());
-        assertEquals(ResultStatus.failed, state.subState("sub_step_4").status());
+        assertEquals(ResultStatus.failed, state.subState(NAME+" sub_step_1").status());
+        assertEquals(ResultStatus.skipped, state.subState(NAME+" sub_step_2").status());
+        assertEquals(ResultStatus.cancelled, state.subState(NAME+" sub_step_3").status());
+        assertEquals(ResultStatus.failed, state.subState(NAME+" sub_step_4").status());
         executor.stop();
         assertEquals(0, aml.leaderboard().getModelCount());
     }
@@ -264,10 +264,10 @@ public class ModelingStepsExecutorTest {
         StepResultState state = executor.submit(aml.session().getModelingStep(NAME, "job_with_all_failed_substeps"), parentJob);
         assertEquals(ResultStatus.failed, state.status());
         assertEquals(5, state.subStates().size());
-        assertEquals(ResultStatus.failed, state.subState("sub_step_1").status());
-        assertEquals(ResultStatus.skipped, state.subState("sub_step_2").status());
-        assertEquals(ResultStatus.cancelled, state.subState("sub_step_3").status());
-        assertEquals(ResultStatus.failed, state.subState("sub_step_4").status());
+        assertEquals(ResultStatus.failed, state.subState(NAME+" sub_step_1").status());
+        assertEquals(ResultStatus.skipped, state.subState(NAME+" sub_step_2").status());
+        assertEquals(ResultStatus.cancelled, state.subState(NAME+" sub_step_3").status());
+        assertEquals(ResultStatus.failed, state.subState(NAME+" sub_step_4").status());
         executor.stop();
         assertEquals(0, aml.leaderboard().getModelCount());
     }

--- a/h2o-automl/src/test/java/ai/h2o/automl/ModelingStepsExecutorTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/ModelingStepsExecutorTest.java
@@ -1,5 +1,6 @@
 package ai.h2o.automl;
 
+import ai.h2o.automl.StepResultState.ResultStatus;
 import ai.h2o.automl.WorkAllocations.JobType;
 import ai.h2o.automl.WorkAllocations.Work;
 import ai.h2o.automl.dummy.DummyStepsProvider;
@@ -7,18 +8,22 @@ import hex.Model;
 import hex.ModelMetricsRegression;
 import hex.tree.gbm.GBM;
 import hex.tree.gbm.GBMModel;
+import jsr166y.CountedCompleter;
 import org.junit.*;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import water.*;
+import water.exceptions.H2OAutoMLException;
 import water.fvec.Frame;
 import water.runner.CloudSize;
 import water.runner.H2ORunner;
 
 import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import static ai.h2o.automl.ModelingStepsExecutor.DEFAULT_STATE_RESOLUTION_STRATEGY;
 import static ai.h2o.automl.dummy.DummyStepsProvider.DummyModelSteps.*;
 import static org.junit.Assert.*;
 import static water.TestUtil.parseTestFile;
@@ -33,12 +38,17 @@ public class ModelingStepsExecutorTest {
         }
         
         private ModelingStep[] defaults = {
-                new TestingModelingStep("job_work", makeJob("dummy_job"), 42, 42, aml()),
-                new TestingModelingStep("job_zero_work", makeJob("dummy_job"), 42, 0, aml()),
-                new TestingModelingStep("job_no_work", makeJob("dummy_job"), 42, -1, aml()),
-                new TestingModelingStep("no_job_work", null, 42, 42, aml()),
-                new TestingModelingStepWithSubsteps("no_job_with_substeps", null, 42, 42, aml()),
-                new TestingModelingStepWithSubsteps("job_with_substeps", makeJob("dummy_job"), 42, 42, aml()),
+                new TestingModelingStepDummyModel("job_work", makeJob("dummy_job"), 42, 42, aml()),
+                new TestingModelingStepDummyModel("job_zero_work", makeJob("dummy_job"), 42, 0, aml()),
+                new TestingModelingStepDummyModel("job_no_work", makeJob("dummy_job"), 42, -1, aml()),
+                new TestingModelingStepDummyModel("no_job_work", null, 42, 42, aml()),
+                new TestingModelingStepWithException("cancelled_job", makeJob("dummy_job"), 42, 42, aml(), new Job.JobCancelledException()),
+                new TestingModelingStepWithException("failed_job", makeJob("dummy_job"), 42, 42, aml(), new H2OAutoMLException("dummy")),
+                new TestingModelingStepWithSubsteps("no_job_with_substeps", null, 42, 42, aml(), new ResultStatus[]{ResultStatus.success, ResultStatus.success}),
+                new TestingModelingStepWithSubsteps("job_with_substeps", makeJob("dummy_job"), 42, 42, aml(), new ResultStatus[]{ResultStatus.success, ResultStatus.success}),
+                new TestingModelingStepWithSubsteps("job_with_1_cancelled_substep", null, 42, 42, aml(), new ResultStatus[]{ResultStatus.success, ResultStatus.cancelled}),
+                new TestingModelingStepWithSubsteps("job_with_1_failed_substep", null, 42, 42, aml(), new ResultStatus[]{ResultStatus.success, ResultStatus.failed, ResultStatus.cancelled}),
+                new TestingModelingStepWithSubsteps("job_with_all_failed_substeps", null, 42, 42, aml(), new ResultStatus[]{ResultStatus.failed, ResultStatus.skipped, ResultStatus.cancelled, ResultStatus.failed}),
         };
 
         @Override
@@ -82,7 +92,7 @@ public class ModelingStepsExecutorTest {
     @Test
     public void test_start_stop() {
         ModelingStepsExecutor executor = new ModelingStepsExecutor(aml.leaderboard(), aml.eventLog(), aml._runCountdown);
-        executor.start(10);
+        executor.start(10, DEFAULT_STATE_RESOLUTION_STRATEGY);
         assertTrue(executor._runCountdown.running());
         executor.stop();
         assertFalse(executor._runCountdown.running());
@@ -91,33 +101,34 @@ public class ModelingStepsExecutorTest {
     @Test
     public void test_submit_training_step_with_zero_work() {
         ModelingStepsExecutor executor = new ModelingStepsExecutor(aml.leaderboard(), aml.eventLog(), aml._runCountdown);
-        executor.start(10);
+        executor.start(10, DEFAULT_STATE_RESOLUTION_STRATEGY);
         Job parentJob = makeJob("parent");
-        boolean started = executor.submit(aml.session().getModelingStep(NAME, "job_zero_work"), parentJob);
-        assertFalse(started);
+        StepResultState state = executor.submit(aml.session().getModelingStep(NAME, "job_zero_work"), parentJob);
+        assertEquals(ResultStatus.skipped, state.status());
         executor.stop();
     }
 
     @Test
     public void test_submit_training_step_with_no_allocated_work() {
         ModelingStepsExecutor executor = new ModelingStepsExecutor(aml.leaderboard(), aml.eventLog(), aml._runCountdown);
-        executor.start(10);
+        executor.start(10, DEFAULT_STATE_RESOLUTION_STRATEGY);
         Job parentJob = makeJob("parent");
-        boolean started = executor.submit(aml.session().getModelingStep(NAME, "job_no_work"), parentJob);
-        assertFalse(started);
+        StepResultState state = executor.submit(aml.session().getModelingStep(NAME, "job_no_work"), parentJob);
+        assertEquals(ResultStatus.skipped, state.status());
         executor.stop();
     }
 
     @Test
     public void test_submit_training_step_with_no_job() {
         ModelingStepsExecutor executor = new ModelingStepsExecutor(aml.leaderboard(), aml.eventLog(), aml._runCountdown);
-        executor.start(10);
+        executor.start(10, DEFAULT_STATE_RESOLUTION_STRATEGY);
         Job parentJob = makeJob("parent");
         startParentJob(parentJob, j -> j.msec() > 1000);
-        
-        boolean started = executor.submit(aml.session().getModelingStep(NAME, "no_job_work"), parentJob);
+        StepResultState state = executor.submit(aml.session().getModelingStep(NAME, "no_job_work"), parentJob);
         executor.stop();
-        assertFalse(started);
+        assertEquals(ResultStatus.skipped, state.status());
+        assertNull(state.error());
+        assertEquals(0, state.subStates().size());
         assertEquals(0.42, parentJob.progress(), 1e-6);  // parent job work should be filled with skipped work
         assertEquals(0, aml.leaderboard().getModelCount());
     }
@@ -125,26 +136,60 @@ public class ModelingStepsExecutorTest {
     @Test
     public void test_submit_valid_training_step() {
         ModelingStepsExecutor executor = new ModelingStepsExecutor(aml.leaderboard(), aml.eventLog(), aml._runCountdown);
-        executor.start(10);
+        executor.start(10, DEFAULT_STATE_RESOLUTION_STRATEGY);
         Job parentJob = makeJob("parent");
         startParentJob(parentJob, j -> j.msec() > 1000);
 
-        boolean started = executor.submit(aml.session().getModelingStep(NAME, "job_work"), parentJob);
+        StepResultState state = executor.submit(aml.session().getModelingStep(NAME, "job_work"), parentJob);
         executor.stop();
-        assertTrue(started);
+        assertEquals(ResultStatus.success, state.status());
+        assertNull(state.error());
+        assertEquals(0, state.subStates().size());
         assertEquals(0.42, parentJob.progress(), 1e-6); // parent job work should be filled with executed work
         assertEquals(1, aml.leaderboard().getModelCount());
     }
+    
+    @Test
+    public void test_submit_cancelled_step() {
+        ModelingStepsExecutor executor = new ModelingStepsExecutor(aml.leaderboard(), aml.eventLog(), aml._runCountdown);
+        executor.start(10, DEFAULT_STATE_RESOLUTION_STRATEGY);
+        Job parentJob = makeJob("parent");
+        startParentJob(parentJob, j -> j.msec() > 1000);
 
+        StepResultState state = executor.submit(aml.session().getModelingStep(NAME, "cancelled_job"), parentJob);
+        executor.stop();
+        assertEquals(ResultStatus.cancelled, state.status());
+        assertNull(state.error());
+        assertEquals(0, state.subStates().size());
+        assertEquals(0.42, parentJob.progress(), 1e-6); // parent job work should be filled with executed work
+        assertEquals(0, aml.leaderboard().getModelCount());
+    }
+    
+    @Test
+    public void test_submit_failed_step() {
+        ModelingStepsExecutor executor = new ModelingStepsExecutor(aml.leaderboard(), aml.eventLog(), aml._runCountdown);
+        executor.start(10, DEFAULT_STATE_RESOLUTION_STRATEGY);
+        Job parentJob = makeJob("parent");
+        startParentJob(parentJob, j -> j.msec() > 1000);
+
+        StepResultState state = executor.submit(aml.session().getModelingStep(NAME, "failed_job"), parentJob);
+        executor.stop();
+        assertEquals(ResultStatus.failed, state.status());
+        assertTrue(state.error() instanceof H2OAutoMLException);
+        assertEquals(0, state.subStates().size());
+        assertEquals(0.42, parentJob.progress(), 1e-6); // parent job work should be filled with executed work
+        assertEquals(0, aml.leaderboard().getModelCount());
+    }
 
     @Test
     public void test_submit_training_step_with_substeps_but_no_main_job() {
         ModelingStepsExecutor executor = new ModelingStepsExecutor(aml.leaderboard(), aml.eventLog(), aml._runCountdown);
-        executor.start(10);
+        executor.start(10, DEFAULT_STATE_RESOLUTION_STRATEGY);
         Job parentJob = makeJob("parent");
         startParentJob(parentJob, j -> j.msec() > 1000);
-        boolean started = executor.submit(aml.session().getModelingStep(NAME, "no_job_with_substeps"), parentJob);
-        assertTrue(started);
+        StepResultState state = executor.submit(aml.session().getModelingStep(NAME, "no_job_with_substeps"), parentJob);
+        assertEquals(ResultStatus.success, state.status());
+        assertEquals(3, state.subStates().size());
         executor.stop();
         assertEquals(2, aml.leaderboard().getModelCount());
     }
@@ -152,16 +197,83 @@ public class ModelingStepsExecutorTest {
     @Test
     public void test_submit_training_step_with_substeps_and_main_job() {
         ModelingStepsExecutor executor = new ModelingStepsExecutor(aml.leaderboard(), aml.eventLog(), aml._runCountdown);
-        executor.start(10);
+        executor.start(10, DEFAULT_STATE_RESOLUTION_STRATEGY);
         Job parentJob = makeJob("parent");
         startParentJob(parentJob, j -> j.msec() > 1000);
-        boolean started = executor.submit(aml.session().getModelingStep(NAME, "job_with_substeps"), parentJob);
-        assertTrue(started);
+        StepResultState state = executor.submit(aml.session().getModelingStep(NAME, "job_with_substeps"), parentJob);
+        assertEquals(ResultStatus.success, state.status());
+        assertEquals(3, state.subStates().size());
         executor.stop();
         assertEquals(3, aml.leaderboard().getModelCount());
     }
+
+    @Test
+    public void test_submit_training_step_with_a_cancelled_substep() {
+        ModelingStepsExecutor executor = new ModelingStepsExecutor(aml.leaderboard(), aml.eventLog(), aml._runCountdown);
+        executor.start(10, DEFAULT_STATE_RESOLUTION_STRATEGY);
+        Job parentJob = makeJob("parent");
+        startParentJob(parentJob, j -> j.msec() > 1000);
+        StepResultState state = executor.submit(aml.session().getModelingStep(NAME, "job_with_1_cancelled_substep"), parentJob);
+        assertEquals(ResultStatus.success, state.status());
+        assertEquals(3, state.subStates().size());
+        assertEquals(ResultStatus.success, state.subState("sub_step_1").status());
+        assertEquals(ResultStatus.cancelled, state.subState("sub_step_2").status());
+        executor.stop();
+        assertEquals(1, aml.leaderboard().getModelCount());
+    }
+
+    @Test
+    public void test_submit_training_step_with_a_failed_substep() {
+        ModelingStepsExecutor executor = new ModelingStepsExecutor(aml.leaderboard(), aml.eventLog(), aml._runCountdown);
+        executor.start(10, DEFAULT_STATE_RESOLUTION_STRATEGY);
+        Job parentJob = makeJob("parent");
+        startParentJob(parentJob, j -> j.msec() > 1000);
+        StepResultState state = executor.submit(aml.session().getModelingStep(NAME, "job_with_1_failed_substep"), parentJob);
+        assertEquals(ResultStatus.success, state.status());
+        assertEquals(4, state.subStates().size());
+        assertEquals(ResultStatus.success, state.subState("sub_step_1").status());
+        assertEquals(ResultStatus.failed, state.subState("sub_step_2").status());
+        assertEquals(ResultStatus.cancelled, state.subState("sub_step_3").status());
+        executor.stop();
+        assertEquals(1, aml.leaderboard().getModelCount());
+    }
+
+    @Test
+    public void test_submit_training_step_with_no_success_substeps_optimistic() {
+        ModelingStepsExecutor executor = new ModelingStepsExecutor(aml.leaderboard(), aml.eventLog(), aml._runCountdown);
+        executor.start(10, DEFAULT_STATE_RESOLUTION_STRATEGY);
+        Job parentJob = makeJob("parent");
+        startParentJob(parentJob, j -> j.msec() > 1000);
+        StepResultState state = executor.submit(aml.session().getModelingStep(NAME, "job_with_all_failed_substeps"), parentJob);
+        assertEquals(ResultStatus.cancelled, state.status());
+        assertEquals(5, state.subStates().size());
+        assertEquals(ResultStatus.failed, state.subState("sub_step_1").status());
+        assertEquals(ResultStatus.skipped, state.subState("sub_step_2").status());
+        assertEquals(ResultStatus.cancelled, state.subState("sub_step_3").status());
+        assertEquals(ResultStatus.failed, state.subState("sub_step_4").status());
+        executor.stop();
+        assertEquals(0, aml.leaderboard().getModelCount());
+    }
     
-    
+    @Test
+    public void test_submit_training_step_with_no_success_substeps_pessimistic() {
+        ModelingStepsExecutor executor = new ModelingStepsExecutor(aml.leaderboard(), aml.eventLog(), aml._runCountdown);
+        executor.start(10, StepResultState.Resolution.pessimistic);
+        Job parentJob = makeJob("parent");
+        startParentJob(parentJob, j -> j.msec() > 1000);
+        StepResultState state = executor.submit(aml.session().getModelingStep(NAME, "job_with_all_failed_substeps"), parentJob);
+        assertEquals(ResultStatus.failed, state.status());
+        assertEquals(5, state.subStates().size());
+        assertEquals(ResultStatus.failed, state.subState("sub_step_1").status());
+        assertEquals(ResultStatus.skipped, state.subState("sub_step_2").status());
+        assertEquals(ResultStatus.cancelled, state.subState("sub_step_3").status());
+        assertEquals(ResultStatus.failed, state.subState("sub_step_4").status());
+        executor.stop();
+        assertEquals(0, aml.leaderboard().getModelCount());
+    }
+
+
+
     private static void startParentJob(Job parent, Predicate<Job> stoppingCondition) {
         parent.start(new H2O.H2OCountedCompleter() {
             @Override
@@ -177,12 +289,12 @@ public class ModelingStepsExecutorTest {
         }, 100);
     }
     
-    private static class TestingModelingStep extends ModelingStep {
+    private static abstract class TestingModelingStep extends ModelingStep {
 
         final Job _job;
 
-        public TestingModelingStep(String id, Job job, int priorityGroup, int weight, AutoML autoML) {
-            super(NAME, Algo.GBM, id, priorityGroup, weight, autoML);
+        public TestingModelingStep(String id, Job job, Algo algo, int priorityGroup, int weight, AutoML autoML) {
+            super(NAME, algo, id, priorityGroup, weight, autoML);
             _job = job;
         }
 
@@ -207,31 +319,76 @@ public class ModelingStepsExecutorTest {
             return _job.start(new H2O.H2OCountedCompleter() {
                 @Override
                 public void compute2() {
-                    GBMModel.GBMParameters parms = new GBMModel.GBMParameters();
-                    GBMModel.GBMOutput output = new GBMModel.GBMOutput(new GBM(parms));
-                    Model res = new GBMModel(_job._result, parms, output);
-                    Frame fr = aml().getTrainingFrame();
-                    output._training_metrics = new ModelMetricsRegression(res, fr, 1, 1, 1, 1, 1, 1, null);
-                    DKV.put(_job._result, res);
+                    doSth();
                     tryComplete();
                 }
             }, _weight);
         }
+        
+        protected abstract void doSth();
+    }
+    
+    private static class TestingModelingStepDummyModel extends TestingModelingStep {
+
+        public TestingModelingStepDummyModel(String id, Job job, int priorityGroup, int weight, AutoML autoML) {
+            super(id, job, Algo.GBM, priorityGroup, weight, autoML);
+        }
+
+        @Override
+        protected void doSth() {
+            GBMModel.GBMParameters parms = new GBMModel.GBMParameters();
+            GBMModel.GBMOutput output = new GBMModel.GBMOutput(new GBM(parms));
+            Model res = new GBMModel(_job._result, parms, output);
+            Frame fr = aml().getTrainingFrame();
+            output._training_metrics = new ModelMetricsRegression(res, fr, 1, 1, 1, 1, 1, 1, null);
+            DKV.put(_job._result, res);
+        }
     }
 
-    private static class TestingModelingStepWithSubsteps extends TestingModelingStep {
+    private static class TestingModelingStepWithException extends TestingModelingStep {
+        
+        final RuntimeException _exception;
+        public TestingModelingStepWithException(String id, Job job, int priorityGroup, int weight, AutoML autoML, RuntimeException exception) {
+            super(id, job, Algo.GBM, priorityGroup, weight, autoML);
+            _exception = exception;
+        }
 
-        public TestingModelingStepWithSubsteps(String id, Job job, int priorityGroup, int weight, AutoML autoML) {
+        @Override
+        protected void doSth() {
+            throw _exception;
+        }
+    }
+
+    private static class TestingModelingStepWithSubsteps extends TestingModelingStepDummyModel {
+
+        final ResultStatus[] _subStepStatuses;
+        public TestingModelingStepWithSubsteps(String id, Job job, int priorityGroup, int weight, AutoML autoML, ResultStatus[] subStepStatuses) {
             super(id, job, priorityGroup, weight, autoML);
+            _subStepStatuses = subStepStatuses;
         }
 
         @Override
         public Iterator<? extends ModelingStep> iterateSubSteps() {
-            int workRatio = _job == null ? 2 : 3; // dividing the work in equal parts depending if there's a main job or not
-            return Stream.of(
-                    new TestingModelingStep("sub_step_1", makeJob("dummy_sub_step_job_1"), _priorityGroup, _weight / workRatio, aml()),
-                    new TestingModelingStep("sub_step_2", makeJob("dummy_sub_step_job_2"), _priorityGroup, _weight / workRatio, aml())
-            ).iterator();
+            int workRatio = _job == null ? _subStepStatuses.length : _subStepStatuses.length+1; // dividing the work in equal parts depending if there's a main job or not
+            AtomicInteger idx = new AtomicInteger();
+            return Stream.of(_subStepStatuses).map(res -> makeSubStep(idx.incrementAndGet(), res, workRatio)).iterator();
         }
+         private TestingModelingStep makeSubStep(int i, ResultStatus status, int workRatio) {
+            switch (status) {
+                case success: 
+                    return new TestingModelingStepDummyModel("sub_step_"+i, makeJob("dummy_sub_step_job_"+i), 
+                            _priorityGroup, _weight / workRatio, aml());
+                case skipped:
+                    return new TestingModelingStepDummyModel("sub_step_"+i, makeJob("dummy_sub_step_job_"+i),
+                            _priorityGroup, 0, aml());
+                case cancelled:
+                    return new TestingModelingStepWithException("sub_step_"+i, makeJob("dummy_sub_step_job_"+i),
+                            _priorityGroup, _weight / workRatio, aml(), new Job.JobCancelledException());
+                case failed:
+                    return new TestingModelingStepWithException("sub_step_"+i, makeJob("dummy_sub_step_job_"+i), 
+                            _priorityGroup, _weight / workRatio, aml(), new H2OAutoMLException("dummy"));
+            }
+            return null;
+         }
     }
 }

--- a/h2o-core/src/main/java/hex/grid/Grid.java
+++ b/h2o-core/src/main/java/hex/grid/Grid.java
@@ -60,7 +60,7 @@ public class Grid<MP extends Model.Parameters> extends Lockable<Grid<MP>> implem
   private static final Key<Model> NO_MODEL_FAILURES_KEY = Key.makeUserHidden("GridSearchFailureEmptyModelKey");
 
   /**
-   * A failure occured during hyperspace exploration.
+   * Failure that occurred during hyperspace exploration.
    */
   public static final class SearchFailure<MP extends Model.Parameters> extends Iced<SearchFailure> {
 
@@ -332,7 +332,9 @@ public class Grid<MP extends Model.Parameters> extends Lockable<Grid<MP>> implem
    */
   private void appendFailedModelParameters(final Key<Model> modelKey, final MP params, final String[] rawParams,
                                            final Throwable t) {
-      final String failureDetails = isJobCanceled(t) ? "Job Canceled" : t.getMessage();
+      final String failureDetails = isJobCanceled(t) 
+              ? "Job Canceled, keeping the incomplete grid with all the models trained before cancellation." 
+              : t.getMessage();
       final String stackTrace = StringUtils.toString(t);
       final Key<Model> searchedKey = modelKey != null ? modelKey : NO_MODEL_FAILURES_KEY;
       SearchFailure searchFailure = _failures.get(searchedKey);
@@ -344,7 +346,7 @@ public class Grid<MP extends Model.Parameters> extends Lockable<Grid<MP>> implem
       searchFailure.appendWarningMessage(_hyper_names, "alpha");
   }
 
-  private static boolean isJobCanceled(final Throwable t) {
+  static boolean isJobCanceled(final Throwable t) {
     for (Throwable ex = t; ex != null; ex = ex.getCause()) {
       if (ex instanceof Job.JobCancelledException) {
         return true;

--- a/h2o-core/src/main/java/hex/grid/Grid.java
+++ b/h2o-core/src/main/java/hex/grid/Grid.java
@@ -332,9 +332,7 @@ public class Grid<MP extends Model.Parameters> extends Lockable<Grid<MP>> implem
    */
   private void appendFailedModelParameters(final Key<Model> modelKey, final MP params, final String[] rawParams,
                                            final Throwable t) {
-      final String failureDetails = isJobCanceled(t) 
-              ? "Job Canceled, keeping the incomplete grid with all the models trained before cancellation." 
-              : t.getMessage();
+      final String failureDetails = isJobCanceled(t) ? "Job Canceled" : t.getMessage();
       final String stackTrace = StringUtils.toString(t);
       final Key<Model> searchedKey = modelKey != null ? modelKey : NO_MODEL_FAILURES_KEY;
       SearchFailure searchFailure = _failures.get(searchedKey);

--- a/h2o-core/src/main/java/hex/grid/Grid.java
+++ b/h2o-core/src/main/java/hex/grid/Grid.java
@@ -99,8 +99,8 @@ public class Grid<MP extends Model.Parameters> extends Lockable<Grid<MP>> implem
      *
      * @param params    model parameters which caused model builder failure, can be null
      * @param rawParams array of "raw" parameter values
-     * @params failureDetails  textual description of model building failure
-     * @params stackTrace  stringify stacktrace
+     * @param failureDetails  textual description of model building failure
+     * @param stackTrace  stringify stacktrace
      */
     private void appendFailedModelParameters(MP params, String[] rawParams, String failureDetails, String stackTrace) {
       assert rawParams != null : "API has to always pass rawParams";
@@ -160,7 +160,7 @@ public class Grid<MP extends Model.Parameters> extends Lockable<Grid<MP>> implem
      * <p> Should be used only from <code>GridSearch</code> job.</p>
      *
      * @param rawParams list of "raw" hyper values which caused a failure to prepare model parameters
-     * @params e exception causing a failure
+     * @param e exception causing a failure
      */
     /* package */ void appendFailedModelParameters(Object[] rawParams, Exception e) {
       assert rawParams != null : "Raw parameters should be always != null !";
@@ -264,7 +264,7 @@ public class Grid<MP extends Model.Parameters> extends Lockable<Grid<MP>> implem
   }
 
 
-  /**
+  /*
    * Ask the Grid for a suggested next hyperparameter value, given an existing Model as a starting
    * point and the complete set of hyperparameter limits. Returning a NaN signals there is no next
    * suggestion, which is reasonable if the obvious "next" value does not exist (e.g. exhausted all
@@ -327,8 +327,7 @@ public class Grid<MP extends Model.Parameters> extends Lockable<Grid<MP>> implem
    * @param modelKey Model the failures are related to
    * @param params    model parameters which caused model builder failure, can be null
    * @param rawParams array of "raw" parameter values
-   * @params failureDetails  textual description of model building failure
-   * @params stackTrace  stringify stacktrace
+   * @param t the exception causing a failure
    */
   private void appendFailedModelParameters(final Key<Model> modelKey, final MP params, final String[] rawParams,
                                            final Throwable t) {
@@ -362,7 +361,7 @@ public class Grid<MP extends Model.Parameters> extends Lockable<Grid<MP>> implem
    * <p> Should be used only from <code>GridSearch</code> job.</p>
    *
    * @param params model parameters which caused model builder failure
-   * @params e  exception causing a failure
+   * @param t the exception causing a failure
    */
   void appendFailedModelParameters(final Key<Model> modelKey, final MP params, final Throwable t) {
     assert params != null : "Model parameters should be always != null !";
@@ -379,7 +378,7 @@ public class Grid<MP extends Model.Parameters> extends Lockable<Grid<MP>> implem
    * <p> Should be used only from <code>GridSearch</code> job.</p>
    *
    * @param rawParams list of "raw" hyper values which caused a failure to prepare model parameters
-   * @params e exception causing a failure
+   * @param e the exception causing a failure
    */
   void appendFailedModelParameters(final Key<Model> modelKey, final Object[] rawParams, final Exception e) {
     assert rawParams != null : "Raw parameters should be always != null !";
@@ -598,7 +597,6 @@ public class Grid<MP extends Model.Parameters> extends Lockable<Grid<MP>> implem
    *
    * @param gridExportDir Full path to the folder this {@link Grid} should be saved to
    * @return Path of the file written
-   * @throws IOException Error serializing the grid.
    */
   public List<String> exportBinary(final String gridExportDir, final boolean exportModels, ModelExportOption... options) {
     Objects.requireNonNull(gridExportDir);

--- a/h2o-core/src/main/java/hex/grid/GridSearch.java
+++ b/h2o-core/src/main/java/hex/grid/GridSearch.java
@@ -429,6 +429,8 @@ public final class GridSearch<MP extends Model.Parameters> {
             ScoringInfo.sort(grid.getScoringInfos(), sortingMetric());
           }
         } catch (RuntimeException e) { // Catch everything
+          grid.appendFailedModelParameters(model != null ? model._key : null, params, e);
+          
           if (Job.isCancelledException(e)) {
             assert model == null;
             final long checksum = params.checksum(IGNORED_FIELDS_PARAM_HASH);
@@ -447,8 +449,6 @@ public final class GridSearch<MP extends Model.Parameters> {
               _job.fail(new H2OGridException("Aborting Grid search after too many consecutive model failures.", e));
             }
           }
-
-          grid.appendFailedModelParameters(model != null ? model._key : null, params, e);
         }
       } catch (IllegalArgumentException e) {
         Log.warn("Grid search: construction of model parameters failed! Exception: ", e);

--- a/h2o-core/src/main/java/hex/grid/GridSearch.java
+++ b/h2o-core/src/main/java/hex/grid/GridSearch.java
@@ -658,6 +658,7 @@ public final class GridSearch<MP extends Model.Parameters> {
    * 
    * @deprecated Prefer use of {@link GridSearch#create(Key, HyperSpaceWalker)}
    */
+  @Deprecated
   public static <MP extends Model.Parameters> Job<Grid> startGridSearch(
           final Key<Grid> destKey,
           final MP params,
@@ -693,6 +694,7 @@ public final class GridSearch<MP extends Model.Parameters> {
    * 
    * @deprecated Prefer use of {@link GridSearch#create(Key, HyperSpaceWalker)}
    */
+  @Deprecated
   public static <MP extends Model.Parameters> Job<Grid> startGridSearch(
       final Key<Job> jobKey,
       final Key<Grid> destKey,
@@ -729,6 +731,7 @@ public final class GridSearch<MP extends Model.Parameters> {
    * 
    * @deprecated Prefer use of {@link GridSearch#create(Key, Model.Parameters, Map)})}
    */
+  @Deprecated
   public static <MP extends Model.Parameters> Job<Grid> startGridSearch(
           final Key<Grid> destKey,
           final MP params,
@@ -755,6 +758,7 @@ public final class GridSearch<MP extends Model.Parameters> {
    *
    * @deprecated Prefer use of {@link GridSearch#create(Key, Model.Parameters, Map)})}
    */
+  @Deprecated
   public static <MP extends Model.Parameters> Job<Grid> startGridSearch(
           final Key<Grid> destKey,
           final MP params,
@@ -777,7 +781,10 @@ public final class GridSearch<MP extends Model.Parameters> {
    * @return GridSearch Job, with models run with these parameters, built as needed - expected to be
    * an expensive operation.  If the models in question are "in progress", a 2nd build will NOT be
    * kicked off.  This is a non-blocking call.
+   * 
+   * @deprecated Prefer use of {@link GridSearch#create(Key, HyperSpaceWalker)}
    */
+  @Deprecated
   public static <MP extends Model.Parameters> Job<Grid> startGridSearch(
           final Key<Grid> destKey,
           final HyperSpaceWalker<MP, ?> hyperSpaceWalker,
@@ -804,6 +811,7 @@ public final class GridSearch<MP extends Model.Parameters> {
    * 
    * @deprecated Prefer use of {@link GridSearch#create(Key, HyperSpaceWalker)}
    */
+  @Deprecated
   public static <MP extends Model.Parameters> Job<Grid> startGridSearch(
       final Key<Job> jobKey,
       final Key<Grid> destKey,

--- a/h2o-core/src/main/java/hex/grid/GridSearch.java
+++ b/h2o-core/src/main/java/hex/grid/GridSearch.java
@@ -92,7 +92,7 @@ public final class GridSearch<MP extends Model.Parameters> {
     
     private final GridSearch<MP> _gridSearch;
 
-    public Builder(Key<Grid> destKey, HyperSpaceWalker<MP, ?> hyperSpaceWalker) {
+    private Builder(Key<Grid> destKey, HyperSpaceWalker<MP, ?> hyperSpaceWalker) {
       assert hyperSpaceWalker != null;
       if (destKey == null) {
         MP params = hyperSpaceWalker.getParams();

--- a/h2o-core/src/main/java/water/exceptions/H2OAbstractRuntimeException.java
+++ b/h2o-core/src/main/java/water/exceptions/H2OAbstractRuntimeException.java
@@ -5,7 +5,10 @@ import water.H2OError;
 import water.util.IcedHashMapGeneric;
 
 /**
- * RuntimeException which results in an http 400 error, and serves as a base class for other error types.
+ * RuntimeException which results in a http 400 error by default, and serves as a base class for other error types.
+ * Note that the HTTP error status can be overridden when converting the exception to {@link H2OError}
+ * when overriding {@link #toH2OError(String)}.
+ * 
  * NOTE: don't use this directly; use more specific types.
  */
 abstract public class H2OAbstractRuntimeException extends RuntimeException {
@@ -28,7 +31,7 @@ abstract public class H2OAbstractRuntimeException extends RuntimeException {
   }
 
   public H2OError toH2OError() {
-    return new H2OError(timestamp, null, getMessage(), dev_message, HTTP_RESPONSE_CODE(), values, this);
+    return toH2OError(null);
   }
 
   public H2OError toH2OError(String error_url) {

--- a/h2o-core/src/main/java/water/exceptions/H2OFailException.java
+++ b/h2o-core/src/main/java/water/exceptions/H2OFailException.java
@@ -22,12 +22,4 @@ public class H2OFailException extends H2OAbstractRuntimeException {
     this(msg);
     this.initCause(cause);
   }
-
-  public H2OError toH2OError() {
-    return new H2OError(timestamp, null, getMessage(), dev_message, HTTP_RESPONSE_CODE(), values, this);
-  }
-
-  public H2OError toH2OError(String error_url) {
-    return new H2OError(timestamp, error_url, getMessage(), dev_message, HTTP_RESPONSE_CODE(), values, this);
-  }
 }

--- a/h2o-core/src/main/java/water/exceptions/H2OGridException.java
+++ b/h2o-core/src/main/java/water/exceptions/H2OGridException.java
@@ -1,0 +1,49 @@
+package water.exceptions;
+
+import water.H2OError;
+
+public class H2OGridException extends H2OAbstractRuntimeException {
+    
+    private final Throwable _rootCause;
+    private final int _httpResponse;
+    
+    public H2OGridException(String msg) {
+        this(msg, null);
+    }
+    
+    public H2OGridException(String msg, Throwable rootException) {
+        this(msg, rootException, 0);
+    }
+    
+    public H2OGridException(String msg, Throwable rootException, int httpResponse) {
+        super(msg, msg);
+        _rootCause = rootException;
+        _httpResponse = httpResponse > 0 ? httpResponse : super.HTTP_RESPONSE_CODE();
+    }
+
+    @Override
+    protected int HTTP_RESPONSE_CODE() {
+        return _httpResponse;
+    }
+
+    @Override
+    public H2OError toH2OError(String error_url) {
+        H2OError err;
+        String rootMessage = _rootCause== null ? null : _rootCause.getMessage().trim();
+        if (_rootCause instanceof H2OAbstractRuntimeException) {
+            err = ((H2OAbstractRuntimeException) _rootCause).toH2OError(error_url);
+        } else {
+            err = new H2OError(timestamp, error_url, getMessage(), dev_message, HTTP_RESPONSE_CODE(), values, _rootCause);
+        }
+        StringBuilder msg = new StringBuilder(getMessage().trim());
+        if (msg.charAt(msg.length()-1) != '.') msg.append('.');
+        if (rootMessage != null) {
+            msg.append(' ');
+            msg.append("Root cause: ");
+            msg.append(rootMessage);
+            err._exception_msg = msg.toString();
+        }
+        return err;
+    }
+    
+}

--- a/h2o-core/src/main/java/water/exceptions/H2OModelBuilderIllegalArgumentException.java
+++ b/h2o-core/src/main/java/water/exceptions/H2OModelBuilderIllegalArgumentException.java
@@ -27,10 +27,6 @@ public class H2OModelBuilderIllegalArgumentException extends H2OIllegalArgumentE
     return exception;
   }
 
-  public H2OModelBuilderError toH2OError() {
-    return new H2OModelBuilderError(timestamp, null, getMessage(), dev_message, HTTP_RESPONSE_CODE(), values, this);
-  }
-
   public H2OModelBuilderError toH2OError(String error_url) {
     return new H2OModelBuilderError(timestamp, error_url, getMessage(), dev_message, HTTP_RESPONSE_CODE(), values, this);
   }

--- a/h2o-py/h2o/automl/__init__.py
+++ b/h2o-py/h2o/automl/__init__.py
@@ -1,3 +1,1 @@
-from .autoh2o import H2OAutoML, get_automl, get_leaderboard
-
-__all__ = ['H2OAutoML', 'get_automl', 'get_leaderboard']
+from .autoh2o import *

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -4,8 +4,10 @@ import functools as ft
 import h2o
 from h2o.utils.typechecks import assert_is_type
 from ._base import _fetch_state, _fetch_leaderboard
-from ._estimator import H2OAutoML  # keep this to link the estimator for backwards compatibility in module imports
+from ._estimator import H2OAutoML
 from ._output import H2OAutoMLOutput
+
+__all__ = ['H2OAutoML', 'get_automl', 'get_leaderboard']
 
 
 def get_automl(project_name):

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_ignore_cols.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_ignore_cols.py
@@ -21,39 +21,48 @@ def check_ignore_cols_automl(models,names,x,y):
 
 def test_columns_not_in_x_and_y_are_ignored():
     ds = import_dataset()
-    #Use same project_name so we add to leaderboard for each run
-    aml = H2OAutoML(max_models=2, stopping_rounds=3, stopping_tolerance=0.001, project_name="aml1")
-
-    print("AutoML with x as a str list, train, valid, and test")
+    names = ds.train.names
     x = ["AGE", "RACE", "DPROS"]
     y = ds.target
-    names = ds.train.names
-    aml.train(x=x, y=y, training_frame=ds.train, validation_frame=ds.valid, leaderboard_frame=ds.test)
-    print("AutoML leaderboard")
-    print(aml.leaderboard)
-    models = aml.leaderboard["model_id"]
-    check_ignore_cols_automl(models, names, x, y)
 
-    print("AutoML with x and y as col indexes, train, valid, and test")
-    aml.train(x=[2, 3, 4], y=1, training_frame=ds.train, validation_frame=ds.valid, leaderboard_frame=ds.test)
-    print("AutoML leaderboard")
-    print(aml.leaderboard)
-    models = aml.leaderboard["model_id"]
-    check_ignore_cols_automl(models, names, x, y)
+    def test_with_x_y_as_str_list():
+        aml = H2OAutoML(max_models=2, stopping_rounds=3, stopping_tolerance=0.001)
+        aml.train(x=x, y=y, training_frame=ds.train, validation_frame=ds.valid, leaderboard_frame=ds.test)
+        print("AutoML leaderboard")
+        print(aml.leaderboard)
+        models = aml.leaderboard["model_id"]
+        check_ignore_cols_automl(models, names, x, y)
 
-    print("AutoML with x as a str list, y as a col index, train, valid, and test")
-    aml.train(x=x, y=1, training_frame=ds.train, validation_frame=ds.valid, leaderboard_frame=ds.test)
-    print("AutoML leaderboard")
-    print(aml.leaderboard)
-    models = aml.leaderboard["model_id"]
-    check_ignore_cols_automl(models, names, x, y)
+    def test_with_x_y_as_indices():
+        aml = H2OAutoML(max_models=2, stopping_rounds=3, stopping_tolerance=0.001)
+        aml.train(x=[2, 3, 4], y=1, training_frame=ds.train, validation_frame=ds.valid, leaderboard_frame=ds.test)
+        print("AutoML leaderboard")
+        print(aml.leaderboard)
+        models = aml.leaderboard["model_id"]
+        check_ignore_cols_automl(models, names, x, y)
 
-    print("AutoML with x as col indexes, y as a str, train, valid, and test")
-    aml.train(x=[2,3,4], y=y, training_frame=ds.train, validation_frame=ds.valid, leaderboard_frame=ds.test)
-    print("AutoML leaderboard")
-    print(aml.leaderboard)
-    models = aml.leaderboard["model_id"]
-    check_ignore_cols_automl(models, names, x, y)
+    def test_with_x_as_str_list_y_as_index():
+        aml = H2OAutoML(max_models=2, stopping_rounds=3, stopping_tolerance=0.001)
+        aml.train(x=x, y=1, training_frame=ds.train, validation_frame=ds.valid, leaderboard_frame=ds.test)
+        print("AutoML leaderboard")
+        print(aml.leaderboard)
+        models = aml.leaderboard["model_id"]
+        check_ignore_cols_automl(models, names, x, y)
+
+    def test_with_x_indices_y_as_str():
+        aml = H2OAutoML(max_models=2, stopping_rounds=3, stopping_tolerance=0.001)
+        aml.train(x=[2,3,4], y=y, training_frame=ds.train, validation_frame=ds.valid, leaderboard_frame=ds.test)
+        print("AutoML leaderboard")
+        print(aml.leaderboard)
+        models = aml.leaderboard["model_id"]
+        check_ignore_cols_automl(models, names, x, y)
+    
+    pu.run_tests([
+        test_with_x_y_as_str_list,
+        test_with_x_y_as_indices,
+        test_with_x_as_str_list_y_as_index,
+        test_with_x_indices_y_as_str
+    ], run_in_isolation=False)
 
 
 pu.run_tests([

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_memory_cleanup.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_memory_cleanup.py
@@ -113,7 +113,7 @@ def test_suite_clean_cv_predictions():
         for m in models.base:
             assert_cv_predictions_on_model(m, False)
         for m in models.se:
-            assert not h2o.get_model(h2o.get_model(m).metalearner()['name']).cross_validation_predictions()
+            assert not h2o.get_model(h2o.get_model(m).metalearner().model_id).cross_validation_predictions()
 
     def test_param_enabled():
         print("\n=== enabling "+kcvp+" ===")
@@ -126,7 +126,7 @@ def test_suite_clean_cv_predictions():
         for m in models.base:
             assert_cv_predictions_on_model(m)
         for m in models.se:
-            assert_cv_predictions_on_model(h2o.get_model(m).metalearner()['name'])
+            assert_cv_predictions_on_model(h2o.get_model(m).metalearner().model_id)
 
     def test_param_disabled():
         print("\n=== disabling "+kcvp+" ===")
@@ -138,7 +138,7 @@ def test_suite_clean_cv_predictions():
         for m in models.base:
             assert_cv_predictions_on_model(m, False)
         for m in models.se:
-            assert not h2o.get_model(h2o.get_model(m).metalearner()['name']).cross_validation_predictions()
+            assert not h2o.get_model(h2o.get_model(m).metalearner().model_id).cross_validation_predictions()
 
     def test_SE_retraining_fails_when_param_disabled():
         print("\n=== disabling "+kcvp+" and retraining ===")
@@ -226,7 +226,7 @@ def test_suite_clean_cv_models():
         for m in models.base:
             assert not h2o.get_model(m).cross_validation_models(), "unexpected cv models for model "+m
         for m in models.se:
-            metal = h2o.get_model(h2o.get_model(m).metalearner()['name'])
+            metal = h2o.get_model(h2o.get_model(m).metalearner().model_id)
             assert not metal.cross_validation_models(), "unexpected cv models for metalearner of model "+m
 
     def test_param_enabled():
@@ -244,7 +244,7 @@ def test_suite_clean_cv_models():
         for m in models.base:
             assert h2o.get_model(m).cross_validation_models(), "missing cv models for model "+m
         for m in models.se:
-            metal = h2o.get_model(h2o.get_model(m).metalearner()['name'])
+            metal = h2o.get_model(h2o.get_model(m).metalearner().model_id)
             assert metal.cross_validation_models(), "missing cv models for metalearner of model "+m
 
     def test_param_disabled():
@@ -261,7 +261,7 @@ def test_suite_clean_cv_models():
         for m in models.base:
             assert not h2o.get_model(m).cross_validation_models(), "unexpected cv models for model "+m
         for m in models.se:
-            metal = h2o.get_model(h2o.get_model(m).metalearner()['name'])
+            metal = h2o.get_model(h2o.get_model(m).metalearner().model_id)
             assert not metal.cross_validation_models(), "unexpected cv models for metalearner of model "+m
 
     return [


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8420

AutoML used to ignore all exceptions thrown by model builders or grids by swallowing them early.
However, in some situations, we want to be able to make decisions on some of those errors without having the exception handling cluttered in various steps, and by ensuring that if an exception is propagated, then it's not swallowed randomly at a higher level.
The proposed solution applies the following logic:
- `ModelingStep`s don't handle exceptions and propagate them wherever they occur: model building validation, or training.
- `ModelingStepsExecutor` catch all job statuses, including the ones failing with exceptions, but collect them into a `ResultState` object that can be used at a higher level to make a decision. By swallowing all exceptions at this level, it should guarantee the robustness of AutoML, that won't fail on model or grid errors by default.
- `AutoML` can analyse the `ResultState` and decide to propagate some specific exceptions, or to throw new ones, for example if too many consecutive step failures as it's a sign a bad configuration.

On grids side: following changes apply:
- cancelled grids are not thrown away anymore and models trained until cancellation are accessible: a user (or AutoML) may want to train a long grid, interrupt it manually and still check the trained models.
- in a similar way to AutoML, if too many consecutive model fail, then the grid itself is aborted and raise a new `H2OGridException`.