### PR TITLE
HEXDEV-0779: Upgrade to log4j 2.15.0 to address CVE-2021-44228

### DIFF
--- a/h2o-logging/impl-log4j2/build.gradle
+++ b/h2o-logging/impl-log4j2/build.gradle
@@ -5,8 +5,8 @@ compileJava {
 }
 
 dependencies {
-    compile("org.apache.logging.log4j:log4j-1.2-api:2.14.1")
-    compile("org.apache.logging.log4j:log4j-core:2.14.1")
+    compile("org.apache.logging.log4j:log4j-1.2-api:2.15.0")
+    compile("org.apache.logging.log4j:log4j-core:2.15.0")
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }


### PR DESCRIPTION
This addresses https://nvd.nist.gov/vuln/detail/CVE-2021-44228