### PR TITLE
PUBDEV-8697: fix glm plotting errors

### DIFF
--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -2530,7 +2530,10 @@ def learning_curve_plot(
 
     timestep = allowed_timesteps[0]
 
-    if "deviance" == metric and model.algo in ["glm", "gam"] and not model.actual_params.get("HGLM", False) and "deviance_train" in scoring_history.col_header:
+    if ("deviance" == metric
+            and model.algo in ["glm", "gam"]
+            and not model.actual_params.get("HGLM", False)
+            and "deviance_train" in scoring_history.col_header):
         training_metric = "deviance_train"
         validation_metric = "deviance_test"
     elif metric in ("objective", "convergence", "loglik", "mean_anomaly_score"):

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -2530,7 +2530,7 @@ def learning_curve_plot(
 
     timestep = allowed_timesteps[0]
 
-    if "deviance" == metric and model.algo in ["glm", "gam"] and not model.actual_params.get("HGLM", False):
+    if "deviance" == metric and model.algo in ["glm", "gam"] and not model.actual_params.get("HGLM", False) and "deviance_train" in scoring_history.col_header:
         training_metric = "deviance_train"
         validation_metric = "deviance_test"
     elif metric in ("objective", "convergence", "loglik", "mean_anomaly_score"):

--- a/h2o-py/h2o/model/extensions/std_coef.py
+++ b/h2o-py/h2o/model/extensions/std_coef.py
@@ -81,25 +81,21 @@ class StandardCoef:
         # if positive create positive legend
         if "#1F77B4" in signage[0:num_of_features] and "#FF7F0E" not in signage[0:num_of_features]:
             color_ids = ("Positive",)
-            markers = [plt.Line2D([0, 0], [0, 0], color=color, marker="s", linestyle="")
-                       for color in signage[0:num_of_features]]
-            lgnd = plt.legend(markers, color_ids, numpoints=1, loc="best", frameon=False, fontsize=13)
-            lgnd.legendHandles[0]._legmarker.set_markersize(10)
+            markers = [plt.Line2D([0, 0], [0, 0], color=color, marker="s", linestyle="", markersize=10)
+                       for color in set(signage[0:num_of_features])]
+            plt.legend(markers, color_ids, numpoints=1, loc="best", frameon=False, fontsize=13)
         # if neg create neg legend
         elif "#FF7F0E" in signage[0:num_of_features] and "#1F77B4" not in signage[0:num_of_features]:
             color_ids = ("Negative",)
-            markers = [plt.Line2D([0, 0], [0, 0], color=color, marker="s", linestyle="")
+            markers = [plt.Line2D([0, 0], [0, 0], color=color, marker="s", linestyle="", markersize=10)
                        for color in set(signage[0:num_of_features])]
-            lgnd = plt.legend(markers, color_ids, numpoints=1, loc="best", frameon=False, fontsize=13)
-            lgnd.legendHandles[0]._legmarker.set_markersize(10)
+            plt.legend(markers, color_ids, numpoints=1, loc="best", frameon=False, fontsize=13)
         # if both provide both colors in legend
         else:
             color_ids = ("Positive", "Negative")
-            markers = [plt.Line2D([0, 0], [0, 0], color=color, marker="s", linestyle="")
+            markers = [plt.Line2D([0, 0], [0, 0], color=color, marker="s", linestyle="", markersize=10)
                        for color in ['#1F77B4', '#FF7F0E']] # blue should always be positive, orange negative
-            lgnd = plt.legend(markers, color_ids, numpoints=1, loc="best", frameon=False, fontsize=13)
-            lgnd.legendHandles[0]._legmarker.set_markersize(10)
-            lgnd.legendHandles[1]._legmarker.set_markersize(10)
+            plt.legend(markers, color_ids, numpoints=1, loc="best", frameon=False, fontsize=13)
 
         # Hide the right and top spines, color others grey
         ax.spines["right"].set_visible(False)

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -3128,7 +3128,10 @@ h2o.learning_curve_plot <- function(model,
   if (metric %in% c("objective", "convergence", "loglik", "mean_anomaly_score")) {
     training_metric <- metric
     validation_metric <- "UNDEFINED"
-  } else if ("deviance" == metric && model@algorithm %in% c("gam", "glm") && !hglm) {
+  } else if ("deviance" == metric &&
+    model@algorithm %in% c("gam", "glm") &&
+    !hglm &&
+    "deviance_train" %in% names(sh)) {
     training_metric <- "deviance_train"
     validation_metric <- "deviance_test"
   } else {


### PR DESCRIPTION
this PR fixes bugs described in https://h2oai.atlassian.net/browse/PUBDEV-8697.


1. we were accessing private field that doesn't work anymore with the updated matplotlib
2. there can be a case when scoring history of glm model does have "training_deviance" col instead of currently expected "deviance_train" col