### PR TITLE
PUBDEV-8674: expose GLM p-values, z-values, std-error to python and R clients

### DIFF
--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -731,6 +731,16 @@ class ModelBase(h2o_meta(Keyed)):
                 return None
             return {name: coef for name, coef in zip(tbl["names"], tbl["standardized_coefficients"])}
 
+    def coef_with_p_values(self):
+        if self.algo == 'glm':
+            if self.parms["compute_p_values"]["actual_value"]:
+                return self._model_json["output"]["coefficients_table"]
+            else:
+                raise ValueError("p-values, z-values and std_error are not found in model.  Make sure to set "
+                                 "compute_p_values=True.")
+        else:
+            raise ValueError("p-values, z-values and std_error are only found in GLM.")
+            
     def _fillMultinomialDict(self, standardize=False):
         if self.algo == 'gam':
             tbl = self._model_json["output"]["coefficients_table"]

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8674_compute_p_values_false.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8674_compute_p_values_false.py
@@ -1,0 +1,28 @@
+from __future__ import print_function
+import sys
+
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+
+# test to make sure we have error when compute_p_value=False and coef_with_p_values is called
+def test_wrong_model_pzvalues_stdErr():
+    cars = h2o.import_file(path=pyunit_utils.locate("smalldata/junit/cars_20mpg.csv"))
+    y = "economy_20mpg"
+    predictors = ["displacement", "power", "weight", "acceleration", "year"]
+    cars[y] = cars[y].asfactor()
+
+    h2oglm_compute_p_value = H2OGeneralizedLinearEstimator(family="binomial", seed=1234)
+    h2oglm_compute_p_value.train(x=predictors, y=y, training_frame=cars)
+
+    try:
+        h2oglm_compute_p_value.coef_with_p_values()
+    except ValueError as e:
+        assert "p-values, z-values and std_error are not found in model" in e.args[0], "Wrong error messages received."
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_wrong_model_pzvalues_stdErr)
+else:
+    test_wrong_model_pzvalues_stdErr()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8674_gbm_no_glm_metrics.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8674_gbm_no_glm_metrics.py
@@ -1,0 +1,28 @@
+from __future__ import print_function
+import sys
+
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+
+
+# make sure error is thrown when non glm model try to call coef_with_p_values
+def test_glm_pvalues_stderr():
+    cars = h2o.import_file(path=pyunit_utils.locate("smalldata/junit/cars_20mpg.csv"))
+    y = "economy_20mpg"
+    predictors = ["displacement", "power", "weight", "acceleration", "year"]
+    cars[y] = cars[y].asfactor()
+
+    gbm_model = H2OGradientBoostingEstimator(distribution="bernoulli", seed=1234)
+    gbm_model.train(x=predictors, y=y, training_frame=cars)
+
+    try:
+        gbm_model.coef_with_p_values()
+    except ValueError as e:
+        assert "p-values, z-values and std_error are only found in GLM" in e.args[0], "Wrong error messages received."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_glm_pvalues_stderr)
+else:
+    test_glm_pvalues_stderr()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8674_pvalues_zvalues_stdErr.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8674_pvalues_zvalues_stdErr.py
@@ -1,0 +1,44 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+
+# make sure correct p-values, z-values, std_errors are returned when coef_with_p_values is called
+def test_glm_pvalues_stderr():
+  cars = h2o.import_file(path=pyunit_utils.locate("smalldata/junit/cars_20mpg.csv"))
+  y = "economy_20mpg"
+  predictors = ["displacement","power","weight","acceleration","year"]
+  cars[y] = cars[y].asfactor()
+
+  h2oglm_compute_p_value =  H2OGeneralizedLinearEstimator(family = "binomial", lambda_=0.0, compute_p_values=True, 
+                                                          seed = 1234)
+
+  h2oglm_compute_p_value.train(x = predictors, y = y, training_frame  = cars)
+  coef_w_p_values = h2oglm_compute_p_value.coef_with_p_values()
+  coef_p_values = coef_w_p_values["p_value"]
+  coef_z_values = coef_w_p_values["z_value"]
+  coef_std_err = coef_w_p_values["std_error"]
+  print("coefficient table with p_values: {0}".format(coef_w_p_values))
+  
+  # manually obtain p_values, z_values and std_err and compare with ones using functions
+  names = h2oglm_compute_p_value._model_json["output"]["coefficients_table"]["names"]
+  manual_pvalue = h2oglm_compute_p_value._model_json["output"]["coefficients_table"]["p_value"]
+  manual_zvalue = h2oglm_compute_p_value._model_json["output"]["coefficients_table"]["z_value"]
+  manual_stderr = h2oglm_compute_p_value._model_json["output"]["coefficients_table"]["std_error"]
+  
+  # check both sets of values are equal
+  for count in range(len(names)):
+      assert abs(coef_p_values[count]-manual_pvalue[count]) < 1e-12, "Expected p-value: {0}, actual p-value: {1}.  They are " \
+                                                              "different".format(coef_p_values[count], manual_pvalue[count])
+      assert abs(coef_z_values[count]-manual_zvalue[count]) < 1e-12, "Expected z-value: {0}, actual z-value: {1}.  They are " \
+                                                              "different".format(coef_z_values[count], manual_zvalue[count])
+      assert abs(coef_std_err[count]-manual_stderr[count]) < 1e-12, "Expected std_err: {0}, actual std_err: {1}.  They are " \
+                                                              "different".format(coef_std_err[count], manual_stderr[count])
+      
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(test_glm_pvalues_stderr)
+else:
+  test_glm_pvalues_stderr()
+

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -2187,6 +2187,44 @@ h2o.giniCoef <- function(object, train=FALSE, valid=FALSE, xval=FALSE) {
 }
 
 #'
+#' Return the coefficients table with coefficients, standardized coefficients, p-values, z-values and std-error for GLM models
+#'
+#' @param object An \linkS4class{H2OModel} object.
+#' @examples 
+#' \dontrun{
+#' library(h2o)
+#' h2o.init()
+#' 
+#' f <- "https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv"
+#' cars <- h2o.importFile(f)
+#' predictors <- c("displacement", "power", "weight", "acceleration", "year")
+#' response <- "cylinders"
+#' cars_split <- h2o.splitFrame(data = cars, ratios = 0.8, seed = 1234)
+#' train <- cars_split[[1]]
+#' valid <- cars_split[[2]]
+#' cars_glm <- h2o.glm(seed = 1234, 
+#'                     lambda=0.0,
+#'                     compute_p_values=TRUE,
+#'                     x = predictors, 
+#'                     y = response, 
+#'                     training_frame = train, 
+#'                     validation_frame = valid)
+#' h2o.coef_with_p_values(cars_glm)
+#' }
+#' @export
+h2o.coef_with_p_values <- function(object) {
+  if (is(object, "H2OModel") && object@algorithm %in% c("glm")) {
+    if (object@parameters$compute_p_values) {
+      object@model$coefficients_table
+    } else {
+      stop("p-values, z-values and std_error are not found in model.  Make sure to set compute_p_values=TRUE.")
+    }
+  } else {
+    stop("p-values, z-values and std_error are only found in GLM.")
+  }
+}
+
+#'
 #' Return the coefficients that can be applied to the non-standardized data.
 #'
 #' Note: standardize = True by default. If set to False, then coef() returns the coefficients that are fit directly.

--- a/h2o-r/h2o-package/pkgdown/_pkgdown.yml
+++ b/h2o-r/h2o-package/pkgdown/_pkgdown.yml
@@ -70,6 +70,7 @@ reference:
       - h2o.clusterStatus
       - h2o.coef
       - h2o.coef_norm
+      - h2o.coef_with_p_values
       - h2o.colnames
       - h2o.columns_by_type
       - h2o.computeGram

--- a/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_8674_compute_p_value_false.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_8674_compute_p_value_false.R
@@ -1,0 +1,17 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# should throw an error when compute_p_value=FALSE
+testGLMcomptuePValueFALSE <- function() {
+	bhexFV <- h2o.importFile(locate("smalldata/logreg/benign.csv"))
+	maxX <- 11
+	Y <- 4
+	X   <- 3:maxX
+	X   <- X[ X != Y ]
+	mFV <- h2o.glm(y=Y, x=colnames(bhexFV)[X], training_frame=bhexFV, lambda=1.0)
+
+	assertError(coefWPValues <- h2o.coef_with_p_values(mFV))
+}
+
+doTest("GLM: make sure error is generated when compute_p_values=FALSE", testGLMcomptuePValueFALSE)
+

--- a/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_8674_pvalue_zvalue_stdError.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_8674_pvalue_zvalue_stdError.R
@@ -1,0 +1,32 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+testGLMPValZValStdError <- function() {
+	bhexFV <- h2o.importFile(locate("smalldata/logreg/benign.csv"))
+	maxX <- 11
+	Y <- 4
+	X   <- 3:maxX
+	X   <- X[ X != Y ]
+	bhexFV$FNDX <- h2o.asfactor(bhexFV$FNDX)
+	mFV <- h2o.glm(y=Y, x=colnames(bhexFV)[X], training_frame=bhexFV, family="binomial", lambda=0.0, compute_p_values=TRUE)
+
+	coefPValues <- h2o.coef_with_p_values(mFV)
+	print("coefficients table with p-values, z-values and std-error")
+	print(coefPValues)
+	coefPValue <- coefPValues$p_value
+	coefZValue <- coefPValues$z_value
+	coefStdErr <- coefPValues$std_error
+	
+	manuelPValues <- mFV@model$coefficients_table$p_value
+	manuelZValues <- mFV@model$coefficients_table$z_value
+	manuelStdError <- mFV@model$coefficients_table$std_error
+	
+	# compare values from model and obtained manually
+  for (ind in c(1:length(manuelPValues)))
+    expect_equal(manuelPValues[ind], coefPValue[ind])
+	  expect_equal(manuelZValues[ind], coefZValue[ind])
+	  expect_equal(manuelStdError[ind], coefStdErr[ind])
+}
+
+doTest("GLM: test p-values, z-values, std-error", testGLMPValZValStdError)
+

--- a/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_8674_wrong_model_gbm.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_8674_wrong_model_gbm.R
@@ -1,0 +1,17 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# call glm functions by a gbm model.  Should generate an error
+testGBMpValueZValueStdErr <- function() {
+	bhexFV <- h2o.importFile(locate("smalldata/logreg/benign.csv"))
+	maxX <- 11
+	Y <- 4
+	X   <- 3:maxX
+	X   <- X[ X != Y ]
+	mFV <- h2o.gbm(y=Y, x=colnames(bhexFV)[X], training_frame=bhexFV)
+
+	assertError(coefWPValues <- h2o.coef_with_p_values(mFV))
+}
+
+doTest("GLM: make sure error is generated when a gbm model calls glm functions", testGBMpValueZValueStdErr)
+


### PR DESCRIPTION
This PR completes the task in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8674 .

I have added p_values(), z_values(), std_error() to both R and Python client so that they don't have to dig into the model to get those values.

I added R and Python unit tests to make sure they work.  Errors will be rasied if compute_p_values=FALSE or other models other than glm calls those functions.