### PR TITLE
PUBDEV-8672 do not produce null pointer when user gives wrong -network parameter to h2o.jar

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -495,6 +495,15 @@ final public class H2O {
     H2O.exitQuietly(1); // argument parsing failed -> we might have inconsistent ARGS and not be able to initialize logging 
   }
 
+  /**
+   * Use when given arguments are incompatible for cluster to run.
+   * Log is flushed into stdout to show important debugging information
+   */
+  public static void clusterInitializationFailed() {
+    Log.flushBufferedMessagesToStdout();
+    H2O.exitQuietly(1);
+  }
+
   public static class OptString {
     final String _s;
     String _lastMatchedFor;

--- a/h2o-core/src/main/java/water/init/NetworkInit.java
+++ b/h2o-core/src/main/java/water/init/NetworkInit.java
@@ -50,7 +50,7 @@ public class NetworkInit {
           Log.err(e.getCause());
         else
           Log.err(e.getMessage());
-        H2O.exit(-1);
+        H2O.clusterInitializationFailed();
       }
     }
     assert false; // should never be reached


### PR DESCRIPTION
Current version gives null pointer when you pass wrong -network, e.g.:

`java -jar h2o.jar -network 10.0.0.0/8`

or just

`java -jar h2o.jar -network hahaha`

This PR should fix it