### PR TITLE
PUBDEV-8603: Added interactions note to MOJO docs

### DIFF
--- a/h2o-docs/src/product/save-and-load-model.rst
+++ b/h2o-docs/src/product/save-and-load-model.rst
@@ -167,6 +167,8 @@ Saving and Importing MOJOs
 
 Importing a MOJO can be done from Python, R, and Flow. H2O imports the model and embraces it for the purpose of scoring. Information output about the model may be limited.
 
+**Note**: Your model will not produce MOJOs if you build it using ``interactions``.
+
 Saving and Importing in R or Python
 '''''''''''''''''''''''''''''''''''
 


### PR DESCRIPTION
For: [PUBDEV-8603](https://h2oai.atlassian.net/browse/PUBDEV-8603)

Added a note that models will not produce MOJOs if they are built using `interactions`. Please let me know if anything needs changed!