### PR TITLE
PUBDEV-8472: AutoML include fast default GLM

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingPlans.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingPlans.java
@@ -97,7 +97,8 @@ final class ModelingPlans {
                     new Step("lr_search", 6, DEFAULT_GRID_TRAINING_WEIGHT)
             ),
             new StepDefinition(Algo.GLM.name(), 
-                    new Step("def_1", 1, DEFAULT_MODEL_TRAINING_WEIGHT)
+                    new Step("def_1", 1, DEFAULT_MODEL_TRAINING_WEIGHT),
+                    new Step("def_2", 4, DEFAULT_GRID_TRAINING_WEIGHT) // giving a mini-grid weight due to alpha+lambda search 
             ),
             new StepDefinition(Algo.DRF.name(), 
                     new Step("def_1", 2, DEFAULT_MODEL_TRAINING_WEIGHT),

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/GLMStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/GLMStepsProvider.java
@@ -35,7 +35,7 @@ public class GLMStepsProvider
 
             public GLMParameters prepareModelParameters() {
                 GLMParameters params = new GLMParameters();
-                params._lambda_search = true;
+                params._missing_values_handling = GLMParameters.MissingValuesHandling.MeanImputation;
                 params._family =
                         aml().getResponseColumn().isBinary() && !(aml().getResponseColumn().isNumeric()) ? GLMParameters.Family.binomial
                                 : aml().getResponseColumn().isCategorical() ? GLMParameters.Family.multinomial
@@ -55,12 +55,13 @@ public class GLMStepsProvider
 
 
         private final ModelingStep[] defaults = new GLMModelStep[] {
-                new GLMModelStep("def_1", aml()) {
+                new GLMModelStep("def_1", aml()) {},
+                new GLMModelStep("def_2", aml()) {
                     @Override
                     public GLMParameters prepareModelParameters() {
                         GLMParameters params = super.prepareModelParameters();
                         params._alpha = new double[] {0.0, 0.2, 0.4, 0.6, 0.8, 1.0};
-                        params._missing_values_handling = GLMParameters.MissingValuesHandling.MeanImputation;
+                        params._lambda_search = true;
                         return params;
                     }
                 },


### PR DESCRIPTION
building 2 GLMs:
- a very basic one, trained in first priority group.
- one with lambda & alpha search (former default) that often takes much longer, and we don't want to allocate too many resources by default to this one, especially for larger datasets, so we're training it in 4th priority group, between XGB grid and GBM grid.