### PR TITLE
PUBDEV-8522: Fixing fit_params passthrough for scikit-learn compatibility

### DIFF
--- a/h2o-py/h2o/sklearn/wrapper.py
+++ b/h2o-py/h2o/sklearn/wrapper.py
@@ -264,7 +264,7 @@ def params_as_h2o_frames(frame_params=('X', 'y'),
             """
             _args = sig.bind(*args, **kwargs).arguments
             for name, param in sig.parameters.items():
-                if param.kind == param.VAR_KEYWORD:
+                if param.kind == param.VAR_KEYWORD and name in _args:
                     kw_arg = _args.pop(name)
                     _args = {**_args, **kw_arg}
 

--- a/h2o-py/h2o/sklearn/wrapper.py
+++ b/h2o-py/h2o/sklearn/wrapper.py
@@ -266,7 +266,7 @@ def params_as_h2o_frames(frame_params=('X', 'y'),
             for name, param in sig.parameters.items():
                 if param.kind == param.VAR_KEYWORD and name in _args:
                     kw_arg = _args.pop(name)
-                    _args = {**_args, **kw_arg}
+                    _args.update(**kw_arg)
 
             classifier = False
             self = {}

--- a/h2o-py/h2o/sklearn/wrapper.py
+++ b/h2o-py/h2o/sklearn/wrapper.py
@@ -263,6 +263,11 @@ def params_as_h2o_frames(frame_params=('X', 'y'),
             :return:
             """
             _args = sig.bind(*args, **kwargs).arguments
+            for name, param in sig.parameters.items():
+                if param.kind == param.VAR_KEYWORD:
+                    kw_arg = _args.pop(name)
+                    _args = {**_args, **kw_arg}
+
             classifier = False
             self = {}
             frame_info = None

--- a/h2o-py/tests/testdir_sklearn/pyunit_sklearn_classification_all_estimators.py
+++ b/h2o-py/tests/testdir_sklearn/pyunit_sklearn_classification_all_estimators.py
@@ -61,7 +61,7 @@ def test_estimator_with_h2o_frames(estimator_cls):
 
     data = _get_data(format='h2o', n_classes=2)
     assert isinstance(data.X_train, h2o.H2OFrame)
-    estimator.fit(data.X_train, data.y_train)
+    estimator.fit(data.X_train, data.y_train, verbose=True)  # Adding verbose to test fit_params integration
     preds = estimator.predict(data.X_test)
     print(preds)
     assert isinstance(preds, h2o.H2OFrame)


### PR DESCRIPTION
In this PR, @NikhilJArora and I have added a fix to ensure that parameters passed using `fit_params` for the `scikit-learn`-compatible estimators are handled correctly. We have added one field to an existing test to ensure the functionality is working as intended.

https://h2oai.atlassian.net/browse/PUBDEV-8522