### PR TITLE
PUBDEV-8643: Add more detailed exception when we suspect the error is caused by RCurl

### DIFF
--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -511,8 +511,21 @@
                    parms = parms, method = method, fileUploadInfo = fileUploadInfo, parms_as_payload=parms_as_payload, ...)
 
   if (rv$curlError) {
-
-    stop(sprintf("Unexpected CURL error: %s", rv$curlErrorMessage))
+    errorMessage <- rv$curlErrorMessage
+    if (!use.package("curl", version = "4.3.0", use = !getOption("prefer_RCurl", FALSE))){
+      curlVersion <- as.numeric(strsplit(RCurl::curlVersion()$version, ".", fixed = TRUE)[[1]])
+      # curl 7.68.0 introduces socketpair, RCurl does not always release the sockets which leads to errors
+      if (curlVersion[[1]] >= 7 && curlVersion[[2]] >= 68) {
+        errorMessage <- paste(
+          errorMessage,
+          "\nThis can be caused by issues with some versions of curl library together with RCurl package.",
+          "Installing R package `curl` version 4.3.0 and above could help.",
+          "Otherwise, using curl system library versions below 7.68.0 or compiled with --disable-socketpair could help,",
+          "in case you cannot use curl R package."
+        )
+      }
+    }
+    stop(sprintf("Unexpected CURL error: %s", errorMessage))
   } else if (rv$httpStatusCode != 200) {
     cat("\n")
     cat(sprintf("ERROR: Unexpected HTTP Status code: %d %s (url = %s)\n", rv$httpStatusCode, rv$httpStatusMessage, rv$url))


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8643

To test this, you can use any version of curl above 7.67.0 and set `options(prefer_RCurl=TRUE)` and then run explain tests (`h2o-r/tests/testdir_misc/runit_explain.R`). It fails during `explanation_test_single_model_multinomial_classification` which is roughly 15 mins after the test is started on my machine.

Result looks like this:

```
Error in .h2o.doSafeREST(h2oRestApiVersion = h2oRestApiVersion, urlSuffix = urlSuffix,  : 
  Unexpected CURL error: Failed to connect to 127.0.0.1 port 54321 after 120010 ms: Connection reset by peer 
This can be caused by issues with some versions of curl library together with RCurl package. Installing R package `curl` version 4.3.0 and above could help. Otherwise, using curl system library versions below 7.68.0 or compiled with --disable-socketpair could help, in case you cannot use curl R package.
```