### PR TITLE
Fix import from S3A on CDP in multinode

### DIFF
--- a/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
+++ b/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
@@ -538,7 +538,7 @@ public class h2odriver extends Configured implements Tool {
     }
 
     void announceNodeCloudSize(String ip, int port, String leaderWebServerIp, int leaderWebServerPort, int cloudSize) throws Exception {
-      System.out.println("H2O node " + ip + ":" + port + " reports H2O cluster size " + cloudSize + " [leader is " + leaderWebServerIp + ":" + leaderWebServerIp + "]");
+      System.out.println("H2O node " + ip + ":" + port + " reports H2O cluster size " + cloudSize + " [leader is " + leaderWebServerIp + ":" + leaderWebServerPort + "]");
       if (cloudSize == _targetCloudSize) {
         announceCloudReadyNode(leaderWebServerIp, leaderWebServerPort);
       }

--- a/h2o-persist-hdfs/src/main/java/water/persist/PersistHdfs.java
+++ b/h2o-persist-hdfs/src/main/java/water/persist/PersistHdfs.java
@@ -90,34 +90,6 @@ public final class PersistHdfs extends Persist {
   public PersistHdfs() { _iceRoot = null; }
   public void cleanUp() { throw H2O.unimpl(); /* user-mode swapping not implemented */}
 
-  // Loading/Writing ice to HDFS
-  public PersistHdfs(URI uri) {
-    try {
-      _iceRoot = new Path(uri + "/ice" + H2O.SELF_ADDRESS.getHostAddress() + "-" + H2O.API_PORT);
-      // Make the directory as-needed
-      FileSystem fs = getFileSystem(_iceRoot, CONF);
-      fs.mkdirs(_iceRoot);
-    } catch( Exception e ) {
-      throw Log.throwErr(e);
-    }
-  }
-
-  /** InputStream from a HDFS-based Key */
-  /*public static InputStream openStream(Key k, Job pmon) throws IOException {
-    H2OHdfsInputStream res = null;
-    Path p = new Path(k.toString());
-    try {
-      res = new H2OHdfsInputStream(p, 0, pmon);
-    } catch( IOException e ) {
-      try {
-        Thread.sleep(1000);
-      } catch( Exception ex ) {}
-      Log.warn("Error while opening HDFS key " + k.toString() + ", will wait and retry.");
-      res = new H2OHdfsInputStream(p, 0, pmon);
-    }
-    return res;
-  }*/
-
   @Override public byte[] load(final Value v) {
     //
     // !!! WARNING !!!

--- a/h2o-persist-hdfs/src/main/java/water/persist/security/HdfsDelegationTokenRefresher.java
+++ b/h2o-persist-hdfs/src/main/java/water/persist/security/HdfsDelegationTokenRefresher.java
@@ -34,7 +34,7 @@ public class HdfsDelegationTokenRefresher implements Runnable {
     public static final String H2O_AUTH_TOKEN_REFRESHER_MAX_ATTEMPTS = "h2o.auth.tokenRefresher.maxAttempts";
     public static final String H2O_AUTH_TOKEN_REFRESHER_RETRY_DELAY_SECS = "h2o.auth.tokenRefresher.retryDelaySecs";
     public static final String H2O_AUTH_TOKEN_REFRESHER_FALLBACK_INTERVAL_SECS = "h2o.auth.tokenRefresher.fallbackIntervalSecs";
-    public final static String H2O_DYNAMIC_AUTH_S3A_TOKEN_REFRESHER_ENABLED = "h2o.auth.dynamicS3ATokenRefresher.enabled";
+    public static final String H2O_DYNAMIC_AUTH_S3A_TOKEN_REFRESHER_ENABLED = "h2o.auth.dynamicS3ATokenRefresher.enabled";
 
     public static void setup(Configuration conf, String tmpDir, String uri) throws IOException {
         boolean enabled = conf.getBoolean(H2O_AUTH_TOKEN_REFRESHER_ENABLED, false) || conf.getBoolean(H2O_DYNAMIC_AUTH_S3A_TOKEN_REFRESHER_ENABLED, false);


### PR DESCRIPTION
- Fix message announcing current leader node in h2odriver
- Remove unused code so that we don't have to deal with it in refactor/fixes
- PersistHdfs: Don't acquire a lock if schema is not S3A
- PersistHdfs: Make sure only high-level function initiate token refresh
- Fix order of field modifiers
- Clean-up delegation token refresher shutdown + more logging
- Fix S3A import on CDP in multi-node setups
