### PR TITLE
[nocheck] lists of strings not represented the same way in Py2 and Py3

### DIFF
--- a/h2o-py/h2o/automl/_estimator.py
+++ b/h2o-py/h2o/automl/_estimator.py
@@ -335,7 +335,7 @@ class H2OAutoML(H2OAutoMLBaseMixin, Keyed):
         if modeling_plan is None:
             return None
 
-        supported_aliases = ['all', 'defaults', 'grids']
+        supported_aliases = PList(['all', 'defaults', 'grids'])
 
         def assert_is_step_def(sd):
             assert 'name' in sd, "each definition must have a 'name' key"

--- a/h2o-py/h2o/utils/compatibility.py
+++ b/h2o-py/h2o/utils/compatibility.py
@@ -163,6 +163,10 @@ def repr2(x):
     return s
 
 
+def _is_py2_unicode(s):
+    return PY2 and type(s) is _native_unicode
+    
+
 class PList(list):
     """
     Wrapper for printable lists ensuring that the list is printed/represented the same way in Py2 and Py3
@@ -172,8 +176,8 @@ class PList(list):
         super(PList, self).__init__(arr)
         
     def __str__(self):
-        return str([str(it) for it in self])
+        return str([str(it) if _is_py2_unicode(it) else it for it in self])
     
     def __repr__(self):
-        return repr([str(it) for it in self])
+        return repr([str(it) if _is_py2_unicode(it) else it for it in self])
     

--- a/h2o-py/h2o/utils/compatibility.py
+++ b/h2o-py/h2o/utils/compatibility.py
@@ -66,8 +66,7 @@ from future.utils import PY2, PY3, with_metaclass
 __all__ = ("PY2", "PY3", "with_metaclass",  "bytes_iterator",
            "range", "filter", "map", "zip", "viewitems", "viewkeys", "viewvalues",
            "apply", "cmp", "coerce", "execfile", "file", "long", "raw_input", "reduce", "reload", "unicode", "xrange",
-           "StandardError", "chr", "input", "open", "next", "round", "super", "csv_dict_writer", "repr2")
-
+           "StandardError", "chr", "input", "open", "next", "round", "super", "csv_dict_writer", "repr2", "PList")
 
 
 #-----------------------------------------------------------------------------------------------------------------------
@@ -84,6 +83,7 @@ if True:
         else:
             return gen.__next__
 
+
 #-----------------------------------------------------------------------------------------------------------------------
 # Disabled functions
 #   -- attempt to use any of these functions will raise an AssertionError now!
@@ -95,6 +95,7 @@ def _disabled_function(name):
         """Disabled function, DO NOT USE."""
         raise NameError("Function %s is not available in Python 3, and was disabled in Python 2 as well." % name)
     return disabled
+
 
 if PY2:
     _native_unicode = unicode
@@ -153,9 +154,26 @@ def bytes_iterator(s):
     else:
         raise TypeError("String argument expected, got %s" % type(s))
 
+
 def repr2(x):
     """Analogous to repr(), but will suppress 'u' prefix when repr-ing a unicode string."""
     s = repr(x)
     if len(s) >= 2 and s[0] == "u" and (s[1] == "'" or s[1] == '"'):
         s = s[1:]
     return s
+
+
+class PList(list):
+    """
+    Wrapper for printable lists ensuring that the list is printed/represented the same way in Py2 and Py3
+    """
+    
+    def __init__(self, arr):
+        super(PList, self).__init__(arr)
+        
+    def __str__(self):
+        return str([str(it) for it in self])
+    
+    def __repr__(self):
+        return repr([str(it) for it in self])
+    

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_modeling_plan.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_modeling_plan.py
@@ -33,6 +33,7 @@ def test_bad_modeling_plan_using_full_syntax():
             dict(name="GBM", alias='all_steps')
         ])
     except AssertionError as e:
+        print(e)
         assert "alias must be one of ['all', 'defaults', 'grids']" in str(e)
 
     try:

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_modeling_plan.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_modeling_plan.py
@@ -33,7 +33,6 @@ def test_bad_modeling_plan_using_full_syntax():
             dict(name="GBM", alias='all_steps')
         ])
     except AssertionError as e:
-        print(e)
         assert "alias must be one of ['all', 'defaults', 'grids']" in str(e)
 
     try:

--- a/h2o-py/tests/testdir_utils/pyunit_compatibility.py
+++ b/h2o-py/tests/testdir_utils/pyunit_compatibility.py
@@ -7,12 +7,14 @@ from tests import pyunit_utils as pu
 
 
 def test_list_to_str():
-    l = ['foo', 'bar']
-    assert repr(l) == str(l) == "[u'foo', u'bar']" if PY2 else "['foo', 'bar']"
+    l = ['foo', 'bar', 1, True, str("baz"), u"bal"]
+    print(repr(l))
+    print(str(l))
+    assert repr(l) == str(l) == "[u'foo', u'bar', 1, True, 'baz', u'bal']" if PY2 else "['foo', 'bar', 1, True, 'baz', 'bal']"
     ll = list(l)
-    assert repr(ll) == str(ll) == "[u'foo', u'bar']" if PY2 else "['foo', 'bar']"
+    assert repr(ll) == str(ll) == "[u'foo', u'bar', 1, True, 'baz', u'bal']" if PY2 else "['foo', 'bar', 1, True, 'baz', 'bal']"
     pl = PList(l)
-    assert repr(pl) == str(pl) == "['foo', 'bar']"
+    assert repr(pl) == str(pl) == "['foo', 'bar', 1, True, 'baz', 'bal']"
 
 
 pu.run_tests([

--- a/h2o-py/tests/testdir_utils/pyunit_compatibility.py
+++ b/h2o-py/tests/testdir_utils/pyunit_compatibility.py
@@ -1,0 +1,20 @@
+from __future__ import print_function, unicode_literals
+import sys
+sys.path.insert(1,"../../")
+
+from h2o.utils.compatibility import PList, PY2
+from tests import pyunit_utils as pu
+
+
+def test_list_to_str():
+    l = ['foo', 'bar']
+    assert repr(l) == str(l) == "[u'foo', u'bar']" if PY2 else "['foo', 'bar']"
+    ll = list(l)
+    assert repr(ll) == str(ll) == "[u'foo', u'bar']" if PY2 else "['foo', 'bar']"
+    pl = PList(l)
+    assert repr(pl) == str(pl) == "['foo', 'bar']"
+
+
+pu.run_tests([
+    test_list_to_str
+])


### PR DESCRIPTION
This is a bit annoying for error messages, and the fix could probably be applied in other places.

Note:
I recently added the py2 compatibility imports to automl module as recommended in `h2o.utils.compatibility` to provide a more consistent behaviour for this module in Py2:
```python
from __future__ import absolute_import, division, print_function, unicode_literals
from h2o.utils.compatibility import *  # NOQA
```
ironically, this import of `unicode_literals` was also the cause of the recent failure of `pyunit_automl_modeling_plan.py` in Py2.
For consistency with the rest of the codebase, I still prefer to keep the compat imports and ensure that the automl code behaves as expected in Py2.
