### PR TITLE
PUBDEV-8692: DKV - Remove key-replicas from API

### DIFF
--- a/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModelInfo.java
+++ b/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModelInfo.java
@@ -769,11 +769,11 @@ final public class DeepLearningModelInfo extends Iced<DeepLearningModelInfo> {
   }
 
   public Key localModelInfoKey(H2ONode node) {
-    return Key.make(_model_id + ".node" + node.index(), (byte) 1 /*replica factor*/, (byte) 31 /*hidden user-key*/, true, node);
+    return Key.make(_model_id + ".node" + node.index(), (byte) 31 /*hidden user-key*/, true, node);
   }
 
   public Key elasticAverageModelInfoKey() {
-    return Key.make(_model_id + ".elasticaverage", (byte) 1 /*replica factor*/, (byte) 31 /*hidden user-key*/, true, H2O.CLOUD._memary[0]);
+    return Key.make(_model_id + ".elasticaverage", (byte) 31 /*hidden user-key*/, true, H2O.CLOUD._memary[0]);
   }
 
   static public class GradientCheck {

--- a/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModelInfo.java
+++ b/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModelInfo.java
@@ -769,11 +769,11 @@ final public class DeepLearningModelInfo extends Iced<DeepLearningModelInfo> {
   }
 
   public Key localModelInfoKey(H2ONode node) {
-    return Key.make(_model_id + ".node" + node.index(), (byte) 31 /*hidden user-key*/, true, node);
+    return Key.make(_model_id + ".node" + node.index(), Key.HIDDEN_USER_KEY, true, node);
   }
 
   public Key elasticAverageModelInfoKey() {
-    return Key.make(_model_id + ".elasticaverage", (byte) 31 /*hidden user-key*/, true, H2O.CLOUD._memary[0]);
+    return Key.make(_model_id + ".elasticaverage", Key.HIDDEN_USER_KEY, true, H2O.CLOUD._memary[0]);
   }
 
   static public class GradientCheck {

--- a/h2o-core/src/main/java/water/Job.java
+++ b/h2o-core/src/main/java/water/Job.java
@@ -103,7 +103,7 @@ public final class Job<T extends Keyed> extends Keyed<Job> {
 
   // Job Keys are pinned to this node (i.e., the node that invoked the
   // computation), because it should be almost always updated locally
-  private static Key<Job> defaultJobKey() { return Key.make((byte) 0, Key.JOB, false, H2O.SELF); }
+  private static Key<Job> defaultJobKey() { return Key.make(Key.JOB, false, H2O.SELF); }
 
 
   /** Job start_time and end_time using Sys.CTM */
@@ -226,7 +226,7 @@ public final class Job<T extends Keyed> extends Keyed<Job> {
 
   // --------------
   /** A system key for global list of Job keys. */
-  public static final Key<Job> LIST = Key.make(" JobList", (byte) 0, Key.BUILT_IN_KEY, false);
+  public static final Key<Job> LIST = Key.make(" JobList", Key.BUILT_IN_KEY, false);
 
   public String[] warns() {
     update_from_remote();

--- a/h2o-core/src/main/java/water/Job.java
+++ b/h2o-core/src/main/java/water/Job.java
@@ -226,7 +226,7 @@ public final class Job<T extends Keyed> extends Keyed<Job> {
 
   // --------------
   /** A system key for global list of Job keys. */
-  public static final Key<Job> LIST = Key.make(" JobList", Key.BUILT_IN_KEY, false);
+  public static final Key<Job> LIST = Key.make(" JobList", Key.BUILT_IN_KEY);
 
   public String[] warns() {
     update_from_remote();

--- a/h2o-core/src/main/java/water/rapids/BinaryMerge.java
+++ b/h2o-core/src/main/java/water/rapids/BinaryMerge.java
@@ -1029,7 +1029,7 @@ class BinaryMerge extends DTask<BinaryMerge> {
     return Key.make("__binary_merge__Chunk_for_col" + col + "_batch" + batch
         // + rightFrame._key.toString() + "_joined_with" + leftFrame._key.toString()
         + "_leftSB._msb" + leftMSB + "_riteSB._msb" + rightMSB,
-      (byte) 1, Key.HIDDEN_USER_KEY, false, SplitByMSBLocal.ownerOfMSB(rightMSB==-1 ? leftMSB : rightMSB)
+      Key.HIDDEN_USER_KEY, false, SplitByMSBLocal.ownerOfMSB(rightMSB==-1 ? leftMSB : rightMSB)
     ); //TODO home locally
   }
 

--- a/h2o-core/src/main/java/water/rapids/SplitByMSBLocal.java
+++ b/h2o-core/src/main/java/water/rapids/SplitByMSBLocal.java
@@ -199,12 +199,12 @@ class SplitByMSBLocal extends MRTask<SplitByMSBLocal> {
 
   static Key getNodeOXbatchKey(boolean isLeft, int MSBvalue, int node, int batch) {
     return Key.make("__radix_order__NodeOXbatch_MSB" + MSBvalue + "_node" + node + "_batch" + batch + (isLeft ? "_LEFT" : "_RIGHT"),
-            (byte) 1, Key.HIDDEN_USER_KEY, false, SplitByMSBLocal.ownerOfMSB(MSBvalue));
+            Key.HIDDEN_USER_KEY, false, SplitByMSBLocal.ownerOfMSB(MSBvalue));
   }
 
   static Key getSortedOXbatchKey(boolean isLeft, int MSBvalue, int batch) {
     return Key.make("__radix_order__SortedOXbatch_MSB" + MSBvalue + "_batch" + batch + (isLeft ? "_LEFT" : "_RIGHT"),
-            (byte) 1, Key.HIDDEN_USER_KEY, false, SplitByMSBLocal.ownerOfMSB(MSBvalue));
+            Key.HIDDEN_USER_KEY, false, SplitByMSBLocal.ownerOfMSB(MSBvalue));
   }
 
 
@@ -216,7 +216,7 @@ class SplitByMSBLocal extends MRTask<SplitByMSBLocal> {
 
   static Key getMSBNodeHeaderKey(boolean isLeft, int MSBvalue, int node) {
     return Key.make("__radix_order__OXNodeHeader_MSB" + MSBvalue + "_node" + node + (isLeft ? "_LEFT" : "_RIGHT"),
-            (byte) 1, Key.HIDDEN_USER_KEY, false, SplitByMSBLocal.ownerOfMSB(MSBvalue));
+            Key.HIDDEN_USER_KEY, false, SplitByMSBLocal.ownerOfMSB(MSBvalue));
   }
 
   static class MSBNodeHeader extends Iced {

--- a/h2o-core/src/test/java/water/AtomicTest.java
+++ b/h2o-core/src/test/java/water/AtomicTest.java
@@ -13,7 +13,7 @@ public class AtomicTest extends TestUtil {
     H2O cloud = H2O.CLOUD;
     H2ONode target = cloud._memary[0];
     if( target == H2O.SELF ) target = cloud._memary[1];
-    return Key.make(n,(byte)1,Key.BUILT_IN_KEY,true,target);
+    return Key.make(n,Key.BUILT_IN_KEY,true,target);
   }
 
   // Simple wrapper class defining an array-of-keys that is serializable.

--- a/h2o-core/src/test/java/water/DKVTest.java
+++ b/h2o-core/src/test/java/water/DKVTest.java
@@ -85,7 +85,7 @@ public class DKVTest extends TestUtil {
         System.out.println("iteration " + r);
         try {
           for (int i = 0; i < keys.length; ++i) // byte rf, byte systemType, boolean hint, H2ONode... replicas
-            DKV.put(keys[i] = Key.make((byte) 1, Key.HIDDEN_USER_KEY, true, H2O.CLOUD._memary[i]), new IcedInt(0));
+            DKV.put(keys[i] = Key.make(Key.HIDDEN_USER_KEY, true, H2O.CLOUD._memary[i]), new IcedInt(0));
           new TestMM(keys).doAllNodes();
         } finally {
           for (Key k : keys)

--- a/h2o-core/src/test/java/water/JobTest.java
+++ b/h2o-core/src/test/java/water/JobTest.java
@@ -132,6 +132,12 @@ public class JobTest extends TestUtil {
   }
 
   @Test
+  public void testDefaultJobKey() {
+    Key<Job> jobKey = new Job<>(Key.make(), Frame.class.getName(), "test")._key;
+    assertEquals(H2O.SELF, jobKey.home_node());
+  }
+  
+  @Test
   public void testBlockingWaitForDone() {
     final Job<Frame> j = new Job<>(Key.make(), Frame.class.getName(), "Test Job");
     final long sleepMs = 1_000;

--- a/h2o-core/src/test/java/water/KVTest.java
+++ b/h2o-core/src/test/java/water/KVTest.java
@@ -99,7 +99,7 @@ public class KVTest extends TestUtil {
     H2O cloud = H2O.CLOUD;
     H2ONode target = cloud._memary[0];
     if( target == H2O.SELF ) target = cloud._memary[1];
-    Key remote_key = Key.make("test4_remote",(byte)1,Key.BUILT_IN_KEY,true,target); // A key homed to a specific target
+    Key remote_key = Key.make("test4_remote",Key.BUILT_IN_KEY,true,target); // A key homed to a specific target
     Value v0 = DKV.get(remote_key);
     assertNull(v0);
     // It's a Big Value
@@ -161,7 +161,7 @@ public class KVTest extends TestUtil {
     H2O cloud = H2O.CLOUD;
     H2ONode target = cloud._memary[0];
     if( target == H2O.SELF ) target = cloud._memary[1];
-    Key key = Key.make("test6_remote",(byte)1,Key.BUILT_IN_KEY,true,target);
+    Key key = Key.make("test6_remote",Key.BUILT_IN_KEY,true,target);
     // It's a plain empty byte array - but too big for atomic update on purpose
     Value v1 = new Value(key,new byte[16]);
     // Remote-put operation

--- a/h2o-core/src/test/java/water/KeyTest.java
+++ b/h2o-core/src/test/java/water/KeyTest.java
@@ -41,6 +41,7 @@ public class KeyTest {
     public void testHomedKeyConsistency() { // to show that refactored code behaves like the old one for the key-homing use case
         H2ONode other = H2O.CLOUD.members()[(H2O.SELF.index() + 1) % H2O.CLOUD.size()];
         Key<?> key = Key.make("homed key", Key.JOB, true, other);
+        Assert.assertTrue(key.custom_homed());
         byte[] bytes = key._kb;
         Assert.assertEquals(Key.JOB, bytes[0]);
         Assert.assertEquals(1, bytes[1]); // indicator that key is specifically homed
@@ -57,6 +58,7 @@ public class KeyTest {
                 leader._key.getApiPort() - 2
         );
         Key<?> key = Key.make("homed key", Key.JOB, false, invalid);
+        Assert.assertFalse(key.custom_homed());
         byte[] bytes = key._kb;
         Assert.assertEquals(Key.JOB, bytes[0]);
         Assert.assertEquals(0, bytes[1]); // indicator that key is NOT specifically homed

--- a/h2o-core/src/test/java/water/KeyTest.java
+++ b/h2o-core/src/test/java/water/KeyTest.java
@@ -1,0 +1,115 @@
+package water;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import water.runner.CloudSize;
+import water.runner.H2ORunner;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+
+@CloudSize(1)
+@RunWith(H2ORunner.class)
+public class KeyTest {
+    
+    @Test
+    public void testBuild_cache() {
+        Assert.assertEquals(10762, Key.build_cache(10, 42));
+        Assert.assertEquals(16777215, Key.build_cache(255, 65535));
+        Assert.assertEquals(16777215, Key.build_cache(255, 65535*2+1));
+    }
+
+    @Test
+    public void testCloud() {
+        Assert.assertEquals(0, Key.cloud(Key.build_cache(0, 42)));
+        Assert.assertEquals(10, Key.cloud(Key.build_cache(10, 42)));
+        Assert.assertEquals(255, Key.cloud(Key.build_cache(255, 42)));
+        Assert.assertEquals(0, Key.cloud(Key.build_cache(255+1, 42)));
+    }
+
+    @Test
+    public void testHome() {
+        Assert.assertEquals(0, Key.home(Key.build_cache(10, 0)));
+        Assert.assertEquals(42, Key.home(Key.build_cache(10, 42)));
+        Assert.assertEquals(65535, Key.home(Key.build_cache(10, 65535)));
+        Assert.assertEquals(0, Key.home(Key.build_cache(10, 65535+1)));
+    }
+
+    @Test
+    public void testHomedKeyConsistency() { // to show that refactored code behaves like the old one for the key-homing use case
+        H2ONode other = H2O.CLOUD.members()[(H2O.SELF.index() + 1) % H2O.CLOUD.size()];
+        Key<?> key = Key.make("homed key", Key.JOB, true, other);
+        byte[] bytes = key._kb;
+        Assert.assertEquals(Key.JOB, bytes[0]);
+        Assert.assertEquals(1, bytes[1]); // indicator that key is specifically homed
+        byte[] oldBytes = old_make_with_replicas("homed key".getBytes(), Key.JOB, true, other);
+        Assert.assertArrayEquals(oldBytes, bytes);
+        Assert.assertEquals(key.D(), other.index());
+    }
+
+    @Test
+    public void testInvalidHomedKeyConsistency() {
+        H2ONode leader = H2O.CLOUD.leader();
+        H2ONode invalid = H2ONode.intern(
+                leader._key.getAddress(), 
+                leader._key.getApiPort() - 2
+        );
+        Key<?> key = Key.make("homed key", Key.JOB, false, invalid);
+        byte[] bytes = key._kb;
+        Assert.assertEquals(Key.JOB, bytes[0]);
+        Assert.assertEquals(0, bytes[1]); // indicator that key is NOT specifically homed
+        byte[] oldBytes = old_make_with_replicas("homed key".getBytes(), Key.JOB, false, invalid);
+        Assert.assertArrayEquals(oldBytes, bytes);
+        Assert.assertNotEquals(-1, key.D()); // just check it won't crash
+    }
+
+    // this is the original version of the method that supported up to 3 replicas
+    private static byte[] old_make_with_replicas(byte[] kb, byte systemType, boolean required, H2ONode... replicas) {
+        // no more than 3 replicas allowed to be stored in the key
+        assert replicas.length <= 3;
+        assert systemType<32; // only system keys allowed
+        boolean inCloud=true;
+        for( H2ONode h2o : replicas ) if( !H2O.CLOUD.contains(h2o) ) inCloud = false;
+        if( required ) assert inCloud; // If required placement, error to find a client as the home
+        else if( !inCloud ) replicas = new H2ONode[0]; // If placement is a hint & cannot be placed, then ignore
+
+        // Key byte layout is:
+        // 0 - systemType, from 0-31
+        // 1 - replica-count, plus up to 3 bits for ip4 vs ip6
+        // 2-n - zero, one, two or 3 IP4 (4+2 bytes) or IP6 (16+2 bytes) addresses
+        // 2-5- 4 bytes of chunk#, or -1 for masters
+        // n+ - repeat of the original kb
+        AutoBuffer ab = new AutoBuffer();
+        ab.put1(systemType).put1(replicas.length);
+        for( H2ONode h2o : replicas )
+            h2o.write(ab);
+        ab.put4(-1);
+        ab.putA1(kb,kb.length);
+        return Arrays.copyOf(ab.buf(),ab.position());
+    }
+
+    @Test
+    public void testMakeHomedKey() {
+        for (H2ONode h2o : H2O.CLOUD.members()) {
+            HomedKeyTask task = RPC.call(h2o, new HomedKeyTask()).get();
+            Assert.assertEquals(h2o, task._self.home_node());
+            Assert.assertEquals(h2o, task._job_self.home_node());
+        }
+    }
+
+    static class HomedKeyTask extends DTask<HomedKeyTask> {
+
+        Key<?> _self;
+        Key<?> _job_self;
+
+        @Override
+        public void compute2() {
+            _self = Key.make(H2O.SELF);
+            _job_self = Key.make(Key.JOB, true, H2O.SELF);
+            tryComplete();
+        }
+    }
+
+}

--- a/h2o-core/src/test/java/water/MRTaskTest.java
+++ b/h2o-core/src/test/java/water/MRTaskTest.java
@@ -28,7 +28,7 @@ public class MRTaskTest extends TestUtil {
       // (Some levels of the tree are used on launching the threads - hence it's (log2(numtasks) - log2(numcpus)*numcpus.
       int max_unreduced_elems = (depth - log + 1)*H2O.NUMCPUS;
       for (int i = 0; i < keys.length; ++i)
-        keys[i] = Key.make((byte) 1, Key.HIDDEN_USER_KEY, true, H2O.SELF);
+        keys[i] = Key.make(Key.HIDDEN_USER_KEY, true, H2O.SELF);
       final AtomicInteger cntr = new AtomicInteger();
       final AtomicInteger maxCntr = new AtomicInteger();
       new MRTask() {


### PR DESCRIPTION
This PR cleans up the Key API without any intended (!) changes in functionality.

The current Key API exposed the concept of replication factor and also homing keys to multiple replicas. This is however deprecated and unused.

Changes:
- replication factor is removed
- multiple replicas can no longer be specified - users can only specify a single node where to pin the given key (home)

FIY: @sebhrusen I am working on a POC of cluster resiliency that would require changes in the Key distribution function - this is therefore done to simplify the logic, remove dead code and keep only stuff that is actually needed/used.