### PR TITLE
PUBDEV-8747: fixed gam cv run failure

### DIFF
--- a/h2o-algos/src/main/java/hex/gam/GAM.java
+++ b/h2o-algos/src/main/java/hex/gam/GAM.java
@@ -192,14 +192,19 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
   @Override
   public void init(boolean expensive) {
     if (_parms._nfolds > 0 || _parms._fold_column != null) {
-      _cvOn = true;
-      _glmNFolds = _parms._fold_column == null ? _parms._nfolds 
+      _parms._glmCvOn = true; // added for client mode
+      _parms._glmNFolds = _parms._fold_column == null ? _parms._nfolds
               : _parms.train().vec(_parms._fold_column).toCategoricalVec().domain().length;
+      _cvOn = true;
+      _glmNFolds = _parms._glmNFolds;
+
       if (_parms._fold_assignment != null) {
+        _parms._glmFoldAssignment = _parms._fold_assignment; // added for client mode
         _foldAssignment = _parms._fold_assignment;
         _parms._fold_assignment = null;
       }
       if (_parms._fold_column != null) {
+        _parms._glmFoldColumn = _parms._fold_column; // added for client mode
         _foldColumn = _parms._fold_column;
         _parms._fold_column = null;
       }
@@ -409,6 +414,14 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
 
   @Override
   protected GAMDriver trainModelImpl() {
+    if (_parms._glmCvOn) {  // for client mode, copy over the cv settings
+      _cvOn = true;
+      if (_parms._glmFoldAssignment != null)
+        _foldAssignment = _parms._glmFoldAssignment;
+      if (_parms._glmFoldColumn != null)
+        _foldColumn = _parms._glmFoldColumn;
+      _glmNFolds = _parms._glmNFolds;
+    }
     return new GAMDriver();
   }
 

--- a/h2o-algos/src/main/java/hex/gam/GAMModel.java
+++ b/h2o-algos/src/main/java/hex/gam/GAMModel.java
@@ -241,6 +241,11 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
     public Key<Frame> _beta_constraints = null;
     public double _lambda_min_ratio = -1;
     public boolean _betaConstraintsOff = false; // used for cross-validations
+    // internal parameters added to support client mode
+    int _glmNFolds = 0;
+    Model.Parameters.FoldAssignmentScheme _glmFoldAssignment = null;
+    String _glmFoldColumn = null;
+    boolean _glmCvOn = false;
 
     @Override
     public long progressUnits() {

--- a/h2o-r/tests/testdir_algos/gam/runit_PUBDEV_8681_paul_gam_cv_no_cv.R
+++ b/h2o-r/tests/testdir_algos/gam/runit_PUBDEV_8681_paul_gam_cv_no_cv.R
@@ -48,4 +48,4 @@ test.model.gam <- function() {
     expect_true(abs(h2o.residual_deviance(object = mod, train = TRUE)-h2o.residual_deviance(object = mod2, train = TRUE))<1e-6)
 }
 
-doTest("General Additive Model test", test.model.gam)
+doTest("General Additive Model test: cv with fold column", test.model.gam)


### PR DESCRIPTION
This PR fixes the problem in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8747

Basically in the client mode, the algorithms are called via different paths.  I have saved global variables that are lost if algos are called in the client mode.  I added a fix.