### PR TITLE
Exclude AWS S3 SDK from CDP builds, CDP provides their own jars [nocheck]

### DIFF
--- a/h2o-hadoop-3/assemblyjar_cdp.gradle
+++ b/h2o-hadoop-3/assemblyjar_cdp.gradle
@@ -6,6 +6,7 @@ description = "H2O HDFS client shadowjar for Hadoop ${ext.hadoopVersion}"
 configurations {
     api.exclude group: 'org.apache.hadoop'
     api.exclude group: 'org.apache.hive'
+    api.exclude group: 'com.amazonaws', module: 'aws-java-sdk-s3'
 }
 
 dependencies {


### PR DESCRIPTION
AWS S3 SDK is already included on CDP, bundling our own causes
the dependencies to conflict.
