### PR TITLE
PUBDEV-8620: Fix cv_computeAndSetOptimalParameters

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -257,7 +257,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
               (g._model._output._submodels[g._model._output._selected_submodel_idx].lambda_value ==
                       alignedSubmodels[g._model._output._selected_submodel_idx + nNullsUntilSelectedSubModel].lambda_value);
       g._model._output._submodels = alignedSubmodels;
-      g._model._output.setSubmodelIdx(g._model._output._selected_submodel_idx + nNullsUntilSelectedSubModel);
+      g._model._output.setSubmodelIdx(g._model._output._selected_submodel_idx + nNullsUntilSelectedSubModel, _parms);
     }
     return lambdas;
   }
@@ -339,7 +339,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       _xval_sd = Arrays.copyOf(_xval_sd, lmin_max + 1);
       for (int i = 0; i < cvModelBuilders.length; ++i) {
         GLM g = (GLM) cvModelBuilders[i];
-        g._model._output.setSubmodelIdx(bestId);
+        g._model._output.setSubmodelIdx(bestId, _parms);
       }
       double bestDev = _xval_deviances[bestId];
       double bestDev1se = bestDev + _xval_sd[bestId];
@@ -2835,7 +2835,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
           if ((_parms._lambda_search || _parms._generate_scoring_history) && (_parms._score_each_iteration || 
                   timeSinceLastScoring() > _scoringInterval || ((_parms._score_iteration_interval > 0) &&
                   ((_state._iter % _parms._score_iteration_interval) == 0)))) {
-            _model._output.setSubmodelIdx(_model._output._best_submodel_idx = submodelCount); // quick and easy way to set submodel parameters
+            _model._output.setSubmodelIdx(_model._output._best_submodel_idx = submodelCount, _parms); // quick and easy way to set submodel parameters
             scoreAndUpdateModel(); // update partial results
           }
           _job.update(_workPerIteration, "iter=" + _state._iter + " lmb=" +
@@ -2861,9 +2861,9 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       if (_state._iter >= _parms._max_iterations)
         _job.warn("Reached maximum number of iterations " + _parms._max_iterations + "!");
       if (_parms._nfolds > 1 && !Double.isNaN(_lambdaCVEstimate))
-        _model._output.setSubmodelIdx(_model._output._best_submodel_idx = _bestCVSubmodel);  // reset best_submodel_idx to what xval has found
+        _model._output.setSubmodelIdx(_model._output._best_submodel_idx = _bestCVSubmodel, _parms);  // reset best_submodel_idx to what xval has found
       else
-        _model._output.pickBestModel();
+        _model._output.pickBestModel(_parms);
       if (_vcov != null) { // should move this up, otherwise, scoring will never use info in _vcov
         _model.setVcov(_vcov);
         _model.update(_job._key);

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -292,6 +292,15 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       int lidx = 0; // index into submodel
       int bestId = 0;   // submodel indedx with best Deviance from xval
       int cnt = 0;
+
+      boolean lambdasSorted = _parms._lambda.length > 1;
+      for (int i = 1; i < _parms._lambda.length; i++) {
+        if (_parms._lambda[i] >= _parms._lambda[i - 1]) {
+          lambdasSorted = false;
+          break;
+        }
+      }
+
       for (; lidx < lmin_max; ++lidx) { // search through submodel with same lambda and alpha values
         double testDev = 0;
         double testDevSq = 0;
@@ -324,7 +333,10 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
         }
         // early stopping - no reason to move further if we're overfitting
         // cannot be used if we have multiple alphas
-        if ((_parms._alpha == null || _parms._alpha.length <= 1) && testDevAvg > bestTestDev && ++cnt == 3) {
+        if ((_parms._alpha == null || _parms._alpha.length <= 1) &&
+                lambdasSorted &&
+                testDevAvg > bestTestDev &&
+                ++cnt == 3) {
           lmin_max = lidx;
           break;
         }

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -119,7 +119,6 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
   @Override public boolean haveMojo() { return true; }
 
   private double _lambdaCVEstimate = Double.NaN; // lambda cross-validation estimate
-  private int _bestCVSubmodel;  // best submodel index found during cv
   private boolean _doInit = true;  // flag setting whether or not to run init
   private double [] _xval_deviances;  // store cross validation average deviance
   private double [] _xval_sd;         // store the standard deviation of cross-validation
@@ -285,7 +284,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       double[] alphasAndLambdas = alignSubModelsAcrossCVModels(cvModelBuilders);
       int numOfSubmodels = alphasAndLambdas.length / 2;
       int lmin_max = 0;
-      boolean lambdasSorted = _parms._lambda.length > 1;
+      boolean lambdasSorted = _parms._lambda.length >= 1;
       for (int i = 1; i < _parms._lambda.length; i++) {
         if (_parms._lambda[i] >= _parms._lambda[i - 1]) {
           lambdasSorted = false;
@@ -354,71 +353,38 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
             Keyed.remove(k);
       }
 
-      if (_parms._alpha != null && _parms._alpha.length > 1) {
-        final int finalBestId = bestId;
-        // All the alphas are the same for the winning model
-        assert Arrays.stream(cvModelBuilders)
-                .mapToDouble(cv -> ((GLM) cv)._model._output._submodels[finalBestId].alpha_value)
-                .distinct()
-                .count() == 1;
-        _parms._alpha = new double[]{((GLM) cvModelBuilders[0])._model._output._submodels[finalBestId].alpha_value};
-
-        // Since we are considering just one alpha, we need to adapt the submodels, xval metrics and related indices
-        int selectedAlphaStart = Integer.MAX_VALUE;
-        int selectedAlphaEnd = -1;
-        for (int i = 0; i < numOfSubmodels; i++) {
-          if (alphasAndLambdas[i] == _parms._alpha[0]) {
-            selectedAlphaStart = Math.min(selectedAlphaStart, i);
-            selectedAlphaEnd = Math.max(selectedAlphaEnd, i);
-          }
-        }
-        selectedAlphaEnd ++; // Upper-bound is exclusive (e.g., in copyOfRange)
-
-        for (int i = 0; i < cvModelBuilders.length; i++) {
-          ((GLM)cvModelBuilders[i])._model._output._submodels = Arrays.copyOfRange(((GLM)cvModelBuilders[i])._model._output._submodels,
-                  selectedAlphaStart,
-                  selectedAlphaEnd);
-        }
-        bestId = bestId - selectedAlphaStart;
-        lmin_max = Math.min(lmin_max - selectedAlphaStart, selectedAlphaEnd - selectedAlphaStart);
-        _parms._lambda = IntStream.range(selectedAlphaStart, selectedAlphaEnd)
-                .mapToDouble(i -> alphasAndLambdas[numOfSubmodels + i])
-                .toArray();
-        _xval_deviances = Arrays.copyOfRange(_xval_deviances, selectedAlphaStart, selectedAlphaEnd);
-        _xval_sd = Arrays.copyOfRange(_xval_sd,  selectedAlphaStart, selectedAlphaEnd);
-      } else {
-        _parms._lambda = Arrays.copyOf(_parms._lambda, lmin_max + 1);
-        _xval_deviances = Arrays.copyOf(_xval_deviances, lmin_max + 1);
-        _xval_sd = Arrays.copyOf(_xval_sd, lmin_max + 1);
-      }
       for (int i = 0; i < cvModelBuilders.length; ++i) {
         GLM g = (GLM) cvModelBuilders[i];
         g._model._output.setSubmodelIdx(bestId, g._parms);
       }
+
       double bestDev = _xval_deviances[bestId];
       double bestDev1se = bestDev + _xval_sd[bestId];
-      final Submodel[] submodels = ((GLM)cvModelBuilders[0])._model._output._submodels;
+      int finalBestId = bestId;
       Integer[] orderedLambdaIndices = IntStream
-              .range(0, numOfSubmodels)
-              .filter(i -> Double.isFinite(_xval_deviances[i]))
-              .boxed()
-              .sorted((a,b) -> (int) Math.signum(submodels[b].lambda_value - submodels[a].lambda_value))
-              .toArray(Integer[]::new);
-    int finalBestId1 = bestId;
-    int bestId1se = IntStream
-              .range(0, orderedLambdaIndices.length)
-              .filter(i -> orderedLambdaIndices[i] == finalBestId1)
-              .findFirst()
-              .orElse(orderedLambdaIndices.length - 1);
+                .range(0, lmin_max)
+                .filter(i -> alphasAndLambdas[i] == alphasAndLambdas[finalBestId]) // get just the lambdas corresponding to the selected alpha
+                .boxed()
+                .sorted((a,b) -> (int) Math.signum(alphasAndLambdas[b+numOfSubmodels] - alphasAndLambdas[a+numOfSubmodels]))
+                .toArray(Integer[]::new);
+      int bestId1se = IntStream
+                .range(0, orderedLambdaIndices.length)
+                .filter(i -> orderedLambdaIndices[i] == finalBestId)
+                .findFirst()
+                .orElse(orderedLambdaIndices.length - 1);
 
       while (bestId1se > 0 && _xval_deviances[orderedLambdaIndices[bestId1se - 1]] <= bestDev1se)
           --bestId1se;
       // get the index into _parms.lambda/_xval_deviances etc
-      _lambdaCVEstimate = ((GLM) cvModelBuilders[0])._model._output._submodels[bestId].lambda_value;
-      _bestCVSubmodel = bestId;
+      _lambdaCVEstimate = alphasAndLambdas[numOfSubmodels + bestId];
       bestId1se = orderedLambdaIndices[bestId1se];
-      _model._output._lambda_1se = bestId1se; // submodel ide with bestDev+one sigma
-      _model._output._selected_submodel_idx = bestId; // set best submodel id here
+      _model._output._lambda_1se = alphasAndLambdas[numOfSubmodels + bestId1se]; // submodel ide with bestDev+one sigma
+
+      // set the final selected alpha and lambda
+      _parms._alpha = new double[] {alphasAndLambdas[bestId]};
+      _parms._lambda = new double[] {alphasAndLambdas[numOfSubmodels + bestId]};
+      _model._output._selected_submodel_idx = 0; // set best submodel id here
+
 
     if (_parms._generate_scoring_history)
       generateCVScoringHistory(cvModelBuilders);
@@ -2930,9 +2896,9 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       if (_state._iter >= _parms._max_iterations)
         _job.warn("Reached maximum number of iterations " + _parms._max_iterations + "!");
       if (_parms._nfolds > 1 && !Double.isNaN(_lambdaCVEstimate))
-        _model._output.setSubmodelIdx(_model._output._best_submodel_idx = _bestCVSubmodel, _parms);  // reset best_submodel_idx to what xval has found
+        _model._output.setSubmodelIdx(_model._output._best_submodel_idx = 0, _model._parms);  // reset best_submodel_idx to what xval has found
       else
-        _model._output.pickBestModel(_parms);
+        _model._output.pickBestModel(_model._parms);
       if (_vcov != null) { // should move this up, otherwise, scoring will never use info in _vcov
         _model.setVcov(_vcov);
         _model.update(_job._key);

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -223,7 +223,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       alphaChangePoints[i + 1] = alphaChangePoints[i] + alphaSubmodels[alphaIndices[i]];
     }
 
-    double[] lambdas = new double[alphaChangePoints[alphas.length]];
+    double[] alphasAndLambdas = new double[alphaChangePoints[alphas.length]*2];
     for (int i = 0; i < cvModelBuilders.length; ++i) {
       GLM g = (GLM) cvModelBuilders[i];
       Submodel[] alignedSubmodels = new Submodel[alphaChangePoints[alphas.length]];
@@ -247,8 +247,13 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
         if (alphaIdx < 0 || g._model._output._submodels[j].alpha_value != alphas[alphaIdx])
           continue;
         alignedSubmodels[alphaChangePoints[alphaIdx] + k] = g._model._output._submodels[j];
-        assert lambdas[alphaChangePoints[alphaIdx] + k] == 0 || lambdas[alphaChangePoints[alphaIdx] + k] == g._model._output._submodels[j].lambda_value;
-        lambdas[alphaChangePoints[alphaIdx] + k++] = g._model._output._submodels[j].lambda_value;
+        assert alphasAndLambdas[alphaChangePoints[alphaIdx] + k] == 0 || (
+                alphasAndLambdas[alphaChangePoints[alphaIdx] + k] == g._model._output._submodels[j].alpha_value &&
+                        alphasAndLambdas[alphaChangePoints[alphas.length] + alphaChangePoints[alphaIdx] + k] == g._model._output._submodels[j].lambda_value
+        );
+        alphasAndLambdas[alphaChangePoints[alphaIdx] + k] = g._model._output._submodels[j].alpha_value;
+        alphasAndLambdas[alphaChangePoints[alphas.length] + alphaChangePoints[alphaIdx] + k] = g._model._output._submodels[j].lambda_value;
+        k++;
       }
       assert g._model._output._selected_submodel_idx == g._model._output._best_submodel_idx;
       assert g._model._output._selected_submodel_idx == g._model._output._best_lambda_idx;
@@ -259,7 +264,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       g._model._output._submodels = alignedSubmodels;
       g._model._output.setSubmodelIdx(g._model._output._selected_submodel_idx + nNullsUntilSelectedSubModel, _parms);
     }
-    return lambdas;
+    return alphasAndLambdas;
   }
 
   /**
@@ -274,11 +279,11 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
    */
   @Override
   public void cv_computeAndSetOptimalParameters(ModelBuilder[] cvModelBuilders) {
-    if(_parms._max_runtime_secs != 0) _parms._max_runtime_secs = 0;
-      _xval_deviances = new double[_parms._lambda.length * _parms._alpha.length];
-      _xval_sd = new double[_parms._lambda.length * _parms._alpha.length];
+      if(_parms._max_runtime_secs != 0) _parms._max_runtime_secs = 0;
       double bestTestDev = Double.POSITIVE_INFINITY;
-      double[] lambdas = alignSubModelsAcrossCVModels(cvModelBuilders);
+      double[] alphasAndLambdas = alignSubModelsAcrossCVModels(cvModelBuilders);
+      _xval_deviances = new double[alphasAndLambdas.length/2];
+      _xval_sd = new double[alphasAndLambdas.length/2];
       int lmin_max = 0;
       for (int i = 0; i < cvModelBuilders.length; ++i) {  // find the highest best_submodel_idx we need to go through
         GLM g = (GLM) cvModelBuilders[i];
@@ -287,28 +292,24 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       int lidx = 0; // index into submodel
       int bestId = 0;   // submodel indedx with best Deviance from xval
       int cnt = 0;
-      int alphaIndex = 0;
       for (; lidx < lmin_max; ++lidx) { // search through submodel with same lambda and alpha values
         double testDev = 0;
         double testDevSq = 0;
-        // Lambdas are sorted in decreasing order for same alpha values
-        if (lidx > 0 && lambdas[lidx] >= lambdas[Math.max(lidx-1, 0)]) {
-          alphaIndex++;
-        }
         for (int i = 0; i < cvModelBuilders.length; ++i) {  // run cv for each lambda value
           GLM g = (GLM) cvModelBuilders[i];
           if (g._model._output._submodels[lidx] == null) {
             double alpha = g._state.alpha();
             try {
               g._insideCVCheck = true;
-              g._state.setAlpha(_parms._alpha[alphaIndex]); // recompute the submodel using the proper alpha value
-              g._driver.computeSubmodel(lidx, lambdas[lidx], Double.NaN, Double.NaN);
+              g._state.setAlpha(alphasAndLambdas[lidx]); // recompute the submodel using the proper alpha value
+              g._driver.computeSubmodel(lidx, alphasAndLambdas[lidx + alphasAndLambdas.length/2], Double.NaN, Double.NaN);
             } finally {
               g._insideCVCheck = false;
               g._state.setAlpha(alpha);
             }
           }
-          assert lambdas[lidx] == g._model._output._submodels[lidx].lambda_value;
+          assert alphasAndLambdas[lidx] == g._model._output._submodels[lidx].alpha_value &&
+                  alphasAndLambdas[lidx + alphasAndLambdas.length/2] == g._model._output._submodels[lidx].lambda_value;
 
           testDev += g._model._output._submodels[lidx].devianceValid;
           testDevSq += g._model._output._submodels[lidx].devianceValid * g._model._output._submodels[lidx].devianceValid;

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -212,15 +212,20 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     }
   }
 
-  public GLMModel addSubmodel(Submodel sm) { // copy from checkpoint model
-    _output._submodels = ArrayUtils.append(_output._submodels,sm);
-    _output.setSubmodelIdx(_output._submodels.length-1);
+  public GLMModel addSubmodel(int idx, Submodel sm) { // copy from checkpoint model
+    if (_output._submodels != null && _output._submodels.length > idx) {
+      _output._submodels[idx] = sm;
+    } else {
+      assert _output._submodels == null || idx == _output._submodels.length;
+      _output._submodels = ArrayUtils.append(_output._submodels, sm);
+    }
+    _output.setSubmodelIdx(idx);
     return this;
   }
 
-  public GLMModel updateSubmodel(Submodel sm) {
-    assert sm.lambda_value == _output._submodels[_output._submodels.length-1].lambda_value;
-    _output._submodels[_output._submodels.length-1] = sm;
+  public GLMModel updateSubmodel(int idx, Submodel sm) {
+    assert sm.lambda_value == _output._submodels[idx].lambda_value && sm.alpha_value == _output._submodels[idx].alpha_value;
+    _output._submodels[idx] = sm;
     return this;
   }
 

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -1174,7 +1174,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     public TwoDimTable _variable_importances;
     public VarImp _varimp;  // should contain the same content as standardized coefficients
     int _lambda_array_size; // store number of lambdas to iterate over
-    public int _lambda_1se = -1; // lambda_best+sd(lambda) submodel index; applicable if running lambda search with cv
+    public double _lambda_1se = -1; // lambda_best+sd(lambda) submodel index; applicable if running lambda search with cv
     public double _lambda_min = -1; // starting lambda value when lambda search is enabled
     public double _lambda_max = -1; // minimum lambda value calculated when lambda search is enabled
     public int _selected_lambda_idx; // lambda index with best deviance
@@ -1185,8 +1185,9 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     public double lambda_best(){return _submodels.length == 0 ? -1 : _submodels[_best_submodel_idx].lambda_value;}
     public double dispersion(){ return _dispersion;}
     public double alpha_best() { return _submodels.length == 0 ? -1 : _submodels[_selected_submodel_idx].alpha_value;}
-    public double lambda_1se(){return (_lambda_1se==-1 || _submodels.length==0 || _lambda_1se>=_submodels.length) ?
-            -1 : _submodels[_lambda_1se].lambda_value;}
+    public double lambda_1se(){
+      return _lambda_1se; // (_lambda_1se==-1 || _submodels.length==0 || _lambda_1se>=_submodels.length) ? -1 : _submodels[_lambda_1se].lambda_value;
+    }
     public int bestSubmodelIndex() { return _selected_submodel_idx; }
     public double lambda_selected(){
       return _submodels[_selected_submodel_idx].lambda_value;

--- a/h2o-py/tests/testdir_algos/glm/pyunit_glm_cv_compute_and_set_optimal_parameters.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_glm_cv_compute_and_set_optimal_parameters.py
@@ -1,0 +1,33 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+
+
+def glm_alpha_lambda_arrays_last_lambda_best():
+    df = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    df["CAPSULE"] = df["CAPSULE"].asfactor()
+    glm = H2OGeneralizedLinearEstimator(family='binomial', lambda_=[0.9, 0.2, 0.8, 0.5, 0.1, 0.099, 0.098],
+                                        alpha=[0.1, 0.5, 0.2, 0.9, 0.8], nfolds=5, seed=1234)
+    glm.train(training_frame=df, y="CAPSULE")
+    assert glm._model_json["output"]["alpha_best"] == 0.1
+    assert glm._model_json["output"]["lambda_best"] == 0.098
+    assert glm._model_json["output"]["lambda_1se"] == 0.1
+
+
+def glm_alpha_lambda_arrays_inner_lambda_best():
+    df = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    df["CAPSULE"] = df["CAPSULE"].asfactor()
+    glm = H2OGeneralizedLinearEstimator(family='binomial', lambda_=[0.9, 0.2, 0.8, 0.5, 0.098, 0.1, 0.099],
+                                        alpha=[0.1, 0.5, 0.2, 0.9, 0.8], nfolds=5, seed=1234)
+    glm.train(training_frame=df, y="CAPSULE")
+    assert glm._model_json["output"]["alpha_best"] == 0.1
+    assert glm._model_json["output"]["lambda_best"] == 0.098
+    assert glm._model_json["output"]["lambda_1se"] == 0.1
+
+
+pyunit_utils.run_tests([
+    glm_alpha_lambda_arrays_last_lambda_best,
+    glm_alpha_lambda_arrays_inner_lambda_best
+])


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8620

This PR deals with 2 bugs in cv_computeAndSetOptimalParameters .

Submodels in different folds can have different alpha, and lambda parameters which is a problem since we take the parameters only from the 1st cv model and assume they are the same across the folds.

Early stopping in parameter selection in cv_computeAndSetOptimalParameters is well defined only if there is just one alpha value which is not always the case.