### PR TITLE
PUBDEV-8682: Fix ambiguity check in consolidate varimp

### DIFF
--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -543,7 +543,9 @@ with_no_h2o_progress <- function(expr) {
   for (col in names(domains)) {
     if (!is.null(domains[[col]])) {
       for (domain in c("missing(NA)", domains[[col]])) {
-        col_domain_mapping[[paste0(col, ".", domain)]] <- col
+        tmp <- list()
+        tmp[[paste0(col, ".", domain)]] <- col
+        col_domain_mapping <- append(col_domain_mapping, tmp)
       }
     }
   }


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8682

This fix just makes sure that `col_domain_mapping` will contain duplicates if the same `variable.category` is used multiple times.

## Why this is needed?
In very rare cases we can encode multiple categorical variables to new one hot encoded variables that have the same name. The part of code in explain that was supposed to check for the ambiguity was broken.

Consider the following data frame:
```
  a | a.b
----+-----
b.c | c
  d | d
```
when one hot encoding it we would end up with two variables named `a.b.c` which could cause issues in the consolidate varimp part of code.