### PR TITLE
Upgrade to latest version to AWS S3 SDK (1.12.127)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,7 +174,7 @@ ext {
     //
     junitVersion  = '4.12'
     jets3tVersion = '0.7.1'
-    awsJavaSdkVersion = '1.8.3'
+    awsJavaSdkVersion = '1.12.127'
 
     //
     // Optional H2O modules which can be included h2o.jar assembly

--- a/h2o-core/build.gradle
+++ b/h2o-core/build.gradle
@@ -35,7 +35,7 @@ dependencies {
   testImplementation project(':h2o-test-support')
   testRuntimeOnly project(":${defaultWebserverModule}")
   testCompileOnly "javax.servlet:javax.servlet-api:${servletApiVersion}"
-  testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.40'
+  testImplementation "com.amazonaws:aws-java-sdk-s3:${awsJavaSdkVersion}"
 }
 
 apply from: "${rootDir}/gradle/dataCheck.gradle"

--- a/h2o-persist-s3/build.gradle
+++ b/h2o-persist-s3/build.gradle
@@ -1,18 +1,10 @@
 description = "H2O Persist S3"
 
-//apply plugin: "io.spring.dependency-management"
-
-//dependencyManagement {
-//  imports {
-//    mavenBom 'com.amazonaws:aws-java-sdk-bom:1.10.47'
-//  }
-//}
-
 dependencies {
   api project(":h2o-core")
-  api 'com.amazonaws:aws-java-sdk-s3:1.12.40'
+  api "com.amazonaws:aws-java-sdk-s3:${awsJavaSdkVersion}"
   api "org.apache.httpcomponents:httpclient:${httpClientVersion}"
-  api 'javax.xml.bind:jaxb-api:2.3.1'
+  api "javax.xml.bind:jaxb-api:2.3.1"
 
   testImplementation project(":h2o-test-support")
   testImplementation "com.adobe.testing:s3mock:2.1.28"


### PR DESCRIPTION
This should resolve an issue of SDK accessing private sun API
and failing to open modules on Java 16+

```
java.lang.reflect.InaccessibleObjectException: Unable to make javax.crypto.SecretKey sun.security.ssl.SSLSessionImpl.getMasterSecret() accessible: module java.base does not "opens sun.security.ssl" to unnamed module @34033bd0
[2021-12-10T07:33:43.288Z] 	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:357)
[2021-12-10T07:33:43.288Z] 	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
[2021-12-10T07:33:43.288Z] 	at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:199)
[2021-12-10T07:33:43.288Z] 	at java.base/java.lang.reflect.Method.setAccessible(Method.java:193)
[2021-12-10T07:33:43.288Z] 	at com.amazonaws.http.conn.ssl.SdkTLSSocketFactory.verifyMasterSecret(SdkTLSSocketFactory.java:186)
[2021-12-10T07:33:43.288Z] 	at com.amazonaws.http.conn.ssl.SdkTLSSocketFactory.connectSocket(SdkTLSSocketFactory.java:128)

```