### PR TITLE
PUBDEV-8528: Change default leaderboard sorting in regression to RMSE

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -370,7 +370,8 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
         if (parms._stopping_metric == StoppingMetric.AUTO) {
             String sort_metric = getSortMetric();
             parms._stopping_metric = sort_metric == null ? StoppingMetric.AUTO
-                    : sort_metric.equals("auc") ? StoppingMetric.logloss
+                    : sort_metric.equals("auc")  ? StoppingMetric.logloss
+                    : sort_metric.equals("rmse") ? StoppingMetric.deviance
                     : metricValueOf(sort_metric);
         }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -368,11 +368,7 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
             parms._stopping_metric = buildSpec.build_control.stopping_criteria.stopping_metric();
 
         if (parms._stopping_metric == StoppingMetric.AUTO) {
-            String sort_metric = getSortMetric();
-            parms._stopping_metric = sort_metric == null ? StoppingMetric.AUTO
-                    : sort_metric.equals("auc")  ? StoppingMetric.logloss
-                    : sort_metric.equals("rmse") ? StoppingMetric.deviance
-                    : metricValueOf(sort_metric);
+            parms._stopping_metric = aml().getResponseColumn().cardinality() == -1 ? StoppingMetric.deviance : StoppingMetric.logloss;
         }
 
         if (parms._stopping_rounds == defaults._stopping_rounds)

--- a/h2o-automl/src/main/java/ai/h2o/automl/leaderboard/Leaderboard.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/leaderboard/Leaderboard.java
@@ -596,7 +596,7 @@ public class Leaderboard extends Lockable<Leaderboard> implements ModelContainer
     } else if (m._output.isMultinomialClassifier()) { // multinomial
       return new String[] {"mean_per_class_error", "logloss", "rmse", "mse"};
     } else if (m._output.isSupervised()) { // regression
-      return new String[] {"mean_residual_deviance", "rmse", "mse", "mae", "rmsle"};
+      return new String[] {"rmse", "mse", "mae", "rmsle", "mean_residual_deviance"};
     }
     return new String[0];
   }

--- a/h2o-automl/src/test/java/ai/h2o/automl/ModelingStepTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/ModelingStepTest.java
@@ -5,6 +5,7 @@ import ai.h2o.automl.dummy.DummyModel;
 import ai.h2o.automl.dummy.DummyStepsProvider;
 import ai.h2o.automl.dummy.DummyStepsProvider.DummyModelStep;
 import hex.Model;
+import hex.ScoreKeeper;
 import hex.grid.Grid;
 import hex.grid.HyperSpaceSearchCriteria;
 import org.junit.After;
@@ -78,7 +79,7 @@ public class ModelingStepTest {
         assertEquals(aml.getBuildSpec().input_spec.response_column, model._parms._response_column);
         assertEquals(aml.getBuildSpec().build_control.nfolds, model._parms._nfolds);
         assertTrue(model._parms._max_runtime_secs > 0);
-        assertEquals(aml.getBuildSpec().build_control.stopping_criteria.stopping_metric(), model._parms._stopping_metric);
+        assertEquals(ScoreKeeper.StoppingMetric.logloss, model._parms._stopping_metric); // Classification
     }
 
     @Test(expected = H2OIllegalArgumentException.class)
@@ -96,7 +97,7 @@ public class ModelingStepTest {
             assertEquals(aml.getBuildSpec().input_spec.response_column, model._parms._response_column);
             assertEquals(aml.getBuildSpec().build_control.nfolds, model._parms._nfolds);
             assertTrue(model._parms._max_runtime_secs > 0);
-            assertEquals(aml.getBuildSpec().build_control.stopping_criteria.stopping_metric(), model._parms._stopping_metric);
+            assertEquals(ScoreKeeper.StoppingMetric.logloss, model._parms._stopping_metric); // Classification
         }
     }
 
@@ -149,7 +150,7 @@ public class ModelingStepTest {
             assertEquals(aml.getBuildSpec().input_spec.response_column, model._parms._response_column);
             assertEquals(aml.getBuildSpec().build_control.nfolds, model._parms._nfolds);
             assertTrue(model._parms._max_runtime_secs > 0);
-            assertEquals(aml.getBuildSpec().build_control.stopping_criteria.stopping_metric(), model._parms._stopping_metric);
+            assertEquals(ScoreKeeper.StoppingMetric.logloss, model._parms._stopping_metric); // Classification
         }
     }
     
@@ -169,7 +170,7 @@ public class ModelingStepTest {
             assertEquals(aml.getBuildSpec().input_spec.response_column, model._parms._response_column);
             assertEquals(aml.getBuildSpec().build_control.nfolds, model._parms._nfolds);
             assertTrue(model._parms._max_runtime_secs > 0);
-            assertEquals(aml.getBuildSpec().build_control.stopping_criteria.stopping_metric(), model._parms._stopping_metric);
+            assertEquals(ScoreKeeper.StoppingMetric.logloss, model._parms._stopping_metric); // Classification
         }
     }
 

--- a/h2o-automl/src/test/java/ai/h2o/automl/leaderboard/LeaderboardTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/leaderboard/LeaderboardTest.java
@@ -82,7 +82,7 @@ public class LeaderboardTest extends water.TestUtil {
       lb = Leaderboard.getOrMake("dummy_rank_tsv", eventLog, null, "mae");
       lb.addModel(model._key);
       Log.info(lb.rankTsv());
-      assertEquals("Error\n[0.3448260574357465, 0.19959320678410908, 0.44675855535636816, 0.19959320678410908, 0.31468498072970547]\n", lb.rankTsv());
+      assertEquals("Error\n[0.3448260574357465, 0.44675855535636816, 0.19959320678410908, 0.31468498072970547, 0.19959320678410908]\n", lb.rankTsv());
     } finally {
       if (lb != null){
         lb.remove();

--- a/h2o-py/tests/testdir_algos/automl/leaderboard/pyunit_automl_leaderboard_regression.py
+++ b/h2o-py/tests/testdir_algos/automl/leaderboard/pyunit_automl_leaderboard_regression.py
@@ -80,7 +80,7 @@ def test_AUTO_stopping_metric_with_no_sorting_metric_regression():
     first = [m for m in base if 'XGBoost_1' in m]
     others = [m for m in base if m not in first]
     check_model_property(first, 'stopping_metric', True, None) #if stopping_rounds == 0, actual value of stopping_metric is set to None
-    check_model_property(others, 'stopping_metric', True, "RMSE")
+    check_model_property(others, 'stopping_metric', True, "deviance")
 
 
 def test_AUTO_stopping_metric_with_custom_sorting_metric_regression():
@@ -99,7 +99,7 @@ def test_AUTO_stopping_metric_with_custom_sorting_metric_regression():
 
     check_leaderboard(aml, exclude_algos, ["rmse", "mse", "mae", "rmsle", "mean_residual_deviance"], "rmse")
     base = get_partitioned_model_names(aml.leaderboard).base
-    check_model_property(base, 'stopping_metric', True, "RMSE")
+    check_model_property(base, 'stopping_metric', True, "deviance")
 
 
 pu.run_tests([

--- a/h2o-py/tests/testdir_algos/automl/leaderboard/pyunit_automl_leaderboard_regression.py
+++ b/h2o-py/tests/testdir_algos/automl/leaderboard/pyunit_automl_leaderboard_regression.py
@@ -25,7 +25,7 @@ def test_leaderboard_for_regression():
                     seed=automl_seed)
     aml.train(y=ds.target, training_frame=ds.train)
 
-    check_leaderboard(aml, exclude_algos, ["mean_residual_deviance", "rmse", "mse", "mae", "rmsle"], "mean_residual_deviance")
+    check_leaderboard(aml, exclude_algos, ["rmse", "mse", "mae", "rmsle", "mean_residual_deviance"], "rmse")
 
 
 def test_leaderboard_for_regression_with_custom_sorting():
@@ -42,7 +42,7 @@ def test_leaderboard_for_regression_with_custom_sorting():
                     sort_metric="RMSE")
     aml.train(y=ds.target, training_frame=ds.train)
 
-    check_leaderboard(aml, exclude_algos, ["rmse", "mean_residual_deviance", "mse", "mae", "rmsle"], "rmse")
+    check_leaderboard(aml, exclude_algos, ["rmse", "mse", "mae", "rmsle", "mean_residual_deviance"], "rmse")
 
 
 def test_leaderboard_for_regression_with_custom_sorting_deviance():
@@ -75,12 +75,12 @@ def test_AUTO_stopping_metric_with_no_sorting_metric_regression():
                     seed=automl_seed)
     aml.train(y=ds.target, training_frame=ds.train)
 
-    check_leaderboard(aml, exclude_algos, ["mean_residual_deviance", "rmse", "mse", "mae", "rmsle"], "mean_residual_deviance")
+    check_leaderboard(aml, exclude_algos, ["rmse", "mse", "mae", "rmsle", "mean_residual_deviance"], "rmse")
     base = get_partitioned_model_names(aml.leaderboard).base
     first = [m for m in base if 'XGBoost_1' in m]
     others = [m for m in base if m not in first]
     check_model_property(first, 'stopping_metric', True, None) #if stopping_rounds == 0, actual value of stopping_metric is set to None
-    check_model_property(others, 'stopping_metric', True, "deviance")
+    check_model_property(others, 'stopping_metric', True, "RMSE")
 
 
 def test_AUTO_stopping_metric_with_custom_sorting_metric_regression():
@@ -97,7 +97,7 @@ def test_AUTO_stopping_metric_with_custom_sorting_metric_regression():
                     sort_metric="rmse")
     aml.train(y=ds.target, training_frame=ds.train)
 
-    check_leaderboard(aml, exclude_algos, ["rmse", "mean_residual_deviance", "mse", "mae", "rmsle"], "rmse")
+    check_leaderboard(aml, exclude_algos, ["rmse", "mse", "mae", "rmsle", "mean_residual_deviance"], "rmse")
     base = get_partitioned_model_names(aml.leaderboard).base
     check_model_property(base, 'stopping_metric', True, "RMSE")
 

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_regression.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_regression.py
@@ -18,7 +18,7 @@ def test_default_automl_with_regression_task():
     aml.train(y=ds.target, training_frame=ds.train, validation_frame=ds.valid, leaderboard_frame=ds.test)
     print(aml.leader)
     print(aml.leaderboard)
-    assert aml.leaderboard.columns == ["model_id", "mean_residual_deviance", "rmse", "mse", "mae", "rmsle"]
+    assert aml.leaderboard.columns == ["model_id", "rmse", "mse", "mae", "rmsle", "mean_residual_deviance"]
 
 
 def test_workaround_for_distribution():

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_leaderboard.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_leaderboard.R
@@ -41,7 +41,7 @@ automl.leaderboard.suite <- function() {
                            project_name = "r_aml_lb_regression_test",
                            exclude_algos = exclude_algos)
         aml@leaderboard
-        expect_equal(names(aml@leaderboard), c("model_id", "mean_residual_deviance", "rmse", "mse", "mae", "rmsle"))
+        expect_equal(names(aml@leaderboard), c("model_id", "rmse", "mse", "mae", "rmsle", "mean_residual_deviance"))
         model_ids <- as.vector(aml@leaderboard$model_id)
         # check that no excluded algos are present in leaderboard
         exclude_algo_count <- sum(sapply(exclude_algos, function(i) sum(grepl(i, model_ids))))

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_sort_metric.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_sort_metric.R
@@ -42,7 +42,7 @@ automl.leaderboard_sort_metric.test <- function() {
                      project_name = "r_lbsm_test_aml2",
                      sort_metric = "RMSE")
   aml2@leaderboard
-  expect_equal(names(aml2@leaderboard), c("model_id", "rmse", "mean_residual_deviance", "mse", "mae", "rmsle"))
+  expect_equal(names(aml2@leaderboard), c("model_id", "rmse", "mse", "mae", "rmsle", "mean_residual_deviance"))
   # check that rmse col is sorted already
   rmse_col <- as.vector(aml2@leaderboard[,"rmse"])
   expect_equal(identical(rmse_col, sort(rmse_col, decreasing = FALSE)), TRUE)
@@ -51,8 +51,8 @@ automl.leaderboard_sort_metric.test <- function() {
   aml2 <- h2o.automl(y = 'runoffnew', training_frame = fr2, max_models = 2,
                      project_name = "r_lbsm_test_aml2_auto")
   aml2@leaderboard
-  # check that leaderboard is sorted by mean_residual_deviance
-  mrd_col <- as.vector(aml2@leaderboard[,"mean_residual_deviance"])
+  # check that leaderboard is sorted by rmse
+  mrd_col <- as.vector(aml2@leaderboard[,"rmse"])
   expect_equal(identical(mrd_col, sort(mrd_col, decreasing = FALSE)), TRUE)
   
   


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8528


I ran several experiments with Huber "distribution" and either `deviance` and `rmse`  as `stopping_metric` and I didn't find any consistent conclusion. On some datasets `stopping_metric="deviance"` had a bit better MAE and RMSLE and on others, they didn't. Interestingly with `stopping_metric="deviance"` sometimes even RMSE was better (mostly SEs) but the differences were very small. I looked at both runs with and without leaderboard (with fixed seed) to find out if there is any benefit of less overfitting when using different stopping metric than the criterium that we optimize but I didn't find any.

The only thing that appeared consistent is that the automl trained with `stopping_metric="deviance"` had a little bit longer training time (less than 4% of total time; with average runtime of an experiment around 35mins so part of it could be just noise). 

After inspecting our early stopping, I believe I can explain that behavior with the attached image. I created an artificial dataset with one outlier. OLS which finds the minimum RMSE is depicted with the red color. Green line is Huber regression (using R's MASS library). And now the problem is that if we are doing iteratively Huber regression (blue line) we should get closer to the green line but the early stopping will find out our RMSE is increasing and stop too early but if we are using deviance we can continue and potentially converge.

<img width="927" alt="Unknown" src="https://user-images.githubusercontent.com/61695433/152546652-c4c3dce5-a789-4894-a05f-b80a58a54a3b.png">

This is easily demonstrated on this artificial dataset but I think it also shows a behavior that is not intuitive (if we would use RMSE by default as stopping metric) - if the user sets `distribution="huber"` they would probably expect something closer to the Huber regression than OLS but our early stopper could stop the regression from converging. 

I believe similar cases could occur in other "distributions" so I think the safest choice for default regression stopping metric is `deviance`.

**Early stopping for metrics where less is better:**
https://github.com/h2oai/h2o-3/blob/b947ecd833eedf4bbae6a94d4a111cb0b453debf/h2o-core/src/main/java/hex/ScoreKeeper.java#L370-L382 



