### PR TITLE
updated log4j library to reload4j in order to address vulnerabilities

### DIFF
--- a/h2o-logging/impl-classic/build.gradle
+++ b/h2o-logging/impl-classic/build.gradle
@@ -5,7 +5,7 @@ compileJava {
 }
 
 dependencies {
-    api("log4j:log4j:1.2.17") {
+    api("ch.qos.reload4j:reload4j:1.2.20") {
         exclude module: "activation"
         exclude module: "jms"
         exclude module: "jmxri"


### PR DESCRIPTION
updated log4j library to reload4j in order to address CVE-2022-23305 CVE-2022-23302 CVE-2021-4104 CVE-2019-17571