### PR TITLE
PUBDEV-8460 fix _upload_python_object method

### DIFF
--- a/h2o-bindings/bin/pymagic.py
+++ b/h2o-bindings/bin/pymagic.py
@@ -72,7 +72,7 @@ def main():
     # magic_files = {}
     for filename in locate_files(ROOT_DIR):
         print("Processing %s" % filename)
-        with open(filename, "rt") as f:
+        with open(filename, "rt", encoding='utf-8') as f:
             tokens = list(tokenize.generate_tokens(f.readline))
             text1 = tokenize.untokenize(tokens)
             ntokens = normalize_tokens(tokens)

--- a/h2o-docs/src/product/conf.py
+++ b/h2o-docs/src/product/conf.py
@@ -67,7 +67,7 @@ author = u'h2o'
 #
 # The short X.Y version.
 if os.path.exists("project_version"):
-    f = open("project_version", "r")
+    f = open("project_version", "r", encoding='utf-8')
     version = f.readline().strip()
 else:
     version = "AnonDeveloperBuild"

--- a/h2o-py/h2o/backend/server.py
+++ b/h2o-py/h2o/backend/server.py
@@ -332,8 +332,8 @@ class H2OLocalServer(object):
         self._stdout = self._tmp_file("stdout")
         self._stderr = self._tmp_file("stderr")
         cwd = os.path.abspath(os.getcwd())
-        out = open(self._stdout, "w")
-        err = open(self._stderr, "w")
+        out = open(self._stdout, "w", encoding='utf-8')
+        err = open(self._stderr, "w", encoding='utf-8')
         if self._verbose:
             print("  JVM stdout: " + out.name)
             print("  JVM stderr: " + err.name)
@@ -357,7 +357,7 @@ class H2OLocalServer(object):
                 else:
                     error_message = "Server process terminated with error code %d" % proc.returncode 
                 if os.stat(self._stderr).st_size > 0:
-                    error_message += ": %s" % open(self._stderr).read()
+                    error_message += ": %s" % open(self._stderr, encoding='utf-8').read()
                 else:
                     error_message += "."
                 raise H2OServerError(error_message)
@@ -479,7 +479,7 @@ class H2OLocalServer(object):
         :returns: (scheme, ip, port) tuple if the server has already started, None otherwise.
         """
         searchstr = ": Open H2O Flow in your web browser:"
-        with open(self._stdout, "rt") as f:
+        with open(self._stdout, "rt", encoding='utf-8') as f:
             for line in f:
                 if searchstr in line:
                     url = line[line.index(searchstr) + len(searchstr):].strip().rstrip("/")

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -84,6 +84,7 @@ class H2OFrame(Keyed):
 
     # Temp flag: set this to false for now if encountering path conversion/expansion issues when import files to remote server
     __LOCAL_EXPANSION_ON_SINGLE_IMPORT__ = True
+    __fdopen_kwargs = {} if PY2 else {'encoding': 'utf-8'}
 
     #-------------------------------------------------------------------------------------------------------------------
     # Construction
@@ -139,7 +140,7 @@ class H2OFrame(Keyed):
 
         # create a temporary file that will be written to
         tmp_handle, tmp_path = tempfile.mkstemp(suffix=".csv")
-        tmp_file = os.fdopen(tmp_handle, 'w')
+        tmp_file = os.fdopen(tmp_handle, 'w', **H2OFrame.__fdopen_kwargs)
         # create a new csv writer object thingy
         csv_writer = csv.writer(tmp_file, dialect="excel", quoting=csv.QUOTE_NONNUMERIC)
         csv_writer.writerow(column_names)
@@ -159,7 +160,7 @@ class H2OFrame(Keyed):
             raise H2OValueError("A sparse matrix expected, got %s" % type(matrix))
 
         tmp_handle, tmp_path = tempfile.mkstemp(suffix=".svmlight")
-        out = os.fdopen(tmp_handle, "wt")
+        out = os.fdopen(tmp_handle, 'wt', **H2OFrame.__fdopen_kwargs)
         if destination_frame is None:
             destination_frame = _py_tmp_key(h2o.connection().session_id)
 

--- a/h2o-py/tests/pydemo_utils/utilsPY.py
+++ b/h2o-py/tests/pydemo_utils/utilsPY.py
@@ -10,7 +10,7 @@ def ipy_notebook_exec(path, save_and_norun=None):
             if "h2o.init" not in line:
                 program += line if '\n' in line else line + '\n'
     if save_and_norun is not None:
-        with open(save_and_norun, "w") as f: f.write(program)
+        with open(save_and_norun, "w", encoding='utf-8') as f: f.write(program)
     else:
         exec(program, dict(__name__='main'))
 
@@ -51,7 +51,7 @@ def ipy_valid_lines(block):
     return lines
 
 def pydemo_exec(test_name):
-    with open(test_name, "r") as t: demo = t.read()
+    with open(test_name, "r", encoding='utf-8') as t: demo = t.read()
     program = ''
     for line in demo.split('\n'):
         if "h2o.init" not in line:

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -395,7 +395,7 @@ def javapredict(algo, equality, train, test, x, y, compile_only=False, separator
         h2o.download_csv(test[x], in_csv)
 
         # hack: the PredictCsv driver can't handle quoted strings, so remove them
-        f = open(in_csv, "r+")
+        f = open(in_csv, "r+", encoding='utf-8')
         csv = f.read()
         csv = re.sub('\"', "", csv)
         csv = re.sub(",", separator, csv)       # replace with arbitrary separator for input dataset
@@ -2982,11 +2982,11 @@ def write_hyper_parameters_json(dir1, dir2, json_filename, hyper_parameters):
     :param hyper_parameters: dict containing hyper-parameters used
     """
     # save hyper-parameter file in test directory
-    with open(os.path.join(dir1, json_filename), 'w') as test_file:
+    with open(os.path.join(dir1, json_filename), 'w', encoding='utf-8') as test_file:
         json.dump(hyper_parameters, test_file)
 
     # save hyper-parameter file in sandbox
-    with open(os.path.join(dir2, json_filename), 'w') as test_file:
+    with open(os.path.join(dir2, json_filename), 'w', encoding='utf-8') as test_file:
         json.dump(hyper_parameters, test_file)
 
 
@@ -4164,7 +4164,7 @@ def write_H2OFrame_2_SVMLight(filename, h2oFrame):
     :param h2oFrame:
     :return:
     '''
-    fwriteFile = open(filename, 'w')
+    fwriteFile = open(filename, 'w', encoding='utf-8')
     ncol = h2oFrame.ncol
     nrow = h2oFrame.nrow
     fdataframe = h2oFrame.as_data_frame(use_pandas=False)
@@ -4189,7 +4189,7 @@ def write_H2OFrame_2_ARFF(filenameWithPath, filename, h2oFrame, uuidVecs, uuidNa
     :return:
     '''
 
-    fwriteFile = open(filenameWithPath, 'w')
+    fwriteFile = open(filenameWithPath, 'w', encoding='utf-8')
     nrow = h2oFrame.nrow
 
     # write the arff headers here

--- a/h2o-py/tests/testdir_parser/pyunit_enforce_utf-8_in_open_method.py
+++ b/h2o-py/tests/testdir_parser/pyunit_enforce_utf-8_in_open_method.py
@@ -1,0 +1,32 @@
+# coding=utf-8
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+import pandas as pd
+import locale
+
+def enforce_utf8_encoding():
+    orig_locale = locale.getlocale()
+    print("original locale is:")
+    print(orig_locale)
+    all_rows = pd.read_csv(pyunit_utils.locate("smalldata/gbm_test/titanic.csv"))
+    all_rows.at[0,0] = "�"
+    try:
+        locale.setlocale(locale.LC_ALL, 'en_US.ISO8859-1')
+        # this reproduces the encoding error when certain codec can't encode certain character 
+        h2o.H2OFrame(all_rows)
+    except locale.Error: # in run in dev-python-3.7 there is not en_US.ISO8859-1 available, but there is POSIX which also reproduces:
+        locale.setlocale(locale.LC_ALL, 'POSIX')
+        h2o.H2OFrame(all_rows)
+    finally:
+        try:
+            locale.setlocale(locale.LC_ALL, orig_locale)
+        except locale.Error: # for dev-python-3.7
+            locale.setlocale(locale.LC_ALL, 'C.UTF-8')
+    
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(enforce_utf8_encoding)
+else:
+    enforce_utf8_encoding()
+


### PR DESCRIPTION

for py 3.5 and higher, the issue is fixed by adding parameter `encoding='utf-8'` to `os.fdopen()` call
for py 2.7, `os.fdopen()` doesn't support  parameter `encoding`, but the issue is anyway not reproducible, by the same test that it is for py 3.8 