### PR TITLE
PUBDEV-8721: Use exact split-points for low-cardinality columns

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/DHistogram.java
+++ b/h2o-algos/src/main/java/hex/tree/DHistogram.java
@@ -133,7 +133,7 @@ public final class DHistogram extends Iced<DHistogram> {
 
   protected double  _min2, _maxIn; // Min/Max, _maxIn is Inclusive.
   public HistogramType _histoType; //whether ot use random split points
-  transient double _splitPts[]; // split points between _min and _maxEx (either random or based on quantiles)
+  transient double[] _splitPts; // split points between _min and _maxEx (either random or based on quantiles)
   transient int _zeroSplitPntPos;
   public final boolean _checkFloatSplits;
   transient float[] _splitPtsFloat;
@@ -162,7 +162,7 @@ public final class DHistogram extends Iced<DHistogram> {
     Left(4),     //test time NA should go left
     Right(5);    //test time NA should go right
 
-    private int value;
+    private final int value;
     NASplitDir(int v) { this.value = v; }
     public int value() { return value; }
   }

--- a/h2o-algos/src/main/java/hex/tree/DTree.java
+++ b/h2o-algos/src/main/java/hex/tree/DTree.java
@@ -410,7 +410,7 @@ public class DTree extends Iced {
 
         nhists[j] = DHistogram.make(h._name, adj_nbins, h._isInt, min, maxEx, h._intOpt, hasNAs,
                 h._seed*0xDECAF+(way+1), parms,
-                h._globalQuantilesKey, cs, h._checkFloatSplits, customSplitPoints);
+                h._globalSplitPointsKey, cs, h._checkFloatSplits, customSplitPoints);
         cnt++;                    // At least some chance of splitting
       }
       return cnt == 0 ? null : nhists;

--- a/h2o-algos/src/main/java/hex/tree/ExactSplitPoints.java
+++ b/h2o-algos/src/main/java/hex/tree/ExactSplitPoints.java
@@ -1,0 +1,133 @@
+package hex.tree;
+
+import water.MRTask;
+import water.fvec.Chunk;
+import water.fvec.Frame;
+import water.util.IcedDouble;
+import water.util.IcedHashSet;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Finds exact split points for low-cardinality columns.
+ */
+public class ExactSplitPoints extends MRTask<ExactSplitPoints> {
+
+    private final int _maxCardinality;
+    private final IcedHashSet<IcedDouble>[] _values;
+
+    static double[][] splitPoints(Frame trainFr, int maxCardinality) {
+        final Frame fr = new Frame();
+        final int[] frToTrain = new int[trainFr.numCols()];
+        for (int i = 0; i < trainFr.numCols(); ++i) {
+            if (!trainFr.vec(i).isNumeric() || trainFr.vec(i).isCategorical() ||
+                    trainFr.vec(i).isBinary() || trainFr.vec(i).isConst()) {
+                continue;
+            }
+            frToTrain[fr.numCols()] = i;
+            fr.add(trainFr.name(i), trainFr.vec(i));
+        }
+        IcedHashSet<IcedDouble>[] values = new ExactSplitPoints(maxCardinality, fr.numCols())
+                .doAll(fr)._values;
+        double[][] splitPoints = new double[trainFr.numCols()][];
+        for (int i = 0; i < values.length; i++) {
+            if (values[i] == null) {
+                continue;
+            }
+            double[] vals = new double[values[i].size()];
+            int valsSize = 0;
+            for (IcedDouble wrapper : values[i]) {
+                vals[valsSize++] = wrapper._val;
+            }
+            assert valsSize == vals.length;
+            Arrays.sort(vals);
+            assert isUniqueSequence(vals);
+            splitPoints[frToTrain[i]] = vals;
+        }
+        return splitPoints;
+    }
+
+    static boolean isUniqueSequence(double[] seq) {
+        if (seq.length == 1)
+            return true;
+        double lastValue = seq[0];
+        for (int i = 1; i < seq.length; i++) {
+            if (lastValue >= seq[i])
+                return false;
+            lastValue = seq[i];
+        }
+        return true;
+    }
+
+    @SuppressWarnings("unchecked")
+    private ExactSplitPoints(int maxCardinality, int nCols) {
+        _maxCardinality = maxCardinality;
+        _values = new IcedHashSet[nCols];
+        for (int i = 0; i < _values.length; i++) {
+            _values[i] = new IcedHashSet<>();
+        }
+    }
+
+    @Override
+    public void map(Chunk[] cs) {
+        Set<IcedDouble> localValues = new HashSet<>(_maxCardinality);
+        for (int col = 0; col < cs.length; col++) {
+            localValues.clear();
+            if (_values[col] == null)
+                continue;
+            Chunk c = cs[col];
+            IcedDouble wrapper = new IcedDouble();
+            for (int i = 0; i < c._len; i++) {
+                double num = c.atd(i);
+                if (Double.isNaN(num))
+                    continue;
+                if (wrapper._val == num)
+                    continue;
+                wrapper.setVal(num);
+                if (localValues.add(wrapper)) {
+                    if (localValues.size() > _maxCardinality) {
+                        _values[col] = null;
+                        break;
+                    }
+                    wrapper = new IcedDouble();
+                }
+            }
+            merge(col, localValues);
+        }
+    }
+
+    private void merge(int col, Collection<IcedDouble> localValues) {
+        final Set<IcedDouble> allValues = _values[col];
+        if (allValues == null)
+            return;
+        allValues.addAll(localValues);
+        if (allValues.size() > _maxCardinality) {
+            _values[col] = null;
+        }
+    }
+
+    @Override
+    public void reduce(ExactSplitPoints mrt) {
+        if (mrt._values != _values) { // merging with a result from a different node
+            for (int col = 0; col < _values.length; col++) {
+                if (_values[col] == null || mrt._values[col] == null)
+                    _values[col] = null;
+                else {
+                    merge(col, mrt._values[col]);
+                }
+            }
+        } // else: nothing to do on the same node
+    }
+
+    @Override
+    protected void postGlobal() {
+        for (int col = 0; col < _values.length; col++) {
+            if (_values[col] != null && _values[col].size() > _maxCardinality) {
+                _values[col] = null;
+            }
+        }
+    }
+}

--- a/h2o-algos/src/main/java/hex/tree/GlobalQuantilesCalc.java
+++ b/h2o-algos/src/main/java/hex/tree/GlobalQuantilesCalc.java
@@ -16,13 +16,28 @@ class GlobalQuantilesCalc {
     /**
      * Calculates split points for histogram type = QuantilesGlobal.
      * 
-     * @param fr (adapted) training frame
-     * @param weightsColumn name of column containing observation weights (optional) 
+     * @param trainFr (adapted) training frame
+     * @param weightsColumn name of column containing observation weights (optional)
+     * @param priorSplitPoints optional pre-existing split points for some columns
      * @param N number of bins
      * @param nbins_top_level number of top-level bins
      * @return array of split points for each feature column of the input training frame
      */
-    static double[][] splitPoints(Frame fr, String weightsColumn, final int N, int nbins_top_level) {
+    static double[][] splitPoints(Frame trainFr, String weightsColumn, 
+                                  double[][] priorSplitPoints, final int N, int nbins_top_level) {
+        final Frame fr = new Frame();
+        final int[] frToTrain = new int[trainFr.numCols()];
+        for (int i = 0; i < trainFr.numCols(); ++i) {
+            if (priorSplitPoints != null && priorSplitPoints[i] != null) {
+                continue;
+            }
+            if (!trainFr.vec(i).isNumeric() || trainFr.vec(i).isCategorical() || 
+                    trainFr.vec(i).isBinary() || trainFr.vec(i).isConst()) {
+                continue;
+            }
+            frToTrain[fr.numCols()] = i;
+            fr.add(trainFr.name(i), trainFr.vec(i));
+        }
         Key<Frame> rndKey = Key.make();
         DKV.put(rndKey, fr);
         QuantileModel qm = null;
@@ -39,13 +54,14 @@ class GlobalQuantilesCalc {
             job.remove();
             double[][] origQuantiles = qm._output._quantiles;
             //pad the quantiles until we have nbins_top_level bins
-            double[][] splitPoints = new double[origQuantiles.length][];
-            for (int i = 0; i < origQuantiles.length; ++i) {
-                if (!fr.vec(i).isNumeric() || fr.vec(i).isCategorical() || fr.vec(i).isBinary() || origQuantiles[i].length <= 1) {
+            double[][] splitPoints = new double[trainFr.numCols()][];
+            for (int q = 0; q < origQuantiles.length; q++) {
+                if (origQuantiles[q].length <= 1) {
                     continue;
                 }
+                final int i = frToTrain[q];
                 // make the quantiles split points unique
-                splitPoints[i] = ArrayUtils.makeUniqueAndLimitToRange(origQuantiles[i], fr.vec(i).min(), fr.vec(i).max());
+                splitPoints[i] = ArrayUtils.makeUniqueAndLimitToRange(origQuantiles[q], fr.vec(q).min(), fr.vec(q).max());
                 if (splitPoints[i].length <= 1) //not enough split points left - fall back to regular binning
                     splitPoints[i] = null;
                 else

--- a/h2o-algos/src/main/java/hex/tree/GlobalQuantilesCalc.java
+++ b/h2o-algos/src/main/java/hex/tree/GlobalQuantilesCalc.java
@@ -27,6 +27,10 @@ class GlobalQuantilesCalc {
                                   double[][] priorSplitPoints, final int N, int nbins_top_level) {
         final int[] frToTrain = new int[trainFr.numCols()];
         final Frame fr = collectColumnsForQuantile(trainFr, weightsColumn, priorSplitPoints, frToTrain);
+        final double[][] splitPoints = new double[trainFr.numCols()][];
+        if (fr.numCols() == 0 || weightsColumn != null && fr.numCols() == 1 && weightsColumn.equals(fr.name(0))) {
+            return splitPoints;
+        }
         Key<Frame> tmpFrameKey = Key.make();
         DKV.put(tmpFrameKey, fr);
         QuantileModel qm = null;
@@ -43,7 +47,6 @@ class GlobalQuantilesCalc {
             job.remove();
             double[][] origQuantiles = qm._output._quantiles;
             //pad the quantiles until we have nbins_top_level bins
-            double[][] splitPoints = new double[trainFr.numCols()][];
             for (int q = 0; q < origQuantiles.length; q++) {
                 if (origQuantiles[q].length <= 1) {
                     continue;

--- a/h2o-algos/src/main/java/hex/tree/SharedTree.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTree.java
@@ -265,7 +265,7 @@ public abstract class SharedTree<
 
         // Compute the print-out response domain; makes for nicer printouts
         assert (_nclass > 1 && actualDomain != null) || (_nclass==1 && actualDomain==null);
-        final String[] domain = _nclass == 1 ? new String[] {"r"} : actualDomain; // For regression, give a nam to class 0   
+        final String[] domain = _nclass == 1 ? new String[] {"r"} : actualDomain; // For regression, give a name to class 0   
 
         // Compute class distribution, used to for initial guesses and to
         // upsample minority classes (if asked for).

--- a/h2o-algos/src/main/java/hex/tree/SharedTree.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTree.java
@@ -265,7 +265,7 @@ public abstract class SharedTree<
 
         // Compute the print-out response domain; makes for nicer printouts
         assert (_nclass > 1 && actualDomain != null) || (_nclass==1 && actualDomain==null);
-        final String[] domain = _nclass == 1 ? new String[] {"r"} : actualDomain; // For regression, give a name to class 0   
+        final String[] domain = _nclass == 1 ? new String[] {"r"} : actualDomain; // For regression, give a nam to class 0   
 
         // Compute class distribution, used to for initial guesses and to
         // upsample minority classes (if asked for).
@@ -322,15 +322,31 @@ public abstract class SharedTree<
         if (_parms._histogram_type == SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesGlobal
                 || _parms._histogram_type == SharedTreeModel.SharedTreeParameters.HistogramType.RoundRobin) {
           _job.update(1, "Computing top-level histogram split-points.");
-          final double[][] splitPoints = GlobalQuantilesCalc.splitPoints(_train, _parms._weights_column, _parms._nbins, _parms._nbins_top_level);
+
+          final Timer exactT = new Timer();
+          final double[][] exactSplitPoints = ExactSplitPoints.splitPoints(_train, _parms._nbins);
+          LOG.info("Calculating exact (low cardinality) histogram split-points took " + exactT);
+
+          final Timer quantileT = new Timer();
+          final double[][] quantileSplitPoints = GlobalQuantilesCalc.splitPoints(_train, _parms._weights_column, 
+                  exactSplitPoints, _parms._nbins, _parms._nbins_top_level);
           Futures fs = new Futures();
-          for (int i = 0; i < splitPoints.length; i++) {
-            Key<DHistogram.HistoQuantiles> key = getGlobalQuantilesKey(i);
-            if (splitPoints[i] != null && key != null) {
-              DKV.put(new DHistogram.HistoQuantiles(key, splitPoints[i]), fs);
+          int qCnt = 0, eCnt = 0;
+          for (int i = 0; i < quantileSplitPoints.length; i++) {
+            assert exactSplitPoints[i] == null || quantileSplitPoints[i] == null;
+            Key<DHistogram.HistoSplitPoints> key = getGlobalSplitPointsKey(i);
+            if (key == null)
+              continue;
+            boolean useQuantiles = exactSplitPoints[i] == null;
+            double[] sp = useQuantiles ? quantileSplitPoints[i] : exactSplitPoints[i];
+            if (sp != null) {
+              if (useQuantiles) { qCnt++; } else { eCnt++; }
+              DKV.put(new DHistogram.HistoSplitPoints(key, sp, useQuantiles), fs);
             }
           }
           fs.blockForPending();
+          LOG.info("Split-points are defined using " + eCnt + " exact sets of points and " + qCnt + " sets of quantile values.");
+          LOG.info("Calculating top-level histogram split-points took " + quantileT);
         }
 
         // Also add to the basic working Frame these sets:
@@ -387,7 +403,7 @@ public abstract class SharedTree<
           _eventPublisher.onAllIterationsComplete();
         }
         if( _model!=null ) _model.unlock(_job);
-        for (Key<?> k : getGlobalQuantilesKeys()) Keyed.remove(k);
+        for (Key<?> k : getGlobalSplitPointsKeys()) Keyed.remove(k);
         if (_validWorkspace != null) {
           _validWorkspace.remove();
           _validWorkspace = null;
@@ -418,17 +434,17 @@ public abstract class SharedTree<
 
     protected Frame makeValidWorkspace() { return null; }
 
-    // Helpers to store quantiles in DKV - keep a cache on each node (instead of sending around over and over)
-    protected Key<DHistogram.HistoQuantiles> getGlobalQuantilesKey(int i) {
+    // Helpers to store split-points in DKV - keep a cache on each node (instead of sending around over and over)
+    protected Key<DHistogram.HistoSplitPoints> getGlobalSplitPointsKey(int i) {
       if (_model==null || _model._key == null || _parms._histogram_type!= SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesGlobal
               && _parms._histogram_type!= SharedTreeModel.SharedTreeParameters.HistogramType.RoundRobin) return null;
-      return Key.makeSystem(_model._key+"_quantiles_col_"+i);
+      return Key.makeSystem(_model._key+"_splits_col_"+i);
     }
-    protected Key<DHistogram.HistoQuantiles>[] getGlobalQuantilesKeys() {
+    protected Key<DHistogram.HistoSplitPoints>[] getGlobalSplitPointsKeys() {
       @SuppressWarnings("unchecked")
-      Key<DHistogram.HistoQuantiles>[] keys = new Key[_ncols];
+      Key<DHistogram.HistoSplitPoints>[] keys = new Key[_ncols];
       for (int i=0;i<keys.length;++i)
-        keys[i] = getGlobalQuantilesKey(i);
+        keys[i] = getGlobalSplitPointsKey(i);
       return keys;
     }
 

--- a/h2o-algos/src/main/java/hex/tree/drf/DRF.java
+++ b/h2o-algos/src/main/java/hex/tree/drf/DRF.java
@@ -198,7 +198,7 @@ public class DRF extends SharedTree<hex.tree.drf.DRFModel, hex.tree.drf.DRFModel
           // inverse of the first (and that the same columns were picked)
           if( k==1 && _nclass==2 && _model.binomialOpt()) continue;
           ktrees[k] = new DTree(_train, _ncols, _mtry, _mtry_per_tree, rseed, _parms);
-          new UndecidedNode(ktrees[k], -1, DHistogram.initialHist(_train, _ncols, adj_nbins, hcs[k][0], rseed, _parms, getGlobalQuantilesKeys(), null,true, null), null, null); // The "root" node
+          new UndecidedNode(ktrees[k], -1, DHistogram.initialHist(_train, _ncols, adj_nbins, hcs[k][0], rseed, _parms, getGlobalSplitPointsKeys(), null, true, null), null, null); // The "root" node
         }
       }
 

--- a/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
+++ b/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
@@ -617,7 +617,7 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
         // Initially setup as-if an empty-split had just happened
         if (_model._output._distribution[k] != 0) {
           ktrees[k] = new DTree(_train, _ncols, _mtry, _mtry_per_tree, rseed, _parms);
-          DHistogram[] hist = DHistogram.initialHist(_train, _ncols, adj_nbins, hcs[k][0], rseed, _parms, getGlobalQuantilesKeys(), cs, false, _ics);
+          DHistogram[] hist = DHistogram.initialHist(_train, _ncols, adj_nbins, hcs[k][0], rseed, _parms, getGlobalSplitPointsKeys(), cs, false, _ics);
           new UndecidedNode(ktrees[k], DTree.NO_PARENT, hist, cs, bics); // The "root" node
         }
       }

--- a/h2o-algos/src/main/java/hex/tree/isofor/IsolationForest.java
+++ b/h2o-algos/src/main/java/hex/tree/isofor/IsolationForest.java
@@ -252,7 +252,7 @@ public class IsolationForest extends SharedTree<IsolationForestModel, IsolationF
 
       // Initially setup as-if an empty-split had just happened
       final DTree tree = ktrees[0];
-      new UndecidedNode(tree, -1, DHistogram.initialHist(_train, _ncols, adj_nbins, hcs[0][0], rseed, _parms, getGlobalQuantilesKeys(), null, false, null), null, null); // The "root" node
+      new UndecidedNode(tree, -1, DHistogram.initialHist(_train, _ncols, adj_nbins, hcs[0][0], rseed, _parms, getGlobalSplitPointsKeys(), null, false, null), null, null); // The "root" node
 
       // ----
       // One Big Loop till the ktrees are of proper depth.

--- a/h2o-algos/src/main/java/hex/tree/uplift/UpliftDRF.java
+++ b/h2o-algos/src/main/java/hex/tree/uplift/UpliftDRF.java
@@ -192,7 +192,7 @@ public class UpliftDRF extends SharedTree<UpliftDRFModel, UpliftDRFModel.UpliftD
             for (int k = 0; k < _nclass; k++) {
                 if (_model._output._distribution[k] != 0) { // Ignore missing classes
                     ktrees[k] = new DTree(_train, _ncols, _mtry, _mtry_per_tree, rseed, _parms);
-                    new DTree.UndecidedNode(ktrees[k], -1, DHistogram.initialHist(_train, _ncols, adj_nbins, hcs[k][0], rseed, _parms, getGlobalQuantilesKeys(), null, false, null), null, null); // The "root" node
+                    new DTree.UndecidedNode(ktrees[k], -1, DHistogram.initialHist(_train, _ncols, adj_nbins, hcs[k][0], rseed, _parms, getGlobalSplitPointsKeys(), null, false, null), null, null); // The "root" node
                 }
             }
 

--- a/h2o-algos/src/test/java/hex/tree/DHistogramTest.java
+++ b/h2o-algos/src/test/java/hex/tree/DHistogramTest.java
@@ -36,7 +36,7 @@ public class DHistogramTest extends TestUtil {
   public void initCachesZeroPosition() {
     Scope.enter();
     try {
-      DHistogram.HistoQuantiles hq = new DHistogram.HistoQuantiles(Key.make(), new double[]{-1.0d, -0.3, -0.0d, 1.0, 1.2, 1.8});
+      DHistogram.HistoSplitPoints hq = new DHistogram.HistoSplitPoints(Key.make(), new double[]{-1.0d, -0.3, -0.0d, 1.0, 1.2, 1.8});
       DKV.put(hq);
       Scope.track_generic(hq);
 
@@ -58,7 +58,7 @@ public class DHistogramTest extends TestUtil {
   public void findBinForNegativeZero() {
     Scope.enter();
     try {
-      DHistogram.HistoQuantiles hq = new DHistogram.HistoQuantiles(Key.make(), new double[]{-1.0d, -0.0d, 1.0});
+      DHistogram.HistoSplitPoints hq = new DHistogram.HistoSplitPoints(Key.make(), new double[]{-1.0d, -0.0d, 1.0});
       DKV.put(hq);
       Scope.track_generic(hq);
 
@@ -99,7 +99,7 @@ public class DHistogramTest extends TestUtil {
         splitPointsQuant[i] = histoRand.binAt(i);
       }
       // make a quantile-global estimator with conceptually the same split points
-      DHistogram.HistoQuantiles hq = new DHistogram.HistoQuantiles(Key.make(), splitPointsQuant);
+      DHistogram.HistoSplitPoints hq = new DHistogram.HistoSplitPoints(Key.make(), splitPointsQuant);
       DKV.put(hq);
       Scope.track_generic(hq);
       DHistogram histoQuant = new DHistogram("quant", 20, 1024, (byte) 0, min, maxEx, false, false, -0.001,

--- a/h2o-algos/src/test/java/hex/tree/GlobalQuantilesCalcTest.java
+++ b/h2o-algos/src/test/java/hex/tree/GlobalQuantilesCalcTest.java
@@ -9,6 +9,10 @@ import water.fvec.Frame;
 import water.runner.CloudSize;
 import water.runner.H2ORunner;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 import static org.junit.Assert.*;
 
 @CloudSize(1)
@@ -36,4 +40,48 @@ public class GlobalQuantilesCalcTest extends TestUtil {
       Scope.exit(); 
     }
   }
+
+  @Test
+  public void testGlobalQuantilesWithGivenSplitPoints() {
+    try {
+      Scope.enter();
+      Frame fr = Scope.track(parseTestFile("smalldata/logreg/prostate.csv"));
+      // first without prior split points
+      final double[][] splitPointsFull = GlobalQuantilesCalc.splitPoints(fr, null, null, 5, 5);
+      Set<Integer> expectedSkipped = new HashSet<>(Arrays.asList(1, 5));
+      assertEquals(splitPointsFull.length, fr.numCols());
+      for (int i = 0; i < splitPointsFull.length; i++) {
+        final double[] spI = splitPointsFull[i]; 
+        if (expectedSkipped.contains(i)) {
+          assertNull(spI);
+        } else {
+          assertNotNull(spI);
+          // expecting quantiles to span from (inclusive) min...maxEx (exclusive)
+          assertEquals(spI[0], fr.vec(i).min(), 0); // first element is minimum
+          assertTrue(spI[spI.length - 1] < fr.vec(i).max() - 1e-3); // last element is not maximum by a good margin
+        }
+      }
+      // now define prior split points and check the columns were skipped
+      final double[][] priorSplitPoints = {
+              {}, null, {}, null, null, {}, {}, null, null
+      };
+      final double[][] splitPoints = GlobalQuantilesCalc.splitPoints(fr, null, priorSplitPoints, 5, 5);
+      assertEquals(splitPoints.length, splitPointsFull.length);
+      for (int i = 0; i < splitPoints.length; i++) {
+        if (priorSplitPoints[i] != null) {
+          assertNull(splitPoints[i]);
+        } else {
+          if (splitPointsFull[i] == null) {
+            assertNull(splitPoints[i]);
+          } else {
+            assertArrayEquals(splitPoints[i], splitPointsFull[i], 0);
+          }
+        }
+      }
+    } finally {
+      Scope.exit();
+    }
+  }
+
+
 }

--- a/h2o-algos/src/test/java/hex/tree/GlobalQuantilesCalcTest.java
+++ b/h2o-algos/src/test/java/hex/tree/GlobalQuantilesCalcTest.java
@@ -24,7 +24,7 @@ public class GlobalQuantilesCalcTest extends TestUtil {
       fr.remove("RACE");
       fr.remove("DCAPS");
       DKV.put(fr);
-      double[][] splitPoints = GlobalQuantilesCalc.splitPoints(fr, null, 5, 5);
+      double[][] splitPoints = GlobalQuantilesCalc.splitPoints(fr, null, null, 5, 5);
       for (int i = 0; i < fr.numCols(); i++) {
         double[] spI = splitPoints[i];
         assertNotNull(spI);

--- a/h2o-algos/src/test/java/hex/tree/HistogramTest.java
+++ b/h2o-algos/src/test/java/hex/tree/HistogramTest.java
@@ -124,7 +124,7 @@ public class HistogramTest extends TestUtil {
       if (histoType == SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesGlobal) {
         splitPts = new double[]{1,1.5,2,2.5,3,4,5,6.1,6.2,6.3,6.7,6.8,6.85};
       }
-      DHistogram.HistoQuantiles hq = new DHistogram.HistoQuantiles(Key.make(), splitPts);
+      DHistogram.HistoSplitPoints hq = new DHistogram.HistoSplitPoints(Key.make(), splitPts);
       DKV.put(hq);
       DHistogram hist = new DHistogram("myhisto",nbins,nbins_cats,isInt,min,maxEx,false,false,0,histoType,seed,hq._key,null, false, false, null, null);
       hist.init();
@@ -196,8 +196,8 @@ public class HistogramTest extends TestUtil {
     long seed = 1234;
     SharedTreeModel.SharedTreeParameters.HistogramType histoType = SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesGlobal;
     double[] splitPts = new double[]{1,1.5,2,2.5,3,4,5,6.1,6.2,6.3,6.7,6.8,6.85};
-    Key<DHistogram.HistoQuantiles> k = Key.make();
-    DKV.put(new DHistogram.HistoQuantiles(k,splitPts));
+    Key<DHistogram.HistoSplitPoints> k = Key.make();
+    DKV.put(new DHistogram.HistoSplitPoints(k,splitPts));
     DHistogram hist = new DHistogram("myhisto",nbins,nbins_cats,isInt,min,maxEx,false,false,0,histoType,seed,k,null, false, false, null, null);
     hist.init();
     assert(hist.binAt(0)==min);

--- a/h2o-core/src/main/java/water/util/IcedDouble.java
+++ b/h2o-core/src/main/java/water/util/IcedDouble.java
@@ -4,6 +4,9 @@ import water.Iced;
 
 public class IcedDouble extends Iced<IcedDouble> {
   public double _val;
+  public IcedDouble() {
+    this(Double.NaN);
+  }
   public IcedDouble(double v){_val = v;}
   @Override public boolean equals( Object o ) {
     return o instanceof IcedDouble && ((IcedDouble) o)._val == _val;

--- a/h2o-core/src/main/java/water/util/Timer.java
+++ b/h2o-core/src/main/java/water/util/Timer.java
@@ -1,6 +1,5 @@
 package water.util;
 
-import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 


### PR DESCRIPTION
H2O implements different histogram types - the default one is UniformAdaptive. UniformAdaptive might not perform ideally for columns with outliers and users can use QuantilesGlobal instead. QuantilesGlobal is, however, computationally more expensive than the default.

This PR aims to improve the runtime performance as well as slightly improve model performance. The main idea is that we don't need to calculate quantiles for columns that have a low number of unique values. Instead of using quantiles in this case, we can directly use the unique values as split points.

This change can bring the runtime to 2/3 on datasets like SpringLeaf while slightly improving model accuracy as well.

While this idea is currently only used for QuantilesGlobal, a similar trick could be used for UniformAdaptive. The next step would be to expose the parameter that would turn the behavior on/off for any histogram type. 


Benchmarking:

I used "accuracy benchmarks" to observe the effect of this change. `champion` is H2O 3.36.0.2 and `challenger` is a build made from this branch.

<img width="1243" alt="Screen Shot 2022-02-17 at 11 33 02 AM" src="https://user-images.githubusercontent.com/20690218/154526894-002c5f30-e5f1-4309-a351-99915172ddb1.png">

Results show this change brings a speed-up in most cases, in some cases quite significantly. Model performance remained practically the same, in some cases improved slightly.

```
combined$auc_diff <- round(combined$challenger_auc - combined$champion_auc, 4)
combined$logloss_diff <- round(combined$challenger_logloss - combined$champion_logloss, 4)
combined$time_diff <- round(combined$challenger_time - combined$champion_time, 1)
combined$time_diff_pct <- round(100 * combined$time_diff / combined$champion_time, 1)
```