### PR TITLE
PUBDEV-8513: Fix import of Parquet files from S3

### DIFF
--- a/h2o-core/src/main/java/water/persist/PersistManager.java
+++ b/h2o-core/src/main/java/water/persist/PersistManager.java
@@ -4,12 +4,10 @@ import water.*;
 import water.api.FSIOException;
 import water.api.HDFSIOException;
 import water.exceptions.H2OIllegalArgumentException;
-import water.fvec.C1NChunk;
 import water.fvec.FileVec;
 import water.fvec.Vec;
 import water.parser.BufferedString;
 import water.util.FileUtils;
-import water.util.FrameUtils;
 import water.util.Log;
 import water.persist.Persist.PersistEntry;
 import water.util.fp.Function2;
@@ -687,14 +685,14 @@ public class PersistManager {
     if (vec instanceof FileVec) {
       FileVec fileVec = (FileVec) vec;
       final String path = fileVec.getPath();
-      if (isHdfsPath(path)) {
-        validateHdfsConfigured();
-        return I[Value.HDFS].openSeekable(path);
-      } else {
-        Persist p = I[fileVec.getBackend()];
-        if (p != null && p.isSeekableOpenSupported()) {
+      final Persist p = I[fileVec.getBackend()];
+      if (p != null) {
+        if (p.isSeekableOpenSupported()) {
           return p.openSeekable(path);
         }
+      } else if (isHdfsPath(path)) {
+        validateHdfsConfigured();
+        return I[Value.HDFS].openSeekable(path);
       }
     }
     // fallback

--- a/h2o-parsers/h2o-parquet-parser-tests/build.gradle
+++ b/h2o-parsers/h2o-parquet-parser-tests/build.gradle
@@ -12,4 +12,5 @@ dependencies {
     api("org.apache.hadoop:hadoop-client:${parquetHadoopVersion}") {
         exclude module: "servlet-api"
     }
+    testRuntimeOnly project(":${defaultWebserverModule}")
 }

--- a/h2o-parsers/h2o-parquet-parser/src/test/java/water/parser/parquet/VecParquetReaderTest.java
+++ b/h2o-parsers/h2o-parquet-parser/src/test/java/water/parser/parquet/VecParquetReaderTest.java
@@ -1,0 +1,49 @@
+package water.parser.parquet;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import water.H2O;
+import water.Key;
+import water.Scope;
+import water.TestUtil;
+import water.fvec.FileVec;
+import water.persist.VecDataInputStream;
+import water.runner.CloudSize;
+import water.runner.H2ORunner;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+@CloudSize(1)
+@RunWith(H2ORunner.class)
+public class VecParquetReaderTest extends TestUtil {
+
+    @Test
+    public void testFooterChunkIsNotCached() throws IOException {
+        try {
+            Scope.enter();
+            FileVec fv = makeNfsFileVec("./smalldata/parser/parquet/airlines-simple.snappy.parquet");
+            assertNotNull(fv);
+            Scope.track(fv);
+
+            VecDataInputStream vdis = new VecDataInputStream(fv, true);
+            FSDataInputStream fsdis = new FSDataInputStream(vdis);
+
+            byte[] footerBytes = VecParquetReader.readFooterAsBytes(fv.length(), fsdis);
+            assertNotNull(VecParquetReader.readFooter(footerBytes));
+
+            // now check that we didn't cache anything on a node that doesn't own the chunks
+            for (int cidx = 0; cidx < fv.nChunks(); cidx++) {
+                Key<?> ck = fv.chunkKey(cidx);
+                if (!ck.home()) {
+                    assertNull("Chunk #" + cidx + " should not be cached on " + H2O.SELF, H2O.STORE.get(ck));
+                }
+            }
+        } finally {
+            Scope.exit();
+        }
+    }
+
+}

--- a/h2o-persist-hdfs/src/main/java/water/persist/PersistHdfs.java
+++ b/h2o-persist-hdfs/src/main/java/water/persist/PersistHdfs.java
@@ -505,7 +505,7 @@ public final class PersistHdfs extends Persist {
   }
 
   public InputStream wrapSeekable(Vec vec) {
-    return new FSDataInputStream(new VecDataInputStream(vec));
+    return new FSDataInputStream(new VecDataInputStream(vec, true));
   }
   
   public boolean isSeekableOpenSupported() {

--- a/h2o-persist-s3/build.gradle
+++ b/h2o-persist-s3/build.gradle
@@ -10,6 +10,8 @@ dependencies {
   testImplementation "com.adobe.testing:s3mock:2.1.28"
   testImplementation "com.adobe.testing:s3mock-junit4:2.1.28"
   testRuntimeOnly project(":${defaultWebserverModule}")
+  testRuntimeOnly project(":h2o-parquet-parser")
+  testRuntimeOnly project(":h2o-persist-hdfs")
 }
 
 apply from: "${rootDir}/gradle/dataCheck.gradle"

--- a/h2o-persist-s3/build.gradle
+++ b/h2o-persist-s3/build.gradle
@@ -1,5 +1,10 @@
 description = "H2O Persist S3"
 
+configurations {
+    testImplementation.exclude group: "ch.qos.logback", module: "logback-classic"
+}
+
+
 dependencies {
   api project(":h2o-core")
   api "com.amazonaws:aws-java-sdk-s3:${awsJavaSdkVersion}"


### PR DESCRIPTION
The issue that caused PUBDEV-8513 was that H2O was falling back to HDFS "s3a"-style import for reading parquet files footers, this worked fine as long as "s3a" was also configured. However, didn't work for community users.