### PR TITLE
PUBDEV-8580: GBM/DRF UniformRobust - a new method for defining histogram split-points

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/SharedTreeV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/SharedTreeV3.java
@@ -81,7 +81,7 @@ public class SharedTreeV3<B extends SharedTree, S extends SharedTreeV3<B,S,P>, P
     @API(help="Minimum relative improvement in squared error reduction for a split to happen", level = API.Level.secondary, gridable = true)
     public double min_split_improvement;
 
-    @API(help="What type of histogram to use for finding optimal split points", values = { "AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin"}, level = API.Level.secondary, gridable = true)
+    @API(help="What type of histogram to use for finding optimal split points", values = { "AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin", "UniformRobust"}, level = API.Level.secondary, gridable = true)
     public SharedTreeParameters.HistogramType histogram_type;
 
     @API(help="Use Platt Scaling to calculate calibrated class probabilities. Calibration can provide more accurate estimates of class probabilities.", level = API.Level.expert)

--- a/h2o-algos/src/main/java/hex/tree/DHistogram.java
+++ b/h2o-algos/src/main/java/hex/tree/DHistogram.java
@@ -138,7 +138,7 @@ public final class DHistogram extends Iced<DHistogram> {
   public final boolean _checkFloatSplits;
   transient float[] _splitPtsFloat;
   public final long _seed;
-  public transient boolean _hasQuantiles;
+  public transient boolean _absoluteSplitPts;
   public Key _globalQuantilesKey; //key under which original top-level quantiles are stored;
 
 
@@ -271,7 +271,7 @@ public final class DHistogram extends Iced<DHistogram> {
     // out of range of any bin - however this binning call only happens during
     // model-building.
     int idx1;
-    double pos = _hasQuantiles ? col_data : ((col_data - _min) * _step);
+    double pos = _absoluteSplitPts ? col_data : ((col_data - _min) * _step);
     if (_splitPts != null) {
       idx1 = pos == 0.0 ? _zeroSplitPntPos : Arrays.binarySearch(_splitPts, pos);
       if (idx1 < 0) idx1 = -idx1 - 2;
@@ -298,7 +298,8 @@ public final class DHistogram extends Iced<DHistogram> {
   }
 
   public double binAt( int b ) {
-    if (_hasQuantiles) return _splitPts[b];
+    if (_absoluteSplitPts)
+      return _splitPts[b];
     return _min + (_splitPts == null ? b : _splitPts[b]) / _step;
   }
 
@@ -344,7 +345,7 @@ public final class DHistogram extends Iced<DHistogram> {
               _histoType = HistogramType.UniformAdaptive;
             }
             else {
-              _hasQuantiles=true;
+              _absoluteSplitPts = true;
               _nbin = (char)_splitPts.length;
               if (LOG.isTraceEnabled()) LOG.trace("Refined splitPoints: " + Arrays.toString(_splitPts));
             }

--- a/h2o-algos/src/main/java/hex/tree/DHistogram.java
+++ b/h2o-algos/src/main/java/hex/tree/DHistogram.java
@@ -139,8 +139,8 @@ public final class DHistogram extends Iced<DHistogram> {
   transient float[] _splitPtsFloat;
   public final long _seed;
   public transient boolean _absoluteSplitPts;
-  public Key _globalQuantilesKey; //key under which original top-level quantiles are stored;
-
+  public Key _globalQuantilesKey; // key under which original top-level quantiles are stored;
+  final double[] _customSplitPoints; // explicitly given split points (for UniformRobust)
 
 
   /**
@@ -181,10 +181,11 @@ public final class DHistogram extends Iced<DHistogram> {
       super("column=" + name + " leads to invalid histogram(check numeric range) -> [max=" + maxEx + ", min = " + min + "], step= " + step + ", xbin= " + xbins);
     }
   }
-  
+
   DHistogram(String name, final int nbins, int nbins_cats, byte isInt, double min, double maxEx, boolean intOpt, boolean initNA,
              double minSplitImprovement, SharedTreeModel.SharedTreeParameters.HistogramType histogramType, long seed, Key globalQuantilesKey,
-             Constraints cs, boolean checkFloatSplits, boolean useUplift, UpliftDRFModel.UpliftDRFParameters.UpliftMetricType upliftMetricType) {
+             Constraints cs, boolean checkFloatSplits, boolean useUplift, UpliftDRFModel.UpliftDRFParameters.UpliftMetricType upliftMetricType,
+             double[] customSplitPoints) {
     assert nbins >= 1;
     assert nbins_cats >= 1;
     assert maxEx > min : "Caller ensures "+maxEx+">"+min+", since if max==min== the column "+name+" is all constants";
@@ -257,6 +258,7 @@ public final class DHistogram extends Iced<DHistogram> {
     assert(_nbin>0);
     assert(_vals == null);
     _checkFloatSplits = checkFloatSplits;
+    _customSplitPoints = customSplitPoints;
     if (LOG.isTraceEnabled()) LOG.trace("Histogram: " + this);
     // Do not allocate the big arrays here; wait for scoreCols to pick which cols will be used.
   }
@@ -312,6 +314,19 @@ public final class DHistogram extends Iced<DHistogram> {
   }
   public double bins(int b) { return w(b); }
 
+  // return number of empty bins (doesn't consider the NA bin) 
+  public int nonEmptyBins() {
+    if (_vals == null)
+      return 0;
+    int nonEmpty = 0;
+    for (int i = 0; i < _vals.length - _vals_dim; i += _vals_dim) { // don't count NA (last bin)
+      if (_vals[i] > 0) {
+        nonEmpty++;
+      }
+    }
+    return nonEmpty;
+  }
+
   public boolean hasNABin() {
     if (_vals == null)
       return _initNA; // we are in the initial histogram (and didn't see the data yet)
@@ -354,7 +369,17 @@ public final class DHistogram extends Iced<DHistogram> {
         }
       }
     }
-    else assert(_histoType== HistogramType.UniformAdaptive);
+    else if (_histoType == HistogramType.UniformRobust) {
+      if (_customSplitPoints != null) {
+        defineSplitPointsFromCustomSplitPoints(_customSplitPoints);
+      } else {
+        // no custom split points were given - meaning no issue was found with data distribution of the column
+        // and UniformRobust should behave just like UniformAdaptive (for now)
+        _histoType = HistogramType.UniformAdaptive;
+      }
+    } else { // UniformAdaptive is all that is left
+      assert _histoType == HistogramType.UniformAdaptive;
+    }
     if (_splitPts != null) {
       // Inject canonical representation of zero - convert "negative zero" to 0.0d
       // This is for PUBDEV-7161 - Arrays.binarySearch used in bin() method is not able to find a negative zero,
@@ -383,9 +408,22 @@ public final class DHistogram extends Iced<DHistogram> {
       }
     }
     assert !_intOpt || _splitPts == null : "Integer-optimization cannot be enabled when split points are defined";
-    assert !_intOpt || _histoType == HistogramType.UniformAdaptive : "Integer-optimization can only be enabled for histogram type 'UniformAdaptive'.";
+    assert !_intOpt || _histoType == HistogramType.UniformAdaptive || _histoType == HistogramType.UniformRobust : "Integer-optimization can only be enabled for histogram type 'UniformAdaptive' or 'UniformRobust'.";
   }
-  
+
+  void defineSplitPointsFromCustomSplitPoints(double[] customSplitPoints) {
+    _splitPts = customSplitPoints;
+    _splitPts = ArrayUtils.limitToRange(_splitPts, _min, _maxEx);
+    if (_splitPts.length <= 1) {
+      _splitPts = null; // abort, fall back to uniform binning
+      _histoType = HistogramType.UniformAdaptive;
+    }
+    else {
+      _absoluteSplitPts = true;
+      _nbin = (char)(_splitPts.length - 1);
+    }
+  }
+
   // Merge two equal histograms together.  Done in a F/J reduce, so no
   // synchronization needed.
   public void add( DHistogram dsh ) {
@@ -442,7 +480,7 @@ public final class DHistogram extends Iced<DHistogram> {
         byte type = (byte) (v.isCategorical() ? 2 : (v.isInt() ? 1 : 0));
         boolean intOpt = useIntOpt(v, parms, cs);
         hs[c] = nacnt == vlen || v.isConst(true) ?
-            null : make(fr._names[c], nbins, type, minIn, maxEx, intOpt, nacnt > 0, seed, parms, globalQuantilesKey[c], cs, checkFloatSplits);
+            null : make(fr._names[c], nbins, type, minIn, maxEx, intOpt, nacnt > 0, seed, parms, globalQuantilesKey[c], cs, checkFloatSplits, null);
       } catch(StepOutOfRangeException e) {
         hs[c] = null;
         LOG.warn("Column " + fr._names[c]  + " with min = " + v.min() + ", max = " + v.max() + " has step out of range (" + e.getMessage() + ") and is ignored.");
@@ -454,12 +492,12 @@ public final class DHistogram extends Iced<DHistogram> {
 
   public static DHistogram make(String name, final int nbins, byte isInt, double min, double maxEx, boolean intOpt, boolean hasNAs, 
                                 long seed, SharedTreeModel.SharedTreeParameters parms, Key globalQuantilesKey, 
-                                Constraints cs, boolean checkFloatSplits) {
+                                Constraints cs, boolean checkFloatSplits, double[] customSplitPoints) {
     boolean useUplift = isUplift(parms);
     UpliftDRFModel.UpliftDRFParameters.UpliftMetricType upliftMetricType = useUplift ?
             ((UpliftDRFModel.UpliftDRFParameters) parms)._uplift_metric : null;
     return new DHistogram(name, nbins, parms._nbins_cats, isInt, min, maxEx, intOpt, hasNAs,
-            parms._min_split_improvement, parms._histogram_type, seed, globalQuantilesKey, cs, checkFloatSplits, useUplift, upliftMetricType);
+            parms._min_split_improvement, parms._histogram_type, seed, globalQuantilesKey, cs, checkFloatSplits, useUplift, upliftMetricType, customSplitPoints);
   }
 
   private static boolean isUplift(SharedTreeModel.SharedTreeParameters parms) {
@@ -485,7 +523,8 @@ public final class DHistogram extends Iced<DHistogram> {
       return false;
     }
     if (parms._histogram_type != HistogramType.AUTO &&
-            parms._histogram_type != HistogramType.UniformAdaptive) {
+            parms._histogram_type != HistogramType.UniformAdaptive && 
+            parms._histogram_type != HistogramType.UniformRobust) {
       // we cannot handle non-integer split points in fast-binning
       return false;
     }

--- a/h2o-algos/src/main/java/hex/tree/DHistogram.java
+++ b/h2o-algos/src/main/java/hex/tree/DHistogram.java
@@ -217,11 +217,12 @@ public final class DHistogram extends Iced<DHistogram> {
     _minSplitImprovement = minSplitImprovement;
     _histoType = histogramType;
     _seed = seed;
-    while (_histoType == SharedTreeModel.SharedTreeParameters.HistogramType.RoundRobin) {
-      SharedTreeModel.SharedTreeParameters.HistogramType[] h = SharedTreeModel.SharedTreeParameters.HistogramType.values();
-      _histoType = h[(int)Math.abs(seed++ % h.length)];
+    if (_histoType == HistogramType.RoundRobin) {
+      HistogramType[] h = HistogramType.ROUND_ROBIN_CANDIDATES;
+      _histoType = h[(int)Math.abs(seed % h.length)];
     }
-    if (_histoType== SharedTreeModel.SharedTreeParameters.HistogramType.AUTO)
+    assert _histoType != SharedTreeModel.SharedTreeParameters.HistogramType.RoundRobin;
+    if (_histoType == SharedTreeModel.SharedTreeParameters.HistogramType.AUTO)
       _histoType= SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive;
     assert(_histoType!= SharedTreeModel.SharedTreeParameters.HistogramType.RoundRobin);
     _globalQuantilesKey = globalQuantilesKey;

--- a/h2o-algos/src/main/java/hex/tree/DTree.java
+++ b/h2o-algos/src/main/java/hex/tree/DTree.java
@@ -310,7 +310,7 @@ public class DTree extends Iced {
      * @param parms user-given parameters (will use nbins, min_rows, etc.)
      * @return Array of histograms to be used for the next level of split finding
      */
-    public DHistogram[] nextLevelHistos(DHistogram currentHistos[], int way, double splat, SharedTreeModel.SharedTreeParameters parms, Constraints cs) {
+    public DHistogram[] nextLevelHistos(DHistogram[] currentHistos, int way, double splat, SharedTreeModel.SharedTreeParameters parms, Constraints cs) {
       double n = way==0 ? _n0 : _n1;
       if( n < parms._min_rows ) {
         if (LOG.isTraceEnabled()) LOG.trace("Not splitting: too few observations left: " + n);
@@ -324,12 +324,12 @@ public class DTree extends Iced {
 
       // Build a next-gen split point from the splitting bin
       int cnt=0;                  // Count of possible splits
-      DHistogram nhists[] = new DHistogram[currentHistos.length]; // A new histogram set
+      DHistogram[] nhists = new DHistogram[currentHistos.length]; // A new histogram set
       for(int j = 0; j< currentHistos.length; j++ ) { // For every column in the new split
         DHistogram h = currentHistos[j];            // old histogram of column
         if( h == null )
           continue;        // Column was not being tracked?
-        int adj_nbins      = Math.max(h.nbins()>>1,parms._nbins); //update number of bins dependent on level depth
+        final int adj_nbins      = Math.max(h.nbins()>>1,parms._nbins); //update number of bins dependent on level depth
 
         // min & max come from the original column data, since splitting on an
         // unrelated column will not change the j'th columns min/max.

--- a/h2o-algos/src/main/java/hex/tree/GuidedSplitPoints.java
+++ b/h2o-algos/src/main/java/hex/tree/GuidedSplitPoints.java
@@ -1,0 +1,159 @@
+package hex.tree;
+
+import water.util.ArrayUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Implements a method for finding new histogram bins split-points based on a result of previous binning.
+ * Idea:
+ *   We take non-empty bins and look at the squared error they have. Based on the target bin number, we discard
+ *   the empty bins and used the frees-up space to refine the non-non empty bins. Splitting of non-empty bins
+ *   is guided by Squared Error accumulated in the bin. Bins with higher SE are split more than the bins with lower SE.
+ *   Sub-bins (bins created from a single original bin) are refined uniformly.
+ *   
+ *   If uniform splitting fails in this iteration (= the distribution of values is significantly skewed), next iteration
+ *   will attempt correct the issue by repeating the procedure with new bins (we are recursively refining the promising
+ *   bins as we get deeper in the tree).
+ */
+public class GuidedSplitPoints {
+
+    static final double LOW_DENSITY_THRESHOLD = 0.2;
+
+    static boolean isApplicableTo(DHistogram h) {
+        return h._vals != null &&  // observations were not yet binned, we don't have the data to guide the splitting
+                h._isInt != 2 &&   // categorical columns have a specific handing
+                !h._intOpt;        // integer optimized columns have a single value per bin, no point in refining such bins
+    }
+
+    static double[] makeSplitPoints(DHistogram h, final int targetNBins, final double min, final double maxEx) {
+        // Collect bins to consider for refining
+        final List<BinDescriptor> bins = extractNonEmptyBins(h);
+
+        // Budget is given by target number of bins in the new layer, we keep all non-empty bins
+        final int totalBudget = targetNBins - bins.size() - 2; // how many bins we have to allocate (save 2 spots for min/max)
+        if (bins.isEmpty() || totalBudget <= 0)
+            return null;
+
+        int budgetLeft = totalBudget; // how many bins do we have left to redistribute
+
+        double totalSE = 0;
+        for (BinDescriptor bin : bins) {
+            totalSE += bin._se;
+        }
+
+        // For each bin find out how many new bins we can split it into
+        int[] newBinCounts = new int[bins.size()];
+        Collections.sort(bins); // sort by SE descending
+        for (int b = 0; budgetLeft > 0 && b < newBinCounts.length; b++) {
+            BinDescriptor bin = bins.get(b);
+            // distributed budget proportionally to SE
+            int newBins = Math.min((int) Math.ceil(totalBudget * bin._se / totalSE), budgetLeft);
+            budgetLeft -= newBins;
+            newBinCounts[b] = newBins;
+        }
+
+        // Define new split-points
+        final double[] customSplitPoints = new double[targetNBins - budgetLeft];
+        int i = 0;
+        for (int b = 0; b < newBinCounts.length; b++) {
+            BinDescriptor bin = bins.get(b);
+            customSplitPoints[i++] = bin._start;
+            double stepSize = (bin._end - bin._start) / (1 + newBinCounts[b]);
+            for (int s = 0; s < newBinCounts[b]; s++) {
+                customSplitPoints[i] = customSplitPoints[i - 1] + stepSize;
+                i++;
+            }
+        }
+        customSplitPoints[i++] = min; // This is based on QuantilesGlobal - DHistogram has assumption min/max will be in the split-points
+        customSplitPoints[i++] = h._maxIn;
+        assert i == customSplitPoints.length;
+
+        Arrays.sort(customSplitPoints);
+        return ArrayUtils.makeUniqueAndLimitToRange(customSplitPoints, min, maxEx);
+    }
+
+    static List<BinDescriptor> extractNonEmptyBins(DHistogram h) {
+        final int nonEmptyBins = h.nonEmptyBins();
+        final List<BinDescriptor> bins = new ArrayList<>(nonEmptyBins);
+        for (int i = 0; i < h.nbins(); i++) {
+            double weight = h.w(i);
+            if (weight > 0) {
+                BinDescriptor bin = BinDescriptor.fromBin(h, i);
+                bins.add(bin);
+            }
+        }
+        return bins;
+    }
+
+    static class BinDescriptor implements Comparable<BinDescriptor> {
+        final double _start;
+        final double _end;
+        final double _se;
+        final double _weight;
+
+        public BinDescriptor(double start, double end, double se, double weight) {
+            _start = start;
+            _end = end;
+            _se = Math.max(se, 0); // rounding errors can cause SE to be negative
+            _weight = weight;
+        }
+
+        @Override
+        public int compareTo(BinDescriptor o) {
+            return -Double.compare(_se, o._se);
+        }
+
+        static BinDescriptor fromBin(DHistogram h, int i) {
+            double w = h.w(i);
+            double wY = h.wY(i);
+            double wYY = h.wYY(i);
+            double se = w != 0 ? wYY - wY * wY / w : 0;
+            return new BinDescriptor(h.binAt(i), h.binAt(i + 1), se, w);
+        }
+
+        // IntelliJ generated //
+
+        @Override
+        public String toString() {
+            return "BinDescriptor{" +
+                    "_start=" + _start +
+                    ", _end=" + _end +
+                    ", _se=" + _se +
+                    ", _weight=" + _weight +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            BinDescriptor that = (BinDescriptor) o;
+
+            if (Double.compare(that._start, _start) != 0) return false;
+            if (Double.compare(that._end, _end) != 0) return false;
+            if (Double.compare(that._se, _se) != 0) return false;
+            return Double.compare(that._weight, _weight) == 0;
+        }
+
+        @Override
+        public int hashCode() {
+            int result;
+            long temp;
+            temp = Double.doubleToLongBits(_start);
+            result = (int) (temp ^ (temp >>> 32));
+            temp = Double.doubleToLongBits(_end);
+            result = 31 * result + (int) (temp ^ (temp >>> 32));
+            temp = Double.doubleToLongBits(_se);
+            result = 31 * result + (int) (temp ^ (temp >>> 32));
+            temp = Double.doubleToLongBits(_weight);
+            result = 31 * result + (int) (temp ^ (temp >>> 32));
+            return result;
+        }
+    }
+
+}

--- a/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
@@ -58,7 +58,7 @@ public abstract class SharedTreeModel<
     public double _min_split_improvement = 1e-5; // Minimum relative improvement in squared error reduction for a split to happen
 
     public enum HistogramType {
-      AUTO, UniformAdaptive, Random, QuantilesGlobal, RoundRobin;
+      AUTO, UniformAdaptive, Random, QuantilesGlobal, RoundRobin, UniformRobust;
       public static HistogramType[] ROUND_ROBIN_CANDIDATES = {
               AUTO, // Note: the inclusion of AUTO means UniformAdaptive has effectively higher chance of being used
               UniformAdaptive, Random, QuantilesGlobal

--- a/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
@@ -57,7 +57,13 @@ public abstract class SharedTreeModel<
 
     public double _min_split_improvement = 1e-5; // Minimum relative improvement in squared error reduction for a split to happen
 
-    public enum HistogramType { AUTO, UniformAdaptive, Random, QuantilesGlobal, RoundRobin }
+    public enum HistogramType {
+      AUTO, UniformAdaptive, Random, QuantilesGlobal, RoundRobin;
+      public static HistogramType[] ROUND_ROBIN_CANDIDATES = {
+              AUTO, // Note: the inclusion of AUTO means UniformAdaptive has effectively higher chance of being used
+              UniformAdaptive, Random, QuantilesGlobal
+      };
+    }
     public HistogramType _histogram_type = HistogramType.AUTO; // What type of histogram to use for finding optimal split points
 
     public double _r2_stopping = Double.MAX_VALUE; // Stop when the r^2 metric equals or exceeds this value

--- a/h2o-algos/src/test/java/hex/tree/DHistogramTest.java
+++ b/h2o-algos/src/test/java/hex/tree/DHistogramTest.java
@@ -41,7 +41,7 @@ public class DHistogramTest extends TestUtil {
       Scope.track_generic(hq);
 
       DHistogram histo = new DHistogram("test", 20, 1024, (byte) 1, -1, 2, false, false, -0.001,
-              SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesGlobal, 42L, hq._key, null, false, false, null);
+              SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesGlobal, 42L, hq._key, null, false, false, null, null);
       histo.init();
 
       // check that -0.0 was converted to 0.0 by the init method
@@ -63,7 +63,7 @@ public class DHistogramTest extends TestUtil {
       Scope.track_generic(hq);
 
       DHistogram histo = new DHistogram("test", 20, 1024, (byte) 1, -1, 2, false, false, -0.001,
-              SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesGlobal, 42L, hq._key, null, false, false, null);
+              SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesGlobal, 42L, hq._key, null, false, false, null, null);
       histo.init();
 
       // check that negative zero can be found
@@ -90,7 +90,7 @@ public class DHistogramTest extends TestUtil {
       values[values.length - 1] = maxEx - 1e-8;
 
       DHistogram histoRand = new DHistogram("rand", 20, 1024, (byte) 0, min, maxEx, false, false, -0.001,
-              SharedTreeModel.SharedTreeParameters.HistogramType.Random, 42L, null, null, false, false, null);
+              SharedTreeModel.SharedTreeParameters.HistogramType.Random, 42L, null, null, false, false, null, null);
       histoRand.init();
 
       // project the random split points into regular space (original values of the column)
@@ -103,7 +103,7 @@ public class DHistogramTest extends TestUtil {
       DKV.put(hq);
       Scope.track_generic(hq);
       DHistogram histoQuant = new DHistogram("quant", 20, 1024, (byte) 0, min, maxEx, false, false, -0.001,
-              SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesGlobal, 42L, hq._key, null, false, false, null);
+              SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesGlobal, 42L, hq._key, null, false, false, null, null);
       histoQuant.init();
 
       int[] bins_rand = new int[values.length];
@@ -121,7 +121,7 @@ public class DHistogramTest extends TestUtil {
   @Test
   public void testExtractData_double() {
     DHistogram histo = new DHistogram("test", 20, 1024, (byte) 1, -1, 2, false, false, -0.001,
-            SharedTreeModel.SharedTreeParameters.HistogramType.AUTO, 42L, null, null, false, false, null);
+            SharedTreeModel.SharedTreeParameters.HistogramType.AUTO, 42L, null, null, false, false, null, null);
     histo.init();
 
     // init with c1
@@ -147,7 +147,7 @@ public class DHistogramTest extends TestUtil {
   @Test
   public void testExtractData_int() {
     DHistogram histo = new DHistogram("test", 20, 1024, (byte) 1, -1, 2, true, false, -0.001,
-            SharedTreeModel.SharedTreeParameters.HistogramType.AUTO, 42L, null, null, false, false, null);
+            SharedTreeModel.SharedTreeParameters.HistogramType.AUTO, 42L, null, null, false, false, null, null);
     histo.init();
 
     // init with c1
@@ -188,14 +188,14 @@ public class DHistogramTest extends TestUtil {
 
     // optimization enabled
     DHistogram histoOpt = new DHistogram("intOpt-on", 1000, 1024, (byte) 1, 0, 1000, true, false, -0.001,
-            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, false, false, null);
+            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, false, false, null, null);
     histoOpt.init();
 
     histoOpt.updateHisto(weights, null, dataInt, ys, null, rows, N, 0, null);
 
     // optimization OFF
     DHistogram histo = new DHistogram("intOpt-off", 1000, 1024, (byte) 1, 0, 1000, false, false, -0.001,
-            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, false, false, null);
+            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, false, false, null, null);
     histo.init();
 
     histo.updateHisto(weights, null, data, ys, null, rows, N, 0, null);
@@ -234,7 +234,7 @@ public class DHistogramTest extends TestUtil {
       for (SharedTreeModel.SharedTreeParameters.HistogramType ht : SharedTreeModel.SharedTreeParameters.HistogramType.values()) {
         TreeParameters tp = new TreeParameters();
         tp._histogram_type = ht;
-        if (ht == SharedTreeModel.SharedTreeParameters.HistogramType.AUTO || ht == SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive) {
+        if (ht == SharedTreeModel.SharedTreeParameters.HistogramType.AUTO || ht == SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive || ht == SharedTreeModel.SharedTreeParameters.HistogramType.UniformRobust) {
           assertTrue(DHistogram.useIntOpt(f.vec("int"), tp, null));
         } else {
           assertFalse(DHistogram.useIntOpt(f.vec("int"), tp, null));
@@ -279,5 +279,42 @@ public class DHistogramTest extends TestUtil {
       return null;
     }
   }
-  
+
+  @Test
+  public void testDefineSplitPointsFromCustomSplitPoints_valid() {
+    DHistogram histo = new DHistogram("custom", 1000, 1024, (byte) 1, 0, 1000, false, false, -0.001,
+            SharedTreeModel.SharedTreeParameters.HistogramType.UniformRobust, 42L, null, null, false, false, null, null);
+
+    histo.defineSplitPointsFromCustomSplitPoints(new double[]{-2, -1, 0, 1, 42, 998, 999, 1000, 1001});
+
+    assertTrue(histo._absoluteSplitPts);
+    assertArrayEquals(new double[]{0, 1, 42, 998, 999}, histo._splitPts, 0);
+    assertEquals(SharedTreeModel.SharedTreeParameters.HistogramType.UniformRobust, histo._histoType);
+  }
+
+  @Test
+  public void testDefineSplitPointsFromCustomSplitPoints_revertToUniformAdaptive() {
+    DHistogram histo = new DHistogram("custom", 1000, 1024, (byte) 1, 0, 1000, false, false, -0.001,
+            SharedTreeModel.SharedTreeParameters.HistogramType.UniformRobust, 42L, null, null, false, false, null, null);
+
+    histo.defineSplitPointsFromCustomSplitPoints(new double[]{-2, -1});
+
+    assertFalse(histo._absoluteSplitPts);
+    assertNull(histo._splitPts);
+    assertEquals(SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, histo._histoType);
+  }
+
+  @Test
+  public void testNonEmptyBins() {
+    DHistogram histo = new DHistogram("nonEmpty", 1000, 1024, (byte) 1, 0, 1000, false, false, -0.001,
+            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, false, false, null, null);
+
+    assertEquals(0, histo.nonEmptyBins());
+
+    histo.init();
+    histo.updateHisto(null, null, new double[]{10, Double.NaN, 999}, new double[]{0.1, 0.2, 0.3}, null, new int[]{0, 1, 2}, 3, 0, null);
+    
+    assertEquals(2, histo.nonEmptyBins());
+  }
+
 }

--- a/h2o-algos/src/test/java/hex/tree/DTreeSplitTest.java
+++ b/h2o-algos/src/test/java/hex/tree/DTreeSplitTest.java
@@ -44,7 +44,7 @@ public class DTreeSplitTest {
         double max = ArrayUtils.maxValue(data);
         double maxEx = DHistogram.find_maxEx(max, 0);
         DHistogram histo = new DHistogram("histo" + nbins, nbins, 2, (byte) 0, min, maxEx, false, false, 0,
-                SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, checkFloatSplits, false, null);
+                SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, checkFloatSplits, false, null, null);
         histo.init();
         histo.updateHisto(
                 ArrayUtils.constAry(data.length, 1.0), 

--- a/h2o-algos/src/test/java/hex/tree/DTreeTest.java
+++ b/h2o-algos/src/test/java/hex/tree/DTreeTest.java
@@ -18,7 +18,7 @@ public class DTreeTest {
     int[] rows  = new int[]   {0,          1,          2,   3  };
 
     DHistogram hs = new DHistogram("test_hs", 2, 2, (byte) 0, 0, 2, false, true, 0.01,
-            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 123, null, null, false, false, null);
+            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 123, null, null, false, false, null, null);
     hs.init();
     hs.updateHisto(ws, null, cs, ys, null, rows, rows.length, 0, null);
 
@@ -32,7 +32,7 @@ public class DTreeTest {
 
     // 3. allow negative (!!!) split improvement, min_rows = #NAs + 1
     DHistogram hsN = new DHistogram("test_hs", 2, 2, (byte) 0, 0, 2, false, true, -9,
-            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 123, null, null, false, false, null);
+            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 123, null, null, false, false, null, null);
     hsN.init();
     hsN.updateHisto(ws, null, cs, ys, null, rows, rows.length, 0, null);
     DTree.Split s3 = DTree.findBestSplitPoint(hsN, 0, 21, 0, Double.NaN, Double.NaN, false, null);
@@ -75,7 +75,7 @@ public class DTreeTest {
     assertEquals(min_pred, c._min, 0);
     assertEquals(max_pred, c._max, 0);
     return new DHistogram("test_hs", nbins, 2, (byte) 0, 0, 10, false, false, 0.01,
-            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 123, null, c, false, false, null);
+            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 123, null, c, false, false, null, null);
   }
   
   private static ExpectedSplitInfo updateHisto(DHistogram hs, final double min_pred, final double max_pred, double na_percent) {

--- a/h2o-algos/src/test/java/hex/tree/GuidedSplitPointsTest.java
+++ b/h2o-algos/src/test/java/hex/tree/GuidedSplitPointsTest.java
@@ -1,0 +1,128 @@
+package hex.tree;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class GuidedSplitPointsTest {
+
+    @Test
+    public void isApplicableTo_positive() {
+        DHistogram histo = new DHistogram("yesPlease", 1000, 1024, (byte) 1, 0, 1000, false, false, -0.001,
+                SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, false, false, null, null);
+        histo._vals = new double[100];
+
+        assertTrue(GuidedSplitPoints.isApplicableTo(histo));
+    }
+
+    @Test
+    public void isApplicableTo_intOptimized() {
+        DHistogram histo = new DHistogram("intOptimized", 1000, 1024, (byte) 1, 0, 1000, true, false, -0.001,
+                SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, false, false, null, null);
+        histo._vals = new double[0];
+
+        assertFalse(GuidedSplitPoints.isApplicableTo(histo));
+    }
+
+    @Test
+    public void isApplicableTo_categorical() {
+        DHistogram histo = new DHistogram("categorical", 1000, 1024, (byte) 2, 0, 1000, false, false, -0.001,
+                SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, false, false, null, null);
+        histo._vals = new double[0];
+
+        assertFalse(GuidedSplitPoints.isApplicableTo(histo));
+    }
+
+    @Test
+    public void isApplicableTo_notBinnedYet() {
+        DHistogram histo = new DHistogram("undefined", 1000, 1024, (byte) 2, 0, 1000, false, false, -0.001,
+                SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, false, false, null, null);
+        histo._vals = null;
+
+        assertFalse(GuidedSplitPoints.isApplicableTo(histo));
+    }
+
+    @Test
+    public void makeSplitPoints_tooSmall() {
+        DHistogram h = makeSmallHistogram();
+        double[] splitPoints = GuidedSplitPoints.makeSplitPoints(h, 4, h._min, h._maxEx);
+        assertNull(splitPoints);
+    }
+
+    @Test
+    public void makeSplitPoints_small() {
+        DHistogram h = makeSmallHistogram();
+        h._maxIn = 17;
+        double[] splitPoints = GuidedSplitPoints.makeSplitPoints(h, 5, h._min, h._maxEx);
+        assertArrayEquals(new double[]{0.0, 1.0, 1.5, 3.0, 17.0}, splitPoints, 0);
+    }
+
+    @Test
+    public void makeSplitPoints() {
+        DHistogram h = new DHistogram("numeric", 4, 1024, (byte) 0, 0, 101, false, false, -0.001,
+                SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, false, false, null, null);
+        h._vals = new double[]{
+                0, 0, 0, // empty
+                0.3, 0.3 * 0.2, 0.3 * 0.2 * 0.2 * 2,
+                0, 0, 0,
+                0.1, 0.2, -1e-9,
+                0, 0, 0 // slot for NA
+        };
+
+        double[] splitPoints = GuidedSplitPoints.makeSplitPoints(h, 13, h._min, h._maxEx);
+        double[] expected = {
+                0.0, 25.25, 27.775, 
+                30.3, 32.8, 35.3, 37.8, 40.4, 42.9, 45.5, 47.9, // expanded 
+                75.75};
+        assertArrayEquals(expected, splitPoints, 0.1);
+    }
+
+    @Test
+    public void extractNonEmptyBins() {
+        DHistogram h = makeSmallHistogram();
+        List<GuidedSplitPoints.BinDescriptor> bins = GuidedSplitPoints.extractNonEmptyBins(h);
+        assertEquals(2, bins.size());
+        assertEquals(Arrays.asList(
+                GuidedSplitPoints.BinDescriptor.fromBin(h, 1),
+                GuidedSplitPoints.BinDescriptor.fromBin(h, 3)
+        ), bins);
+    }
+
+    @Test
+    public void testBinDescriptorFromBin() {
+        DHistogram histo = makeSmallHistogram();
+
+        assertEquals(
+                GuidedSplitPoints.BinDescriptor.fromBin(histo, 0), 
+                new GuidedSplitPoints.BinDescriptor(0, 1, 0, 0)
+        );
+
+        assertEquals(
+                GuidedSplitPoints.BinDescriptor.fromBin(histo, 1),
+                new GuidedSplitPoints.BinDescriptor(1, 2, 0.012, 0.3)
+        );
+
+        assertEquals(
+                GuidedSplitPoints.BinDescriptor.fromBin(histo, 3),
+                new GuidedSplitPoints.BinDescriptor(3, 4, 0, 0.1)
+        );
+    }
+
+    private DHistogram makeSmallHistogram() {
+        DHistogram histo = new DHistogram("numeric", 1000, 1024, (byte) 0, 0, 1000, false, false, -0.001,
+                SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 42L, null, null, false, false, null, null);
+        histo._nbin = 4;
+        histo._vals = new double[]{
+                0, 0, 0, // empty
+                0.3, 0.3 * 0.2, 0.3 * 0.2 * 0.2 * 2,
+                0, 0, 0,
+                0.1, 0.2, -1e-9,
+                0, 0, 0 // slot for NA
+        };
+        return histo;
+    }
+    
+}

--- a/h2o-algos/src/test/java/hex/tree/HistogramTest.java
+++ b/h2o-algos/src/test/java/hex/tree/HistogramTest.java
@@ -126,7 +126,7 @@ public class HistogramTest extends TestUtil {
       }
       DHistogram.HistoQuantiles hq = new DHistogram.HistoQuantiles(Key.make(), splitPts);
       DKV.put(hq);
-      DHistogram hist = new DHistogram("myhisto",nbins,nbins_cats,isInt,min,maxEx,false,false,0,histoType,seed,hq._key,null, false, false, null);
+      DHistogram hist = new DHistogram("myhisto",nbins,nbins_cats,isInt,min,maxEx,false,false,0,histoType,seed,hq._key,null, false, false, null, null);
       hist.init();
       int N=10000000;
       int bin=-1;
@@ -163,7 +163,7 @@ public class HistogramTest extends TestUtil {
     double maxEx = 6.900000000000001;
     long seed = 1234;
     SharedTreeModel.SharedTreeParameters.HistogramType histoType = SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive;
-    DHistogram hist = new DHistogram("myhisto", nbins, nbins_cats, isInt, min, maxEx, false,false, 0, histoType, seed, null, null, false, false, null);
+    DHistogram hist = new DHistogram("myhisto", nbins, nbins_cats, isInt, min, maxEx, false,false, 0, histoType, seed, null, null, false, false, null, null);
     hist.init();
     assert(hist.binAt(0)==min);
     assert(hist.binAt(nbins-1)<maxEx);
@@ -179,7 +179,7 @@ public class HistogramTest extends TestUtil {
     double maxEx = 6.900000000000001;
     long seed = 1234;
     SharedTreeModel.SharedTreeParameters.HistogramType histoType = SharedTreeModel.SharedTreeParameters.HistogramType.Random;
-    DHistogram hist = new DHistogram("myhisto", nbins, nbins_cats, isInt, min, maxEx, false, false,0, histoType, seed, null, null, false, false, null);
+    DHistogram hist = new DHistogram("myhisto", nbins, nbins_cats, isInt, min, maxEx, false, false,0, histoType, seed, null, null, false, false, null, null);
     hist.init();
     assert(hist.binAt(0)==min);
     assert(hist.binAt(nbins-1)<maxEx);
@@ -198,7 +198,7 @@ public class HistogramTest extends TestUtil {
     double[] splitPts = new double[]{1,1.5,2,2.5,3,4,5,6.1,6.2,6.3,6.7,6.8,6.85};
     Key<DHistogram.HistoQuantiles> k = Key.make();
     DKV.put(new DHistogram.HistoQuantiles(k,splitPts));
-    DHistogram hist = new DHistogram("myhisto",nbins,nbins_cats,isInt,min,maxEx,false,false,0,histoType,seed,k,null, false, false, null);
+    DHistogram hist = new DHistogram("myhisto",nbins,nbins_cats,isInt,min,maxEx,false,false,0,histoType,seed,k,null, false, false, null, null);
     hist.init();
     assert(hist.binAt(0)==min);
     assert(hist.binAt(nbins-1)<maxEx);

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -79,7 +79,7 @@ class H2OGradientBoostingEstimator(H2OEstimator):
                  col_sample_rate_change_per_level=1.0,  # type: float
                  col_sample_rate_per_tree=1.0,  # type: float
                  min_split_improvement=1e-05,  # type: float
-                 histogram_type="auto",  # type: Literal["auto", "uniform_adaptive", "random", "quantiles_global", "round_robin"]
+                 histogram_type="auto",  # type: Literal["auto", "uniform_adaptive", "random", "quantiles_global", "round_robin", "uniform_robust"]
                  max_abs_leafnode_pred=None,  # type: Optional[float]
                  pred_noise_bandwidth=0.0,  # type: float
                  categorical_encoding="auto",  # type: Literal["auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "label_encoder", "sort_by_response", "enum_limited"]
@@ -261,7 +261,7 @@ class H2OGradientBoostingEstimator(H2OEstimator):
         :type min_split_improvement: float
         :param histogram_type: What type of histogram to use for finding optimal split points
                Defaults to ``"auto"``.
-        :type histogram_type: Literal["auto", "uniform_adaptive", "random", "quantiles_global", "round_robin"]
+        :type histogram_type: Literal["auto", "uniform_adaptive", "random", "quantiles_global", "round_robin", "uniform_robust"]
         :param max_abs_leafnode_pred: Maximum absolute value of a leaf node prediction
                Defaults to ``∞``.
         :type max_abs_leafnode_pred: float
@@ -1740,8 +1740,8 @@ class H2OGradientBoostingEstimator(H2OEstimator):
         """
         What type of histogram to use for finding optimal split points
 
-        Type: ``Literal["auto", "uniform_adaptive", "random", "quantiles_global", "round_robin"]``, defaults to
-        ``"auto"``.
+        Type: ``Literal["auto", "uniform_adaptive", "random", "quantiles_global", "round_robin", "uniform_robust"]``,
+        defaults to ``"auto"``.
 
         :examples:
 
@@ -1767,7 +1767,7 @@ class H2OGradientBoostingEstimator(H2OEstimator):
 
     @histogram_type.setter
     def histogram_type(self, histogram_type):
-        assert_is_type(histogram_type, None, Enum("auto", "uniform_adaptive", "random", "quantiles_global", "round_robin"))
+        assert_is_type(histogram_type, None, Enum("auto", "uniform_adaptive", "random", "quantiles_global", "round_robin", "uniform_robust"))
         self._parms["histogram_type"] = histogram_type
 
     @property

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -71,7 +71,7 @@ class H2ORandomForestEstimator(H2OEstimator):
                  col_sample_rate_change_per_level=1.0,  # type: float
                  col_sample_rate_per_tree=1.0,  # type: float
                  min_split_improvement=1e-05,  # type: float
-                 histogram_type="auto",  # type: Literal["auto", "uniform_adaptive", "random", "quantiles_global", "round_robin"]
+                 histogram_type="auto",  # type: Literal["auto", "uniform_adaptive", "random", "quantiles_global", "round_robin", "uniform_robust"]
                  categorical_encoding="auto",  # type: Literal["auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "label_encoder", "sort_by_response", "enum_limited"]
                  calibrate_model=False,  # type: bool
                  calibration_frame=None,  # type: Optional[Union[None, str, H2OFrame]]
@@ -231,7 +231,7 @@ class H2ORandomForestEstimator(H2OEstimator):
         :type min_split_improvement: float
         :param histogram_type: What type of histogram to use for finding optimal split points
                Defaults to ``"auto"``.
-        :type histogram_type: Literal["auto", "uniform_adaptive", "random", "quantiles_global", "round_robin"]
+        :type histogram_type: Literal["auto", "uniform_adaptive", "random", "quantiles_global", "round_robin", "uniform_robust"]
         :param categorical_encoding: Encoding scheme for categorical features
                Defaults to ``"auto"``.
         :type categorical_encoding: Literal["auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "label_encoder",
@@ -1524,8 +1524,8 @@ class H2ORandomForestEstimator(H2OEstimator):
         """
         What type of histogram to use for finding optimal split points
 
-        Type: ``Literal["auto", "uniform_adaptive", "random", "quantiles_global", "round_robin"]``, defaults to
-        ``"auto"``.
+        Type: ``Literal["auto", "uniform_adaptive", "random", "quantiles_global", "round_robin", "uniform_robust"]``,
+        defaults to ``"auto"``.
 
         :examples:
 
@@ -1551,7 +1551,7 @@ class H2ORandomForestEstimator(H2OEstimator):
 
     @histogram_type.setter
     def histogram_type(self, histogram_type):
-        assert_is_type(histogram_type, None, Enum("auto", "uniform_adaptive", "random", "quantiles_global", "round_robin"))
+        assert_is_type(histogram_type, None, Enum("auto", "uniform_adaptive", "random", "quantiles_global", "round_robin", "uniform_robust"))
         self._parms["histogram_type"] = histogram_type
 
     @property

--- a/h2o-py/h2o/estimators/uplift_random_forest.py
+++ b/h2o-py/h2o/estimators/uplift_random_forest.py
@@ -43,7 +43,7 @@ class H2OUpliftRandomForestEstimator(H2OEstimator):
                  sample_rate_per_class=None,  # type: Optional[List[float]]
                  col_sample_rate_change_per_level=1.0,  # type: float
                  col_sample_rate_per_tree=1.0,  # type: float
-                 histogram_type="auto",  # type: Literal["auto", "uniform_adaptive", "random", "quantiles_global", "round_robin"]
+                 histogram_type="auto",  # type: Literal["auto", "uniform_adaptive", "random", "quantiles_global", "round_robin", "uniform_robust"]
                  categorical_encoding="auto",  # type: Literal["auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "label_encoder", "sort_by_response", "enum_limited"]
                  distribution="auto",  # type: Literal["auto", "bernoulli", "multinomial", "gaussian", "poisson", "gamma", "tweedie", "laplace", "quantile", "huber"]
                  check_constant_response=True,  # type: bool
@@ -124,7 +124,7 @@ class H2OUpliftRandomForestEstimator(H2OEstimator):
         :type col_sample_rate_per_tree: float
         :param histogram_type: What type of histogram to use for finding optimal split points
                Defaults to ``"auto"``.
-        :type histogram_type: Literal["auto", "uniform_adaptive", "random", "quantiles_global", "round_robin"]
+        :type histogram_type: Literal["auto", "uniform_adaptive", "random", "quantiles_global", "round_robin", "uniform_robust"]
         :param categorical_encoding: Encoding scheme for categorical features
                Defaults to ``"auto"``.
         :type categorical_encoding: Literal["auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "label_encoder",
@@ -470,14 +470,14 @@ class H2OUpliftRandomForestEstimator(H2OEstimator):
         """
         What type of histogram to use for finding optimal split points
 
-        Type: ``Literal["auto", "uniform_adaptive", "random", "quantiles_global", "round_robin"]``, defaults to
-        ``"auto"``.
+        Type: ``Literal["auto", "uniform_adaptive", "random", "quantiles_global", "round_robin", "uniform_robust"]``,
+        defaults to ``"auto"``.
         """
         return self._parms.get("histogram_type")
 
     @histogram_type.setter
     def histogram_type(self, histogram_type):
-        assert_is_type(histogram_type, None, Enum("auto", "uniform_adaptive", "random", "quantiles_global", "round_robin"))
+        assert_is_type(histogram_type, None, Enum("auto", "uniform_adaptive", "random", "quantiles_global", "round_robin", "uniform_robust"))
         self._parms["histogram_type"] = histogram_type
 
     @property

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -85,7 +85,7 @@
 #' @param col_sample_rate_per_tree Column sample rate per tree (from 0.0 to 1.0) Defaults to 1.
 #' @param min_split_improvement Minimum relative improvement in squared error reduction for a split to happen Defaults to 1e-05.
 #' @param histogram_type What type of histogram to use for finding optimal split points Must be one of: "AUTO", "UniformAdaptive",
-#'        "Random", "QuantilesGlobal", "RoundRobin". Defaults to AUTO.
+#'        "Random", "QuantilesGlobal", "RoundRobin", "UniformRobust". Defaults to AUTO.
 #' @param max_abs_leafnode_pred Maximum absolute value of a leaf node prediction Defaults to 1.797693135e+308.
 #' @param pred_noise_bandwidth Bandwidth (sigma) of Gaussian multiplicative noise ~N(1,sigma) for tree node predictions Defaults to 0.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
@@ -166,7 +166,7 @@ h2o.gbm <- function(x,
                     col_sample_rate_change_per_level = 1,
                     col_sample_rate_per_tree = 1,
                     min_split_improvement = 1e-05,
-                    histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin"),
+                    histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin", "UniformRobust"),
                     max_abs_leafnode_pred = 1.797693135e+308,
                     pred_noise_bandwidth = 0,
                     categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse", "EnumLimited"),
@@ -369,7 +369,7 @@ h2o.gbm <- function(x,
                                     col_sample_rate_change_per_level = 1,
                                     col_sample_rate_per_tree = 1,
                                     min_split_improvement = 1e-05,
-                                    histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin"),
+                                    histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin", "UniformRobust"),
                                     max_abs_leafnode_pred = 1.797693135e+308,
                                     pred_noise_bandwidth = 0,
                                     categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse", "EnumLimited"),

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -77,7 +77,7 @@
 #' @param col_sample_rate_per_tree Column sample rate per tree (from 0.0 to 1.0) Defaults to 1.
 #' @param min_split_improvement Minimum relative improvement in squared error reduction for a split to happen Defaults to 1e-05.
 #' @param histogram_type What type of histogram to use for finding optimal split points Must be one of: "AUTO", "UniformAdaptive",
-#'        "Random", "QuantilesGlobal", "RoundRobin". Defaults to AUTO.
+#'        "Random", "QuantilesGlobal", "RoundRobin", "UniformRobust". Defaults to AUTO.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
 #'        "Binary", "Eigen", "LabelEncoder", "SortByResponse", "EnumLimited". Defaults to AUTO.
 #' @param calibrate_model \code{Logical}. Use Platt Scaling to calculate calibrated class probabilities. Calibration can provide more
@@ -155,7 +155,7 @@ h2o.randomForest <- function(x,
                              col_sample_rate_change_per_level = 1,
                              col_sample_rate_per_tree = 1,
                              min_split_improvement = 1e-05,
-                             histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin"),
+                             histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin", "UniformRobust"),
                              categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse", "EnumLimited"),
                              calibrate_model = FALSE,
                              calibration_frame = NULL,
@@ -334,7 +334,7 @@ h2o.randomForest <- function(x,
                                              col_sample_rate_change_per_level = 1,
                                              col_sample_rate_per_tree = 1,
                                              min_split_improvement = 1e-05,
-                                             histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin"),
+                                             histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin", "UniformRobust"),
                                              categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse", "EnumLimited"),
                                              calibrate_model = FALSE,
                                              calibration_frame = NULL,

--- a/h2o-r/h2o-package/R/upliftrandomforest.R
+++ b/h2o-r/h2o-package/R/upliftrandomforest.R
@@ -39,7 +39,7 @@
 #' @param col_sample_rate_change_per_level Relative change of the column sampling rate for every level (must be > 0.0 and <= 2.0) Defaults to 1.
 #' @param col_sample_rate_per_tree Column sample rate per tree (from 0.0 to 1.0) Defaults to 1.
 #' @param histogram_type What type of histogram to use for finding optimal split points Must be one of: "AUTO", "UniformAdaptive",
-#'        "Random", "QuantilesGlobal", "RoundRobin". Defaults to AUTO.
+#'        "Random", "QuantilesGlobal", "RoundRobin", "UniformRobust". Defaults to AUTO.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
 #'        "Binary", "Eigen", "LabelEncoder", "SortByResponse", "EnumLimited". Defaults to AUTO.
 #' @param distribution Distribution function Must be one of: "AUTO", "bernoulli", "multinomial", "gaussian", "poisson", "gamma",
@@ -78,7 +78,7 @@ h2o.upliftRandomForest <- function(x,
                                    sample_rate_per_class = NULL,
                                    col_sample_rate_change_per_level = 1,
                                    col_sample_rate_per_tree = 1,
-                                   histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin"),
+                                   histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin", "UniformRobust"),
                                    categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse", "EnumLimited"),
                                    distribution = c("AUTO", "bernoulli", "multinomial", "gaussian", "poisson", "gamma", "tweedie", "laplace", "quantile", "huber"),
                                    check_constant_response = TRUE,
@@ -192,7 +192,7 @@ h2o.upliftRandomForest <- function(x,
                                                    sample_rate_per_class = NULL,
                                                    col_sample_rate_change_per_level = 1,
                                                    col_sample_rate_per_tree = 1,
-                                                   histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin"),
+                                                   histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin", "UniformRobust"),
                                                    categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse", "EnumLimited"),
                                                    distribution = c("AUTO", "bernoulli", "multinomial", "gaussian", "poisson", "gamma", "tweedie", "laplace", "quantile", "huber"),
                                                    check_constant_response = TRUE,


### PR DESCRIPTION
In this PR we implemented a POC of a new method for defining split-points in tree-based models' histograms.

This method is designed to address outlier issues with the default UniformAdaptive method while preserving runtime performance advantages compared to the method QuantilesGlobal.

In H2O tree-based algos, an outlier in a column can cause issues with binning. This can be observed on datasets like SpringLeaf which has many columns with artificial values like 99999, 999998 in columns where the main domain is mostly small integers. While this can be addressed by a data scientist in pre-processing, the default binning method can fail on features with these characteristics: Uniform binning will take a look at the min and max values in the column from the observations in the current tree node and split the interval into bins of the same length. With large outliers, the outliers can be classified into a single bin while the rest of the observations end up in another single bin leaving most of the bins unused.

To mitigate that we introduce a new histogram type: UniformRobust.

The idea: "learn from histograms from the previous layer to fine-tune split points for the current layer"

- in the root of the tree use UniformAdaptive binning
- after the first split is made learn from how the histograms were populated - at this point we do not know the distributions of the data in the left and right child nodes (we already made the split but didn't see the data yet) but we do know the distribution of the data before the split is made, we can assume that if uniform binning failed - the issue might still exist in the child nodes and approximate the distribution in the child nodes by the distribution in the parent node: we look at the bins of the histogram and check how many bins were empty compared to the total number of bins. If there are too few populated bins we switch to the new method of binning - for the next level of split-points we take the boundaries of the non-empty bins and refine them according to the Squared Error that is accumulated in each bin:

We take non-empty bins and look at the squared error they have. Based on the desired target number of bins, we discard
the empty bins and use the freed-up space to refine the non-empty bins. Splitting of non-empty bins
is guided by Squared Error accumulated in the bin. Bins with higher SE are split more than the bins with lower SE.
Sub-bins (bins created from a single original bin) are refined uniformly.

If uniform splitting fails in this iteration (= the distribution of values is still significantly skewed), the next iteration
will attempt to correct the issue by repeating the procedure with new bins (we are recursively refining the promising
bins as we get deeper in the tree).

The method is implemented in https://github.com/h2oai/h2o-3/pull/6063/files#diff-91f0d72c4b9c1bd22049aeef775bcd7fdb5335d5c6386fc1d6c6a621b9102b18R32

In our limited experimentation, we observe that UniformRobust has runtime performance and accuracy similar to UniformAdaptive on datasets that have no outliers (the method doesn't kick in for most columns, and a tree is essentially built with UniformAdaptive). On datasets with issues, like SpringLeaf, we see that UniformRobust slightly outperforms QuantilesGlobal in accuracy (and significantly outperforms UniformAdaptive) while being much faster (2x) than QuantilesGlobal (in single node setting).
