### PR TITLE
Buildscript: Publish k8s image with steam assembly

### DIFF
--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -585,26 +585,20 @@ check-leaks:
 		exit 1; \
 	fi
 
-h2o-k8s-docker-build:
-	 cp LICENSE build/LICENSE
-	 docker build --build-arg H2O_VERSION=$(DOCKER_IMAGE_TAG) -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) -f docker/public/Dockerfile-h2o-release build/
-	 rm build/LICENSE
+h2o-k8s-docker-copy-resources:
+	mkdir -p h2o-assemblies/$(H2O_ASSEMBLY)/build/tmp_docker/
+	cp h2o-assemblies/$(H2O_ASSEMBLY)/build/libs/$(H2O_ASSEMBLY).jar h2o-assemblies/$(H2O_ASSEMBLY)/build/tmp_docker/h2o.jar
+	cp LICENSE h2o-assemblies/$(H2O_ASSEMBLY)/build/tmp_docker/
+
+h2o-k8s-docker-build: h2o-k8s-docker-copy-resources
+	docker build --build-arg H2O_VERSION=$(DOCKER_IMAGE_TAG) -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) -f docker/public/Dockerfile-h2o-release h2o-assemblies/$(H2O_ASSEMBLY)/build/tmp_docker/
+
+h2o-k8s-docker-build-latest: h2o-k8s-docker-copy-resources
+	docker build --build-arg H2O_VERSION=$(DOCKER_IMAGE_TAG) -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_LATEST_TAG) -f docker/public/Dockerfile-h2o-release h2o-assemblies/$(H2O_ASSEMBLY)/build/tmp_docker/
 
 h2o-k8s-docker-push:
 	docker login -u $(DOCKERHUB_USERNAME) -p $(DOCKERHUB_PASSWORD)
 	docker push $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)
-	
-h2o-k8s-docker-push-redhat:
-	echo ${H2O_RED_HAT_REGISTRY_KEY} | docker login -u unused scan.connect.redhat.com --password-stdin
-	docker tag $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) scan.connect.redhat.com/$(H2O_RED_HAT_PID)/h2oai/h2o:$(DOCKER_IMAGE_TAG)
-	docker push scan.connect.redhat.com/$(H2O_RED_HAT_PID)/h2oai/h2o:$(DOCKER_IMAGE_TAG)
-	$(eval DIGEST := $(shell docker images --no-trunc --quiet scan.connect.redhat.com/$(H2O_RED_HAT_PID)/h2oai/h2o:$(DOCKER_IMAGE_TAG)))
-	python scripts/jenkins/red_hat/red_hat_docker_certification.py --api_key $(H2O_RED_HAT_APIKEY) --pid $(H2O_RED_HAT_PID) --tag $(DOCKER_IMAGE_TAG) $(DIGEST)
-	
-h2o-k8s-docker-build-latest:
-	cp LICENSE build/LICENSE
-	docker build --build-arg H2O_VERSION=$(DOCKER_IMAGE_TAG) -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_LATEST_TAG) -f docker/public/Dockerfile-h2o-release build/
-	rm build/LICENSE
 
 h2o-k8s-docker-push-latest: h2o-k8s-docker-push
 	docker push $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_LATEST_TAG)

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
@@ -533,67 +533,87 @@ EOF
                         }
                     }
     
-                    def BUILD_H2O_DOCKER_STAGE_NAME = 'Build H2O Docker container'
-                    if (params.BUILD_H2O_DOCKER) {
-                        stage(BUILD_H2O_DOCKER_STAGE_NAME) {
-                            try {
-                                pipelineContext.getBuildSummary().addStageSummary(this, BUILD_H2O_DOCKER_STAGE_NAME, env.BUILD_NUMBER_DIR)
-                                pipelineContext.getBuildSummary().setStageDetails(this, BUILD_H2O_DOCKER_STAGE_NAME, env.NODE_NAME, env.WORKSPACE)
-                                withCredentials([
-                                      usernamePassword(credentialsId: 'dockerhub', passwordVariable: 'DOCKERHUB_PASSWORD', usernameVariable: 'DOCKERHUB_USERNAME'),
-                                      string(credentialsId: 'H2O_RED_HAT_REGISTRY_KEY', variable: 'H2O_RED_HAT_REGISTRY_KEY'),
-                                      string(credentialsId: 'H2O_RED_HAT_PID', variable: 'H2O_RED_HAT_PID'),
-                                      string(credentialsId: 'H2O_RED_HAT_APIKEY', variable: 'H2O_RED_HAT_APIKEY')
-                                      ]) {
-                                    env["H2O_ASSEMBLY"] = "main"
-                                    imageType = "open-source"
-                                    if (params.TEST_RELEASE) {
-                                        env["DOCKER_IMAGE_NAME"] = "opsh2oai/h2o-${imageType}-k8s-test"
-                                        // Test release goes to opsh2oai namespace
-                                        env["DOCKER_IMAGE_LATEST_TAG"] = "latest"
-                                        // the most recent test build is always latest
-                                        env["DOCKER_IMAGE_TAG"] = env["BRANCH_NAME"] + "-" + currentBuild.number
+    /*
+                        if (params.BUILD_CONDA) {
     
-                                        sh """
-                                          cd ${env.BUILD_NUMBER_DIR}
-                                          make -f scripts/jenkins/Makefile.jenkins h2o-k8s-docker-build-latest h2o-k8s-docker-push-latest
-                                        """
-                                    } else {
-                                        env["DOCKER_IMAGE_NAME"] = "h2oai/h2o-${imageType}-k8s"
-                                        // Normal releases go to h2oai/ namespace
-                                        if (env.NIGHTLY_BUILD) {
-                                            // If the build is not a test build and is nightly, then re-write the latest nightly
-                                            env["DOCKER_IMAGE_TAG"] = "nightly"
+                            final def condaS3Dir = "${env.S3_ROOT}/${env.BRANCH_NAME}/${currentBuild.number}/Python/Conda"
+                            final def pyVersions = pipelineContext.getBuildConfig().PYTHON_VERSIONS.findAll { Double.parseDouble(it) >= 3.6 }
+    
+                            // build for all Python versions
+                            for (pyVersion in pyVersions) {
+                                def uploadToCondaStageName = "Build Py${pyVersion} Conda Packages"
+                                stage(uploadToCondaStageName) {
+    
+*/
+    
+    
+                    if (params.BUILD_H2O_DOCKER) {
+                        def assemblies = [
+                            main: "open-source",
+                            steam: "steam"
+                        ]
+                        assemblies.each { assemblyName, imageType ->
+                            def BUILD_H2O_DOCKER_STAGE_NAME = "Build H2O Docker container (${imageType})")
+                            stage(BUILD_H2O_DOCKER_STAGE_NAME) {
+                                try {
+                                    pipelineContext.getBuildSummary().addStageSummary(this, BUILD_H2O_DOCKER_STAGE_NAME, env.BUILD_NUMBER_DIR)
+                                    pipelineContext.getBuildSummary().setStageDetails(this, BUILD_H2O_DOCKER_STAGE_NAME, env.NODE_NAME, env.WORKSPACE)
+                                    withCredentials([
+                                          usernamePassword(credentialsId: 'dockerhub', passwordVariable: 'DOCKERHUB_PASSWORD', usernameVariable: 'DOCKERHUB_USERNAME'),
+                                          string(credentialsId: 'H2O_RED_HAT_REGISTRY_KEY', variable: 'H2O_RED_HAT_REGISTRY_KEY'),
+                                          string(credentialsId: 'H2O_RED_HAT_PID', variable: 'H2O_RED_HAT_PID'),
+                                          string(credentialsId: 'H2O_RED_HAT_APIKEY', variable: 'H2O_RED_HAT_APIKEY')
+                                          ]) {
+                                        env["H2O_ASSEMBLY"] = "main"
+                                        imageType = "open-source"
+                                        if (params.TEST_RELEASE) {
+                                            env["DOCKER_IMAGE_NAME"] = "opsh2oai/h2o-${imageType}-k8s-test"
+                                            // Test release goes to opsh2oai namespace
+                                            env["DOCKER_IMAGE_LATEST_TAG"] = "latest"
+                                            // the most recent test build is always latest
+                                            env["DOCKER_IMAGE_TAG"] = env["BRANCH_NAME"] + "-" + currentBuild.number
+        
                                             sh """
                                               cd ${env.BUILD_NUMBER_DIR}
-                                              make -f scripts/jenkins/Makefile.jenkins h2o-k8s-docker-build h2o-k8s-docker-push
+                                              make -f scripts/jenkins/Makefile.jenkins h2o-k8s-docker-build-latest h2o-k8s-docker-push-latest
                                             """
                                         } else {
-                                            env["DOCKER_IMAGE_TAG"] = env["PROJECT_VERSION"]
-                                            if (params.UPDATE_LATEST) {
-                                                // If the build is not a test build and is an ordinary release, update the version tag.
-                                                // The "latest" tag means stable. If UPDATE_LATEST is set to true, also update the latest docker tag.
-                                                env["DOCKER_IMAGE_LATEST_TAG"] = "latest"
-                                                sh """
-                                                  cd ${env.BUILD_NUMBER_DIR}
-                                                  make -f scripts/jenkins/Makefile.jenkins h2o-k8s-docker-build-latest h2o-k8s-docker-push-latest
-                                                """
-                                            } else {
-                                                // If the build is not a test build and is an ordinary release, update the latest tag.
-                                                // The "latest" tag means stable. If UPDATE_LATEST is set to false do not update the latest tag and push only the version tag.
-                                                // Push to Red Hat either way
+                                            env["DOCKER_IMAGE_NAME"] = "h2oai/h2o-${imageType}-k8s"
+                                            // Normal releases go to h2oai/ namespace
+                                            if (env.NIGHTLY_BUILD) {
+                                                // If the build is not a test build and is nightly, then re-write the latest nightly
+                                                env["DOCKER_IMAGE_TAG"] = "nightly"
                                                 sh """
                                                   cd ${env.BUILD_NUMBER_DIR}
                                                   make -f scripts/jenkins/Makefile.jenkins h2o-k8s-docker-build h2o-k8s-docker-push
                                                 """
+                                            } else {
+                                                env["DOCKER_IMAGE_TAG"] = env["PROJECT_VERSION"]
+                                                if (params.UPDATE_LATEST) {
+                                                    // If the build is not a test build and is an ordinary release, update the version tag.
+                                                    // The "latest" tag means stable. If UPDATE_LATEST is set to true, also update the latest docker tag.
+                                                    env["DOCKER_IMAGE_LATEST_TAG"] = "latest"
+                                                    sh """
+                                                      cd ${env.BUILD_NUMBER_DIR}
+                                                      make -f scripts/jenkins/Makefile.jenkins h2o-k8s-docker-build-latest h2o-k8s-docker-push-latest
+                                                    """
+                                                } else {
+                                                    // If the build is not a test build and is an ordinary release, update the latest tag.
+                                                    // The "latest" tag means stable. If UPDATE_LATEST is set to false do not update the latest tag and push only the version tag.
+                                                    // Push to Red Hat either way
+                                                    sh """
+                                                      cd ${env.BUILD_NUMBER_DIR}
+                                                      make -f scripts/jenkins/Makefile.jenkins h2o-k8s-docker-build h2o-k8s-docker-push
+                                                    """
+                                                }
                                             }
                                         }
                                     }
+                                    pipelineContext.getBuildSummary().markStageSuccessful(this, BUILD_H2O_DOCKER_STAGE_NAME)
+                                } catch (Exception e) {
+                                    pipelineContext.getBuildSummary().markStageFailed(this, BUILD_H2O_DOCKER_STAGE_NAME)
+                                    e.printStackTrace()
                                 }
-                                pipelineContext.getBuildSummary().markStageSuccessful(this, BUILD_H2O_DOCKER_STAGE_NAME)
-                            } catch (Exception e) {
-                                pipelineContext.getBuildSummary().markStageFailed(this, BUILD_H2O_DOCKER_STAGE_NAME)
-                                e.printStackTrace()
                             }
                         }
                     }

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
@@ -545,8 +545,10 @@ EOF
                                       string(credentialsId: 'H2O_RED_HAT_PID', variable: 'H2O_RED_HAT_PID'),
                                       string(credentialsId: 'H2O_RED_HAT_APIKEY', variable: 'H2O_RED_HAT_APIKEY')
                                       ]) {
+                                    env["H2O_ASSEMBLY"] = "main"
+                                    imageType = "open-source"
                                     if (params.TEST_RELEASE) {
-                                        env["DOCKER_IMAGE_NAME"] = "opsh2oai/h2o-open-source-k8s-test"
+                                        env["DOCKER_IMAGE_NAME"] = "opsh2oai/h2o-${imageType}-k8s-test"
                                         // Test release goes to opsh2oai namespace
                                         env["DOCKER_IMAGE_LATEST_TAG"] = "latest"
                                         // the most recent test build is always latest
@@ -557,7 +559,7 @@ EOF
                                           make -f scripts/jenkins/Makefile.jenkins h2o-k8s-docker-build-latest h2o-k8s-docker-push-latest
                                         """
                                     } else {
-                                        env["DOCKER_IMAGE_NAME"] = "h2oai/h2o-open-source-k8s"
+                                        env["DOCKER_IMAGE_NAME"] = "h2oai/h2o-${imageType}-k8s"
                                         // Normal releases go to h2oai/ namespace
                                         if (env.NIGHTLY_BUILD) {
                                             // If the build is not a test build and is nightly, then re-write the latest nightly


### PR DESCRIPTION
- Refactor release scripts to allow other types of assemblies
- Add docker image for Steam assembly
