### PR TITLE
PUBDEV-8612: Speed-up job polling (in R)

### DIFF
--- a/h2o-core/src/main/java/water/api/RegisterV3Api.java
+++ b/h2o-core/src/main/java/water/api/RegisterV3Api.java
@@ -475,6 +475,14 @@ public class RegisterV3Api extends AbstractRegister {
             "DELETE /3/InitID", RapidsHandler.class, "endSession",
             "End a session.");
 
+    context.registerEndpoint("setSessionProperty",
+            "POST /3/SessionProperties", RapidsHandler.class, "setSessionProperty",
+            "Set session property.");
+
+    context.registerEndpoint("getSessionProperty",
+            "GET /3/SessionProperties", RapidsHandler.class, "getSessionProperty",
+            "Get session property.");
+
     context.registerEndpoint("garbageCollect",
             "POST /3/GarbageCollect", GarbageCollectHandler.class, "gc",
             "Explicitly call System.gc().");

--- a/h2o-core/src/main/java/water/api/RequestServer.java
+++ b/h2o-core/src/main/java/water/api/RequestServer.java
@@ -240,7 +240,9 @@ public class RequestServer extends HttpServlet {
    */
   public void doGeneric(String method, HttpServletRequest request, HttpServletResponse response) {
     try {
-      ServletUtils.startTransaction(request.getHeader("User-Agent"));
+      String userAgent = request.getHeader("User-Agent");
+      String sessionKey = request.getHeader("Session-Key");
+      ServletUtils.startTransaction(userAgent, sessionKey);
 
       // Note that getServletPath does an un-escape so that the %24 of job id's are turned into $ characters.
       String uri = request.getServletPath();

--- a/h2o-core/src/main/java/water/api/schemas3/InitIDV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/InitIDV3.java
@@ -6,4 +6,7 @@ import water.api.API;
 public class InitIDV3 extends RequestSchemaV3<Iced, InitIDV3> {
   @API(help="Session ID", direction = API.Direction.INOUT)
   public String session_key;
+
+  @API(help="Indicates whether users are allowed to set and modify session properties", direction = API.Direction.OUTPUT)
+  public boolean session_properties_allowed;
 }

--- a/h2o-core/src/main/java/water/api/schemas3/SessionPropertyV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/SessionPropertyV3.java
@@ -1,0 +1,17 @@
+package water.api.schemas3;
+
+import water.Iced;
+import water.api.API;
+
+public class SessionPropertyV3 extends RequestSchemaV3<Iced, SessionPropertyV3> {
+
+    @API(help="Session ID", direction = API.Direction.INOUT)
+    public String session_key;
+
+    @API(help="Property Key", direction = API.Direction.INOUT)
+    public String key;
+
+    @API(help="Property Value", direction = API.Direction.INOUT)
+    public String value;
+
+}

--- a/h2o-core/src/main/java/water/rapids/Session.java
+++ b/h2o-core/src/main/java/water/rapids/Session.java
@@ -11,6 +11,7 @@ import water.util.Log;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * Session is a long-lasting environment supporting caching and Copy-On-Write optimization of Vecs.  This session may
@@ -51,6 +52,7 @@ public class Session {
   // set.
   private NonBlockingHashSet<Key<Vec>> GLOBALS = new NonBlockingHashSet<>();
 
+  private final Properties properties = new Properties();
 
   /**
    * Constructor
@@ -68,6 +70,18 @@ public class Session {
   /** Return this session's id. */
   public String id() {
     return id;
+  }
+
+  public void setProperty(String key, String value) {
+    if (value != null) {
+      properties.setProperty(key, value);
+    } else {
+      properties.remove(key);
+    }
+  }
+
+  public String getProperty(String key, String defaultValue) {
+    return properties.getProperty(key, defaultValue);
   }
 
   /**

--- a/h2o-core/src/main/resources/META-INF/services/water.api.Schema
+++ b/h2o-core/src/main/resources/META-INF/services/water.api.Schema
@@ -123,6 +123,7 @@ water.api.schemas3.RemoveV3
 water.api.schemas3.RequestSchemaV3
 water.api.schemas3.RouteV3
 water.api.schemas3.SaveToHiveTableV3
+water.api.schemas3.SessionPropertyV3
 water.api.schemas3.SchemaMetadataV3
 water.api.schemas3.SchemaV3
 water.api.schemas3.ShutdownV3

--- a/h2o-core/src/test/java/water/rapids/SessionTest.java
+++ b/h2o-core/src/test/java/water/rapids/SessionTest.java
@@ -1,0 +1,26 @@
+package water.rapids;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import water.runner.CloudSize;
+import water.runner.H2ORunner;
+
+import static org.junit.Assert.*;
+
+@CloudSize(1)
+@RunWith(H2ORunner.class)
+public class SessionTest {
+
+    @Test
+    public void testProperties() {
+        assertNull(new Session().getProperty("invalid", null));
+        assertEquals("tst_default", new Session().getProperty("invalid", "tst_default"));
+
+        Session s = new Session();
+        s.setProperty("key1", "value1");
+        assertEquals("value1", s.getProperty("key1", null));
+        s.setProperty("key1", null);
+        assertNull(s.getProperty("key1", null));
+    }
+
+}

--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -105,7 +105,7 @@
 
   beginTimeSeconds <- as.numeric(proc.time())[3L]
 
-  header <- c('Connection' = 'close')
+  header <- .default.headers(conn)
   if(!is.na(conn@cookies)) {
     header['Cookie'] <- paste0(conn@cookies, collapse=';')
   }
@@ -183,6 +183,13 @@
        httpStatusCode = httpStatusCode,
        httpStatusMessage = httpStatusMessage,
        payload = payload)
+}
+
+.default.headers <- function(conn) {
+  c(
+    'Connection' = 'close',
+    'Session-Key' = conn@mutable$session_id
+  )
 }
 
 .h2o.doRawREST <- function(conn, h2oRestApiVersion, urlSuffix, parms, method, fileUploadInfo, binary=FALSE, parms_as_payload = FALSE, ...) {
@@ -294,8 +301,7 @@
   beginTimeSeconds = as.numeric(proc.time())[3L]
 
   tmp <- NULL
-  header <- c('Connection' = 'close')
-
+  header <- .default.headers(conn)
   if(!is.na(conn@cookies)) {
     header['Cookie'] = paste0(conn@cookies, collapse=';')
   }

--- a/h2o-r/h2o-package/R/constants.R
+++ b/h2o-r/h2o-package/R/constants.R
@@ -67,7 +67,8 @@ assign("LOG_FILE_NAME", NULL,  .pkg.env)
 .h2o.__CLOUD          <- "Cloud?skip_ticks=true"
 .h2o.__SHUTDOWN       <- "Shutdown"
 .h2o.__DOWNLOAD_LOGS  <- "3/Logs/download"
-.h2o.__RESUME         <- "3/Recovery/resume"
+.h2o.__RESUME         <- "Recovery/resume"
+.h2o.__SESSION_PROPERTIES <- "SessionProperties"
 
 #' Removal Endpoints
 .h2o.__DKV            <- "DKV"

--- a/h2o-r/h2o-package/R/kvstore.R
+++ b/h2o-r/h2o-package/R/kvstore.R
@@ -86,7 +86,10 @@ h2o.removeAll <- function(timeout_secs=0, retained_elements = c()) {
     parms <- list()
     parms$retained_keys <- paste0("[", paste(retained_keys, collapse=','), "]")
     
-    invisible(.h2o.__remoteSend(.h2o.__DKV, method = "DELETE", timeout=timeout_secs, .params = parms))},
+    .h2o.__remoteSend(.h2o.__DKV, method = "DELETE", timeout=timeout_secs, .params = parms)
+    # remove all will also destroy all sessions, explicitly start a new one with a new ID
+    invisible(.attach.new.session(h2o.getConnection()))
+    },
     error = function(e) {
       print("Timeout on DELETE /DKV from R")
       print("Attempt thread dump...")

--- a/h2o-r/tests/testdir_misc/runit_job_polling.R
+++ b/h2o-r/tests/testdir_misc/runit_job_polling.R
@@ -1,0 +1,50 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+train.models <- function(prostate.hex) {
+    wasted_times <- c()
+    for (i in seq(5)) {
+        start_time <- Sys.time()
+        prostate.h2o <- h2o.gbm(x = 3:9, y = "CAPSULE", training_frame = prostate.hex,
+                                ntrees = 100, max_depth = 5, learn_rate = 0.01)
+        end_time <- Sys.time()
+
+        print("Waited:")
+        print(end_time - start_time)
+        print("Run-time (ms):")
+        print(prostate.h2o@model$run_time)
+        print("Wasted time (ms):")
+        wasted <- as.numeric(end_time - start_time)*1000 - prostate.h2o@model$run_time
+        print(wasted)
+        wasted_times <- c(wasted_times, wasted)
+    }
+    return(wasted_times)
+}
+
+test.job.polling <- function() {
+    prostate.hex <- h2o.importFile(locate("smalldata/logreg/prostate.csv"))
+
+    prostate.hex$CAPSULE <- as.factor(prostate.hex$CAPSULE)
+    prostate.hex$RACE <- as.factor(prostate.hex$RACE)
+
+    conn <- h2o.getConnection()
+
+    # check that default timeout is 1000ms
+    default_timeout <- .get.session.property(conn@mutable$session_id, "job.fetch_timeout_ms")
+    expect_equal(default_timeout, "1000")
+
+    print("\n CLASSIC POLLING \n")
+    .set.session.property(conn@mutable$session_id, "job.fetch_timeout_ms", "-1")
+
+    overhead.classic <- train.models(prostate.hex)
+
+    print("\n BACKEND WAIT POLLING \n")
+    .set.session.property(conn@mutable$session_id, "job.fetch_timeout_ms", "1000")
+
+    overhead.waiting <- train.models(prostate.hex)
+
+    expect_gt(mean(overhead.classic) / mean(overhead.waiting), 2) # at least 2x fast but in reality much more
+}
+
+doTest("Test Job polling works better with internal wait on backend", test.job.polling)
+

--- a/h2o-r/tests/testdir_misc/runit_session_properties.R
+++ b/h2o-r/tests/testdir_misc/runit_session_properties.R
@@ -1,0 +1,24 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+test.session.properties <- function() {
+  conn <- h2o.getConnection()
+
+  expect_null(.get.session.property(conn@mutable$session_id, "test_key_0"))
+  
+  .set.session.property(conn@mutable$session_id, "test_key_1", "test_value_1")
+  expect_equal(.get.session.property(conn@mutable$session_id, "test_key_1"), "test_value_1")
+
+  .set.session.property(conn@mutable$session_id, "test_key_2", NULL)
+  expect_null(.get.session.property(conn@mutable$session_id, "test_key_2"))
+
+
+  .set.session.property(conn@mutable$session_id, "test_key_3", "test_value_3")
+  expect_equal(.get.session.property(conn@mutable$session_id, "test_key_3"), "test_value_3")
+
+  h2o.removeAll()
+  expect_null(.get.session.property(conn@mutable$session_id, "test_key_3"))
+}
+
+doTest("Test Job polling works better with internal wait on backend", test.session.properties)
+


### PR DESCRIPTION
This script show that we can save ~800ms per model training just on polling in R.

```
prostate.hex <- h2o.importFile("smalldata/logreg/prostate.csv")

prostate.hex$CAPSULE <- as.factor(prostate.hex$CAPSULE)
prostate.hex$RACE <- as.factor(prostate.hex$RACE)

ntrees <- 100

for (test in c(FALSE, TRUE)) {
  if (test) {
    h2o.rapids('(setproperty "fast_polling" "true")')
    print("\n FAST POLLING \n")
  } else {
    print("\n REGULAR POLLING \n")
    h2o.rapids('(setproperty "fast_polling" "false")')
  }
  
  for (i in seq(5)) {
    start_time <- Sys.time()
    prostate.h2o <- h2o.gbm(x = 3:9, y = "CAPSULE", training_frame = prostate.hex, distribution = "bernoulli", ntrees = ntrees, max_depth = 5, min_rows = 10, learn_rate = 0.1)
    end_time <- Sys.time()
    
    print("Waited:")
    print(end_time - start_time)
    print("Run-time (ms):")
    print(prostate.h2o@model$run_time)
    print("Wasted time (ms):")
    print(as.numeric(end_time - start_time)*1000 - prostate.h2o@model$run_time)
  }
}
```

Results:

```
[1] "\n REGULAR POLLING \n"
  |======================================================================================================================================================================| 100%
[1] "Waited:"
Time difference of 1.171726 secs
[1] "Run-time (ms):"
[1] 273
[1] "Wasted time (ms):"
[1] 898.726
  |======================================================================================================================================================================| 100%
[1] "Waited:"
Time difference of 1.132804 secs
[1] "Run-time (ms):"
[1] 271
[1] "Wasted time (ms):"
[1] 861.8042
  |======================================================================================================================================================================| 100%
[1] "Waited:"
Time difference of 1.12984 secs
[1] "Run-time (ms):"
[1] 270
[1] "Wasted time (ms):"
[1] 859.8399
  |======================================================================================================================================================================| 100%
[1] "Waited:"
Time difference of 1.129631 secs
[1] "Run-time (ms):"
[1] 272
[1] "Wasted time (ms):"
[1] 857.631
  |======================================================================================================================================================================| 100%
[1] "Waited:"
Time difference of 1.129786 secs
[1] "Run-time (ms):"
[1] 275
[1] "Wasted time (ms):"
[1] 854.786
```

And fast polling:

```
[1] "\n FAST POLLING \n"
  |======================================================================================================================================================================| 100%
[1] "Waited:"
Time difference of 0.374512 secs
[1] "Run-time (ms):"
[1] 279
[1] "Wasted time (ms):"
[1] 95.51196
  |======================================================================================================================================================================| 100%
[1] "Waited:"
Time difference of 0.3655801 secs
[1] "Run-time (ms):"
[1] 271
[1] "Wasted time (ms):"
[1] 94.58008
  |======================================================================================================================================================================| 100%
[1] "Waited:"
Time difference of 0.3723218 secs
[1] "Run-time (ms):"
[1] 280
[1] "Wasted time (ms):"
[1] 92.32184
  |======================================================================================================================================================================| 100%
[1] "Waited:"
Time difference of 0.372376 secs
[1] "Run-time (ms):"
[1] 289
[1] "Wasted time (ms):"
[1] 83.37597
  |======================================================================================================================================================================| 100%
[1] "Waited:"
Time difference of 0.374588 secs
[1] "Run-time (ms):"
[1] 280
[1] "Wasted time (ms):"
[1] 94.58801
```