### PR TITLE
Tests: Fix Target Encoder scripts - not running in single node [nocheck]

### DIFF
--- a/h2o-extensions/target-encoder/testMultiNode.sh
+++ b/h2o-extensions/target-encoder/testMultiNode.sh
@@ -73,11 +73,6 @@ fi
 JVM="nice $JAVA_CMD $COVERAGE -ea -Xmx${MAX_MEM} -Xms${MAX_MEM} -DcloudSize=4 -cp ${JVM_CLASSPATH} ${ADDITIONAL_TEST_JVM_OPTS}"
 echo "$JVM" > $OUTDIR/jvm_cmd.txt
 
-# Tests
-# Must run first, before the cloud locks (because it tests cloud locking)
-JUNIT_TESTS_BOOT=""
-JUNIT_TESTS_BIG="hex.word2vec.Word2VecTest"
-
 # Runner
 # Default JUnit runner is org.junit.runner.JUnitCore
 JUNIT_RUNNER="water.junit.H2OTestRunner"
@@ -92,7 +87,7 @@ JUNIT_RUNNER="water.junit.H2OTestRunner"
 # If randomness is desired, replace sort with the unix 'shuf'
 # Use /usr/bin/sort because of cygwin on windows. 
 # Windows has sort.exe which you don't want. Fails? (is it a lineend issue)
-(cd src/test/java; /usr/bin/find . -name '*.java' | cut -c3- | sed 's/.....$//' | sed -e 's/\//./g') | grep -v $JUNIT_TESTS_BIG | /usr/bin/sort > $OUTDIR/tests.txt
+(cd src/test/java; /usr/bin/find . -name '*.java' | cut -c3- | sed 's/.....$//' | sed -e 's/\//./g') | /usr/bin/sort > $OUTDIR/tests.txt
 
 # Output the comma-separated list of ignored/dooonly tests
 # Ignored tests trump do-only tests

--- a/h2o-extensions/target-encoder/testSingleNode.sh
+++ b/h2o-extensions/target-encoder/testSingleNode.sh
@@ -72,10 +72,6 @@ echo "$JVM" > $OUTDIR/jvm_cmd.txt
 # classpath before the main classpath.
 #JVM="nice java -ea -cp build/classes/test${SEP}build/classes/main${SEP}../h2o-core/build/classes/test${SEP}../h2o-core/build/classes/main${SEP}../lib/*"
 
-# Tests
-# Must run first, before the cloud locks (because it tests cloud locking)
-JUNIT_TESTS_BIG=""
-
 # Runner
 # Default JUnit runner is org.junit.runner.JUnitCore
 JUNIT_RUNNER="water.junit.H2OTestRunner"
@@ -90,7 +86,7 @@ JUNIT_RUNNER="water.junit.H2OTestRunner"
 # If randomness is desired, replace sort with the unix 'shuf'
 # Use /usr/bin/sort because of cygwin on windows. 
 # Windows has sort.exe which you don't want. Fails? (is it a lineend issue)
-(cd src/test/java; /usr/bin/find . -name '*.java' | cut -c3- | sed 's/.....$//' | sed -e 's/\//./g') | grep -v $JUNIT_TESTS_BIG | sort | grep -v AAA_PreCloudLock > $OUTDIR/tests.txt
+(cd src/test/java; /usr/bin/find . -name '*.java' | cut -c3- | sed 's/.....$//' | sed -e 's/\//./g') | /usr/bin/sort > $OUTDIR/tests.txt
 
 # Output the comma-separated list of ignored/dooonly tests
 # Ignored tests trump do-only tests

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -368,12 +368,12 @@ test-junit-xgb-multi-jenkins:
 test-junit-xgb-multi:
 	./gradlew h2o-ext-xgboost:testMultiNode $$ADDITIONAL_GRADLE_OPTS
 
-test-junit-1x:
+test-junit-11:
 	./gradlew test -x h2o-ext-mojo-pipeline:test -x h2o-automl:test -x h2o-ext-xgboost:testMultiNode -x h2o-ext-target-encoder:testMultiNode -x h2o-clustering:test $$ADDITIONAL_GRADLE_OPTS
 
-test-junit-1x-jenkins:
+test-junit-11-jenkins:
 	$(call sed_test_scripts)
-	@$(MAKE) -f $(THIS_FILE) test-junit-1x
+	@$(MAKE) -f $(THIS_FILE) test-junit-11
 
 test-junit-16-jenkins:
 	$(call sed_test_scripts)

--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -431,7 +431,7 @@ def call(final pipelineContext) {
       component: pipelineContext.getBuildConfig().COMPONENT_JAVA
     ],
     [
-      stageName: 'Java 11 JUnit', target: 'test-junit-1x-jenkins', pythonVersion: '2.7', javaVersion: 11,
+      stageName: 'Java 11 JUnit', target: 'test-junit-11-jenkins', pythonVersion: '2.7', javaVersion: 11,
       timeoutValue: 180, component: pipelineContext.getBuildConfig().COMPONENT_JAVA, 
       additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY],
       imageSpecifier: "python-2.7-jdk-11"


### PR DESCRIPTION
- Tests: Fix Target Encoder scripts - not running in single node
- Makefile clean-up: junit-1x tests are actually only running junit-11
