### PR TITLE
PUBDEV-8712: Expose Sequential Walker

### DIFF
--- a/h2o-core/src/main/java/hex/grid/HyperSpaceSearchCriteria.java
+++ b/h2o-core/src/main/java/hex/grid/HyperSpaceSearchCriteria.java
@@ -16,7 +16,7 @@ public class HyperSpaceSearchCriteria extends Iced {
       case Cartesian: return new CartesianSearchCriteria();
       case RandomDiscrete: return new RandomDiscreteValueSearchCriteria();
       case Sequential: return new SequentialSearchCriteria();
-      default: throw new H2OIllegalArgumentException("search_criteria.strategy", strategy.toString());
+      default: throw new H2OIllegalArgumentException("strategy", strategy.toString());
     }
   }
   public static class StoppingCriteria extends Iced {
@@ -178,7 +178,7 @@ public class HyperSpaceSearchCriteria extends Iced {
   public static final class SequentialSearchCriteria extends HyperSpaceSearchCriteria {
 
     private StoppingCriteria _stoppingCriteria;
-    private boolean _early_stopping; // has to be snake_case to match the field in the schema
+    private boolean _early_stopping;
 
     public SequentialSearchCriteria() {
       this(new StoppingCriteria(), true);

--- a/h2o-core/src/main/java/hex/grid/HyperSpaceWalker.java
+++ b/h2o-core/src/main/java/hex/grid/HyperSpaceWalker.java
@@ -214,6 +214,8 @@ public interface HyperSpaceWalker<MP extends Model.Parameters, C extends HyperSp
             return new HyperSpaceWalker.CartesianWalker<>(params, hyperParams, paramsBuilderFactory, (CartesianSearchCriteria) search_criteria);
           case RandomDiscrete:
             return new HyperSpaceWalker.RandomDiscreteValueWalker<>(params, hyperParams, paramsBuilderFactory, (RandomDiscreteValueSearchCriteria) search_criteria);
+          case Sequential:
+            return new SequentialWalker<>(params, hyperParams, paramsBuilderFactory, (HyperSpaceSearchCriteria.SequentialSearchCriteria) search_criteria);
           default:
             throw new H2OIllegalArgumentException("strategy", "GridSearch", strategy);
         }

--- a/h2o-core/src/main/java/hex/schemas/GridSearchSchema.java
+++ b/h2o-core/src/main/java/hex/schemas/GridSearchSchema.java
@@ -2,6 +2,7 @@ package hex.schemas;
 
 import hex.Model;
 import hex.grid.Grid;
+import hex.grid.HyperSpaceSearchCriteria;
 import water.H2O;
 import water.Key;
 import water.api.API;
@@ -112,22 +113,15 @@ public class GridSearchSchema<G extends Grid<MP>,
           throw new H2OIllegalArgumentException("search_criteria.strategy", "null");
         }
 
-        // TODO: move this into a factory method in HyperSpaceSearchCriteriaV99
-        String strategy = (String)p.get("strategy");
-        if ("Cartesian".equals(strategy)) {
-          search_criteria = new HyperSpaceSearchCriteriaV99.CartesianSearchCriteriaV99();
-        } else if ("RandomDiscrete".equals(strategy)) {
-          search_criteria = new HyperSpaceSearchCriteriaV99.RandomDiscreteValueSearchCriteriaV99();
-          if (p.containsKey("max_runtime_secs") && Double.parseDouble((String) p.get("max_runtime_secs"))<0) {
-            throw new H2OIllegalArgumentException("max_runtime_secs must be >= 0 (0 for unlimited time)", strategy);
-          }
-          if (p.containsKey("max_models") && Integer.parseInt((String) p.get("max_models"))<0) {
-            throw new H2OIllegalArgumentException("max_models must be >= 0 (0 for all models)", strategy);
-          }
-        } else {
-          throw new H2OIllegalArgumentException("search_criteria.strategy", strategy);
+        HyperSpaceSearchCriteria.Strategy strategy = HyperSpaceSearchCriteria.Strategy.valueOf((String) p.get("strategy"));
+        search_criteria = HyperSpaceSearchCriteriaV99.make(strategy);
+        if (p.containsKey("max_runtime_secs") && Double.parseDouble((String) p.get("max_runtime_secs"))<0) {
+          throw new H2OIllegalArgumentException("max_runtime_secs must be >= 0 (0 for unlimited time)", strategy.toString());
         }
-        
+        if (p.containsKey("max_models") && Integer.parseInt((String) p.get("max_models"))<0) {
+          throw new H2OIllegalArgumentException("max_models must be >= 0 (0 for all models)", strategy.toString());
+        }
+
         search_criteria.fillWithDefaults();
         search_criteria.fillFromParms(p);
       }

--- a/h2o-core/src/main/resources/META-INF/services/water.api.Schema
+++ b/h2o-core/src/main/resources/META-INF/services/water.api.Schema
@@ -4,6 +4,7 @@ hex.schemas.GridSearchSchema
 hex.schemas.HyperSpaceSearchCriteriaV99
 hex.schemas.HyperSpaceSearchCriteriaV99$CartesianSearchCriteriaV99
 hex.schemas.HyperSpaceSearchCriteriaV99$RandomDiscreteValueSearchCriteriaV99
+hex.schemas.HyperSpaceSearchCriteriaV99$SequentialSearchCriteriaV99
 hex.schemas.ModelBuilderSchema
 hex.schemas.QuantileV3
 hex.schemas.QuantileV3$QuantileParametersV3

--- a/h2o-docs/src/product/grid-search.rst
+++ b/h2o-docs/src/product/grid-search.rst
@@ -47,7 +47,9 @@ Grid Search in R and Python
 
     More about ``search_criteria``:  
 
-    This is a named list of control parameters for smarter hyperparameter search.  The list can include values for: ``strategy``, ``max_models``, ``max_runtime_secs``, ``stopping_metric``, ``stopping_tolerance``, ``stopping_rounds`` and ``seed``. The default value for ``strategy``, "Cartesian", covers the entire space of hyperparameter combinations.  If you want to use cartesian grid search, you can leave the ``search_criteria`` argument unspecified.  Specify the "RandomDiscrete" strategy to perform a random search of all the combinations of your hyperparameters. RandomDiscrete should be usually combined with at least one early stopping criterion, ``max_models`` and/or ``max_runtime_secs``.  Some examples below:
+    This is a named list of control parameters for smarter hyperparameter search.  The list can include values for: ``strategy``, ``max_models``, ``max_runtime_secs``, ``stopping_metric``, ``stopping_tolerance``, ``stopping_rounds`` and ``seed``. The default value for ``strategy``, "Cartesian", covers the entire space of hyperparameter combinations.  If you want to use cartesian grid search, you can leave the ``search_criteria`` argument unspecified.  Specify the "RandomDiscrete" strategy to perform a random search of all the combinations of your hyperparameters. RandomDiscrete should be usually combined with at least one early stopping criterion, ``max_models`` and/or ``max_runtime_secs``.
+    You can also use "Sequential", which goes through the specified parameters in sequence and requires the specified parameter lists to have the same length. "Sequential" strategy exposes ``early_stopping`` parameter (defaults to TRUE) that can be used to disable early stopping while still obeying the ``max_models`` and ``max_runtime_secs``.
+    Some examples below:
 
     .. code-block:: r 
 
@@ -57,6 +59,11 @@ Grid Search in R and Python
         list(strategy = "RandomDiscrete", stopping_tolerance = 0.001, stopping_rounds = 10)
         list(strategy = "RandomDiscrete", stopping_metric = "misclassification", stopping_tolerance = 0.0005, stopping_rounds = 5)
 
+        list(strategy = "Sequential", max_runtime_secs = 3600)
+        list(strategy = "Sequential", max_models = 42, max_runtime_secs = 28800)
+        list(strategy = "Sequential", stopping_tolerance = 0.001, stopping_rounds = 10)
+        list(strategy = "Sequential", early_stopping = FALSE)
+        list(strategy = "Sequential", early_stopping = FALSE, max_models = 42, max_runtime_secs = 28800)
    .. group-tab:: Python
 
     -  Class is ``H2OGridSearch``
@@ -79,7 +86,9 @@ Grid Search in R and Python
 
     More about ``search_criteria``:  
 
-    This is a dictionary of control parameters for smarter hyperparameter search.  The dictionary can include values for: ``strategy``, ``max_models``, ``max_runtime_secs``, ``stopping_metric``, ``stopping_tolerance``, ``stopping_rounds`` and ``seed``. The default value for ``strategy``, "Cartesian", covers the entire space of hyperparameter combinations.  If you want to use cartesian grid search, you can leave the ``search_criteria`` argument unspecified.  Specify the "RandomDiscrete" strategy to perform a random search of all the combinations of your hyperparameters. RandomDiscrete should be usually combined with at least one early stopping criterion, ``max_models`` and/or ``max_runtime_secs``.  Some examples below:
+    This is a dictionary of control parameters for smarter hyperparameter search.  The dictionary can include values for: ``strategy``, ``max_models``, ``max_runtime_secs``, ``stopping_metric``, ``stopping_tolerance``, ``stopping_rounds`` and ``seed``. The default value for ``strategy``, "Cartesian", covers the entire space of hyperparameter combinations.  If you want to use cartesian grid search, you can leave the ``search_criteria`` argument unspecified.  Specify the "RandomDiscrete" strategy to perform a random search of all the combinations of your hyperparameters. RandomDiscrete should be usually combined with at least one early stopping criterion, ``max_models`` and/or ``max_runtime_secs``.
+    You can also use "Sequential", which goes through the specified parameters in sequence and requires the specified parameter lists to have the same length. "Sequential" strategy exposes ``early_stopping`` parameter (defaults to True) that can be used to disable early stopping while still obeying the ``max_models`` and ``max_runtime_secs``.
+    Some examples below:
 
     .. code-block:: python
 
@@ -88,6 +97,12 @@ Grid Search in R and Python
         {'strategy': "RandomDiscrete", 'max_models': 42, 'max_runtime_secs': 28800}
         {'strategy': "RandomDiscrete", 'stopping_tolerance': 0.001, 'stopping_rounds': 10}
         {'strategy': "RandomDiscrete", 'stopping_metric': "misclassification", 'stopping_tolerance': 0.0005, 'stopping_rounds': 5}
+
+        {'strategy': "Sequential", 'max_runtime_secs': 3600}
+        {'strategy': "Sequential", 'max_models': 42, 'max_runtime_secs': 28800}
+        {'strategy': "Sequential", 'stopping_tolerance': 0.001, 'stopping_rounds': 10}
+        {'strategy': "Sequential", 'early_stopping': False}
+        {'strategy': "Sequential", 'early_stopping': False, 'max_models': 42, 'max_runtime_secs': 28800}
 
 
 Grid Search Examples

--- a/h2o-py/tests/testdir_algos/grid/pyunit_grid_sequential.py
+++ b/h2o-py/tests/testdir_algos/grid/pyunit_grid_sequential.py
@@ -1,0 +1,76 @@
+import sys
+import os
+import tempfile
+
+sys.path.insert(1, os.path.join("..", "..", ".."))
+import h2o
+from tests import pyunit_utils
+from h2o.grid.grid_search import H2OGridSearch
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+
+
+def test_grid_sequential():
+    train = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+    # run GBM Grid Search
+    hyper_parameters_1 = {
+        "ntrees": [i for i in range(1, 11)],
+        "learn_rate": [10.0**(-i) for i in range(1, 11)]
+    }
+
+    grid1 = H2OGridSearch(
+        H2OGradientBoostingEstimator,
+        hyper_params=hyper_parameters_1,
+        search_criteria=dict(
+            strategy="Sequential",
+            early_stopping=False,
+            stopping_tolerance=1e5,
+            stopping_rounds=2
+        )
+    )
+    grid1.train(x=list(range(4)), y=4, training_frame=train, seed=1)
+    assert len(grid1.model_ids) == 10
+
+    grid2 = H2OGridSearch(
+        H2OGradientBoostingEstimator,
+        hyper_params=hyper_parameters_1,
+        search_criteria=dict(
+            strategy="Sequential",
+            early_stopping=True,
+            stopping_tolerance=1e5,
+            stopping_rounds=2
+        )
+    )
+    grid2.train(x=list(range(4)), y=4, training_frame=train, seed=1)
+    assert len(grid2.model_ids) == 5
+
+    grid3 = H2OGridSearch(
+        H2OGradientBoostingEstimator,
+        hyper_params=hyper_parameters_1,
+        search_criteria=dict(
+            strategy="Sequential",
+            early_stopping=False,
+            max_models=3
+        )
+    )
+    grid3.train(x=list(range(4)), y=4, training_frame=train, seed=1)
+    assert len(grid3.model_ids) == 3
+
+    hyper_parameters_2 = {
+        "ntrees": [i for i in range(1, 10001)],
+        "learn_rate": [10.0**(-i) for i in range(1, 10001)]
+    }
+
+    grid4 = H2OGridSearch(
+        H2OGradientBoostingEstimator,
+        hyper_params=hyper_parameters_2,
+        search_criteria=dict(
+            strategy="Sequential",
+            early_stopping=False,
+            max_runtime_secs=1
+        )
+    )
+    grid4.train(x=list(range(4)), y=4, training_frame=train, seed=1)
+    assert len(grid4.model_ids) < 1000
+
+
+pyunit_utils.standalone_test(test_grid_sequential)

--- a/h2o-py/tests/testdir_algos/grid/pyunit_grid_sequential.py
+++ b/h2o-py/tests/testdir_algos/grid/pyunit_grid_sequential.py
@@ -1,6 +1,5 @@
 import sys
 import os
-import tempfile
 
 sys.path.insert(1, os.path.join("..", "..", ".."))
 import h2o
@@ -13,8 +12,8 @@ def test_grid_sequential():
     train = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
     # run GBM Grid Search
     hyper_parameters_1 = {
-        "ntrees": [i for i in range(1, 11)],
-        "learn_rate": [10.0**(-i) for i in range(1, 11)]
+        "ntrees": [i for i in range(1, 7)],
+        "learn_rate": [10.0**(-i) for i in range(1, 7)]
     }
 
     grid1 = H2OGridSearch(
@@ -28,7 +27,7 @@ def test_grid_sequential():
         )
     )
     grid1.train(x=list(range(4)), y=4, training_frame=train, seed=1)
-    assert len(grid1.model_ids) == 10
+    assert len(grid1.model_ids) == 6
 
     grid2 = H2OGridSearch(
         H2OGradientBoostingEstimator,

--- a/h2o-r/tests/testdir_algos/grid/runit_grid_sequential.R
+++ b/h2o-r/tests/testdir_algos/grid/runit_grid_sequential.R
@@ -1,0 +1,51 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+
+
+test.grid.sequential <- function() {
+  iris.hex <- h2o.importFile(path = locate("smalldata/iris/iris.csv"), destination_frame="iris.hex")
+
+  ntrees_opts <- 1:10
+  learn_rate_opts <- 10**(-(1:10))
+  size_of_hyper_space <- length(ntrees_opts)
+
+  hyper_parameters <- list(ntrees = ntrees_opts, learn_rate = learn_rate_opts)
+  grid1 <- h2o.grid("gbm",
+                    x=1:4, y=5,
+                    training_frame=iris.hex,
+                    hyper_params = hyper_parameters,
+                    seed=1,
+                    search_criteria = list(strategy = "Sequential", early_stopping = FALSE, stopping_tolerance=1e5, stopping_rounds=2))
+  expect_equal(length(grid1@model_ids), size_of_hyper_space)
+
+  grid2 <- h2o.grid("gbm",
+                    x=1:4, y=5,
+                    training_frame=iris.hex,
+                    hyper_params = hyper_parameters,
+                    seed=1,
+                    search_criteria = list(strategy = "Sequential", early_stopping = TRUE, stopping_tolerance=1e5, stopping_rounds=2))
+  expect_equal(length(grid2@model_ids), 5)
+
+  grid3 <- h2o.grid("gbm",
+                    x=1:4, y=5,
+                    training_frame=iris.hex,
+                    hyper_params = hyper_parameters,
+                    seed=1,
+                    search_criteria = list(strategy = "Sequential", early_stopping = FALSE, max_models = 3))
+  expect_equal(length(grid3@model_ids), 3)
+
+  ntrees_opts <- 1:10000
+  learn_rate_opts <- 10**(-(1:10000))
+  hyper_parameters <- list(ntrees = ntrees_opts, learn_rate = learn_rate_opts)
+  grid4 <- h2o.grid("gbm",
+                    x=1:4, y=5,
+                    training_frame=iris.hex,
+                    hyper_params = hyper_parameters,
+                    seed=1,
+                    search_criteria = list(strategy = "Sequential", early_stopping = FALSE, max_runtime_secs=1))
+  expect_less_than(length(grid4@model_ids), 1000)
+
+}
+
+doTest("Test sequential grid", test.grid.sequential)

--- a/h2o-r/tests/testdir_algos/grid/runit_grid_sequential.R
+++ b/h2o-r/tests/testdir_algos/grid/runit_grid_sequential.R
@@ -6,8 +6,8 @@ source("../../../scripts/h2o-r-test-setup.R")
 test.grid.sequential <- function() {
   iris.hex <- h2o.importFile(path = locate("smalldata/iris/iris.csv"), destination_frame="iris.hex")
 
-  ntrees_opts <- 1:10
-  learn_rate_opts <- 10**(-(1:10))
+  ntrees_opts <- 1:6
+  learn_rate_opts <- 10^(-(1:6))
   size_of_hyper_space <- length(ntrees_opts)
 
   hyper_parameters <- list(ntrees = ntrees_opts, learn_rate = learn_rate_opts)


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8712

Currently, SequentialWalker is used only for AutoML's exploitation phase - training one model after another in a pre-defined sequence early stopping if the models don't get better.

This PR exposes it, so it is usable from the clients (R/Py) and adds an early stopping option to disable early stopping so we can do an exhaustive search over the provided parameters. Another addition is `max_models` and `max_runtime_secs` parameters to the SequentialWalker.