### PR TITLE
PUBDEV-8546: Updated copyright for user guide and python documentation to 2022

### DIFF
--- a/h2o-docs/src/product/conf.py
+++ b/h2o-docs/src/product/conf.py
@@ -58,7 +58,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'H2O'
-copyright = u'2016-2021 H2O.ai'
+copyright = u'2016-2022 H2O.ai'
 author = u'h2o'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/h2o-py/docs/conf.py
+++ b/h2o-py/docs/conf.py
@@ -50,7 +50,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'H2O'
-copyright = '2015-2021 H2O.ai'
+copyright = '2015-2022 H2O.ai'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
For: [PUBDEV-8546](https://h2oai.atlassian.net/browse/PUBDEV-8546)

I noticed that the copyright year hasn't been updated yet. Updated it here for the python documentation and the user guide