### PR TITLE
Infogram without available XGBoost is failing to start H2O

### DIFF
--- a/h2o-admissibleml/src/main/java/hex/Infogram/InfogramExtension.java
+++ b/h2o-admissibleml/src/main/java/hex/Infogram/InfogramExtension.java
@@ -1,11 +1,10 @@
 package hex.Infogram;
 
-import hex.tree.xgboost.XGBoostExtension;
 import org.apache.log4j.Logger;
 import water.AbstractH2OExtension;
 
 public class InfogramExtension extends AbstractH2OExtension {
-  private static final Logger LOG = Logger.getLogger(XGBoostExtension.class);
+  private static final Logger LOG = Logger.getLogger(InfogramExtension.class);
   public static String NAME = "Infogram";
   @Override
   public String getExtensionName() {


### PR DESCRIPTION
Hello @wendycwong, how we should handle if we run Infogram without available XGBoost?

Currently, when I run water.H2OApp in Idea then it fail with 

```
Exception in thread "main" java.util.ServiceConfigurationError: water.AbstractH2OExtension: Provider hex.Infogram.InfogramExtension could not be instantiated
	at java.util.ServiceLoader.fail(ServiceLoader.java:232)
	at java.util.ServiceLoader.access$100(ServiceLoader.java:185)
	at java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:384)
	at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:404)
	at java.util.ServiceLoader$1.next(ServiceLoader.java:480)
	at water.ExtensionManager.registerCoreExtensions(ExtensionManager.java:102)
	at water.H2O.main(H2O.java:2305)
	at water.H2OStarter.start(H2OStarter.java:22)
	at water.H2OStarter.start(H2OStarter.java:48)
	at water.H2OApp.main(H2OApp.java:12)
Caused by: java.lang.NoClassDefFoundError: hex/tree/xgboost/XGBoostExtension
	at hex.Infogram.InfogramExtension.<clinit>(InfogramExtension.java:8)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:380)
	... 7 more
Caused by: java.lang.ClassNotFoundException: hex.tree.xgboost.XGBoostExtension
	at java.net.URLClassLoader.findClass(URLClassLoader.java:387)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:355)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	... 14 more
```

It is obviously mistake I fixed here: 61305e5ee03c5a3dd11cdf5144311d894a6c8947

But after that I fail with:

```
Exception in thread "main" java.util.ServiceConfigurationError: water.api.Schema: Provider hex.schemas.InfogramV3 could not be instantiated
	at java.util.ServiceLoader.fail(ServiceLoader.java:232)
	at java.util.ServiceLoader.access$100(ServiceLoader.java:185)
	at java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:384)
	at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:404)
	at java.util.ServiceLoader$1.next(ServiceLoader.java:480)
	at water.api.AbstractRegister.registerSchemas(AbstractRegister.java:13)
	at water.ExtensionManager.registerRestApiExtensions(ExtensionManager.java:160)
	at water.H2OStarter.start(H2OStarter.java:30)
	at water.H2OStarter.start(H2OStarter.java:48)
	at water.H2OApp.main(H2OApp.java:12)
Caused by: java.lang.NoClassDefFoundError: hex/schemas/XGBoostV3$XGBoostParametersV3
	at java.lang.Class.getDeclaredConstructors0(Native Method)
	at java.lang.Class.privateGetDeclaredConstructors(Class.java:2671)
	at java.lang.Class.getConstructor0(Class.java:3075)
	at java.lang.Class.newInstance(Class.java:412)
	at hex.schemas.ModelBuilderSchema.createParametersSchema(ModelBuilderSchema.java:76)
	at hex.schemas.ModelBuilderSchema.<init>(ModelBuilderSchema.java:56)
	at hex.schemas.InfogramV3.<init>(InfogramV3.java:24)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:380)
	... 7 more
Caused by: java.lang.ClassNotFoundException: hex.schemas.XGBoostV3$XGBoostParametersV3
	at java.net.URLClassLoader.findClass(URLClassLoader.java:387)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:355)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	... 20 more
```
My hypothesis is that it is because XGBoost is not enabled and Infogram is not reflecting the available algos. Can we do something about that? See: f520cc77dbb5c42df650e1261c7876aba95a09da