### PR TITLE
PUBDEV-8742: Using the model performance API to avoid unnecessary transforms in the scikit-learn wrapper

### DIFF
--- a/h2o-py/h2o/sklearn/wrapper.py
+++ b/h2o-py/h2o/sklearn/wrapper.py
@@ -773,13 +773,14 @@ class H2OEstimatorScoreSupport(BaseEstimatorMixin):
             return delegate.score(_to_numpy(X), y=(_vector_to_1d_array(y)), sample_weight=sample_weight)
 
         # delegate to default sklearn scoring methods
-        scoring_frame = X if y is None else X.concat(y)
-        if hasattr(self._estimator, 'model_performance') and self.is_classifier():
-            # sklearn default classification metric is accuracy
-            return self._estimator.model_performance(scoring_frame).accuracy()
-        elif hasattr(self._estimator, 'model_performance') and self.is_regressor():
-            # sklearn default regression metric is r2
-            return self._estimator.model_performance(scoring_frame).r2()
+        if sample_weight is None and hasattr(self._estimator, 'model_performance'):
+            scoring_frame = X if y is None else X.concat(y)
+            if self.is_classifier():
+                # sklearn default classification metric is accuracy
+                return self._estimator.model_performance(scoring_frame).accuracy()
+            elif self.is_regressor():
+                # sklearn default regression metric is r2
+                return self._estimator.model_performance(scoring_frame).r2()
         else:
             parent = super(H2OEstimatorScoreSupport, self)
             if hasattr(parent, 'score') and callable(parent.score):


### PR DESCRIPTION
In this PR, @NikhilJArora and I have updated the estimator score support in the `scikit-learn` wrapper to avoid unnecessary transformations between `h2o.H2OFrame` and `numpy.ndarray`. For classification models, we copied `sklearn.base.ClassifierMixin` and `sklearn.base.RegressorMixin` to determine the default metrics.

https://h2oai.atlassian.net/browse/PUBDEV-8742