### PR TITLE
PUBDEV-8568: Use curl package in R client but keep RCurl as fallback (ssl fix)

### DIFF
--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -59,7 +59,7 @@
   }
   if (conn@https) {
     if (conn@insecure) {
-      curl::handle_setopt(handle, ssl.verifypeer = 0L, ssl.verifyhost=0L)
+      curl::handle_setopt(handle, ssl_verifypeer = 0L, ssl_verifyhost=0L)
     } else if (! is.na(conn@cacert)) {
       curl::handle_setopt(handle, cainfo = conn@cacert)
     }


### PR DESCRIPTION
Part of https://h2oai.atlassian.net/browse/PUBDEV-8568

Fixes change in naming convention that occurred between RCurl and curl. 

continuation of this https://github.com/h2oai/h2o-3/pull/6058 experimental PR.