### PR TITLE
PUBDEV-8617: Avoid using sleep() in AutoML job monitoring

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStepsExecutor.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStepsExecutor.java
@@ -12,7 +12,6 @@ import hex.ModelContainer;
 import water.Iced;
 import water.Job;
 import water.Key;
-import water.util.ArrayUtils;
 import water.util.Countdown;
 import water.util.Log;
 
@@ -35,9 +34,7 @@ class ModelingStepsExecutor extends Iced<ModelingStepsExecutor> {
             if (parentJob.stop_requested()) {
                 job.stop();
             }
-            try {
-                Thread.sleep(pollingIntervalInMillis);
-            } catch (InterruptedException ignored) {}
+            job.blockingWaitForDone(pollingIntervalInMillis);
         }
     }
 
@@ -169,11 +166,7 @@ class ModelingStepsExecutor extends Iced<ModelingStepsExecutor> {
                     }
                 }
 
-                try {
-                    Thread.sleep(_pollingIntervalInMillis);
-                } catch (InterruptedException e) {
-                    // keep going
-                }
+                job.blockingWaitForDone(_pollingIntervalInMillis);
                 lastWorkedSoFar = workedSoFar;
             }
 

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_early_stopping.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_early_stopping.py
@@ -91,13 +91,13 @@ def test_max_runtime_secs_can_be_set_in_combination_with_max_models_and_max_mode
 
 def test_max_runtime_secs_can_be_set_in_combination_with_max_models_and_max_runtime_wins():
     ds = import_dataset()
-    aml = H2OAutoML(project_name="py_all_stopping_constraints", seed=1, max_models=20, max_runtime_secs=12)
+    aml = H2OAutoML(project_name="py_all_stopping_constraints", seed=1, max_models=100, max_runtime_secs=5)
     aml.train(y=ds.target, training_frame=ds.train)
     max_runtime = aml._build_resp['build_control']['stopping_criteria']['max_runtime_secs']
     max_models = aml._build_resp['build_control']['stopping_criteria']['max_models']
-    assert max_runtime == 12
-    assert max_models == 20
-    assert aml.leaderboard.nrows < 20
+    assert max_runtime == 5
+    assert max_models == 100
+    assert aml.leaderboard.nrows < 100
     assert int(aml.training_info['duration_secs']) < 2*max_runtime  # being generous to avoid errors on slow Jenkins
 
 

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile
@@ -47,7 +47,7 @@ try {
               // clear the folder
               deleteDir()
               // checkout H2O-3
-              retryWithTimeout(60, 3) {
+              retryWithTimeout(180, 3) {
                 echo "###### Checkout H2O-3 ######"
                 if (env.ghprbPullId) {
                   // building PR from fork


### PR DESCRIPTION
sleep doesn't return the F/J thread to the pool - making it unusable for
other work