### PR TITLE
PUBDEV-8568: Use curl package in R client but keep RCurl as fallback (part 3)

### DIFF
--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -48,7 +48,7 @@
 
 .h2o.doRawREST.with.curl <- function(conn, url, method, parms, fileUploadInfo, binary=FALSE, parms_as_payload = FALSE, ...){
   timeout_secs <- 0
-  handle <- curl::new_handle(customrequest = method)
+  handle <- curl::new_handle(customrequest = method, followlocation = FALSE)
   if (conn@use_spnego) {
     negotiateAuth <- 4
     curl::handle_setopt(handle, httpauth = negotiateAuth, userpwd = ":")
@@ -149,7 +149,7 @@
                   error = function(x) { .__curlError <<- TRUE; .__curlErrorMessage <<- x$message })
   if (! .__curlError) {
     httpStatusCode <- as.numeric(tmp$status_code)
-    httpStatusMessage <- sub(sprintf("HTTP.*?\\s%d\\s(.*?)\\s*$", httpStatusCode),
+    httpStatusMessage <- sub("HTTP.*?\\s+\\d+\\s+(.*?)\\s*$",
                              "\\1",
                              strsplit(rawToChar(tmp$headers), "[\n\r]")[[1]][[1]],
                              perl = TRUE)


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8568

This PR fixes hopefully the last issue with R `curl` package and Hadoop. The issue is caused by following redirection. 


Affected test: `runit_hive_jdbc_import.R` only "ON HADOOP" not "STANDALONE".
```
Error in h2o.init(ip = H2O.IP, port = H2O.PORT, startH2O = FALSE, https = H2O.HTTPS,  : 
  Cannot connect to H2O server. Please check that H2O is running at https://192.168.254.9:54321/
Calls: source ... withVisible -> eval -> eval -> h2oTestSetup -> h2o.init
```

```mermaid
sequenceDiagram
    R->>H2O Backend: GET /
    H2O Backend-->>R: 301: try looking at flow
    R -->> H2O Backend: GET /flow/index.html
    H2O Backend ->> R: 404: disabled by running with `-disable_flow`
```

And since the 404 is considered unsuccessful `h2o.init` fails.