### PR TITLE
PUBDEV-8675 modelselection backward mode fails with categorical columns

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -1200,6 +1200,8 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     public double lambda_1se(){
       return _lambda_1se; // (_lambda_1se==-1 || _submodels.length==0 || _lambda_1se>=_submodels.length) ? -1 : _submodels[_lambda_1se].lambda_value;
     }
+    
+    public DataInfo getDinfo() { return _dinfo; }
     public int bestSubmodelIndex() { return _selected_submodel_idx; }
     public double lambda_selected(){
       return _submodels[_selected_submodel_idx].lambda_value;

--- a/h2o-algos/src/main/java/hex/modelselection/ModelSelection.java
+++ b/h2o-algos/src/main/java/hex/modelselection/ModelSelection.java
@@ -6,16 +6,13 @@ import hex.glm.GLMModel;
 import water.DKV;
 import water.H2O;
 import water.Key;
-import water.Scope;
 import water.exceptions.H2OModelBuilderIllegalArgumentException;
 import water.fvec.Frame;
-import water.util.Log;
 
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import static hex.genmodel.utils.MathUtils.combinatorial;
 import static hex.glm.GLMModel.GLMParameters.Family.*;
@@ -249,6 +246,9 @@ public class ModelSelection extends ModelBuilder<hex.modelselection.ModelSelecti
         private int buildBackwardModels(ModelSelectionModel model) {
             List<String> coefNames = new ArrayList<>(Arrays.asList(_predictorNames));
             List<Integer> coefIndice = IntStream.rangeClosed(0, coefNames.size()-1).boxed().collect(Collectors.toList());
+            Frame train = DKV.getGet(_parms._train);
+            List<String> numPredNames = coefNames.stream().filter(x -> train.vec(x).isNumeric()).collect(Collectors.toList());
+            List<String> catPredNames = coefNames.stream().filter(x -> !numPredNames.contains(x)).collect(Collectors.toList());
             int numModelsBuilt = 0;
             String[] coefName = coefNames.toArray(new String[0]);
             for (int predNum = _numPredictors; predNum >= _parms._min_predictor_number; predNum--) {
@@ -263,7 +263,8 @@ public class ModelSelection extends ModelBuilder<hex.modelselection.ModelSelecti
 
                 // evaluate which variable to drop for next round of testing and store corresponding values
                 // if p_values_threshold is specified, model building may stop
-                model._output.extractPredictors4NextModel(glmModel, modelIndex, coefNames, coefIndice);
+                model._output.extractPredictors4NextModel(glmModel, modelIndex, coefNames, coefIndice, numPredNames, 
+                        catPredNames);
                 numModelsBuilt++;
                 DKV.remove(trainingFrame._key);
                 _job.update(predNum, "Finished building all models with "+predNum+" predictors.");

--- a/h2o-algos/src/test/java/hex/modelselection/ModelSelectionAllSubsetsTests.java
+++ b/h2o-algos/src/test/java/hex/modelselection/ModelSelectionAllSubsetsTests.java
@@ -181,9 +181,7 @@ public class ModelSelectionAllSubsetsTests extends TestUtil {
                 assertTrue(scoreFrame.numRows() == trainF.numRows());
                 Scope.track(scoreFrame);
                 String[] coeff = oneModel._output._coefficient_names;   // contains the name intercept as well
-                String[] coeffWOIntercept = new String[coeff.length - 1];
-                System.arraycopy(coeff, 0, coeffWOIntercept, 0, coeffWOIntercept.length);
-                assertArrayEquals("best predictor subset containing different predictors", coeffWOIntercept,
+                assertArrayEquals("best predictor subset containing different predictors", coeff, 
                         bestPredictorSubsets[index]);
             }
         } finally {

--- a/h2o-py/h2o/estimators/model_selection.py
+++ b/h2o-py/h2o/estimators/model_selection.py
@@ -66,14 +66,14 @@ class H2OModelSelectionEstimator(H2OEstimator):
                  max_iterations=0,  # type: int
                  objective_epsilon=-1.0,  # type: float
                  beta_epsilon=0.0001,  # type: float
-                 gradient_epsilon=-1.0,  # type: float
+                 gradient_epsilon=0.0,  # type: float
                  startval=None,  # type: Optional[List[float]]
                  prior=0.0,  # type: float
                  cold_start=False,  # type: bool
                  lambda_min_ratio=0.0,  # type: float
                  beta_constraints=None,  # type: Optional[Union[None, str, H2OFrame]]
                  max_active_predictors=-1,  # type: int
-                 obj_reg=-1.0,  # type: float
+                 obj_reg=0.0,  # type: float
                  stopping_rounds=0,  # type: int
                  stopping_metric="auto",  # type: Literal["auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "aucpr", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"]
                  stopping_tolerance=0.001,  # type: float
@@ -224,7 +224,7 @@ class H2OModelSelectionEstimator(H2OEstimator):
                L-BFGS solver. Default (of -1.0) indicates: If lambda_search is set to False and lambda is equal to zero,
                the default value of gradient_epsilon is equal to .000001, otherwise the default value is .0001. If
                lambda_search is set to True, the conditional values above are 1E-8 and 1E-6 respectively.
-               Defaults to ``-1.0``.
+               Defaults to ``0.0``.
         :type gradient_epsilon: float
         :param startval: double array to initialize fixed and random coefficients for HGLM, coefficients for GLM.
                Defaults to ``None``.
@@ -253,7 +253,7 @@ class H2OModelSelectionEstimator(H2OEstimator):
                Defaults to ``-1``.
         :type max_active_predictors: int
         :param obj_reg: Likelihood divider in objective value computation, default (of -1.0) will set it to 1/nobs
-               Defaults to ``-1.0``.
+               Defaults to ``0.0``.
         :type obj_reg: float
         :param stopping_rounds: Early stopping based on convergence of stopping_metric. Stop if simple moving average of
                length k of the stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable)
@@ -872,7 +872,7 @@ class H2OModelSelectionEstimator(H2OEstimator):
         gradient_epsilon is equal to .000001, otherwise the default value is .0001. If lambda_search is set to True, the
         conditional values above are 1E-8 and 1E-6 respectively.
 
-        Type: ``float``, defaults to ``-1.0``.
+        Type: ``float``, defaults to ``0.0``.
         """
         return self._parms.get("gradient_epsilon")
 
@@ -976,7 +976,7 @@ class H2OModelSelectionEstimator(H2OEstimator):
         """
         Likelihood divider in objective value computation, default (of -1.0) will set it to 1/nobs
 
-        Type: ``float``, defaults to ``-1.0``.
+        Type: ``float``, defaults to ``0.0``.
         """
         return self._parms.get("obj_reg")
 

--- a/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8428_modelselection_backward_binomial_large.py
+++ b/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8428_modelselection_backward_binomial_large.py
@@ -9,8 +9,8 @@ from h2o.estimators.model_selection import H2OModelSelectionEstimator as modelSe
 # test modelselection with mode=binomial.  Aim to compare with customer run.  However, we do not have good 
 # agreement here.
 def test_modelselection_backward_gaussian():
-    predictor_elimination_order = ["C15", "C33", "C164", "C144", "C27"]
-    eliminated_p_values = [0.6702, 0.6663, 0.0157, 0.0026, 0.0002]
+    predictor_elimination_order = ['C33', 'C24', 'C164', 'C66', 'C15']
+    eliminated_p_values = [0.9711, 0.0694, 0.0388, 0.0127, 0.0009]
     tst_data = h2o.import_file(pyunit_utils.locate("bigdata/laptop/model_selection/backwardBinomial200C50KRows.csv"))
     predictors = tst_data.columns[0:-1]
     response_col = 'response'
@@ -38,13 +38,10 @@ def test_modelselection_backward_gaussian():
         pred_pvalue.append(round(model_backward._model_json["output"]["coef_p_values"][ind][predictor_removed_index], 4))
         counter += 1
         coefs = model_backward.coef(len(pred_large)) # check coefficients result correct length
-        assert len(coefs) == len(pred_large)+1, "Expected coef length: {0}, Actual: {1}".format(len(coefs), len(pred_large)+1)
+        assert len(coefs) == len(pred_large), "Expected coef length: {0}, Actual: {1}".format(len(coefs), len(pred_large))
     common_elimination = list(set(predictor_elimination_order) & set(pred_ele))
-    assert len(common_elimination) >= 2
-    print("Expected predictor elimination order: {0}".format(predictor_elimination_order))
-    print("Expected predictor p-values: {0}".format(eliminated_p_values))
-    print("Predictor elimination order: {0}".format(pred_ele))
-    print("Predictor p-values: {0}".format(pred_pvalue))
+    assert len(common_elimination) == len(pred_ele)
+    pyunit_utils.equal_two_arrays(pred_pvalue, eliminated_p_values, tolerance=1e-6)
     
 if __name__ == "__main__":
     pyunit_utils.standalone_test(test_modelselection_backward_gaussian)

--- a/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8428_modelselection_backward_gaussian_large.py
+++ b/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8428_modelselection_backward_gaussian_large.py
@@ -41,7 +41,7 @@ def test_modelselection_backward_gaussian():
             "".format(eliminated_p_values[counter], removed_pvalue)
         counter += 1
         coefs = model_backward.coef(len(pred_large)) # check coefficients result correct length
-        assert len(coefs) == len(pred_large)+1, "Expected coef length: {0}, Actual: {1}".format(len(coefs), len(pred_large)+1)
+        assert len(coefs) == len(pred_large), "Expected coef length: {0}, Actual: {1}".format(len(coefs), len(pred_large))
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(test_modelselection_backward_gaussian)

--- a/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8675_modelselection_fail.py
+++ b/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8675_modelselection_fail.py
@@ -1,0 +1,121 @@
+from __future__ import print_function
+from __future__ import division
+import sys
+import math
+
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.model_selection import H2OModelSelectionEstimator
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+
+# Megan Kurka found that categorical columns do not work with modelselection backward mode.  I fixed the bug and 
+# extended her test to check that each time a predictor is dropped, it must has the smallest z-value magnitude.
+def test_megan_failure():
+    df = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/demos/bank-additional-full.csv")
+    y = "y"
+    x = [i for i in df.col_names if i not in [y, "previous", "poutcome", "pdays"]]
+
+    # Build & train the model:
+    backward_model = H2OModelSelectionEstimator(min_predictor_number=5, seed=1234, mode="backward", 
+                                                remove_collinear_columns=True)
+    backward_model.train(x=x, y=y, training_frame=df)
+    
+    # verify that deleted predictors have minimum abs(z-values)
+    coefficient_orders = backward_model._model_json['output']['best_model_predictors']
+    predictor_z_values = backward_model._model_json['output']['z_values']
+    num_models = len(coefficient_orders)
+    counter = 0
+    for ind in list(range(num_models-1, 0, -1)):
+        pred_large = coefficient_orders[ind]
+        pred_small = coefficient_orders[ind-1]
+        z_values_large = predictor_z_values[ind]
+        predictor_removed = list(set(pred_large).symmetric_difference(pred_small))
+        z_values_removed = extract_z_removed(pred_large, predictor_removed, z_values_large)
+
+        # assert z-values removed has smallest magnitude
+        assert_smallest_z_removed(z_values_large, z_values_removed, pred_large, predictor_removed, x, y, df)
+        
+        counter += 1
+
+def assert_smallest_z_removed(z_values_backward, z_values_removed, coeff_backward, predictor_removed, x, y, df):
+    glm_model = H2OGeneralizedLinearEstimator(seed=1234, remove_collinear_columns=True, lambda_=0.0, compute_p_values=True)
+    glm_model.train(x=x, y=y, training_frame=df)
+    cat_predictors = extractCatCols(df, x)
+    num_predictors = list(set(x).symmetric_difference(cat_predictors))
+    # compare both models are the same model by comparing the z-values
+    model_z_values = glm_model._model_json["output"]["coefficients_table"]["z_value"]
+    model_coeffs = glm_model._model_json["output"]["coefficients_table"]["names"]
+    assert_equal_z_values(z_values_backward, coeff_backward, model_z_values, model_coeffs)
+    min_z_value = min(z_values_removed)
+    # check that predictor with smallest z-value magnitude is removed
+    assert_smallest_z_value_numerical(num_predictors, min_z_value, model_coeffs, model_z_values)
+    assert_smallest_z_value_categorical(cat_predictors, min_z_value, model_coeffs, model_z_values)
+
+    for name in cat_predictors:
+        for coeff_name in predictor_removed:
+            if name in coeff_name: # cat predictor is removed
+                x.remove(name)
+                return
+    x.remove(predictor_removed[0])   # numerical predictor is removed
+
+def assert_smallest_z_value_categorical(cat_predictors, min_z_value, model_coeffs, model_z_values):
+    for name in cat_predictors:
+        model_z = []
+        for coeff_name in model_coeffs:
+            if name in coeff_name:
+                z_val = model_z_values[model_coeffs.index(coeff_name)]
+                if math.isnan(z_val):
+                    model_z.append(0)
+                else:
+                    model_z.append(abs(z_val))
+        assert max(model_z) >= min_z_value, "predictor ({0}) with wrong z value is removed: {1} has smaller magnitude" \
+                                            "than mininum_z_values {2}".format(name, model_z, min_z_value)
+                
+    
+def assert_smallest_z_value_numerical(num_predictors, min_z_value, model_coeffs, model_z_values):
+    for name in num_predictors:
+        pred_ind = model_coeffs.index(name)
+        val = model_z_values[pred_ind]
+        if not(math.isnan(val)):
+            assert abs(val) >= min_z_value, "predictor with wrong z value is removed: predictor z-value: {0} has " \
+                                                "smaller magnitude than minimum z_values: {1}".format(abs(val), min_z_value)    
+
+def extractCatCols(df, x): 
+    cat_pred=[]
+    col_types = df.types
+    for name in x:
+        if col_types[name]=='enum':
+            cat_pred.append(name)
+    return cat_pred
+    
+def assert_equal_z_values(z_values_backward, coeff_backward, model_z_values, glm_coeff):
+    for coeff in coeff_backward:
+        backward_z_value = z_values_backward[coeff_backward.index(coeff)]
+        model_z_value = model_z_values[glm_coeff.index(coeff)]
+        if (backward_z_value=='NaN'):
+            assert math.isnan(model_z_value), "Expected z-value to be nan but is {0} for predictor" \
+                                              " {1}".format(model_z_value, coeff)
+        else:
+            if math.isnan(model_z_value):
+                assert False, "Expected z-value should not be nan for predictor {0}".format(coeff)
+            else:
+                assert abs(backward_z_value-model_z_value) < 1e-12, \
+                    "Expected z-value: {0}.  Actual z_value: {1}. They are very different." \
+                    "".format(backward_z_value, model_z_value)
+
+ 
+def extract_z_removed(pred_large, predictor_removed, z_values_large):
+    z_values_removed = []
+    for x in predictor_removed:
+        z_value = z_values_large[pred_large.index(x)]
+        if z_value=='NaN':
+            z_values_removed.append(0)
+        else:
+            z_values_removed.append(abs(z_value))
+    return z_values_removed
+    
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_megan_failure)
+else:
+    test_megan_failure()

--- a/h2o-r/h2o-package/R/modelselection.R
+++ b/h2o-r/h2o-package/R/modelselection.R
@@ -76,7 +76,7 @@
 #' @param gradient_epsilon Converge if  objective changes less (using L-infinity norm) than this, ONLY applies to L-BFGS solver. Default
 #'        (of -1.0) indicates: If lambda_search is set to False and lambda is equal to zero, the default value of
 #'        gradient_epsilon is equal to .000001, otherwise the default value is .0001. If lambda_search is set to True,
-#'        the conditional values above are 1E-8 and 1E-6 respectively. Defaults to -1.
+#'        the conditional values above are 1E-8 and 1E-6 respectively. Defaults to 0.
 #' @param startval double array to initialize fixed and random coefficients for HGLM, coefficients for GLM.
 #' @param prior Prior probability for y==1. To be used only for logistic regression iff the data has been sampled and the mean
 #'        of response does not reflect reality. Defaults to 0.
@@ -91,7 +91,7 @@
 #' @param max_active_predictors Maximum number of active predictors during computation. Use as a stopping criterion to prevent expensive model
 #'        building with many predictors. Default indicates: If the IRLSM solver is used, the value of
 #'        max_active_predictors is set to 5000 otherwise it is set to 100000000. Defaults to -1.
-#' @param obj_reg Likelihood divider in objective value computation, default (of -1.0) will set it to 1/nobs Defaults to -1.
+#' @param obj_reg Likelihood divider in objective value computation, default (of -1.0) will set it to 1/nobs Defaults to 0.
 #' @param stopping_rounds Early stopping based on convergence of stopping_metric. Stop if simple moving average of length k of the
 #'        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable) Defaults to 0.
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and
@@ -165,14 +165,14 @@ h2o.modelSelection <- function(x,
                                max_iterations = 0,
                                objective_epsilon = -1,
                                beta_epsilon = 0.0001,
-                               gradient_epsilon = -1,
+                               gradient_epsilon = 0,
                                startval = NULL,
                                prior = 0,
                                cold_start = FALSE,
                                lambda_min_ratio = 0,
                                beta_constraints = NULL,
                                max_active_predictors = -1,
-                               obj_reg = -1,
+                               obj_reg = 0,
                                stopping_rounds = 0,
                                stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "AUCPR", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
                                stopping_tolerance = 0.001,
@@ -353,14 +353,14 @@ h2o.modelSelection <- function(x,
                                                max_iterations = 0,
                                                objective_epsilon = -1,
                                                beta_epsilon = 0.0001,
-                                               gradient_epsilon = -1,
+                                               gradient_epsilon = 0,
                                                startval = NULL,
                                                prior = 0,
                                                cold_start = FALSE,
                                                lambda_min_ratio = 0,
                                                beta_constraints = NULL,
                                                max_active_predictors = -1,
-                                               obj_reg = -1,
+                                               obj_reg = 0,
                                                stopping_rounds = 0,
                                                stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "AUCPR", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
                                                stopping_tolerance = 0.001,

--- a/h2o-r/tests/testdir_algos/modelselection/runit_PUBDEV_8428_modelselection_backward_binomial.R
+++ b/h2o-r/tests/testdir_algos/modelselection/runit_PUBDEV_8428_modelselection_backward_binomial.R
@@ -20,7 +20,7 @@ testModelSelection <- function() {
     predMissing <- xor(predNamesL, predNamesS)
     print(predMissing)
     coefs <- h2o.coef(backwardModel, length(predNamesL))
-    expect_equal(length(coefs), length(predNamesL)+1, tol=1e-6) # coefficient length should be equal to arguments used
+    expect_equal(length(coefs), length(predNamesL), tol=1e-6) # coefficient length should be equal to arguments used
   }
 }
 


### PR DESCRIPTION
This PR fixes the bug in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8675

The modelselection backward mode does this:
1.  It wil run GLM, calculate z-values/p-values
2. Take the abs(z_values) and delete the predictor with the smallest magnitude;
3. goto step one but this time, run with one less predictor and repeat until only one predictor is found or the min_predictor_number is hit or the p-value thresholds are reached.

Basically, with categorical columns, there will be multiple coefficients associated with that categorical columns.  Hence, when we try to compare the p-values of a categorical column, we need to look at all the p-values associated with all the levels of that categorical column.  Among all the p-values associated with that categorical column, I will take the minimum of all the p-values.  This minimum is then used to compare to the p-values of other columns.  The predictor with the highest p-values will be eliminated in the next round.

Multiple tests are added to make sure my implementation is correct.