### PR TITLE
PUBDEV-8631: Shifting docs page info to the user guide

### DIFF
--- a/h2o-docs/src/product/additional-resources.rst
+++ b/h2o-docs/src/product/additional-resources.rst
@@ -116,10 +116,6 @@ Java
 - `H2O Core Javadoc <https://docs.h2o.ai/h2o/latest-stable/h2o-core/javadoc/index.html>`__
 - `H2O Algorithms Javadoc <https://docs.h2o.ai/h2o/latest-stable/h2o-algos/javadoc/index.html>`__
 
-Scala
-'''''
-
-???
 
 API Reference
 -------------

--- a/h2o-docs/src/product/additional-resources.rst
+++ b/h2o-docs/src/product/additional-resources.rst
@@ -2,7 +2,7 @@ Additional Resources
 ====================
 
 - `H2O README <https://github.com/h2oai/h2o-3/blob/master/README.md>`__
-- `H2O Book <https://shop.oreilly.com/product/0636920053170.do>`__ (O'Reilly)
+- `H2O Book <https://shop.oreilly.com/product/0636920053170.do>`__ (O'Reilly) 
 
 Videos
 ------

--- a/h2o-docs/src/product/additional-resources.rst
+++ b/h2o-docs/src/product/additional-resources.rst
@@ -1,0 +1,180 @@
+Additional Resources
+====================
+
+- `H2O README <https://github.com/h2oai/h2o-3/blob/master/README.md>`__
+- `H2O Book <https://shop.oreilly.com/product/0636920053170.do>`__ (O'Reilly)
+
+Videos
+------
+
+- `Quick Start with Flow Web UI <https://docs.h2o.ai/h2o/latest-stable/h2o-docs/quick-start-videos.html#h2o-quick-start-with-flow>`__
+- `Quick Start with Python <https://docs.h2o.ai/h2o/latest-stable/h2o-docs/quick-start-videos.html#h2o-quick-start-with-python>`__
+- `Quick Start with R <https://docs.h2o.ai/h2o/latest-stable/h2o-docs/quick-start-videos.html#h2o-quick-start-with-r>`__
+
+Algorithms
+----------
++------------------+----------------------------------------------------+--------------------------------------------------+----------------------------------------+---------------------------------------------------+
+| Supervised       |                                                    |                                                  |                                        |                                                   |
+| Learning         |                                                    |                                                  |                                        |                                                   |
++==================+====================================================+==================================================+========================================+===================================================+
+| AutoML           | `Tutorial <https://docs.h2o.ai/h2o-tutorials/      | Booklet                                          | `Reference <https://docs.h2o.ai/h2o/   | Tuning                                            |
+|                  | latest-stable/h2o-world-2017/automl/index.html>`__ |                                                  | latest-stable/h2o-docs/automl.html>`__ |                                                   |
++------------------+----------------------------------------------------+--------------------------------------------------+----------------------------------------+---------------------------------------------------+
+| Cox Proportional | Tutorial                                           | Booklet                                          | `Reference <https://docs.h2o.ai/h2o/   | Tuning                                            |
+| Hazards (CoxPH)  |                                                    |                                                  | h2o-docs/data-science/coxph.html>`__   |                                                   |
++------------------+----------------------------------------------------+--------------------------------------------------+----------------------------------------+---------------------------------------------------+
+| Deep Learning    | `Tutorial <https://docs.h2o.ai/h2o-tutorials/      | `Booklet <https://docs.h2o.ai/h2o/latest-stable/ | `Reference <https://docs.h2o.ai/h2o/   | `Tuning <https://docs.h2o.ai/h2o/                 |
+| (DL)             | latest-stable/tutorials/deeplearning/index.html>`__| h2o-docs/booklets/DeepLearningBooklet.pdf>`__    | latest-stable/h2o-docs/data-science/   | latest-stable/h2o-docs/data-science/              |
+|                  |                                                    |                                                  | deep-learning.html>`__                 | deep-learning.html#deep-learning-tuning-guide>`__ |
++------------------+----------------------------------------------------+--------------------------------------------------+----------------------------------------+---------------------------------------------------+
+| Distributed      | `Tutorial <https://github.com/h2oai/h2o-3/blob/    | Booklet                                          | `Reference <https://docs.h2o.ai/h2o/   | Tuning                                            |
+| Random Forest    | master/h2o-docs/src/product/tutorials/rf/rf.md>`__ |                                                  | latest-stable/h2o-docs/data-science/   |                                                   |
+| (DRF)            |                                                    |                                                  | drf.html>`__                           |                                                   |
++------------------+----------------------------------------------------+--------------------------------------------------+----------------------------------------+---------------------------------------------------+
+| Generalized      | `Tutorial <https://docs.h2o.ai/h2o-tutorials/      | `Booklet <https://docs.h2o.ai/h2o/latest-stable/ | `Reference <https://docs.h2o.ai/h2o/   | Tuning                                            |
+| Linear Modeling  | latest-stable/tutorials/glm/glm.html>`__           | h2o-docs/booklets/GLMBooklet.pdf>`__             | latest-stable/h2o-docs/data-science/   |                                                   |
+| (GLM)            |                                                    |                                                  | glm.html>`__                           |                                                   |
++------------------+----------------------------------------------------+--------------------------------------------------+----------------------------------------+---------------------------------------------------+
+| Maximum R Square | Tutorial                                           | Booklet                                          | `Reference <https://docs.h2o.ai/h2o/   | Tuning                                            |
+| Improvements     |                                                    |                                                  | latest-stable/h2o-docs/data-science/   |                                                   |
+| (MAXR)           |                                                    |                                                  | maxrglm.html>`__                       |                                                   |
++------------------+----------------------------------------------------+--------------------------------------------------+----------------------------------------+---------------------------------------------------+
+| Generalized      | Tutorial                                           | Booklet                                          | `Reference <https://docs.h2o.ai/h2o/   | Tuning                                            |
+| Additive Models  |                                                    |                                                  | latest-stable/h2o-docs/data-science/   |                                                   |
+| (GAM)            |                                                    |                                                  | gam.html>`__                           |                                                   |
++------------------+----------------------------------------------------+--------------------------------------------------+----------------------------------------+---------------------------------------------------+
+| ANOVA GLM        | Tutorial                                           | Booklet                                          | `Reference <https://docs.h2o.ai/h2o/   | Tuning                                            |
+|                  |                                                    |                                                  | latest-stable/h2o-docs/data-science/   |                                                   |
+|                  |                                                    |                                                  | anova_glm.html>`__                     |                                                   |
++------------------+----------------------------------------------------+--------------------------------------------------+----------------------------------------+---------------------------------------------------+
+| Gradient Boosting| `Tutorial <https://docs.h2o.ai/h2o-tutorials/      | `Booklet <https://docs.h2o.ai/h2o/latest-stable/ | `Reference <https://docs.h2o.ai/h2o/   | `Tuning <https://docs.h2o.ai/h2o/latest-stable/   |
+| Machine (GBM)    | latest-stable/tutorials/gbm-randomforest/          | h2o-docs/booklets/GBMBooklet.pdf>`__             | latest-stable/h2o-docs/data-science/   | h2o-docs/data-science/                            |
+|                  | index.html>`__                                     |                                                  | gbm.html>`__                           | gbm.html#gbm-tuning-guide>`__                     |
++------------------+----------------------------------------------------+--------------------------------------------------+----------------------------------------+---------------------------------------------------+
+| Naive Bayes      | Tutorial                                           | Booklet                                          | `Reference <https://docs.h2o.ai/h2o/   | Tuning                                            |
+|                  |                                                    |                                                  | latest-stable/h2o-docs/data-science/   |                                                   |
+|                  |                                                    |                                                  | naive-bayes.html>`__                   |                                                   |
++------------------+----------------------------------------------------+--------------------------------------------------+----------------------------------------+---------------------------------------------------+
+| Stacked          | `Tutorial <https://docs.h2o.ai/h2o-tutorials/      | Booklet                                          | `Reference <https://docs.h2o.ai/h2o/   | Tuning                                            |
+| Ensembles        | latest-stable/tutorials/ensembles-stacking/        |                                                  | latest-stable/h2o-docs/data-science/   |                                                   |
+|                  | index.html>`__                                     |                                                  | stacked-ensembles.html>`__             |                                                   |
++------------------+----------------------------------------------------+--------------------------------------------------+----------------------------------------+---------------------------------------------------+
+| Distributed      | `Tutorial <https://github.com/h2oai/h2o-3/blob/    | Booklet                                          | `Reference <https://docs.h2o.ai/h2o/   | Tuning                                            |
+| Uplift Random    | master/h2o-py/demos/                               |                                                  | latest-stable/h2o-docs/data-science/   |                                                   |
+| Forest           | uplift_random_forest_compare_causalml.ipynb>`__    |                                                  | upliftdrf.html>`__                     |                                                   |
+| (Uplift DRF)     |                                                    |                                                  |                                        |                                                   |
++------------------+----------------------------------------------------+--------------------------------------------------+----------------------------------------+---------------------------------------------------+
+| XGBoost          | Tutorial                                           | Booklet                                          | `Reference <https://docs.h2o.ai/h2o/   | Tuning                                            |
+|                  |                                                    |                                                  | latest-stable/h2o-docs/data-science/   |                                                   |
+|                  |                                                    |                                                  | xgboost.html>`__                       |                                                   |
++------------------+----------------------------------------------------+--------------------------------------------------+----------------------------------------+---------------------------------------------------+
+
++-------------------+----------------------------------------------------+---------------------------------------------------------+
+| Unsupervised      |                                                    |                                                         |
+| Learning          |                                                    |                                                         |
++===================+====================================================+=========================================================+
+| Aggregator        | Tutorial                                           | `Reference <https://docs.h2o.ai/h2o/                    |
+|                   |                                                    | latest-stable/h2o-docs/data-science/aggregator.html>`__ |
++-------------------+----------------------------------------------------+---------------------------------------------------------+
+| Generalized Low   | `Tutorial <https://docs.h2o.ai/h2o-tutorials/      | `Reference <https://docs.h2o.ai/h2o/latest-stable/      |
+| Rank Models (GLRM)| latest-stable/tutorials/glrm/glrm-tutorial.html>`__| h2o-docs/data-science/glrm.html>`__                     |
++-------------------+----------------------------------------------------+---------------------------------------------------------+
+| K-Means           | `Tutorial <https://github.com/h2oai/h2o-3/blob/    | `Reference <https://docs.h2o.ai/h2o/latest-stable/      |
+| Clustering        | master/h2o-docs/src/product/tutorials/kmeans/      | h2o-docs/data-science/k-means.html>`__                  |
+|                   | kmeans.md>`__                                      |                                                         |
++-------------------+----------------------------------------------------+---------------------------------------------------------+
+| Isolation         | `Tutorial <https://github.com/h2oai/h2o-tutorials/ | `Reference <https://docs.h2o.ai/h2o/latest-stable/      |
+| Forest            | tree/master/tutorials/isolation-forest>`__         | h2o-docs/data-science/if.html>`__                       |
++-------------------+----------------------------------------------------+---------------------------------------------------------+
+| Principal         | `Tutorial <https://github.com/h2oai/h2o-3/blob/    | `Reference <https://docs.h2o.ai/h2o/latest-stable/      |
+| Component Analysis| master/h2o-docs/src/product/tutorials/pca/         | h2o-docs/data-science/pca.html>`__                      |
+| (PCA)             | pca.md>`__                                         |                                                         |
++-------------------+----------------------------------------------------+---------------------------------------------------------+
+
+Languages
+---------
+
+R
+'
+- `R Booklet <https://docs.h2o.ai/h2o/latest-stable/h2o-docs/booklets/RBooklet.pdf>`__
+- `R Studio Cheat sheet <https://github.com/rstudio/cheatsheets/blob/master/h2o.pdf>`__
+- `R Package README <https://github.com/h2oai/h2o-3/blob/master/h2o-r/README.md>`__
+- `H2O Ensemble R Package README <https://github.com/h2oai/h2o-3/blob/master/h2o-r/ensemble/README.md>`__
+- `Examples and Demos <https://github.com/h2oai/h2o-3/tree/master/h2o-r/demos>`__
+- `R FAQ <https://docs.h2o.ai/h2o/latest-stable/h2o-docs/faq/r.html>`__
+
+Python
+''''''
+- `Python Booklet <https://docs.h2o.ai/h2o/latest-stable/h2o-docs/booklets/PythonBooklet.pdf>`__
+- `Python Package README <https://github.com/h2oai/h2o-3/blob/master/h2o-py/README.md>`__
+- `Examples and Demos <https://github.com/h2oai/h2o-3/tree/master/h2o-py/demos>`__
+- `Python FAQ <https://docs.h2o.ai/h2o/latest-stable/h2o-docs/faq/python.html>`__
+
+Java
+''''
+- `POJO and MOJO Javadoc <https://docs.h2o.ai/h2o/latest-stable/h2o-genmodel/javadoc/index.html>`__
+- `H2O Core Javadoc <https://docs.h2o.ai/h2o/latest-stable/h2o-core/javadoc/index.html>`__
+- `H2O Algorithms Javadoc <https://docs.h2o.ai/h2o/latest-stable/h2o-algos/javadoc/index.html>`__
+
+Scala
+'''''
+
+???
+
+API Reference
+-------------
+- `REST API Endpoint Reference <https://docs.h2o.ai/h2o/latest-stable/h2o-docs/rest-api-reference.html>`__
+- `REST API Schema Reference <https://docs.h2o.ai/h2o/latest-stable/h2o-docs/rest-api-reference.html#schema-reference>`__
+
+Tutorials
+---------
+H2O Tutorials 
+
+- `HTML <https://docs.h2o.ai/h2o-tutorials/latest-stable/index.html>`__
+- `PDF <https://docs.h2o.ai/h2o-tutorials/latest-stable/H2OTutorialsBook.pdf>`__
+
+Use Case Examples
+-----------------
++-------------------+----------------------------------------------------+--------------------------------------------------+-----------------------------------------------------+-------------------------------------------+
+| Examples          |                                                    |                                                  |                                                     |                                           |
++===================+====================================================+==================================================+=====================================================+===========================================+
+| Chicago Crime     | `R <https://github.com/h2oai/h2o-3/blob/master/    | `Python <https://github.com/h2oai/h2o-3/blob/    | `ScalaSW <https://github.com/h2oai/sparkling-water/ | `PySW <https://docs.h2o.ai/h2o-tutorials/ |
+| Prediction        | h2o-r/demos/rdemo.chicago.crime.large.R>`__        | master/h2o-py/demos/H2O_chicago_crimes.ipynb>`__ | blob/master/examples/src/main/scala/ai/h2o/         | latest-stable/tutorials/pysparkling/      |
+|                   |                                                    |                                                  | sparkling/examples/ChicagoCrimeApp.scala>`__        | Chicago_Crime_Demo.html>`__               |
++-------------------+----------------------------------------------------+--------------------------------------------------+-----------------------------------------------------+-------------------------------------------+
+| Airline Delays    | `R <https://github.com/h2oai/h2o-3/blob/master/    | `Python <https://github.com/h2oai/h2o-3/blob/    | `ScalaSW <https://github.com/h2oai/sparkling-water/ | PySW                                      |
+| Prediction        | h2o-r/demos/rdemo.airlines.delay.large.R>`__       | master/h2o-py/demos/airlines_demo_small.ipynb>`__| blob/master/examples/src/main/scala/ai/h2o/         |                                           |
+|                   |                                                    |                                                  | sparkling/examples/AirlinesWithWeatherDemo.scala>`__|                                           |
++-------------------+----------------------------------------------------+--------------------------------------------------+-----------------------------------------------------+-------------------------------------------+
+| Lending Club      | `R <https://github.com/h2oai/h2o-3/blob/master/    | Python                                           | ScalaSW                                             | PySW                                      |
+| Load Prediction   | h2o-r/demos/rdemo.lending.club.large.R>`__         |                                                  |                                                     |                                           |
++-------------------+----------------------------------------------------+--------------------------------------------------+-----------------------------------------------------+-------------------------------------------+
+| Ham or Spam       | R                                                  | Python                                           | `ScalaSW <https://github.com/h2oai/sparkling-water/ | PySW                                      |
+|                   |                                                    |                                                  | blob/master/examples/src/main/scala/ai/h2o/         |                                           |
+|                   |                                                    |                                                  | sparkling/examples/HamOrSpamDemo.scala>`__          |                                           |
++-------------------+----------------------------------------------------+--------------------------------------------------+-----------------------------------------------------+-------------------------------------------+
+| Prediction with   | R                                                  | `Python <https://github.com/h2oai/h2o-3/blob/    | `ScalaSW <https://github.com/h2oai/sparkling-water/ | PySW                                      |
+| Prostate Dataset  |                                                    | master/h2o-py/demos/prostate_gbm.ipynb>`__       | blob/master/examples/src/main/scala/ai/h2o/         |                                           |
+|                   |                                                    |                                                  | sparkling/examples/ProstateDemo.scala>`__           |                                           |
++-------------------+----------------------------------------------------+--------------------------------------------------+-----------------------------------------------------+-------------------------------------------+
+| Craigslist Job    | `R <https://github.com/h2oai/h2o-3/blob/master/    | `Python <https://github.com/h2oai/h2o-3/blob/    | `ScalaSW <https://github.com/h2oai/sparkling-water/ | PySW                                      |
+| Titles            | h2o-r/demos/                                       | master/h2o-py/demos/                             | blob/master/examples/src/main/scala/ai/h2o/         |                                           |
+|                   | rdemo.word2vec.craigslistjobtitles.R>`__           | word2vec_craigslistjobtitles.ipynb>`__           | sparkling/examples/CraigslistJobTitlesApp.scala>`__ |                                           |
++-------------------+----------------------------------------------------+--------------------------------------------------+-----------------------------------------------------+-------------------------------------------+
+
+Security Features
+-----------------
+`Security Features <https://docs.h2o.ai/h2o/latest-stable/h2o-docs/security.html>`__ for H2O-3
+
+Architecture
+------------
+`H2O-3's Internal Architecture <https://docs.h2o.ai/h2o/latest-stable/h2o-docs/architecture.html>`__
+
+Productionizing H2O-3
+---------------------
+`Production Recipes <https://docs.h2o.ai/h2o/latest-stable/h2o-docs/productionizing.html>`__ for H2O-3
+
+Contribute to H2O-3
+-------------------
+`Contributing <https://github.com/h2oai/h2o-3/blob/master/CONTRIBUTING.md>`__
+

--- a/h2o-docs/src/product/index.rst
+++ b/h2o-docs/src/product/index.rst
@@ -159,3 +159,12 @@ Additional Resources:
 
    api-reference
 
+.. toctree::
+   :maxdepth: 2
+
+   additional-resources
+
+.. toctree::
+
+   Recent Changes <https://github.com/h2oai/h2o-3/blob/master/Changes.md>
+

--- a/h2o-docs/src/product/index.rst
+++ b/h2o-docs/src/product/index.rst
@@ -16,7 +16,6 @@ Additional Resources:
 - See how are customers are using H2O at https://www.h2o.ai/customers/.
 - Keep up to date with the latest H2O blogs at https://www.h2o.ai/blog/.
 - Review projects, applications, research papers, tutorials, courses, and books that use H2O at https://github.com/h2oai/awesome-h2o.
-- `Change Log <https://github.com/h2oai/h2o-3/blob/master/Changes.md>`__
 
 .. toctree::
    :maxdepth: 2
@@ -165,6 +164,8 @@ Additional Resources:
    additional-resources
 
 .. toctree::
+   :maxdepth: 1
+   :caption: Change log
 
    Recent Changes <https://github.com/h2oai/h2o-3/blob/master/Changes.md>
 


### PR DESCRIPTION
For: [PUBDEV-8631](https://h2oai.atlassian.net/browse/PUBDEV-8631)

Created an "Additional Resources" page and added the Release Notes link to the bottom of the index. After this PR is merged, I will clear out the [docs page ](https://docs.h2o.ai/h2o-3/index.html) of all but the User Guide, Python Module, & R Module links. 