### PR TITLE
PUBDEV-8624: Data Ingest from Secured Hive using h2odriver.jar in standalone

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -412,6 +412,9 @@ final public class H2O {
     /** --ga_hadoop_ver=ga_hadoop_ver; Version string for Hadoop */
     public String ga_hadoop_ver = null;
 
+    /** -Hkey=value; additional configuration to merge into the Hadoop Configuration */
+    public final Properties hadoop_properties = new Properties();
+
     //-----------------------------------------------------------------------------------
     // Recovery
     //-----------------------------------------------------------------------------------
@@ -666,6 +669,13 @@ final public class H2O {
       }
       else if (s.matches("hdfs_skip")) {
         trgt.hdfs_skip = true;
+      }
+      else if (s.matches("H")) {
+        i = s.incrementAndCheck(i, args);
+        String key = args[i];
+        i = s.incrementAndCheck(i, args);
+        String value = args[i];
+        trgt.hadoop_properties.setProperty(key, value);
       }
       else if (s.matches("aws_credentials")) {
         i = s.incrementAndCheck(i, args);

--- a/h2o-core/src/main/java/water/init/StandaloneKerberosComponent.java
+++ b/h2o-core/src/main/java/water/init/StandaloneKerberosComponent.java
@@ -1,0 +1,47 @@
+package water.init;
+
+import water.H2O;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Interface of a component that needs to be initialized during boot of H2O running
+ * in a Standalone mode in Kerberos environment
+ */
+public interface StandaloneKerberosComponent {
+
+    /**
+     * Name of the component
+     * @return short identifier of the component
+     */
+    String name();
+
+    /**
+     * Initialization priority - components with higher priority will be initialized before
+     * components with lower priority. Third parties can use 0-999, 1000+ is reserved for internal H2O components.
+     * @return initialization priority of the component
+     */
+    int priority();
+
+    /**
+     * Initializes the component, called after Kerberos is initialized in Standalone mode
+     * 
+     * @param conf instance of Hadoop Configuration object
+     * @param args parsed H2O arguments
+     * @return flag indicating if component was successfully initialized 
+     */
+    boolean initComponent(Object conf, H2O.OptArgs args);
+
+    static List<StandaloneKerberosComponent> loadAll() {
+        ServiceLoader<StandaloneKerberosComponent> componentLoader = ServiceLoader.load(StandaloneKerberosComponent.class);
+        return StreamSupport
+                .stream(componentLoader.spliterator(), false)
+                .sorted(Comparator.comparingInt(StandaloneKerberosComponent::priority).reversed())
+                .collect(Collectors.toList());
+    }
+
+}

--- a/h2o-extensions/krbstandalone/src/test/java/hex/security/KerberosExtensionTest.java
+++ b/h2o-extensions/krbstandalone/src/test/java/hex/security/KerberosExtensionTest.java
@@ -2,6 +2,7 @@ package hex.security;
 
 import org.junit.Test;
 import water.H2O;
+import water.init.StandaloneKerberosComponent;
 
 import static org.junit.Assert.*;
 
@@ -29,6 +30,55 @@ public class KerberosExtensionTest {
         };
         KerberosExtension ext = new KerberosExtension(standaloneArgs);
         assertTrue(ext.isEnabled());
+    }
+
+    @Test
+    public void testInitComponents() {
+        assertFalse(TestComponent1._init_called);
+        assertFalse(TestComponent2._init_called);
+        KerberosExtension.initComponents(null, H2O.ARGS);
+        assertTrue(TestComponent1._init_called);
+        assertTrue(TestComponent2._init_called);
+    }
+
+    public static class TestComponent1 implements StandaloneKerberosComponent {
+        static boolean _init_called;
+
+        @Override
+        public String name() {
+            return "Component1";
+        }
+
+        @Override
+        public int priority() {
+            return 2_000;
+        }
+
+        @Override
+        public boolean initComponent(Object conf, H2O.OptArgs args) {
+            _init_called = true;
+            return false;
+        }
+    }
+
+    public static class TestComponent2 implements StandaloneKerberosComponent {
+        static boolean _init_called;
+
+        @Override
+        public String name() {
+            return "Component2";
+        }
+
+        @Override
+        public int priority() {
+            return 10_000;
+        }
+
+        @Override
+        public boolean initComponent(Object conf, H2O.OptArgs args) {
+            _init_called = true;
+            return true;
+        }
     }
 
 }

--- a/h2o-extensions/krbstandalone/src/test/resources/META-INF/services/water.init.StandaloneKerberosComponent
+++ b/h2o-extensions/krbstandalone/src/test/resources/META-INF/services/water.init.StandaloneKerberosComponent
@@ -1,0 +1,2 @@
+hex.security.KerberosExtensionTest$TestComponent1
+hex.security.KerberosExtensionTest$TestComponent2

--- a/h2o-hive/src/main/java/water/hive/HiveComponent.java
+++ b/h2o-hive/src/main/java/water/hive/HiveComponent.java
@@ -1,0 +1,24 @@
+package water.hive;
+
+import org.apache.hadoop.conf.Configuration;
+import water.H2O;
+import water.init.StandaloneKerberosComponent;
+
+public class HiveComponent implements StandaloneKerberosComponent {
+
+    @Override
+    public String name() {
+        return "SecuredHive";
+    }
+
+    @Override
+    public int priority() {
+        return 1000;
+    }
+
+    @Override
+    public boolean initComponent(Object conf, H2O.OptArgs args) {
+        return DelegationTokenRefresher.startRefresher((Configuration) conf, args);
+    }
+
+}

--- a/h2o-hive/src/main/resources/META-INF/services/water.init.StandaloneKerberosComponent
+++ b/h2o-hive/src/main/resources/META-INF/services/water.init.StandaloneKerberosComponent
@@ -1,0 +1,1 @@
+water.hive.HiveComponent

--- a/h2o-hive/tests/python/hive-direct-tests.txt
+++ b/h2o-hive/tests/python/hive-direct-tests.txt
@@ -1,0 +1,2 @@
+pyunit_hive_import_varchar_direct.py
+pyunit_hive_import_direct.py

--- a/h2o-hive/tests/python/pyunit_hive_import_direct.py
+++ b/h2o-hive/tests/python/pyunit_hive_import_direct.py
@@ -9,11 +9,6 @@ from h2o.frame import H2OFrame
 from tests import pyunit_utils
 
 def hive_import():
-    connection_url = "jdbc:hive2://localhost:10000/default"
-    krb_enabled = os.getenv('KRB_ENABLED', 'false').lower() == 'true'
-    if krb_enabled:
-        connection_url += ";auth=delegationToken"
-
     # import from empty table should fail
     try:
         h2o.import_hive_table("default", "test_table_empty")
@@ -34,12 +29,6 @@ def hive_import():
     assert test_table_normal.nrow==3, "test_table_normal number of rows is incorrect. h2o.import_hive_table() is not working."
     assert test_table_normal.ncol==5, "test_table_normal number of columns is incorrect. h2o.import_hive_table() is not working."
 
-    # import from regular table JDBC
-    test_table_normal = h2o.import_hive_table(connection_url, "test_table_normal")
-    assert_is_type(test_table_normal, H2OFrame)
-    assert test_table_normal.nrow==3, "test_table_normal JDBC number of rows is incorrect. h2o.import_hive_table() is not working."
-    assert test_table_normal.ncol==5, "test_table_normal JDBC number of columns is incorrect. h2o.import_hive_table() is not working."
-
     # import from partitioned table with multi format should fail
     try:
         h2o.import_hive_table("default", "test_table_multi_format")
@@ -53,35 +42,17 @@ def hive_import():
     assert test_table_multi_format.nrow==3, "test_table_multi_format number of rows is incorrect. h2o.import_hive_table() is not working."
     assert test_table_multi_format.ncol==5, "test_table_multi_format number of columns is incorrect. h2o.import_hive_table() is not working."
 
-    # import from partitioned table with multi format enabled JDBC
-    test_table_multi_format = h2o.import_hive_table(connection_url, "test_table_multi_format", allow_multi_format=True)
-    assert_is_type(test_table_multi_format, H2OFrame)
-    assert test_table_multi_format.nrow==3, "test_table_multi_format JDBC number of rows is incorrect. h2o.import_hive_table() is not working."
-    assert test_table_multi_format.ncol==5, "test_table_multi_format JDBC number of columns is incorrect. h2o.import_hive_table() is not working."
-
     # import from partitioned table with single format and partition filter
     test_table_multi_key = h2o.import_hive_table("default", "test_table_multi_key", partitions=[["2017", "2"]])
     assert_is_type(test_table_multi_key, H2OFrame)
     assert test_table_multi_key.nrow==3, "test_table_multi_key number of rows is incorrect. h2o.import_hive_table() is not working."
     assert test_table_multi_key.ncol==5, "test_table_multi_key number of columns is incorrect. h2o.import_hive_table() is not working."
 
-    # import from partitioned table with single format and partition filter JDBC
-    test_table_multi_key = h2o.import_hive_table(connection_url, "test_table_multi_key", partitions=[["2017", "2"]])
-    assert_is_type(test_table_multi_key, H2OFrame)
-    assert test_table_multi_key.nrow==3, "test_table_multi_key JDBC number of rows is incorrect. h2o.import_hive_table() is not working."
-    assert test_table_multi_key.ncol==5, "test_table_multi_key JDBC number of columns is incorrect. h2o.import_hive_table() is not working."
-
     # import from partitioned table with single format and special characters in partition names
     test_table_escaping = h2o.import_hive_table("default", "test_table_escaping")
     assert_is_type(test_table_multi_key, H2OFrame)
     assert test_table_escaping.nrow==8, "test_table_escaping number of rows is incorrect. h2o.import_hive_table() is not working."
     assert test_table_escaping.ncol==2, "test_table_escaping number of columns is incorrect. h2o.import_hive_table() is not working."
-
-    # import from partitioned table with single format and special characters in partition names JDBC
-    test_table_escaping = h2o.import_hive_table(connection_url, "test_table_escaping")
-    assert_is_type(test_table_escaping, H2OFrame)
-    assert test_table_escaping.nrow==8, "test_table_escaping JDBC number of rows is incorrect. h2o.import_hive_table() is not working."
-    assert test_table_escaping.ncol==2, "test_table_escaping JDBC number of columns is incorrect. h2o.import_hive_table() is not working."
 
 
 if __name__ == "__main__":

--- a/h2o-hive/tests/python/pyunit_hive_import_jdbc.py
+++ b/h2o-hive/tests/python/pyunit_hive_import_jdbc.py
@@ -1,0 +1,45 @@
+#! /usr/env/python
+
+import sys
+import os
+import h2o
+sys.path.insert(1, os.path.join("..", "..", "..", "h2o-py"))
+from h2o.utils.typechecks import (assert_is_type)
+from h2o.frame import H2OFrame
+from tests import pyunit_utils
+
+def hive_import():
+    connection_url = "jdbc:hive2://localhost:10000/default"
+    krb_enabled = os.getenv('KRB_ENABLED', 'false').lower() == 'true'
+    if krb_enabled:
+        connection_url += ";auth=delegationToken"
+
+    # import from regular table JDBC
+    test_table_normal = h2o.import_hive_table(connection_url, "test_table_normal")
+    assert_is_type(test_table_normal, H2OFrame)
+    assert test_table_normal.nrow==3, "test_table_normal JDBC number of rows is incorrect. h2o.import_hive_table() is not working."
+    assert test_table_normal.ncol==5, "test_table_normal JDBC number of columns is incorrect. h2o.import_hive_table() is not working."
+
+    # import from partitioned table with multi format enabled JDBC
+    test_table_multi_format = h2o.import_hive_table(connection_url, "test_table_multi_format", allow_multi_format=True)
+    assert_is_type(test_table_multi_format, H2OFrame)
+    assert test_table_multi_format.nrow==3, "test_table_multi_format JDBC number of rows is incorrect. h2o.import_hive_table() is not working."
+    assert test_table_multi_format.ncol==5, "test_table_multi_format JDBC number of columns is incorrect. h2o.import_hive_table() is not working."
+
+    # import from partitioned table with single format and partition filter JDBC
+    test_table_multi_key = h2o.import_hive_table(connection_url, "test_table_multi_key", partitions=[["2017", "2"]])
+    assert_is_type(test_table_multi_key, H2OFrame)
+    assert test_table_multi_key.nrow==3, "test_table_multi_key JDBC number of rows is incorrect. h2o.import_hive_table() is not working."
+    assert test_table_multi_key.ncol==5, "test_table_multi_key JDBC number of columns is incorrect. h2o.import_hive_table() is not working."
+
+    # import from partitioned table with single format and special characters in partition names JDBC
+    test_table_escaping = h2o.import_hive_table(connection_url, "test_table_escaping")
+    assert_is_type(test_table_escaping, H2OFrame)
+    assert test_table_escaping.nrow==8, "test_table_escaping JDBC number of rows is incorrect. h2o.import_hive_table() is not working."
+    assert test_table_escaping.ncol==2, "test_table_escaping JDBC number of columns is incorrect. h2o.import_hive_table() is not working."
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(hive_import)
+else:
+    hive_import()

--- a/h2o-hive/tests/python/pyunit_hive_import_varchar_direct.py
+++ b/h2o-hive/tests/python/pyunit_hive_import_varchar_direct.py
@@ -9,18 +9,8 @@ from h2o.frame import H2OFrame
 from tests import pyunit_utils
 
 def hive_import_varchar():
-    connection_url = "jdbc:hive2://localhost:10000/default"
-    krb_enabled = os.getenv('KRB_ENABLED', 'false').lower() == 'true'
-    if krb_enabled:
-        connection_url += ";auth=delegationToken"
-
     # import from regular table that contains VARCHAR(x) specification
     test_table_normal = h2o.import_hive_table("default", "AirlinesTest")
-    assert_is_type(test_table_normal, H2OFrame)
-    assert test_table_normal.nrow > 0
-
-    # import from regular table JDBC that contains VARCHAR(x) specification
-    test_table_normal = h2o.import_hive_table(connection_url, "AirlinesTest")
     assert_is_type(test_table_normal, H2OFrame)
     assert test_table_normal.nrow > 0
 

--- a/h2o-hive/tests/python/pyunit_hive_import_varchar_jdbc.py
+++ b/h2o-hive/tests/python/pyunit_hive_import_varchar_jdbc.py
@@ -1,0 +1,26 @@
+#! /usr/env/python
+
+import sys
+import os
+import h2o
+sys.path.insert(1, os.path.join("..", "..", "..", "h2o-py"))
+from h2o.utils.typechecks import (assert_is_type)
+from h2o.frame import H2OFrame
+from tests import pyunit_utils
+
+def hive_import_varchar():
+    connection_url = "jdbc:hive2://localhost:10000/default"
+    krb_enabled = os.getenv('KRB_ENABLED', 'false').lower() == 'true'
+    if krb_enabled:
+        connection_url += ";auth=delegationToken"
+
+    # import from regular table JDBC that contains VARCHAR(x) specification
+    test_table_normal = h2o.import_hive_table(connection_url, "AirlinesTest")
+    assert_is_type(test_table_normal, H2OFrame)
+    assert test_table_normal.nrow > 0
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(hive_import_varchar)
+else:
+    hive_import_varchar()

--- a/h2o-persist-hdfs/src/main/java/water/persist/PersistHdfs.java
+++ b/h2o-persist-hdfs/src/main/java/water/persist/PersistHdfs.java
@@ -11,6 +11,7 @@ import java.util.concurrent.Callable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.hadoop.hdfs.util.ByteArrayManager;
 import water.*;
 import water.api.HDFSIOException;
 import water.fvec.HDFSFileVec;
@@ -73,7 +74,16 @@ public final class PersistHdfs extends Persist {
         Log.debug("Cannot find HADOOP_CONF_DIR or YARN_CONF_DIR - default HDFS properties are NOT loaded!");
       }
     }
+    // add manually passed configuration
+    configureFromProperties(conf, H2O.ARGS.hadoop_properties);
     CONF = conf;
+  }
+
+  static void configureFromProperties(Configuration conf, Properties props) {
+    for (Object propertyKey : Collections.list(props.keys())) {
+      String propertyValue = props.getProperty((String) propertyKey);
+      conf.set((String) propertyKey, propertyValue);
+    }
   }
 
   // Loading HDFS files

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -470,6 +470,8 @@ test-hadoop-common-smoke-hive-basic:
 	echo "Hive version 3 installed, not running Hive tests."
 test-hadoop-common-smoke-hive-spnego:
 	echo "Hive version 3 installed, not running Hive tests."
+test-hadoop-common-smoke-hive-jdbc-spnego:
+	echo "Hive version 3 installed, not running Hive tests."
 else
 test-hadoop-common-smoke-hive-basic:
 	cd h2o-hive/tests/python && ../../../scripts/run.py --wipeall --usecloud "https://$$CLOUD_IP:$$CLOUD_PORT" --ldap.username $$LDAP_USERNAME --ldap.password $$LDAP_PASSWORD
@@ -477,6 +479,8 @@ test-hadoop-common-smoke-hive-basic:
 test-hadoop-common-smoke-hive-spnego:
 	cd h2o-hive/tests/python && ../../../scripts/run.py --wipeall --usecloud "https://$$CLOUD_IP:$$CLOUD_PORT" --kerb.principal $$KERB_PRINCIPAL
 	cd h2o-hive/tests/R && ../../../scripts/run.py --wipeall --usecloud "https://$$CLOUD_IP:$$CLOUD_PORT" --kerb.principal $$KERB_PRINCIPAL
+test-hadoop-common-smoke-hive-jdbc-spnego:
+	cd h2o-hive/tests/python && ../../../scripts/run.py --wipeall --usecloud "https://$$CLOUD_IP:$$CLOUD_PORT" --kerb.principal $$KERB_PRINCIPAL --excludelist hive-direct-tests.txt
 endif
 
 test-hadoop-common-smoke-basic:
@@ -499,12 +503,16 @@ test-kerberos-common-spnego:
 test-kerberos-hadoop-2-standalone: test-kerberos-common-spnego
 	cd h2o-hadoop-2/tests/python && ../../../scripts/run.py --wipeall --usecloud "https://$$CLOUD_IP:$$CLOUD_PORT" --kerb.principal $$KERB_PRINCIPAL
 
+test-kerberos-hadoop-2-standalone-driver: test-kerberos-hadoop-2-standalone test-hadoop-common-smoke-hive-jdbc-spnego
+
 test-kerberos-hadoop-2-hdp: test-hadoop-2-smoke-standalone test-hadoop-common-smoke-hive-basic
 
 test-kerberos-hadoop-2-spnego: test-kerberos-hadoop-2-standalone test-hadoop-common-smoke-hive-spnego
 
 test-kerberos-hadoop-3-standalone: test-kerberos-common-spnego
 	cd h2o-hadoop-3/tests/python && ../../../scripts/run.py --wipeall --usecloud "https://$$CLOUD_IP:$$CLOUD_PORT" --kerb.principal $$KERB_PRINCIPAL
+
+test-kerberos-hadoop-3-standalone-driver: test-kerberos-hadoop-3-standalone test-hadoop-common-smoke-hive-jdbc-spnego
 
 test-kerberos-hadoop-3-hdp: test-hadoop-3-smoke-standalone test-hadoop-common-smoke-hive-basic
 

--- a/scripts/jenkins/groovy/hadoopStage.groovy
+++ b/scripts/jenkins/groovy/hadoopStage.groovy
@@ -96,8 +96,9 @@ private String getMakeTargetSuffix(final stageConfig) {
             return "-spnego"
         case H2O_HADOOP_STARTUP_MODE_STANDALONE:
         case H2O_HADOOP_STARTUP_MODE_STANDALONE_KEYTAB:
-        case H2O_HADOOP_STARTUP_MODE_STANDALONE_DRIVER_KEYTAB:
             return "-standalone"
+        case H2O_HADOOP_STARTUP_MODE_STANDALONE_DRIVER_KEYTAB:
+            return "-standalone-driver"
         default:
             error("Startup mode ${stageConfig.customData.mode} for H2O with Hadoop is not supported by the makefile (cannot make Makefile target)")
     }


### PR DESCRIPTION
This change enables to use Hadoop `h2odriver.jar` to import data from Hive in Standalone deployment (= not running Hadoop).

The support is enabled using JDBC as a metadata source. Direct metadata source (=HiveServer) is not supported.

Changes made to test infrastructure:
- split tests that use both JDBC and direct ingest into 2 tests (use the suffix `_direct`/`_jdbc`)
- extend the existing "driver keytab" stage to also run Hive tests that use JDBC (direct tests are excluded)

General improvements:
- added a command-line option `-H` that allows setting Hadoop Configuration property from the command line
- introduced interface StandaloneKerberosComponent - for initialization of any component that depends on Kerberos running in Standalone mode, currently only used for Hive - in subsequent PRs - the HDFS component should be refactored to follow the same pattern

Minimal example:

```
java -cp hive-jdbc-fat.jar:h2o.jar water.H2OApp -principal jenkins@H2O.AI -keytab /tmp/jenkins.keytab \\
        -H h2o.hive.principal hive/localhost@H2O.AI -H h2o.hive.jdbc.host localhost:10000
```