### PR TITLE
fix: don't specify linetype for partial dependence line twice [nocheck]

### DIFF
--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -1408,9 +1408,8 @@ handle_ice <- function(model, newdata, column, target, centered, show_logodds, s
                                    },
                                    data = pdp, color = "black"
     )
-    pdp_dashed <- ggplot2::scale_linetype_manual(values = c("Partial Dependence" = "dashed"))
 
-    q <- q + pdp_part + pdp_dashed
+    q <- q + pdp_part
   }
   q <- q + shape_legend_manual + shape_legend_manual2
   

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -1348,12 +1348,12 @@ handle_ice <- function(model, newdata, column, target, centered, show_logodds, s
     } else {
       sprintf(" with Target = \"%s\"", target)
     },
-    model@model_id,
-    caption = sprintf(" *Note that response values out of [ \"%s\",  \"%s\"] are not displayed.",
-                      min(y_range),
-                      max(y_range)
-    )
-  ))
+    model@model_id),
+                             caption = sprintf(" *Note that response values out of [ \"%s\",  \"%s\"] are not displayed.",
+                                               min(y_range),
+                                               max(y_range)
+                             )
+  )
   # make the histogram closer to the axis. (0.05 is the default value)
   histogram_alignment <- ggplot2::scale_y_continuous(expand = ggplot2::expansion(mult = c(0, 0.05)))
   theme_part <- ggplot2::theme_bw()


### PR DESCRIPTION
this fixes following warning in R:
```
Scale for 'linetype' is already present. Adding another scale for 'linetype', which will replace the existing scale.
Warning in sprintf("Individual Conditional Expectations on \"%s\"%s\nfor Model: \"%s\"",  :
  one argument not used by format 'Individual Conditional Expectations on "%s"%s
```

