### PR TITLE
PUBDEV-8622: Make GLM fail when beta constraints and multinomial or ordinal family

### DIFF
--- a/h2o-algos/src/main/java/hex/ensemble/Metalearners.java
+++ b/h2o-algos/src/main/java/hex/ensemble/Metalearners.java
@@ -228,7 +228,11 @@ public class Metalearners {
             parms._score_iteration_interval = (parms._valid == null) ? 5 : -1;
 
             //specific to AUTO mode
-            parms._non_negative = true;
+            // beta_constraints/non_negative are not supported for multinomial and ordinal families
+            parms._non_negative = !(
+                    parms._family.equals(GLMParameters.Family.multinomial) ||
+                    parms._family.equals(GLMParameters.Family.ordinal)
+            );
             //parms._alpha = new double[] {0.0, 0.25, 0.5, 0.75, 1.0};
 
             // feature columns are already homogeneous (probabilities); when standardization is enabled,

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -787,7 +787,13 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       if (hasOffsetCol() && ordinal.equals(_parms._family)) 
         error("offset_column", " does not work with ordinal family right now.  Will be fixed in" +
                 " the future.");
-      
+
+      if ((_parms._family.equals(multinomial) || _parms._family.equals(ordinal)) &&
+              (_parms._beta_constraints != null || _parms._non_negative)) {
+        error(_parms._non_negative ? "non_negative" : "beta_constraints",
+                " does not work with " + _parms._family + " family.");
+      }
+
       boolean standardizeQ = _parms._HGLM?false:_parms._standardize;
       _dinfo = new DataInfo(_train.clone(), _valid, 1, _parms._use_all_factor_levels || _parms._lambda_search, standardizeQ ? DataInfo.TransformType.STANDARDIZE : DataInfo.TransformType.NONE, DataInfo.TransformType.NONE, 
               _parms.missingValuesHandling() == MissingValuesHandling.Skip, 

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -656,11 +656,11 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
         case AUTO:
           if (nclasses() == 1 & _parms._link != Link.family_default && _parms._link != Link.identity 
                   && _parms._link != Link.log && _parms._link != Link.inverse) {
-            error("_family", H2O.technote(2, "AUTO for undelying response requires the link to be family_default, identity, log or inverse."));
+            error("_family", H2O.technote(2, "AUTO for underlying response requires the link to be family_default, identity, log or inverse."));
           } else if (nclasses() == 2 & _parms._link != Link.family_default && _parms._link != Link.logit) {
-            error("_family", H2O.technote(2, "AUTO for undelying response requires the link to be family_default or logit."));
+            error("_family", H2O.technote(2, "AUTO for underlying response requires the link to be family_default or logit."));
           } else if (nclasses() > 2 & _parms._link != Link.family_default & _parms._link != Link.multinomial) {
-            error("_family", H2O.technote(2, "AUTO for undelying response requires the link to be family_default or multinomial."));
+            error("_family", H2O.technote(2, "AUTO for underlying response requires the link to be family_default or multinomial."));
           }
           break;
         case binomial:

--- a/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
@@ -1533,7 +1533,6 @@ public class StackedEnsembleTest extends TestUtil {
             GLMModel.GLMParameters glmParams =  (GLMModel.GLMParameters) stackedEnsembleParameters._metalearner_parameters;
             glmParams._generate_scoring_history = true;
             glmParams._score_iteration_interval = (glmParams._valid == null) ? 5 : -1;
-            glmParams._non_negative = true;
             glmParams._alpha = new double[] {0.5, 1.0};
             glmParams._standardize = false;
 

--- a/h2o-algos/src/test/java/hex/glm/GLMBasicTestMultinomial.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMBasicTestMultinomial.java
@@ -94,7 +94,7 @@ public class GLMBasicTestMultinomial extends TestUtil {
     try {
       Scope.enter();
       Frame df = parseTestFile("smalldata/glm_test/rollup_stat_test.csv");
-      df.replace(df.numCols()-1,df.vec("RACE").toCategoricalVec()).remove();
+      df.replace(df.numCols() - 1, df.vec("RACE").toCategoricalVec()).remove();
       Scope.track(df);
       DKV.put(df);
       GLMModel.GLMParameters params = new GLMModel.GLMParameters();
@@ -109,6 +109,9 @@ public class GLMBasicTestMultinomial extends TestUtil {
       params._train = df._key;
       GLMModel model = new GLM(params).trainModel().get();
       Scope.track_generic(model);
+    } catch (IllegalArgumentException e) {
+      // Keeping this test since it can be useful in future once beta constraints are supported with multinomial family
+      assertEquals("ERRR on field: non_negative:  does not work with multinomial family.\n", e.getMessage());
     } finally {
       Scope.exit();
     }

--- a/h2o-docs/src/product/data-science/algo-params/beta_constraints.rst
+++ b/h2o-docs/src/product/data-science/algo-params/beta_constraints.rst
@@ -41,7 +41,7 @@ If you want to supply the beta constraints for a standardized model, scale your 
 
 **Notes**:
 
-- ``beta_constraints`` is not supported for ``family="multinomial"``. 
+- ``beta_constraints`` is not supported for ``family="multinomial"`` or ``family="ordinal"``.
 - P-values cannot be computed for constrained problems.
 
 Related Parameters

--- a/h2o-docs/src/product/data-science/algo-params/non_negative.rst
+++ b/h2o-docs/src/product/data-science/algo-params/non_negative.rst
@@ -11,6 +11,10 @@ At times when working with real-world data, regression models can yield counteri
 
 To enforce the algorithm to only use positive coefficients, you are (in a sense) indicating that you know that the features are all correlated with positive outcomes. As such, this option is generally only useful if you know the predictive features are positively correlated with the outcome. In superlearning, this does hold true. But you should use caution when enabling this command, keeping in mind that your best chance for catching overfitting with some negative coefficients performing worse is when your model has unseen data that looks a little different. 
 
+**Notes**:
+
+- ``non_negative`` is not supported for ``family="multinomial"`` or ``family="ordinal"``.
+
 Related Parameters
 ~~~~~~~~~~~~~~~~~~
 

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8079_rollup_stats.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8079_rollup_stats.py
@@ -10,8 +10,13 @@ def test_rollup_stats():
     df = h2o.import_file(pyunit_utils.locate("smalldata/glm_test/rollup_stat_test.csv"))
     df["RACE"] = df["RACE"].asfactor()  # this is important
     glm = H2OGeneralizedLinearEstimator(generate_scoring_history=True, score_iteration_interval=5, non_negative=True,
-                                    alpha=[0.5, 1.0], standardize=False, nfolds=5, seed=7)
-    glm.train(y="RACE", training_frame=df)
+                                        alpha=[0.5, 1.0], standardize=False, nfolds=5, seed=7)
+    try:
+        glm.train(y="RACE", training_frame=df)
+    except (OSError, EnvironmentError) as e:
+        # Keeping this test as it might be useful once beta constraints are supported
+        # with multinomial family.
+        assert "non_negative:  does not work with multinomial family." in str(e)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8622

Beta constraints and non_negative constraints are unsupported when used with multinomial/ordinal family but the GLM only [warns](https://github.com/h2oai/h2o-3/blob/93d2d53044dacf66a03035eb4cc45d59bdead141/h2o-algos/src/main/java/hex/glm/GLM.java#L855-L864) and trains anyway leading to an unexpected result or failing halfway through the training (seems to happen only with L-BFGS solver).

This PR aims to fail quickly (in the GLM.init).