### PR TITLE
[PUBDEV-8452][FOLLOWUP] Rename lambda Field on RuleFitParameters to _lambda

### DIFF
--- a/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
+++ b/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
@@ -167,8 +167,8 @@ public class RuleFit extends ModelBuilder<RuleFitModel, RuleFitModel.RuleFitPara
             glmParameters._weights_column = "linear." + _parms._weights_column;
         }
         glmParameters._auc_type = _parms._auc_type;
-        if (_parms.lambda != null) {
-            glmParameters._lambda = _parms.lambda;
+        if (_parms._lambda != null) {
+            glmParameters._lambda = _parms._lambda;
         }
     }
 

--- a/h2o-algos/src/main/java/hex/rulefit/RuleFitModel.java
+++ b/h2o-algos/src/main/java/hex/rulefit/RuleFitModel.java
@@ -69,7 +69,7 @@ public class RuleFitModel extends Model<RuleFitModel, RuleFitModel.RuleFitParame
         public boolean _remove_duplicates = true;
         
         // lambda for lasso
-        public double[] lambda;
+        public double[] _lambda;
         
 
         public void validate(RuleFit rfit) {


### PR DESCRIPTION
This exception in naming conventions for fields on parameter classes breaks API generation in SW. Fields on parameter classes (e.g.`RuleFitParameters`) serve as a source of default values for SW API.