### PR TITLE
PUBDEV-8699: remove duplicate runs in maxr

### DIFF
--- a/h2o-algos/src/main/java/hex/modelselection/ModelSelection.java
+++ b/h2o-algos/src/main/java/hex/modelselection/ModelSelection.java
@@ -224,13 +224,14 @@ public class ModelSelection extends ModelBuilder<hex.modelselection.ModelSelecti
             List<String> coefNames = new ArrayList<>(Arrays.asList(_predictorNames));
             List<Integer> validSubset = IntStream.rangeClosed(0, coefNames.size() - 1).boxed().collect(Collectors.toList());
             for (int predNum = 1; predNum <= _parms._max_predictor_number; predNum++) { // perform for each subset size
+                Set<BitSet> usedCombos = new HashSet<>();
                 GLMModel bestR2Model = forwardStep(currSubsetIndices, coefNames, predNum - 1, validSubset,
-                        _parms, _foldColumn, _glmNFolds, _foldAssignment); // forward step
+                        _parms, _foldColumn, _glmNFolds, _foldAssignment, usedCombos); // forward step
                 validSubset.removeAll(currSubsetIndices);
                 _job.update(predNum, "Finished building all models with "+predNum+" predictors.");
                 if (predNum < _numPredictors && predNum > 1) {
                     GLMModel currBestR2Model = replacement(currSubsetIndices, coefNames, bestR2Model.r2(), _parms,
-                            _glmNFolds, _foldColumn, validSubset, _foldAssignment);
+                            _glmNFolds, _foldColumn, validSubset, _foldAssignment, usedCombos);
                     if (currBestR2Model != null) {
                         bestR2Model.delete();
                         bestR2Model = currBestR2Model;
@@ -360,18 +361,22 @@ public class ModelSelection extends ModelBuilder<hex.modelselection.ModelSelecti
         // generate training frames
         Frame[] trainingFrames = generateMaxRTrainingFrames(parms, predictorNames, foldColumn,
                 currSubsetIndices, predPos, validSubsets, usedCombo);
-        // find GLM model with best R2 value and return it
-        GLMModel bestModel = buildExtractBestR2Model(trainingFrames, parms, glmNFolds, foldColumn, foldAssignment);
-        List<String> coefUsed = extraModelColumnNames(coefNames, bestModel);
-        for (int predIndex = coefUsed.size()-1; predIndex >= 0; predIndex--) {
-            int index = coefNames.indexOf(coefUsed.get(predIndex));
-            if (!currSubsetIndices.contains(index)) {
-                currSubsetIndices.add(predPos, index);
-                break;
+        if (trainingFrames.length > 0) {
+            // find GLM model with best R2 value and return it
+            GLMModel bestModel = buildExtractBestR2Model(trainingFrames, parms, glmNFolds, foldColumn, foldAssignment);
+            List<String> coefUsed = extraModelColumnNames(coefNames, bestModel);
+            for (int predIndex = coefUsed.size() - 1; predIndex >= 0; predIndex--) {
+                int index = coefNames.indexOf(coefUsed.get(predIndex));
+                if (!currSubsetIndices.contains(index)) {
+                    currSubsetIndices.add(predPos, index);
+                    break;
+                }
             }
+            removeTrainingFrames(trainingFrames);
+            return bestModel;
+        } else {
+            return null;
         }
-        removeTrainingFrames(trainingFrames);
-        return bestModel;
     }
 
     public static GLMModel forwardStep(List<Integer> currSubsetIndices, List<String> coefNames, int predPos,
@@ -397,13 +402,8 @@ public class ModelSelection extends ModelBuilder<hex.modelselection.ModelSelecti
     public static GLMModel replacement(List<Integer> currSubsetIndices, List<String> coefNames,
                                        double bestR2, ModelSelectionModel.ModelSelectionParameters parms,
                                        int glmNFolds, String foldColumn, List<Integer> validSubset,
-                                       Model.Parameters.FoldAssignmentScheme foldAssignment) {
+                                       Model.Parameters.FoldAssignmentScheme foldAssignment, Set<BitSet> usedCombos) {
         int currSubsetSize = currSubsetIndices.size();
-        
-        Integer[] sortedCurrSubset = currSubsetIndices.toArray(new Integer[0]);
-        Arrays.sort(sortedCurrSubset);
-        Set<BitSet> usedCombos = new HashSet<>();
-        usedCombos.add(setBitSet(currSubsetIndices.stream().mapToInt(i->i).toArray(), coefNames.size()));
         int lastBestR2PosIndex = -1;
         GLMModel bestR2Model = null;
         GLMModel[] bestR2Models = new GLMModel[currSubsetSize];

--- a/h2o-algos/src/main/java/hex/modelselection/ModelSelectionUtils.java
+++ b/h2o-algos/src/main/java/hex/modelselection/ModelSelectionUtils.java
@@ -125,18 +125,27 @@ public class ModelSelectionUtils {
         int[] predIndices = changedSubset.stream().mapToInt(Integer::intValue).toArray();
         int predNum = predictorNames.length;
         BitSet tempIndices =  new BitSet(predNum);
+        int predSizes = changedSubset.size();
+        boolean emptyUsedCombo = (usedCombo != null) && (usedCombo.size() == 0);
         for (int predIndex : validSubsets) {  // consider valid predictor indices only
             predIndices[newPredPos] = predIndex;
-            if (usedCombo != null) {   // only need to check for replacement step 
+            if (emptyUsedCombo && predSizes > 1) {   // add all indice set into usedCombo
                 tempIndices.clear();
                 setBitSet(tempIndices, predIndices);
-                if (!usedCombo.contains(tempIndices)) {
-                    usedCombo.add((BitSet) tempIndices.clone());
+                usedCombo.add((BitSet) tempIndices.clone());
+                Frame trainFrame = generateOneFrame(predIndices, parms, predictorNames, foldColumn);
+                DKV.put(trainFrame);
+                trainFramesList.add(trainFrame);
+                
+            } else if (usedCombo != null && predSizes > 1) {   // only need to check for forward and replacement step for maxR
+                tempIndices.clear();
+                setBitSet(tempIndices, predIndices);
+                if (usedCombo.add((BitSet) tempIndices.clone())) {  // returns true if not in keyset
                     Frame trainFrame = generateOneFrame(predIndices, parms, predictorNames, foldColumn);
                     DKV.put(trainFrame);
                     trainFramesList.add(trainFrame);
                 }
-            } else {
+            } else {     // just build without checking duplicates for other modes
                 Frame trainFrame = generateOneFrame(predIndices, parms, predictorNames, foldColumn);
                 DKV.put(trainFrame);
                 trainFramesList.add(trainFrame);

--- a/h2o-algos/src/test/java/hex/modelselection/ModelSelectionMaxRTests.java
+++ b/h2o-algos/src/test/java/hex/modelselection/ModelSelectionMaxRTests.java
@@ -310,7 +310,7 @@ public class ModelSelectionMaxRTests extends TestUtil {
         List<Integer> validSubset = IntStream.rangeClosed(0, coefNames.size()-1).boxed().collect(Collectors.toList()); 
         validSubset.removeAll(currSubset);
         GLMModel bestR2Model = replacement(currSubset, coefNames, bestR2, parms, 0,
-                null, validSubset,null);
+                null, validSubset,null, new HashSet<BitSet>());
         if (bestR2Model == null && okToBeNull) {
             return;
         }

--- a/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8619_maxr_slow.py
+++ b/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8619_maxr_slow.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import division
 import sys
 sys.path.insert(1, "../../../")
 import h2o


### PR DESCRIPTION
This PR fixes the bug in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8699

The bug is caused by not adding the first forward run predictor subset indices into usedCombo which will check again duplicate runs in the replacement step.  I have hence corrected this oversight.