### PR TITLE
PUBDEV-8520: bump mojo2 version from 2.5.3 to 2.7.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -71,4 +71,4 @@ jetty9MinimalVersion=9.4.44.v20210927
 servletApiVersion=3.1.0
 
 # MOJO2 Integration
-mojo2version=2.5.3
+mojo2version=2.7.5


### PR DESCRIPTION
noticed when analysing sparkling water classpath