### PR TITLE
TestRunner: make sure test reports in multi and single node don't clash [nocheck]

### DIFF
--- a/h2o-test-support/src/main/java/water/TestUtil.java
+++ b/h2o-test-support/src/main/java/water/TestUtil.java
@@ -45,7 +45,7 @@ public class TestUtil extends Iced {
   /**
    * Minimal cloud size to start test.
    */
-  protected static int MINCLOUDSIZE = Integer.parseInt(System.getProperty("cloudSize", "1"));
+  public static int MINCLOUDSIZE = Integer.parseInt(System.getProperty("cloudSize", "1"));
   /**
    * Default time in ms to wait for clouding
    */


### PR DESCRIPTION
When run on jenkins they are overwriting each other
