### PR TITLE
[PUBDEV-8733] Fix Upload of Big Files in SW Deployment

### DIFF
--- a/h2o-core/src/main/java/water/server/ServletUtils.java
+++ b/h2o-core/src/main/java/water/server/ServletUtils.java
@@ -124,7 +124,11 @@ public class ServletUtils {
 
   public static InputStream extractInputStream(HttpServletRequest request, HttpServletResponse response) throws IOException {
     final InputStream is;
-    if (request.getContentType() == null) {
+    final String contentType = request.getContentType();
+    
+    // The Python client sends requests with null content-type when uploading large files,
+    // whereas Sparkling Water proxy sends requests with content-type set to application/octet-stream.
+    if (contentType == null || contentType.equals("application/octet-stream")) {
       is = request.getInputStream();
     } else {
       is = extractPartInputStream(request, response);


### PR DESCRIPTION
Sparkling Water sends requests with `content-type` set to  `application/octet-stream`.  Current codebase doesn't expect such  requests and thus they cause the following error:
```
Content type must be multipart/form-data
```