### PR TITLE
PUBDEV-8587: Infogram doesn't need XGBoost as compile dependency

### DIFF
--- a/h2o-admissibleml/build.gradle
+++ b/h2o-admissibleml/build.gradle
@@ -4,7 +4,6 @@ dependencies {
   api project(":h2o-genmodel")
   api project(":h2o-core")
   api project(":h2o-algos")
-  compileOnly project(":h2o-ext-xgboost")
 
   // Test dependencies only
   testImplementation project(":h2o-test-support")

--- a/h2o-admissibleml/src/main/java/hex/Infogram/Infogram.java
+++ b/h2o-admissibleml/src/main/java/hex/Infogram/Infogram.java
@@ -611,7 +611,7 @@ public class Infogram extends ModelBuilder<hex.Infogram.InfogramModel, hex.Infog
      */
     private void extractRelevance(Model model, Model.Parameters parms) {
       if (_buildCore) {           // full model is last one, just extract varImp
-        _varImp = extractVarImp(_parms._algorithm, model);
+        _varImp = model._output.getVariableImportances();
       } else {                    // need to build model for fair info grame
         Frame fullFrame = subtractAdd2Frame(_baseOrSensitiveFrame, _parms.train(), _parms._protected_columns,
                 _topKPredictors); // training frame is topKPredictors minus protected_columns
@@ -620,7 +620,7 @@ public class Infogram extends ModelBuilder<hex.Infogram.InfogramModel, hex.Infog
         _generatedFrameKeys[keyIndex++] = fullFrame._key;
         ModelBuilder builder = ModelBuilder.make(parms);
         Model fairModel = (Model) builder.trainModel().get();
-        _varImp = extractVarImp(_parms._algorithm, fairModel);
+        _varImp = fairModel._output.getVariableImportances();
         Scope.track_generic(fairModel);
       }
     }

--- a/h2o-admissibleml/src/main/java/hex/Infogram/Infogram.java
+++ b/h2o-admissibleml/src/main/java/hex/Infogram/Infogram.java
@@ -307,8 +307,8 @@ public class Infogram extends ModelBuilder<hex.Infogram.InfogramModel, hex.Infog
       try {
         boolean validPresent = _parms.valid() != null;
         prepareModelTrainingFrame(); // generate training frame with predictors and sensitive features (if specified)
-        _model = new hex.Infogram.InfogramModel(dest(), _parms, new hex.Infogram.InfogramModel.InfogramModelOutput(Infogram.this));
-        _model.delete_and_lock(_job);
+        InfogramModel model = new hex.Infogram.InfogramModel(dest(), _parms, new hex.Infogram.InfogramModel.InfogramModelOutput(Infogram.this));
+        _model = model.delete_and_lock(_job);
         _model._output._start_time = System.currentTimeMillis();
         _cmiRaw = new double[_numModels];
         if (_parms.valid() != null)
@@ -349,10 +349,11 @@ public class Infogram extends ModelBuilder<hex.Infogram.InfogramModel, hex.Infog
             keepFrameKeys(keep, _cmiRelKeyValid);
           if (_cmiRelKeyCV != null)
             keepFrameKeys(keep, _cmiRelKeyCV);
+          // final model update
+          _model.update(_job._key);
+          _model.unlock(_job);
         }
         Scope.exit(keep.toArray(new Key[keep.size()]));
-        _model.update(_job._key);
-        _model.unlock(_job);
       }
     }
     

--- a/h2o-admissibleml/src/main/java/hex/schemas/InfogramV3.java
+++ b/h2o-admissibleml/src/main/java/hex/schemas/InfogramV3.java
@@ -5,13 +5,14 @@ import com.google.gson.reflect.TypeToken;
 import hex.Infogram.Infogram;
 import hex.Infogram.InfogramModel;
 import hex.Model;
+import hex.ModelBuilder;
 import hex.deeplearning.DeepLearningModel;
 import hex.glm.GLMModel;
 import hex.tree.drf.DRFModel;
 import hex.tree.gbm.GBMModel;
-import hex.tree.xgboost.XGBoostModel;
 import water.api.API;
 import water.api.EnumValuesProvider;
+import water.api.SchemaServer;
 import water.api.schemas3.KeyV3;
 import water.api.schemas3.ModelParametersSchemaV3;
 import static hex.util.DistributionUtils.distributionToFamily;
@@ -223,8 +224,8 @@ public class InfogramV3 extends ModelBuilderSchema<Infogram, InfogramV3, Infogra
           params = new DeepLearningModel.DeepLearningParameters();
           break;
         case xgboost:
-          paramsSchema = new XGBoostV3.XGBoostParametersV3();
-          params = new XGBoostModel.XGBoostParameters();
+          params = ModelBuilder.makeParameters("XGBoost");
+          paramsSchema = (ModelParametersSchemaV3<?, ?>) SchemaServer.schema(params);
           break;
         default:
           throw new UnsupportedOperationException("Unknown algo: " + parms._algorithm);
@@ -263,7 +264,7 @@ public class InfogramV3 extends ModelBuilderSchema<Infogram, InfogramV3, Infogra
     }
 
     ParamNParamSchema generateParamsSchema(InfogramModel.InfogramParameters.Algorithm chosenAlgo) {
-      ModelParametersSchemaV3 paramsSchema;
+      ModelParametersSchemaV3<?, ?> paramsSchema;
       Model.Parameters params;
       switch (chosenAlgo) {
         case AUTO:
@@ -285,8 +286,8 @@ public class InfogramV3 extends ModelBuilderSchema<Infogram, InfogramV3, Infogra
           params = new DeepLearningModel.DeepLearningParameters();
           break;
         case xgboost:
-          paramsSchema = new XGBoostV3.XGBoostParametersV3();
-          params = new XGBoostModel.XGBoostParameters();
+          params = ModelBuilder.makeParameters("XGBoost");
+          paramsSchema = (ModelParametersSchemaV3<?, ?>) SchemaServer.schema(params);
           break;
         default:
           throw new UnsupportedOperationException("Unknown given algo: " + chosenAlgo);

--- a/h2o-admissibleml/src/test/java/hex/Infogram/InfogramPipingTest.java
+++ b/h2o-admissibleml/src/test/java/hex/Infogram/InfogramPipingTest.java
@@ -13,7 +13,6 @@ import water.runner.CloudSize;
 import water.runner.H2ORunner;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static hex.DMatrix.transpose;

--- a/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModel.java
+++ b/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModel.java
@@ -62,6 +62,10 @@ public class DeepLearningModel extends Model<DeepLearningModel,DeepLearningModel
     double[] normrespsub;
     int[] catoffsets;
     public TwoDimTable _variable_importances;
+    @Override
+    public TwoDimTable getVariableImportances() {
+      return _variable_importances;
+    }
 
     @Override public ModelCategory getModelCategory() {
       return autoencoder ? ModelCategory.AutoEncoder : super.getModelCategory();

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -1204,7 +1204,12 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     public double[] getZValues() {
       return _zvalues;
     }
-    
+
+    @Override
+    public TwoDimTable getVariableImportances() {
+      return _variable_importances;
+    }
+
     @Override public ModelCategory getModelCategory() {
       return _binomial?ModelCategory.Binomial:(_multinomial?ModelCategory.Multinomial:(_ordinal?ModelCategory.Ordinal:ModelCategory.Regression));
     }

--- a/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
@@ -194,6 +194,10 @@ public abstract class SharedTreeModel<
      */
     public TwoDimTable _variable_importances;
     public VarImp _varimp;
+    @Override
+    public TwoDimTable getVariableImportances() {
+      return _variable_importances;
+    }
 
     public GLMModel _calib_model;
 

--- a/h2o-bindings/bin/gen_all.py
+++ b/h2o-bindings/bin/gen_all.py
@@ -25,9 +25,9 @@ if not os.path.exists(results_dir):
 # Allow override of the H2O jarfile so we can use this with projects which extend h2o.jar
 h2o_jarfile = os.getenv('H2O_JARFILE', '../../build/h2o.jar')
 h2o_java_version = os.getenv('H2O_JAVA_VERSION', '1.8')
-h2o_jvm_opts = "-Dsys.ai.h2o.debug.noJavaVersionCheck=true"
+h2o_jvm_opts = ["-Dsys.ai.h2o.ext.rest.toggle.XGBoost=true", "-Dsys.ai.h2o.ext.core.toggle.XGBoost=true"]
 if h2o_java_version != '1.8':
-    h2o_jvm_opts += " --add-opens=java.base/java.lang=ALL-UNNAMED"
+    h2o_jvm_opts += ["--add-opens=java.base/java.lang=ALL-UNNAMED"]
 
 
 # Start H2O cloud

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -1153,6 +1153,14 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
     }
     public boolean isAutoencoder() { return false; } // Override in DeepLearning and so on.
 
+    /**
+     * Retrieves variable importances
+     * @return instance of TwoDimTable if model supports variable importances, null otherwise
+     */
+    public TwoDimTable getVariableImportances() {
+      return null;
+    }
+    
     public synchronized Key<ModelMetrics>[] clearModelMetrics(boolean keepModelTrainingMetrics) {
       Key<ModelMetrics>[] removed;
       if (keepModelTrainingMetrics) {

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -142,6 +142,11 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     return Optional.of((B) BUILDERS[idx]);
   }
 
+  @SuppressWarnings("unchecked")
+  public static <P extends Model.Parameters> P makeParameters(String algo) {
+    return (P) make(algo, null, null)._parms;
+  }
+
   /** Factory method to create a ModelBuilder instance for given the algo name.
    *  Shallow clone of both the default ModelBuilder instance and a Parameter. */
   public static <B extends ModelBuilder> B make(String algo, Job job, Key<Model> result) {

--- a/h2o-core/src/main/java/water/api/SchemaServer.java
+++ b/h2o-core/src/main/java/water/api/SchemaServer.java
@@ -251,6 +251,10 @@ public class SchemaServer {
     return schema(version, impl.getClass().getSimpleName());
   }
 
+  public static Schema schema (Iced impl) {
+    return schema(STABLE_VERSION, impl);
+  }
+
   /**
    * For a given version and Iced class return an appropriate Schema instance, if any.
    * @param version Version of the schema to create, or pass -1 to use the latest version.

--- a/h2o-extensions/xgboost/src/main/java/hex/api/xgboost/RegisterRestApi.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/api/xgboost/RegisterRestApi.java
@@ -16,7 +16,10 @@ public class RegisterRestApi extends AlgoAbstractRegister {
   @Override
   public void registerEndPoints(RestApiContext context) {
     XGBoostExtension ext = (XGBoostExtension) ExtensionManager.getInstance().getCoreExtension(XGBoostExtension.NAME);
-    ext.logNativeLibInfo();
+    if (ext != null) {
+      // We might not have the extension available if running from h2o-bindings
+      ext.logNativeLibInfo();
+    }
     XGBoost xgBoostMB = new XGBoost(true);
     // Register XGBoost model builder REST API
     registerModelBuilder(context, xgBoostMB, SchemaServer.getStableVersion());

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostExtension.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostExtension.java
@@ -58,6 +58,10 @@ public class XGBoostExtension extends AbstractH2OExtension {
   }
 
   public void logNativeLibInfo() {
+    if (nativeLibInfo == null) {
+      LOG.warn("No native XGBoost library found.");
+      return;
+    }
     LOG.info("Found XGBoost backend with library: " + nativeLibInfo.name);
     if (nativeLibInfo.flags.length == 0) {
       LOG.warn("Your system supports only minimal version of XGBoost (no GPUs, no multithreading)!");

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostOutput.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostOutput.java
@@ -37,6 +37,10 @@ public class XGBoostOutput extends Model.Output implements Model.GetNTrees, Plat
   }
   public long[/*ntrees+1*/] _training_time_ms = {System.currentTimeMillis()};
   public TwoDimTable _variable_importances; // gain
+  @Override
+  public TwoDimTable getVariableImportances() {
+    return _variable_importances;
+  }
   public TwoDimTable _variable_importances_cover;
   public TwoDimTable _variable_importances_frequency;
   public XgbVarImp _varimp;

--- a/h2o-test-support/src/main/java/water/TestUtil.java
+++ b/h2o-test-support/src/main/java/water/TestUtil.java
@@ -623,7 +623,7 @@ public class TestUtil extends Iced {
   }
 
   private static boolean runWithoutLocalFiles() {
-    return Boolean.valueOf(System.getenv("H2O_JUNIT_ALLOW_NO_SMALLDATA"));
+    return Boolean.parseBoolean(System.getenv("H2O_JUNIT_ALLOW_NO_SMALLDATA"));
   }
 
   protected static void downloadTestFileFromS3(String fname) throws IOException {
@@ -631,8 +631,12 @@ public class TestUtil extends Iced {
       fname = fname.substring(2);
     File f = new File(fname);
     if (!f.exists()) {
-      if (f.getParentFile() != null)
-        f.getParentFile().mkdirs();
+      if (f.getParentFile() != null) {
+        boolean dirsCreated = f.getParentFile().mkdirs();
+        if (! dirsCreated) {
+          Log.warn("Failed to create directory:" + f.getParentFile());
+        }
+      }
       File tmpFile = File.createTempFile(f.getName(), "tmp", f.getParentFile());
       org.apache.commons.io.FileUtils.copyURLToFile(
               new URL("https://h2o-public-test-data.s3.amazonaws.com/" + fname),

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -359,7 +359,7 @@ class H2OCloudNode(object):
                "-Xmx" + self.xmx,
                "-ea"]
         if self.jvm_opts is not None:
-            cmd += [self.jvm_opts]
+            cmd += self.jvm_opts if isinstance(self.jvm_opts, list) else [self.jvm_opts]
         port_spec = "-port" if self.strict_port else "-baseport"
         cmd += ["-cp", classpath,
                main_class,


### PR DESCRIPTION
@wendycwong the dependency was previously incorrectly specified as "compile-only" while Infogram in actuality couldn't run without xgboost on the classpath (hard code dependences). This PR makes it optional + adds a bunch of fly-by fixes.