### PR TITLE
PUBDEV-8496: show original values on ice lines

### DIFF
--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -1460,6 +1460,8 @@ def _get_response(mean_response, show_logodds):
         return np.log(mean_response / (1 - mean_response))
     else:
         return mean_response
+
+
 def _isnan(value):
     if isinstance(value, float):
         return np.isnan(value)

--- a/h2o-py/tests/testdir_misc/pyunit_ice_plot.py
+++ b/h2o-py/tests/testdir_misc/pyunit_ice_plot.py
@@ -101,6 +101,7 @@ def _get_cols_to_test(train, y):
             cols_to_test.append(col)
     return cols_to_test
 
+
 def _assert_pyplot_was_produced(cols_to_test, model, train, target=None):
     for col in cols_to_test:
         if target is None:

--- a/h2o-py/tests/testdir_misc/pyunit_ice_plot.py
+++ b/h2o-py/tests/testdir_misc/pyunit_ice_plot.py
@@ -81,13 +81,13 @@ def test_handle_orig_values():
 
                 if type_test[test_id] == "Regression":
                     assert gbm.training_model_metrics()["model_category"] == "Regression"
-                    np.testing.assert_almost_equal(orig_value_prediction, gbm.predict(frame).as_data_frame()["predict"][index], 5)
+                    np.testing.assert_almost_equal(orig_value_prediction["mean_response"], gbm.predict(frame).as_data_frame()["predict"][index], 5)
                 elif type_test[test_id] == "Binomial":
                     assert gbm.training_model_metrics()["model_category"] == "Binomial"
-                    np.testing.assert_almost_equal(orig_value_prediction, gbm.predict(frame).as_data_frame()["p1"][index], 5)
+                    np.testing.assert_almost_equal(orig_value_prediction["mean_response"], gbm.predict(frame).as_data_frame()["p1"][index], 5)
                 elif type_test[test_id] == "Multinomial":
                     assert gbm.training_model_metrics()["model_category"] == "Multinomial"
-                    np.testing.assert_almost_equal(orig_value_prediction, gbm.predict(frame).as_data_frame()[targets[test_id]][index], 5)
+                    np.testing.assert_almost_equal(orig_value_prediction["mean_response"], gbm.predict(frame).as_data_frame()[targets[test_id]][index], 5)
 
 
 def _get_cols_to_test(train, y):

--- a/h2o-py/tests/testdir_misc/pyunit_ice_plot.py
+++ b/h2o-py/tests/testdir_misc/pyunit_ice_plot.py
@@ -30,6 +30,7 @@ def test_original_values():
 
         _assert_pyplot_was_produced(cols_to_test, gbm, train, target=targets[i])
 
+
 def test_handle_orig_values():
     type_test = ["Regression", "Binomial", "Multinomial"]
     paths = ["smalldata/titanic/titanic_expanded.csv",  "smalldata/logreg/prostate.csv", "smalldata/iris/iris2.csv"]

--- a/h2o-py/tests/testdir_misc/pyunit_ice_plot.py
+++ b/h2o-py/tests/testdir_misc/pyunit_ice_plot.py
@@ -1,15 +1,138 @@
 from __future__ import print_function
 
-import os
 import sys
 
-sys.path.insert(1,"../../")
+sys.path.insert(1, os.path.join("..", "..", ".."))
 import matplotlib
 matplotlib.use("Agg")  # remove warning from python2 (missing TKinter)
 import h2o
 import matplotlib.pyplot
 from tests import pyunit_utils
 from h2o.estimators import *
+from h2o.explanation._explain import *
+from h2o.explanation._explain import _handle_orig_values
+
+
+def test_original_values():
+    paths = ["smalldata/titanic/titanic_expanded.csv", "smalldata/logreg/prostate.csv", "smalldata/iris/iris2.csv"]
+    ys = ["fare", "CAPSULE", "response"]
+    names_to_extract = ["name", None, None]
+    targets = [None, None, "setosa"]
+
+    for i in range(len(paths)):
+        train = h2o.upload_file(pyunit_utils.locate(paths[i]))
+        gbm = H2OGradientBoostingEstimator(seed=1234, model_id="my_awesome_model_py" + str(i))
+        gbm.train(y=ys[i], training_frame=train)
+
+        cols_to_test = _get_cols_to_test(train, ys[i])
+        if names_to_extract[i] is not None:
+            if names_to_extract[i] in cols_to_test: cols_to_test.remove(names_to_extract[i])
+
+        _assert_pyplot_was_produced(cols_to_test, gbm, train, target=targets[i])
+
+def test_handle_orig_values():
+    type_test = ["Regression", "Binomial", "Multinomial"]
+    paths = ["smalldata/titanic/titanic_expanded.csv",  "smalldata/logreg/prostate.csv", "smalldata/iris/iris2.csv"]
+    ys = ["fare", "CAPSULE", "response"]
+    names_to_extract = ["name", None, None]
+    targets = [None, None, "setosa"]
+    colormap = "plasma"
+
+    for test_id in range(len(paths)):
+        train = h2o.upload_file(pyunit_utils.locate(paths[test_id]))
+        if type_test[test_id] in ["Binomial", "Multinomial"]:
+            train[ys[test_id]] = train[ys[test_id]].asfactor()
+
+        gbm = H2OGradientBoostingEstimator(seed=1234, model_id="my_awesome_model_py" + str(test_id))
+        gbm.train(y=ys[test_id], training_frame=train)
+
+        cols_to_test = _get_cols_to_test(train, ys[test_id])
+        print(cols_to_test)
+        if names_to_extract[test_id] is not None:
+            if names_to_extract[test_id] in cols_to_test: cols_to_test.remove(names_to_extract[test_id])
+
+        plt = get_matplotlib_pyplot(False, raise_if_not_available=True)
+        frame = train.sort(gbm.actual_params["response_column"])
+        for column in cols_to_test:
+            is_factor = frame[column].isfactor()[0]
+            deciles = [int(round(frame.nrow * dec / 10)) for dec in range(11)]
+            deciles[10] = frame.nrow - 1
+            colors = plt.get_cmap(colormap, 11)(list(range(11)))
+            for i, index in enumerate(deciles):
+                percentile_string = "{}th Percentile".format(i * 10)
+                if targets[test_id] is not None:
+                    target = [targets[test_id]]
+                else:
+                    target = None
+                tmp = NumpyFrame(
+                    gbm.partial_plot(
+                        frame,
+                        cols=[column],
+                        plot=False,
+                        row_index=index,
+                        targets=target,
+                        nbins=100 if not is_factor else 1 + frame[column].nlevels()[0],
+                        include_na=True
+                    )[0]
+                )
+                encoded_col = tmp.columns[0]
+                orig_value_prediction = _handle_orig_values(is_factor, tmp, encoded_col, plt, target, gbm,
+                                                            frame, index, column, colors[i], percentile_string)
+
+                if type_test[test_id] == "Regression":
+                    assert gbm.training_model_metrics()["model_category"] == "Regression"
+                    np.testing.assert_almost_equal(orig_value_prediction, gbm.predict(frame).as_data_frame()["predict"][index], 5)
+                elif type_test[test_id] == "Binomial":
+                    assert gbm.training_model_metrics()["model_category"] == "Binomial"
+                    np.testing.assert_almost_equal(orig_value_prediction, gbm.predict(frame).as_data_frame()["p1"][index], 5)
+                elif type_test[test_id] == "Multinomial":
+                    assert gbm.training_model_metrics()["model_category"] == "Multinomial"
+                    np.testing.assert_almost_equal(orig_value_prediction, gbm.predict(frame).as_data_frame()[targets[test_id]][index], 5)
+
+
+def _get_cols_to_test(train, y):
+    cols_to_test = []
+    for col, typ in train.types.items():
+        for ctt in cols_to_test:
+            if typ == train.types[ctt] or col == y:
+                break
+        else:
+            cols_to_test.append(col)
+    return cols_to_test
+
+def _assert_pyplot_was_produced(cols_to_test, model, train, target=None):
+    for col in cols_to_test:
+        if target is None:
+            assert isinstance(model.ice_plot(train, col).figure(), matplotlib.pyplot.Figure)
+        else:
+            assert isinstance(model.ice_plot(train, col, target=target).figure(), matplotlib.pyplot.Figure)
+    matplotlib.pyplot.close("all")
+
+def test_display_mode():
+    train = h2o.upload_file(pyunit_utils.locate("smalldata/titanic/titanic_expanded.csv"))
+    y = "fare"
+
+    # get at most one column from each type
+    cols_to_test = []
+    for col, typ in train.types.items():
+        for ctt in cols_to_test:
+            if typ == train.types[ctt] or col == y:
+                break
+        else:
+            cols_to_test.append(col)
+
+    gbm = H2OGradientBoostingEstimator(seed=1234, model_id="my_awesome_model")
+    gbm.train(y=y, training_frame=train)
+
+    assert isinstance(gbm.ice_plot(train, 'title').figure(), matplotlib.pyplot.Figure)
+    assert isinstance(gbm.ice_plot(train, 'title', show_pdp=True).figure(), matplotlib.pyplot.Figure)
+    assert isinstance(gbm.ice_plot(train, 'title', show_pdp=False).figure(), matplotlib.pyplot.Figure)
+
+    assert isinstance(gbm.ice_plot(train, 'age').figure(), matplotlib.pyplot.Figure)
+    assert isinstance(gbm.ice_plot(train, 'age', show_pdp=True).figure(), matplotlib.pyplot.Figure)
+    assert isinstance(gbm.ice_plot(train, 'age', show_pdp=False).figure(), matplotlib.pyplot.Figure)
+    matplotlib.pyplot.close("all")
+
 
 def test_binary_response_scale():
     train = h2o.upload_file(pyunit_utils.locate("smalldata/titanic/titanic_expanded.csv"))
@@ -73,8 +196,10 @@ def test_show_pdd():
 
 
 
-
 pyunit_utils.run_tests([
+    test_original_values,
+    test_handle_orig_values,
+    test_display_mode,
     test_binary_response_scale,
     test_show_pdd
 ])

--- a/h2o-py/tests/testdir_misc/pyunit_ice_plot.py
+++ b/h2o-py/tests/testdir_misc/pyunit_ice_plot.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import sys
+import os
 
 sys.path.insert(1, os.path.join("..", "..", ".."))
 import matplotlib

--- a/h2o-py/tests/testdir_misc/pyunit_ice_plot.py
+++ b/h2o-py/tests/testdir_misc/pyunit_ice_plot.py
@@ -109,6 +109,7 @@ def _assert_pyplot_was_produced(cols_to_test, model, train, target=None):
             assert isinstance(model.ice_plot(train, col, target=target).figure(), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close("all")
 
+
 def test_display_mode():
     train = h2o.upload_file(pyunit_utils.locate("smalldata/titanic/titanic_expanded.csv"))
     y = "fare"

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -2505,6 +2505,7 @@ h2o.ice_plot <- function(model,
         orig_tmp[["name"]] <- percentile_str
         orig_values <-
           rbind(orig_values, orig_tmp[, c(column, "name", "mean_response")])
+        results <- rbind(results, orig_tmp[, c(column, "name", "mean_response")])
       }
       if (is.factor(newdata[[column]])) {
         tmp <- tmp[which(tmp[[column]] != ".missing(NA)"),]

--- a/h2o-r/tests/testdir_misc/runit_ice_plot.R
+++ b/h2o-r/tests/testdir_misc/runit_ice_plot.R
@@ -3,11 +3,105 @@ source("../../scripts/h2o-r-test-setup.R")
 
 
 expect_ggplot <- function(gg) {
-    p <- force(gg)
-    expect_true("gg" %in% class(p))
-    file <- tempfile(fileext = ".png")
-    # try to actually plot it - otherwise ggplot is not evaluated
-    tryCatch({ggplot2::ggsave(file, plot = p)}, finally = unlink(file))
+  p <- force(gg)
+  expect_true("gg" %in% class(p))
+  file <- tempfile(fileext = ".png")
+  # try to actually plot it - otherwise ggplot is not evaluated
+  tryCatch({ggplot2::ggsave(file, plot = p)}, finally = unlink(file))
+}
+
+test_original_values <- function() {
+  train <- h2o.uploadFile(locate("smalldata/titanic/titanic_expanded.csv"))
+  y <- "fare"
+
+  gbm1 <- h2o.gbm(y = y,
+  training_frame = train,
+  seed = 1234,
+  model_id = "my_awesome_model1")
+
+  col_types <- setNames(unlist(h2o.getTypes(train)), names(train))
+  col_types <- col_types[names(col_types) != y]
+  cols_to_test <- names(col_types[!duplicated(col_types)])
+
+  for (col in cols_to_test) {
+    if (col != "name")
+      expect_ggplot(h2o.ice_plot(gbm1, train, col))
+  }
+  # for (col in cols_to_test) {
+  #   if (col != "name") # name is string colum -> not supported
+  #     p = h2o.ice_plot(gbm1, train, col)#, show_logodds=TRUE)
+  #     file = paste("Rplot", "titanic", col, ".png", sep = "")
+  #     print(file)
+  #     ggplot2::ggsave(file, plot = p, path = getwd())
+  # }
+
+  train <- h2o.uploadFile(locate("smalldata/logreg/prostate.csv"))
+  y <- "CAPSULE"
+  train[, y] <- as.factor(train[, y])
+
+  col_types <- setNames(unlist(h2o.getTypes(train)), names(train))
+  col_types <- col_types[names(col_types) != y]
+  cols_to_test <- names(col_types[!duplicated(col_types)])
+
+  gbm2 <- h2o.gbm(y = y,
+  training_frame = train,
+  seed = 1234,
+  model_id = "my_awesome_model2")
+
+  for (col in cols_to_test) {
+    expect_ggplot(h2o.ice_plot(gbm2, train, col))
+  }
+  # for (col in cols_to_test) {
+  #   p = h2o.ice_plot(gbm2, train, col)#, show_logodds=TRUE)
+  #   file = paste("Rplot", "prostate", col, ".png", sep = "")
+  #   print(file)
+  #   ggplot2::ggsave(file, plot = p, path = getwd())
+  # }
+
+  train <- h2o.uploadFile(locate("smalldata/iris/iris2.csv"))
+  y <- "response"
+  train[, y] <- as.factor(train[, y])
+
+  col_types <- setNames(unlist(h2o.getTypes(train)), names(train))
+  col_types <- col_types[names(col_types) != y]
+  cols_to_test <- names(col_types[!duplicated(col_types)])
+
+  gbm3 <- h2o.gbm(y = y,
+  training_frame = train,
+  seed = 1234,
+  model_id = "my_awesome_model3")
+
+  for (col in cols_to_test) {
+     expect_ggplot(h2o.ice_plot(gbm3, train, col, target = "setosa"))
+  }
+  # for (col in cols_to_test) {
+  #   p = h2o.ice_plot(gbm3, train, col, target = "setosa")
+  #   file = paste("Rplot", "iris", col, ".png", sep = "")
+  #   print(file)
+  #   ggplot2::ggsave(file, plot = p, path = getwd())
+  # }
+}
+
+ice_plot_display_mode <- function() {
+    train <- h2o.uploadFile(locate("smalldata/titanic/titanic_expanded.csv"))
+    y <- "fare"
+
+    col_types <- setNames(unlist(h2o.getTypes(train)), names(train))
+    col_types <- col_types[names(col_types) != y]
+    cols_to_test <- names(col_types[!duplicated(col_types)])
+
+    gbm <- h2o.gbm(y = y,
+    training_frame = train,
+    seed = 1234,
+    model_id = "my_awesome_model")
+
+    for (col in cols_to_test) {
+        if (col != "name") { # a string column
+            expect_ggplot(h2o.ice_plot(gbm, train, col))
+            expect_ggplot(h2o.ice_plot(gbm, train, col, show_pdp=FALSE))
+            expect_ggplot(h2o.ice_plot(gbm, train, col, show_pdp=TRUE))
+        }
+    }
 }
 
 ice_plot_test_binary_response_scale <- function() {
@@ -42,6 +136,7 @@ ice_plot_test_binary_response_scale <- function() {
 
 }
 
+
 ice_plot_display_mode <- function() {
     train <- h2o.uploadFile(locate("smalldata/titanic/titanic_expanded.csv"))
     y <- "fare"
@@ -65,8 +160,9 @@ ice_plot_display_mode <- function() {
 }
 
 
-
 doSuite("Explanation Tests", makeSuite(
+    test_original_values,
+    ice_plot_display_mode,
     ice_plot_test_binary_response_scale,
     ice_plot_display_mode
 ))


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8496

Do you think there should be a parameter to switch this off/on? Currently there is no switcher.


python examples:

binary:
![bin_prostate_VOL](https://user-images.githubusercontent.com/18303397/152400878-eec3b442-42fa-49ba-8082-7d8cee19aed2.png)

regression (no NAs/ NAs/ ICE by categorical variable):
![reg_titanic_fare](https://user-images.githubusercontent.com/18303397/152401122-0397aa9a-de06-46bc-b6a3-4892b2a7ca43.png)
![reg_titanic_body](https://user-images.githubusercontent.com/18303397/152401147-81c6ae16-24ed-4c6f-a68f-5a837ba4323d.png)
![reg_titanic_cabin_type](https://user-images.githubusercontent.com/18303397/152401162-3b4947c2-e1a8-4a00-871c-b8b62339f750.png)

multiclass:
![mult_iris_Petal Length](https://user-images.githubusercontent.com/18303397/152401280-27709c58-21b7-4e05-804e-16f1fbaef1e7.png)



R examples:

binary:
![RplotprostateID](https://user-images.githubusercontent.com/18303397/152401623-56035282-d608-4ae5-8ff5-f091108302c3.png)
![RplotprostatePSA](https://user-images.githubusercontent.com/18303397/152401631-b4c3d8bc-07f8-43c7-ab20-8ade56127bf8.png)

regression (numerical/categorical):
![Rplottitanicage](https://user-images.githubusercontent.com/18303397/152402519-0c272064-f518-46be-8f88-7cf46a30e995.png)
![Rplottitanicpclass](https://user-images.githubusercontent.com/18303397/152402525-b08110d0-032c-4767-93ff-229b8f5353e1.png)


multiclass:

![RplotirisSepal Length](https://user-images.githubusercontent.com/18303397/152402586-463cc252-00ad-4801-842e-5084c534f18c.png)



thanks to this, there will be shown original values on ice lines.
