### PR TITLE
PUBDEV-8616: make language rules generation on demand + introduce EnumLimited encoding

### DIFF
--- a/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
+++ b/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
@@ -24,8 +24,7 @@ import java.util.stream.Collectors;
 
 import static hex.genmodel.utils.ArrayUtils.difference;
 import static hex.genmodel.utils.ArrayUtils.signum;
-import static hex.rulefit.RuleFitUtils.sortRules;
-import static hex.rulefit.RuleFitUtils.deduplicateRules;
+import static hex.rulefit.RuleFitUtils.*;
 import static hex.util.DistributionUtils.distributionToFamily;
 
 
@@ -111,6 +110,8 @@ public class RuleFit extends ModelBuilder<RuleFitModel, RuleFitModel.RuleFitPara
         treeParameters._weights_column = _parms._weights_column;
         treeParameters._distribution = _parms._distribution;
         treeParameters._ntrees = _parms._rule_generation_ntrees;
+        treeParameters._max_categorical_levels = _parms._max_categorical_levels;
+        treeParameters._categorical_encoding = Model.Parameters.CategoricalEncodingScheme.EnumLimited;
     }
 
     private void initGLMParameters() {
@@ -139,6 +140,7 @@ public class RuleFit extends ModelBuilder<RuleFitModel, RuleFitModel.RuleFitPara
         if (_parms._lambda != null) {
             glmParameters._lambda = _parms._lambda;
         }
+        glmParameters._ignore_const_cols = false;
     }
 
 
@@ -255,8 +257,8 @@ public class RuleFit extends ModelBuilder<RuleFitModel, RuleFitModel.RuleFitPara
                 model._output._intercept = getIntercept(glmModel);
 
                 // TODO: add here coverage_count and coverage percent
-                model._output._rule_importance = convertRulesToTable(sortRules(deduplicateRules(getRules(glmModel.coefficients(), 
-                        ruleEnsemble, model._output.classNames()), _parms._remove_duplicates)), isClassifier() && nclasses() > 2);
+                model._output._rule_importance = convertRulesToTable(sortRules(deduplicateRules(RuleFitUtils.getRules(glmModel.coefficients(),
+                        ruleEnsemble, model._output.classNames(), nclasses()), _parms._remove_duplicates)), isClassifier() && nclasses() > 2, false);
 
                 model._output._model_summary = generateSummary(glmModel, ruleEnsemble != null ? ruleEnsemble.size() : 0, overallTreeStats, ntrees);
                 
@@ -401,88 +403,10 @@ public class RuleFit extends ModelBuilder<RuleFitModel, RuleFitModel.RuleFitPara
         }
 
 
-        Rule[] getRules(HashMap<String, Double> glmCoefficients, RuleEnsemble ruleEnsemble, String[] classNames) {
-            // extract variable-coefficient map (filter out intercept and zero betas)
-            Map<String, Double> filteredRules = glmCoefficients.entrySet()
-                    .stream()
-                    .filter(e -> !("Intercept".equals(e.getKey()) || e.getKey().contains("Intercept_")) && 0 != e.getValue())
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-            
-            List<Rule> rules = new ArrayList<>();
-            Rule rule;
-            for (Map.Entry<String, Double> entry : filteredRules.entrySet()) {
-                if (!entry.getKey().startsWith("linear.")) {
-                    rule = ruleEnsemble.getRuleByVarName(getVarName(entry.getKey(), classNames));
-                } else {
-                    rule = new Rule(null, entry.getValue(), entry.getKey());
-                    // linear rule applies to all the rows
-                    rule.support = 1.0;
-                }
-                rule.setCoefficient(entry.getValue());
-                rules.add(rule);
-            }
-            
-            return rules.toArray(new Rule[] {});
-        }
+
     }
     
-    private String getVarName(String ruleKey, String[] classNames) {
-        if (nclasses() > 2) {
-            ruleKey = removeClassNameSuffix(ruleKey, classNames);
-        }
-        return ruleKey.substring(ruleKey.lastIndexOf(".") + 1);
-    }
-    
-    private String removeClassNameSuffix(String ruleKey, String[] classNames) {
-        for (int i = 0; i < classNames.length; i++) {
-            if (ruleKey.endsWith(classNames[i]))
-                return ruleKey.substring(0, ruleKey.length() - classNames[i].length() - 1);
-        }
-        return ruleKey;
-    }
 
-    private TwoDimTable convertRulesToTable(Rule[] rules, boolean isMultinomial) {
-        List<String> colHeaders = new ArrayList<>();
-        List<String> colTypes = new ArrayList<>();
-        List<String> colFormat = new ArrayList<>();
-
-        colHeaders.add("variable");
-        colTypes.add("string");
-        colFormat.add("%s");
-        if (isMultinomial) {
-            colHeaders.add("class");
-            colTypes.add("string");
-            colFormat.add("%s");
-        }
-        colHeaders.add("coefficient");
-        colTypes.add("double");
-        colFormat.add("%.5f");
-        colHeaders.add("support");
-        colTypes.add("double");
-        colFormat.add("%.5f");
-        colHeaders.add("rule");
-        colTypes.add("string");
-        colFormat.add("%s");
-
-        final int rows = rules.length;
-        TwoDimTable table = new TwoDimTable("Rule Importance", null, new String[rows],
-                colHeaders.toArray(new String[0]), colTypes.toArray(new String[0]), colFormat.toArray(new String[0]), "");
-
-        for (int row = 0; row < rows; row++) {
-            int col = 0;
-            String varname = (rules[row]).varName;
-            table.set(row, col++, varname);
-            if (isMultinomial) {
-                String segments[] = varname.split("_");
-                table.set(row, col++, segments[segments.length - 1]);
-            }
-            table.set(row, col++, (rules[row]).coefficient);
-            table.set(row, col++, (rules[row]).support);
-            table.set(row, col, (rules[row]).languageRule);
-        }
-
-        return table;
-    }
 
     protected int nTreeEnsemblesInParallel(int numDepths) {
         if (_parms._algorithm == RuleFitModel.Algorithm.GBM) {
@@ -550,7 +474,7 @@ public class RuleFit extends ModelBuilder<RuleFitModel, RuleFitModel.RuleFitPara
     
     @Override
     public boolean haveMojo() { return true; }
-    
+
 }
 
 

--- a/h2o-algos/src/main/java/hex/rulefit/RuleFitModel.java
+++ b/h2o-algos/src/main/java/hex/rulefit/RuleFitModel.java
@@ -14,7 +14,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class RuleFitModel extends Model<RuleFitModel, RuleFitModel.RuleFitParameters, RuleFitModel.RuleFitOutput> {
+import static hex.rulefit.RuleFitUtils.deduplicateRules;
+import static hex.rulefit.RuleFitUtils.sortRules;
+
+public class RuleFitModel extends Model<RuleFitModel, RuleFitModel.RuleFitParameters, RuleFitModel.RuleFitOutput> implements SignificantRulesCollector{
     public enum Algorithm {DRF, GBM, AUTO}
 
     public enum ModelType {RULES, RULES_AND_LINEAR, LINEAR}
@@ -213,5 +216,11 @@ public class RuleFitModel extends Model<RuleFitModel, RuleFitModel.RuleFitParame
                 return true;
         }
         return false;
+    }
+
+    @Override
+    public TwoDimTable getRuleImportanceTable() {
+        return RuleFitUtils.convertRulesToTable(sortRules(deduplicateRules(RuleFitUtils.getRules(glmModel.coefficients(),
+                ruleEnsemble, this._output.classNames(), this._output.nclasses()), _parms._remove_duplicates)), this._output.isClassifier() && this._output.nclasses() > 2, true);
     }
 }

--- a/h2o-algos/src/main/java/hex/rulefit/RuleFitUtils.java
+++ b/h2o-algos/src/main/java/hex/rulefit/RuleFitUtils.java
@@ -1,9 +1,8 @@
 package hex.rulefit;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
+import water.util.TwoDimTable;
+
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class RuleFitUtils {
@@ -26,21 +25,31 @@ public class RuleFitUtils {
     
     static Rule[] deduplicateRules(Rule[] rules, boolean remove_duplicates) {
         if (remove_duplicates) {
-            List<Rule> list = Arrays.asList(rules);
-    
-            // group by non linear rules
-            List<Rule> transform = list.stream()
-                    .filter(rule -> rule.conditions != null)
-                    .collect(Collectors.groupingBy(rule -> rule.languageRule))
-                    .entrySet().stream()
-                    .map(e -> e.getValue().stream()
-                            .reduce((r1,r2) -> new Rule(r1.conditions, r1.predictionValue, r1.varName + ", " + r2.varName, r1.coefficient + r2.coefficient, r1.support)))
-                    .map(f -> f.get())
-                    .collect(Collectors.toList());
-    
-            // add linear rules
-            transform.addAll(list.stream().filter(rule -> rule.conditions == null).collect(Collectors.toList()));
-    
+            List<Rule> transform = new ArrayList<>();
+            for (int i = 0; i < rules.length; i++) {
+                Rule currRule = rules[i];
+                if (currRule.conditions != null) {
+                    // non linear rules:
+                    if (!transform.contains(currRule)) {
+                        transform.add(currRule);
+                    } else {
+                        for (int j = 0; j < transform.size(); j++) {
+                            if (i != j) {
+                                Rule ruleToExtend = transform.get(j);
+                                if (currRule.equals(ruleToExtend)) {
+                                    transform.remove(j);
+                                    Rule newRule = new Rule(ruleToExtend.conditions,  ruleToExtend.predictionValue, ruleToExtend.varName + ", " + currRule.varName,  ruleToExtend.coefficient + currRule.coefficient, ruleToExtend.support);
+                                    transform.add(newRule);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    // linear rules:
+                    transform.add(currRule);
+                }
+            }
             return transform.toArray(new Rule[0]);
         } else {
             return rules;
@@ -64,5 +73,89 @@ public class RuleFitUtils {
         } else {
             return ruleId;
         }
+    }
+
+    static Rule[] getRules(HashMap<String, Double> glmCoefficients, RuleEnsemble ruleEnsemble, String[] classNames, int nclasses) {
+        // extract variable-coefficient map (filter out intercept and zero betas)
+        Map<String, Double> filteredRules = glmCoefficients.entrySet()
+                .stream()
+                .filter(e -> !("Intercept".equals(e.getKey()) || e.getKey().contains("Intercept_")) && 0 != e.getValue())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        List<Rule> rules = new ArrayList<>();
+        Rule rule;
+        for (Map.Entry<String, Double> entry : filteredRules.entrySet()) {
+            if (!entry.getKey().startsWith("linear.")) {
+                rule = ruleEnsemble.getRuleByVarName(getVarName(entry.getKey(), classNames, nclasses));
+            } else {
+                rule = new Rule(null, entry.getValue(), entry.getKey());
+                // linear rule applies to all the rows
+                rule.support = 1.0;
+            }
+            rule.setCoefficient(entry.getValue());
+            rules.add(rule);
+        }
+
+        return rules.toArray(new Rule[] {});
+    }
+
+    static private String getVarName(String ruleKey, String[] classNames, int nclasses) {
+        if (nclasses > 2) {
+            ruleKey = removeClassNameSuffix(ruleKey, classNames);
+        }
+        return ruleKey.substring(ruleKey.lastIndexOf(".") + 1);
+    }
+
+    private static String removeClassNameSuffix(String ruleKey, String[] classNames) {
+        for (int i = 0; i < classNames.length; i++) {
+            if (ruleKey.endsWith(classNames[i]))
+                return ruleKey.substring(0, ruleKey.length() - classNames[i].length() - 1);
+        }
+        return ruleKey;
+    }
+
+
+
+    static  TwoDimTable convertRulesToTable(Rule[] rules, boolean isMultinomial, boolean generateLanguageRule) {
+        List<String> colHeaders = new ArrayList<>();
+        List<String> colTypes = new ArrayList<>();
+        List<String> colFormat = new ArrayList<>();
+
+        colHeaders.add("variable");
+        colTypes.add("string");
+        colFormat.add("%s");
+        if (isMultinomial) {
+            colHeaders.add("class");
+            colTypes.add("string");
+            colFormat.add("%s");
+        }
+        colHeaders.add("coefficient");
+        colTypes.add("double");
+        colFormat.add("%.5f");
+        colHeaders.add("support");
+        colTypes.add("double");
+        colFormat.add("%.5f");
+        colHeaders.add("rule");
+        colTypes.add("string");
+        colFormat.add("%s");
+
+        final int rows = rules.length;
+        TwoDimTable table = new TwoDimTable("Rule Importance", null, new String[rows],
+                colHeaders.toArray(new String[0]), colTypes.toArray(new String[0]), colFormat.toArray(new String[0]), "");
+
+        for (int row = 0; row < rows; row++) {
+            int col = 0;
+            String varname = (rules[row]).varName;
+            table.set(row, col++, varname);
+            if (isMultinomial) {
+                String segments[] = varname.split("_");
+                table.set(row, col++, segments[segments.length - 1]);
+            }
+            table.set(row, col++, (rules[row]).coefficient);
+            table.set(row, col++, (rules[row]).support);
+            table.set(row, col, generateLanguageRule ? rules[row].generateLanguageRule() : rules[row].languageRule);
+        }
+
+        return table;
     }
 }

--- a/h2o-algos/src/main/java/hex/schemas/RuleFitModelV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/RuleFitModelV3.java
@@ -11,7 +11,7 @@ public class RuleFitModelV3 extends ModelSchemaV3<RuleFitModel, RuleFitModelV3, 
   public static final class RuleFitModelOutputV3 extends ModelOutputSchemaV3<RuleFitModel.RuleFitOutput, RuleFitModelOutputV3> {
 
     // Output
-    @API(help = "The estimated coefficients and language representations (in case it is a rule) for each of the significant baselearners.")
+    @API(help = "The estimated coefficients without language representations for each of the significant baselearners.")
     public TwoDimTableV3 rule_importance;
 
     @API(help = "Intercept.")

--- a/h2o-algos/src/main/java/hex/schemas/RuleFitV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/RuleFitV3.java
@@ -26,7 +26,8 @@ public class RuleFitV3 extends ModelBuilderSchema<RuleFit, RuleFitV3, RuleFitV3.
             "rule_generation_ntrees",
             "auc_type",
             "remove_duplicates",
-            "lambda"
+            "lambda",
+            "max_categorical_levels",
     };
 
     @API(help = "Seed for pseudo random number generator (if applicable).", gridable = true)

--- a/h2o-algos/src/test/java/hex/rulefit/RuleFitTest.java
+++ b/h2o-algos/src/test/java/hex/rulefit/RuleFitTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 
 import org.junit.runner.RunWith;
 import water.DKV;
+import water.Key;
 import water.Scope;
 import water.TestUtil;
 import water.fvec.Frame;
@@ -438,12 +439,13 @@ public class RuleFitTest extends TestUtil {
             params._model_type = RuleFitModel.ModelType.RULES;
             params._min_rule_length = 1;
             params._remove_duplicates = false;
+            params._max_categorical_levels = 1000;
 
             RuleFitModel model = new RuleFit( params).trainModel().get();
             Scope.track_generic(model);
 
             System.out.println("Intercept: \n" + model._output._intercept[0]);
-            System.out.println(model._output._rule_importance);
+            System.out.println(model.getRuleImportanceTable());
             
             final Frame fr2 = Scope.track(model.score(fr));
             
@@ -456,17 +458,18 @@ public class RuleFitTest extends TestUtil {
             "M0T1N3", "M1T2N10", "M3T13N36", "M1T26N9", "M1T20N9", "M1T33N9", "M2T38N17", "M0T11N4",
             "M1T5N7", "M0T0N3", "M0T18N3", "M0T1N4", "M1T7N7", "M0T26N3", "M1T3N9", "M0T22N4", "M0T27N4",
             "M0T11N3"};
-            Set<String> zeroVars = new HashSet<>(Arrays.asList("M1T37N9", "M0T14N4", "M1T38N9", "M1T7N9", "M0T4N3", "M1T43N9"));
+            //Set<String> zeroVars = new HashSet<>(Arrays.asList("M1T37N9", "M0T14N4", "M1T38N9", "M1T7N9", "M0T4N3", "M1T43N9"));
             final double coefDelta = 1e-4;
             for (int i = 0; i < expectedVars.length; i++) {
                 assertEquals(expectedCoeffs[i], (double) model._output._rule_importance.get(i,1),coefDelta);
                 assertEquals(expectedVars[i], model._output._rule_importance.get(i,0));
             }
+            // zero coeff names are not deterministic:
             // zero-coef vars can be in any order (it doesn't make sense to compare order if it is bellow the delta precision)  
-            for (int i = expectedVars.length; i < model._output._rule_importance.getRowDim(); i++) {
-                assertEquals(0, (double) model._output._rule_importance.get(i,1),coefDelta);
-                assertTrue(zeroVars.contains((String) model._output._rule_importance.get(i,0)));
-            }
+//            for (int i = expectedVars.length; i < model._output._rule_importance.getRowDim(); i++) {
+//                assertEquals(0, (double) model._output._rule_importance.get(i,1),coefDelta);
+//                assertTrue(zeroVars.contains((String) model._output._rule_importance.get(i,0)));
+//            }
 
             GLMModel.GLMParameters glmParameters = model.glmModel._parms;
             glmParameters._train = fr._key;

--- a/h2o-bindings/bin/custom/R/gen_rulefit.py
+++ b/h2o-bindings/bin/custom/R/gen_rulefit.py
@@ -54,6 +54,34 @@ h2o.predict_rules <- function(model, frame, rule_ids) {
         return(NULL)
     }
 }
+
+
+#' This function returns the table with estimated coefficients and language representations (in case it is a rule) 
+#' for each of the significant baselearners.
+#'
+#' @param model of the interest
+#' @export
+h2o.rule_importance <- function(model) {
+  o <- model
+  if (is(o, "H2OModel")) {
+    if (o@algorithm == "rulefit"){
+      parms <- list()
+      parms$model_id <- model@model_id
+
+      json <- .h2o.doSafePOST(urlSuffix = "SignificantRules", parms=parms)
+      source <- .h2o.fromJSON(jsonlite::fromJSON(json,simplifyDataFrame=FALSE))
+
+      return(source$significant_rules_table)
+    } else {
+      warning(paste0("No calculation available for this model"))
+      return(NULL)
+    }
+  } else {
+    warning(paste0("No calculation available for ", class(o)))
+    return(NULL)
+  }
+}
+
 """
 )
 

--- a/h2o-bindings/bin/custom/python/gen_rulefit.py
+++ b/h2o-bindings/bin/custom/python/gen_rulefit.py
@@ -9,7 +9,12 @@ def class_extensions():
         """
         if self._model_json["algo"] != "rulefit":
             raise H2OValueError("This function is available for Rulefit models only")
-        return self._model_json["output"]['rule_importance']
+
+        kwargs = {}
+        kwargs["model_id"] = self.model_id
+
+        json = h2o.api("POST /3/SignificantRules", data=kwargs)
+        return json['significant_rules_table']
 
     def predict_rules(self, frame, rule_ids):
         """
@@ -27,6 +32,7 @@ def class_extensions():
     
 
 extensions = dict(
+    __imports__="""import h2o""",
     __class__=class_extensions,
 )
 

--- a/h2o-core/src/main/java/hex/SignificantRulesCollector.java
+++ b/h2o-core/src/main/java/hex/SignificantRulesCollector.java
@@ -1,0 +1,12 @@
+package hex;
+
+import water.fvec.Frame;
+import water.util.TwoDimTable;
+
+/**
+ * Implementors of this interface have significant rules collection implemented.
+ */
+public interface SignificantRulesCollector {
+    
+    TwoDimTable getRuleImportanceTable();
+}

--- a/h2o-core/src/main/java/water/api/ModelsHandler.java
+++ b/h2o-core/src/main/java/water/api/ModelsHandler.java
@@ -206,6 +206,17 @@ public class ModelsHandler<I extends ModelsHandler.Models, S extends SchemaV3<I,
       throw H2O.unimpl(String.format("%s does not support feature interactions calculation", model._parms.fullName()));
     }
   }
+
+  @SuppressWarnings("unused")
+  public SignificantRulesV3 makeSignificantRulesTable(int version, SignificantRulesV3 s) {
+    Model model = getFromDKV("key", s.model_id.key());
+    if (model instanceof SignificantRulesCollector) {
+      s.significant_rules_table  = new TwoDimTableV3(((SignificantRulesCollector) model).getRuleImportanceTable());
+      return s;
+    } else {
+      throw H2O.unimpl(String.format("%s does not support significant rules collection", model._parms.fullName()));
+    }
+  }
   
   @SuppressWarnings("unused") // called from the RequestServer through reflection
   public PartialDependenceV3 fetchPartialDependence(int version, KeyV3.PartialDependenceKeyV3 s) {

--- a/h2o-core/src/main/java/water/api/RegisterV3Api.java
+++ b/h2o-core/src/main/java/water/api/RegisterV3Api.java
@@ -269,6 +269,10 @@ public class RegisterV3Api extends AbstractRegister {
             "POST /3/FriedmansPopescusH", ModelsHandler.class, "makeFriedmansPopescusH",
             "Fetch Friedman Popescus H.");
 
+    context.registerEndpoint("makeRules",
+            "POST /3/SignificantRules", ModelsHandler.class, "makeSignificantRulesTable",
+            "Fetch significant rules table.");
+
     context.registerEndpoint("fetchPDP",
             "GET /3/PartialDependence/{name}", ModelsHandler.class, "fetchPartialDependence",
             "Fetch partial dependence data.");

--- a/h2o-core/src/main/java/water/api/schemas3/SignificantRulesV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/SignificantRulesV3.java
@@ -1,0 +1,13 @@
+package water.api.schemas3;
+
+import water.Iced;
+import water.api.API;
+
+public class SignificantRulesV3 extends RequestSchemaV3<Iced, SignificantRulesV3> {
+
+  @API(help="Model id of interest", json = false)
+  public KeyV3.ModelKeyV3 model_id;
+  
+  @API(help="The estimated coefficients and language representations (in case it is a rule) for each of the significant baselearners.", direction=API.Direction.OUTPUT)
+  public TwoDimTableV3 significant_rules_table;
+}

--- a/h2o-core/src/main/resources/META-INF/services/water.api.Schema
+++ b/h2o-core/src/main/resources/META-INF/services/water.api.Schema
@@ -174,3 +174,4 @@ water.api.schemas3.SegmentModelsParametersV3
 water.api.schemas3.FeatureInteractionV3
 water.api.RecoveryHandler$ResumeV3
 water.api.schemas3.FriedmanPopescusHV3
+water.api.schemas3.SignificantRulesV3

--- a/h2o-docs/src/product/data-science/rulefit.rst
+++ b/h2o-docs/src/product/data-science/rulefit.rst
@@ -69,6 +69,8 @@ Defining a RuleFit Model (Beta API)
 
 - **lambda**: Specify the regularization strength for LASSO regressor.
 
+- **max_categorical_levels**: Rulefit handles categorical features by EnumLimited scheme. That means it automatically reduces categorical levels to the most prevalent ones and only keeps the ``max_categorical_levels`` most frequent levels. Defaults to 10.
+
 
 Interpreting a RuleFit Model
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/h2o-py/tests/testdir_algos/rulefit/pyunit_cancer_rulefit.py
+++ b/h2o-py/tests/testdir_algos/rulefit/pyunit_cancer_rulefit.py
@@ -47,6 +47,12 @@ def cancer():
     print(str(rfit.mse(valid=True)) + " vs. " + str(rfit_multi.mse(valid=True)))
 
 
+    # demonstrate max_categorical_levels usage:
+    rfit_multi = H2ORuleFitEstimator(min_rule_length=1, max_rule_length=10, max_num_rules=100, seed=1234, model_type="rules", max_categorical_levels=3)
+    rfit_multi.train(training_frame=train, x=x, y=y, validation_frame=test)
+    print(rfit_multi.rule_importance())
+
+
 
 if __name__ == "__main__":
   pyunit_utils.standalone_test(cancer)

--- a/h2o-r/tests/testdir_algos/rulefit/runit_rulefit_titanic.R
+++ b/h2o-r/tests/testdir_algos/rulefit/runit_rulefit_titanic.R
@@ -22,7 +22,7 @@ test.rulefit.titanic <- function() {
 
     rfit <- h2o.rulefit(y = response, x = predictors, training_frame = train, min_rule_length = 1, max_rule_length = 10, max_num_rules = 100, seed = 1, model_type="rules")
 
-    print(rfit@model$rule_importance)
+    print(h2o.rule_importance(rfit))
     expect_true(!is.null(rfit@model$model_summary))
     expect_true(length(rfit@model$model_summary) > 0)
 
@@ -34,19 +34,24 @@ test.rulefit.titanic <- function() {
     rfit2 <- h2o.rulefit(y = response, x = predictors, training_frame = train, validation_frame = test, min_rule_length = 1, max_rule_length = 10, max_num_rules = 100, seed = 1, model_type="rules", lambda=1e-8)
 
     expect_true(!is.null(rfit@model$validation_metrics))
-    expect_true(length(rfit@model$rule_importance$rule) < length(rfit2@model$rule_importance$rule))
+    expect_true(length(h2o.rule_importance(rfit)$rule) < length(h2o.rule_importance(rfit2)$rule))
 
     result = h2o.predict_rules(rfit, train, c("M1T0N7, M1T49N7, M1T16N7", "M1T36N7", "M2T19N19"))
     expect_true(sum(result[2]) ==  210)
     expect_true(sum(result[3]) ==  632)
 
     rfit <- h2o.rulefit(y = response, x = predictors, training_frame = train, min_rule_length = 1, max_rule_length = 10, max_num_rules = 100, seed = 1, model_type="rules_and_linear")
-    print(rfit@model$rule_importance)
+    print(h2o.rule_importance(rfit))
     result = h2o.predict_rules(rfit, train, c("M3T19N35", "M4T29N58", "linear.fare"))
     expect_true(sum(result["M3T19N35"]) == 497)
     expect_true(sum(result["M4T29N58"]) == 449)
     expect_true(sum(result["linear.fare"]) == h2o.nrow(train))
-    
+
+
+    # demonstrate max_categorical_levels usage:
+    rfit <- h2o.rulefit(y = response, x = predictors, training_frame = train, min_rule_length = 1, max_rule_length = 10,
+                        max_num_rules = 100, seed = 1, model_type="rules_and_linear", max_categorical_levels = 3)
+    print(h2o.rule_importance(rfit))
 }
 
 doTest("RuleFit Test: Titanic Data", test.rulefit.titanic)


### PR DESCRIPTION
this change will ensure that the language rule representations are created only on demand for significant rules, and not during the training for all the rules.

https://h2oai.atlassian.net/browse/PUBDEV-8616