### PR TITLE
Update explain.rst

### DIFF
--- a/h2o-docs/src/product/explain.rst
+++ b/h2o-docs/src/product/explain.rst
@@ -119,7 +119,7 @@ The example below uses a version of the `Wine Quality <https://archive.ics.uci.e
 
         # Import wine quality dataset
         f = "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
-        df = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv")
+        df = h2o.import_file(f)
 
         # Reponse column
         y = "quality"


### PR DESCRIPTION
The python tab for AutoML Explain example had a duplicated url as in the following statement:

```
f = "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
df = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv")
```

Which left the `f` variable unutilized. Thus I modify it so it is passed down as an argument to `h2o.import_file()`