### PR TITLE
PUBDEV-8475: Remove "H2O API Extensions" from h2o.init() output

### DIFF
--- a/h2o-py/h2o/backend/cluster.py
+++ b/h2o-py/h2o/backend/cluster.py
@@ -279,7 +279,6 @@ class H2OCluster(H2OSchema):
             status += ", healthy"
         else:
             status += ", %d nodes are not healthy" % unhealthy_nodes
-        api_extensions = self.list_api_extensions()
         values = [get_human_readable_time(self.cloud_uptime_millis),
                   self.cloud_internal_timezone,
                   self.datafile_parser_timezone,
@@ -294,7 +293,6 @@ class H2OCluster(H2OSchema):
                   h2o.connection().base_url,
                   json.dumps(h2o.connection().proxy),
                   self.internal_security_enabled,
-                  ', '.join(api_extensions),
                   "%d.%d.%d %s" % tuple(sys.version_info[:4])]
         return values
 
@@ -302,7 +300,7 @@ class H2OCluster(H2OSchema):
 _cluster_status_info_keys = ["H2O_cluster_uptime", "H2O_cluster_timezone", "H2O_data_parsing_timezone",
             "H2O_cluster_version", "H2O_cluster_version_age", "H2O_cluster_name", "H2O_cluster_total_nodes",
             "H2O_cluster_free_memory", "H2O_cluster_total_cores", "H2O_cluster_allowed_cores", "H2O_cluster_status",
-            "H2O_connection_url", "H2O_connection_proxy", "H2O_internal_security", "H2O_API_Extensions", "Python_version"]
+            "H2O_connection_url", "H2O_connection_proxy", "H2O_internal_security", "Python_version"]
     
 _cluster_status_detailed_info_keys = ["h2o", "healthy", "last_ping", "num_cpus", "sys_load", "mem_value_size",
                                       "free_mem", "pojo_mem", "swap_mem", "free_disk", "max_disk", "pid", "num_keys",

--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -792,7 +792,6 @@ h2o.clusterInfo <- function() {
   cat("    H2O Connection port:       ", port, "\n")
   cat("    H2O Connection proxy:      ", proxy, "\n")
   cat("    H2O Internal Security:     ", res$internal_security_enabled, "\n")
-  cat("    H2O API Extensions:        ", paste(extensions, collapse = ", "), "\n")
   cat("    R Version:                 ", R.version.string, "\n")
 
   cpusLimited <- sapply(nodeInfo, function(x) x[['num_cpus']] > 1L && x[['nthreads']] != 1L && x[['cpus_allowed']] == 1L)


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8475

Manually verified in Python & R:

```
In [3]: h2o.init()
Checking whether there is an H2O instance running at http://localhost:54321 . connected.
--------------------------  -----------------------------
H2O_cluster_uptime:         49 secs
H2O_cluster_timezone:       America/Los_Angeles
H2O_data_parsing_timezone:  UTC
H2O_cluster_version:        3.36.0.99999
H2O_cluster_version_age:    36 minutes
H2O_cluster_name:           H2O_from_python_me_269ara
H2O_cluster_total_nodes:    1
H2O_cluster_free_memory:    3.542 Gb
H2O_cluster_total_cores:    8
H2O_cluster_allowed_cores:  8
H2O_cluster_status:         locked, healthy
H2O_connection_url:         http://localhost:54321
H2O_connection_proxy:       {"http": null, "https": null}
H2O_internal_security:      False
Python_version:             3.8.9 final
--------------------------  -----------------------------
```