### PR TITLE
PUBDEV-8576: ModelBuilder private parameter allowing AutoML to enforce time budget on the final model after CV 

### DIFF
--- a/h2o-algos/src/main/java/hex/deeplearning/DeepLearning.java
+++ b/h2o-algos/src/main/java/hex/deeplearning/DeepLearning.java
@@ -164,7 +164,8 @@ public class DeepLearning extends ModelBuilder<DeepLearningModel,DeepLearningMod
     if( !_parms._quiet_mode ) {
       warn("_epochs", "Setting optimal _epochs to " + _parms._epochs + " for cross-validation main model based on early stopping of cross-validation models.");
       warn("_stopping_rounds", "Disabling convergence-based early stopping for cross-validation main model.");
-      warn("_max_runtime_secs", "Disabling maximum allowed runtime for cross-validation main model.");
+      if (_parms._main_model_time_budget_factor == 0)
+        warn("_max_runtime_secs", "Disabling maximum allowed runtime for cross-validation main model.");
     }
   }
   

--- a/h2o-algos/src/main/java/hex/deeplearning/DeepLearning.java
+++ b/h2o-algos/src/main/java/hex/deeplearning/DeepLearning.java
@@ -156,7 +156,7 @@ public class DeepLearning extends ModelBuilder<DeepLearningModel,DeepLearningMod
     if( _parms._stopping_rounds == 0 && _parms._max_runtime_secs == 0) return; // No exciting changes to stopping conditions
     // Extract stopping conditions from each CV model, and compute the best stopping answer
     _parms._stopping_rounds = 0;
-    _parms._max_runtime_secs = 0;
+    setMaxRuntimeSecsForMainModel();
     double sum = 0;
     for( ModelBuilder cvmb : cvModelBuilders )
       sum += ((DeepLearningModel)DKV.getGet(cvmb.dest())).last_scored().epoch_counter;

--- a/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
+++ b/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
@@ -116,6 +116,7 @@ public abstract class Metalearner<B extends ModelBuilder<M, P, ?>, M extends Mod
     parms._max_runtime_secs = _maxRuntimeSecs;
     parms._weights_column = _model._parms._weights_column;
     parms._offset_column = _model._parms._offset_column;
+    parms._main_model_time_budget_factor = _model._parms._main_model_time_budget_factor;
   }
 
   protected void setCrossValidationParams(P parms) {

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -280,7 +280,9 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
    */
   @Override
   public void cv_computeAndSetOptimalParameters(ModelBuilder[] cvModelBuilders) {
-      if(_parms._max_runtime_secs != 0) _parms._max_runtime_secs = 0;
+      setMaxRuntimeSecsForMainModel();
+      _xval_deviances = new double[_parms._lambda.length * _parms._alpha.length];
+      _xval_sd = new double[_parms._lambda.length * _parms._alpha.length];
       double bestTestDev = Double.POSITIVE_INFINITY;
       double[] alphasAndLambdas = alignSubModelsAcrossCVModels(cvModelBuilders);
       int numOfSubmodels = alphasAndLambdas.length / 2;

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -281,8 +281,6 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
   @Override
   public void cv_computeAndSetOptimalParameters(ModelBuilder[] cvModelBuilders) {
       setMaxRuntimeSecsForMainModel();
-      _xval_deviances = new double[_parms._lambda.length * _parms._alpha.length];
-      _xval_sd = new double[_parms._lambda.length * _parms._alpha.length];
       double bestTestDev = Double.POSITIVE_INFINITY;
       double[] alphasAndLambdas = alignSubModelsAcrossCVModels(cvModelBuilders);
       int numOfSubmodels = alphasAndLambdas.length / 2;

--- a/h2o-algos/src/main/java/hex/tree/SharedTree.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTree.java
@@ -1167,7 +1167,8 @@ public abstract class SharedTree<
 
     warn("_ntrees", "Setting optimal _ntrees to " + _parms._ntrees + " for cross-validation main model based on early stopping of cross-validation models.");
     warn("_stopping_rounds", "Disabling convergence-based early stopping for cross-validation main model.");
-    warn("_max_runtime_secs", "Disabling maximum allowed runtime for cross-validation main model.");
+    if (_parms._main_model_time_budget_factor == 0)
+      warn("_max_runtime_secs", "Disabling maximum allowed runtime for cross-validation main model.");
   }
 
   private int computeOptimalNTrees(ModelBuilder<M, P, O>[] cvModelBuilders) {
@@ -1193,7 +1194,7 @@ public abstract class SharedTree<
       return false;
 
     _parms._stopping_rounds = 0;
-    _parms._max_runtime_secs = 0;
+    setMaxRuntimeSecsForMainModel();
 
     _ntrees = 1;
     _parms._ntrees = _ntrees;

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -320,11 +320,11 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
         params._keep_cross_validation_fold_assignment = buildSpec.build_control.nfolds != 0 && buildSpec.build_control.keep_cross_validation_fold_assignment;
         params._export_checkpoints_dir = buildSpec.build_control.export_checkpoints_dir;
 
-        // Give main model 2x the time to finish than a cv model has; more precisely
-        // 2 * cv_max_runtime * nfold/(nfold-1) since the main model uses data from all folds to train.
+        // Give main model main_model_time_budget_factor-times the time to finish than a cv model has; more precisely
+        // main_model_time_budget_factor * cv_max_runtime * nfold/(nfold-1) since the main model uses data from all folds to train.
         // Main intention is to prevent GLM/DeepLearning non-converging main model to spend
         // way more time than it should while giving well-behaved models enough time to converge.
-        params._main_model_time_budget_factor = 2;
+        params._main_model_time_budget_factor = 1;
     }
     
     protected void setCrossValidationParams(Model.Parameters params) {

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -319,7 +319,12 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
         params._keep_cross_validation_models = buildSpec.build_control.keep_cross_validation_models;
         params._keep_cross_validation_fold_assignment = buildSpec.build_control.nfolds != 0 && buildSpec.build_control.keep_cross_validation_fold_assignment;
         params._export_checkpoints_dir = buildSpec.build_control.export_checkpoints_dir;
-        params._main_model_time_budget_factor = 1;
+
+        // Give main model 2x the time to finish than a cv model has; more precisely
+        // 2 * cv_max_runtime * nfold/(nfold-1) since the main model uses data from all folds to train.
+        // Main intention is to prevent GLM/DeepLearning non-converging main model to spend
+        // way more time than it should while giving well-behaved models enough time to converge.
+        params._main_model_time_budget_factor = 2;
     }
     
     protected void setCrossValidationParams(Model.Parameters params) {

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -324,7 +324,7 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
         // main_model_time_budget_factor * cv_max_runtime * nfold/(nfold-1) since the main model uses data from all folds to train.
         // Main intention is to prevent GLM/DeepLearning non-converging main model to spend
         // way more time than it should while giving well-behaved models enough time to converge.
-        params._main_model_time_budget_factor = 1;
+        params._main_model_time_budget_factor = 2;
     }
     
     protected void setCrossValidationParams(Model.Parameters params) {

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -320,10 +320,10 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
         params._keep_cross_validation_fold_assignment = buildSpec.build_control.nfolds != 0 && buildSpec.build_control.keep_cross_validation_fold_assignment;
         params._export_checkpoints_dir = buildSpec.build_control.export_checkpoints_dir;
 
-        // Give main model main_model_time_budget_factor-times the time to finish than a cv model has; more precisely
-        // main_model_time_budget_factor * cv_max_runtime * nfold/(nfold-1) since the main model uses data from all folds to train.
-        // Main intention is to prevent GLM/DeepLearning non-converging main model to spend
-        // way more time than it should while giving well-behaved models enough time to converge.
+        /** Using _main_model_time_budget_factor to determine if and how we should restrict the time for the main model.
+         *  Value 0 means do not use time constraint for the main model.
+         *  More details in {@link ModelBuilder#setMaxRuntimeSecsForMainModel()}.
+         */
         params._main_model_time_budget_factor = 2;
     }
     

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -319,6 +319,7 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
         params._keep_cross_validation_models = buildSpec.build_control.keep_cross_validation_models;
         params._keep_cross_validation_fold_assignment = buildSpec.build_control.nfolds != 0 && buildSpec.build_control.keep_cross_validation_fold_assignment;
         params._export_checkpoints_dir = buildSpec.build_control.export_checkpoints_dir;
+        params._main_model_time_budget_factor = 1;
     }
     
     protected void setCrossValidationParams(Model.Parameters params) {

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -425,10 +425,8 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
     public double _max_runtime_secs = 0;
 
     /** Using _main_model_time_budget_factor to determine if and how we should restrict the time for the main model.
-     * In general, we should use 0 or > 1 to be reasonably certain that the main model will have time to converge.
-     * if _main_model_time_budget_factor < 0 use max(1, -_main_model_time_budget_factor * remaining time) as max runtime secs
-     * if _main_model_time_budget_factor == 0 do not restrict time for the main model
-     * if _main_model_time_budget_factor > 0 use max(remaining time, _main_model_time_budget_factor * time for a single cv model) as max runtime secs
+     *  Value 0 means do not use time constraint for the main model.
+     *  More details in {@link ModelBuilder#setMaxRuntimeSecsForMainModel()}.
      */
     public double _main_model_time_budget_factor = 0;
 

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -424,6 +424,14 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
      */
     public double _max_runtime_secs = 0;
 
+    /** Using _main_model_time_budget_factor to determine if and how we should restrict the time for the main model.
+     * In general, we should use 0 or > 1 to be reasonably certain that the main model will have time to converge.
+     * if _main_model_time_budget_factor < 0 use max(1, -_main_model_time_budget_factor * remaining time) as max runtime secs
+     * if _main_model_time_budget_factor == 0 do not restrict time for the main model
+     * if _main_model_time_budget_factor > 0 use max(remaining time, _main_model_time_budget_factor * time for a single cv model) as max runtime secs
+     */
+    public double _main_model_time_budget_factor = 0;
+
     /**
      * Early stopping based on convergence of stopping_metric.
      * Stop if simple moving average of the stopping_metric does not improve by stopping_tolerance for

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -1013,7 +1013,7 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     } else {
       // looser version that uses max of remaining time and estimated remaining time based on number of folds
       _parms._max_runtime_secs = Math.max(remainingTimeSecs(),
-              _parms._main_model_time_budget_factor * maxRuntimeSecsPerModel(nFoldWork(), nModelsInParallel(nFoldWork())) * nFoldWork()/(nFoldWork() - 1));
+              _parms._main_model_time_budget_factor * maxRuntimeSecsPerModel(nFoldWork(), nModelsInParallel(nFoldWork())) * nFoldWork()/((double) nFoldWork() - 1));
     }
   }
 

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -1001,9 +1001,9 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
   /** Set max_runtime_secs for the main model.
    * Using _main_model_time_budget_factor to determine if and how we should restrict the time for the main model.
    * In general, we should use 0 or > 1 to be reasonably certain that the main model will have time to converge.
-   * if _main_model_time_budget_factor < 0 use max(1, -_main_model_time_budget_factor * remaining time) as max runtime secs
-   * if _main_model_time_budget_factor == 0 do not restrict time for the main model
-   * if _main_model_time_budget_factor > 0 use max(remaining time, _main_model_time_budget_factor * time for a single cv model) as max runtime secs
+   * if _main_model_time_budget_factor < 0, main_model_time_budget_factor is applied on remaining time to get max runtime secs.
+   * if _main_model_time_budget_factor == 0, do not restrict time for the main model.
+   * if _main_model_time_budget_factor > 0, use max_runtime_secs estimate using nfolds (doesn't depend on the remaining time).
    */
   protected void setMaxRuntimeSecsForMainModel() {
     if (_parms._max_runtime_secs == 0) return;
@@ -1011,9 +1011,10 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
       // strict version that uses the actual remaining time or 1 sec in case we ran out of time
       _parms._max_runtime_secs = Math.max(1, -_parms._main_model_time_budget_factor * remainingTimeSecs());
     } else {
+      int nFolds = nFoldWork();
       // looser version that uses max of remaining time and estimated remaining time based on number of folds
       _parms._max_runtime_secs = Math.max(remainingTimeSecs(),
-              _parms._main_model_time_budget_factor * maxRuntimeSecsPerModel(nFoldWork(), nModelsInParallel(nFoldWork())) * nFoldWork()/((double) nFoldWork() - 1));
+              _parms._main_model_time_budget_factor * maxRuntimeSecsPerModel(nFolds, nModelsInParallel(nFolds)) * nFolds /((double) nFolds - 1));
     }
   }
 

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
@@ -775,7 +775,7 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
     if( _parms._stopping_rounds == 0 && _parms._max_runtime_secs == 0) return; // No exciting changes to stopping conditions
     // Extract stopping conditions from each CV model, and compute the best stopping answer
     _parms._stopping_rounds = 0;
-    _parms._max_runtime_secs = 0;
+    setMaxRuntimeSecsForMainModel();
     int sum = 0;
     for (ModelBuilder mb : cvModelBuilders)
       sum += ((XGBoostOutput) DKV.<Model>getGet(mb.dest())._output)._ntrees;


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8576

This PR solves time-related issues in cases where algos don't converge this happens most often on GLM and sometimes on DeepLearning.

And unfortunately, it reveals another time-related issue in SE - when GLM metalearner gets really wide data even the time limitation doesn't help much as it gets stuck during the first iteration on basic arithmetic operations (see `training_time_ms`; in this case the GLM metalearner had ~380 000 coefficients). 
```
model_id                                                  mean_per_class_error    logloss      rmse       mse    training_time_ms    predict_time_per_row_ms  algo
------------------------------------------------------  ----------------------  ---------  --------  --------  ------------------  -------------------------  ---------------
XGBoost_1_AutoML_1_20220309_30412                                     0.160015   0.749095  0.40925   0.167485     91562                             0.01348   XGBoost
GBM_1_AutoML_1_20220309_30412                                         0.559473  11.7121    0.739764  0.547251     78544                             0.026412  GBM
GLM_1_AutoML_1_20220309_30412                                         0.743113   4.42976   0.982134  0.964587     39267                             0.003189  GLM
StackedEnsemble_BestOfFamily_1_AutoML_1_20220309_30412                0.9972     5.84797   0.996971  0.99395          4.02602e+06                   0.07838   StackedEnsemble
```
![GLM-flamegraph](https://user-images.githubusercontent.com/61695433/157463017-9ee87966-84e8-413d-871a-1a137a7a1e4a.png)