### PR TITLE
PUBDEV-8750: added transform for GLRM

### DIFF
--- a/h2o-bindings/bin/custom/python/gen_glrm.py
+++ b/h2o-bindings/bin/custom/python/gen_glrm.py
@@ -1,6 +1,5 @@
 supervised_learning = False
 
-
 doc = dict(
     __class__="""
 Builds a generalized low rank model of a H2O dataset.
@@ -384,4 +383,23 @@ examples = dict(
 ...                 validation_frame=iris)
 >>> iris_glrm.show()
 """
+)
+
+def class_extensions():
+    def transform_frame(self, fr):
+        """
+        GLRM performs A=X*Y during training.  When a new dataset is given, GLRM will perform Anew = Xnew*Y.  When
+        predict is called, Xnew*Y is returned.  When transform_frame is called, Xnew is returned instead.
+        :return: an H2OFrame that contains Xnew.
+        """
+        return H2OFrame._expr(expr=ExprNode("transform", ASTId(self.key), ASTId(fr.key)))._frame(fill_cache=True)
+
+extensions = dict(
+    __imports__="""
+    from h2o.base import Keyed
+    from h2o.frame import H2OFrame
+    from h2o.expr import ExprNode
+    from h2o.expr import ASTId
+""",
+    __class__=class_extensions,
 )

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -1849,6 +1849,10 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
     throw new UnsupportedOperationException("this model doesn't support constant frame results");
   }
 
+  public Frame transform(Frame fr) {
+    throw new UnsupportedOperationException("this model doesn't support constant frame results");
+  }
+
   /** Bulk score the frame {@code fr}, producing a Frame result; the 1st
    *  Vec is the predicted class, the remaining Vecs are the probability
    *  distributions.  For Regression (single-class) models, the 1st and only

--- a/h2o-core/src/main/java/water/rapids/Env.java
+++ b/h2o-core/src/main/java/water/rapids/Env.java
@@ -334,6 +334,9 @@ public class Env extends Iced {
     // generate result frame
     init(new AstResultFrame());
 
+    // generate transform frame
+    init(new AstTransformFrame());
+
     // Custom (eg. algo-specific)
     for (AstPrimitive prim : PrimsService.INSTANCE.getAllPrims())
       init(prim);

--- a/h2o-core/src/main/java/water/rapids/ast/prims/models/AstTransformFrame.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/models/AstTransformFrame.java
@@ -1,0 +1,32 @@
+package water.rapids.ast.prims.models;
+
+import hex.Model;
+import water.DKV;
+import water.fvec.Frame;
+import water.rapids.Env;
+import water.rapids.ast.AstPrimitive;
+import water.rapids.ast.AstRoot;
+import water.rapids.vals.ValFrame;
+
+public class AstTransformFrame extends AstPrimitive {
+    
+    @Override
+    public int nargs()      { return 1 + 2; }
+
+    @Override
+    public String str() {
+        return "transform";
+    }
+
+    @Override
+    public String[] args() {
+        return new String[]{"model key", "frame key"};
+    }
+
+    @Override
+    public ValFrame apply(Env env, Env.StackHelp stk, AstRoot asts[]) {
+        Model model = stk.track(asts[1].exec(env)).getModel();
+        Frame fr = DKV.get(asts[2].toString()).get();
+        return new ValFrame(model.transform(fr));
+    }
+}

--- a/h2o-py/h2o/estimators/glrm.py
+++ b/h2o-py/h2o/estimators/glrm.py
@@ -6,6 +6,10 @@
 #
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from h2o.base import Keyed
+from h2o.frame import H2OFrame
+from h2o.expr import ExprNode
+from h2o.expr import ASTId
 from h2o.estimators.estimator_base import H2OEstimator
 from h2o.exceptions import H2OValueError
 from h2o.frame import H2OFrame
@@ -1052,3 +1056,10 @@ class H2OGeneralizedLowRankEstimator(H2OEstimator):
         self._parms["export_checkpoints_dir"] = export_checkpoints_dir
 
 
+    def transform_frame(self, fr):
+        """
+        GLRM performs A=X*Y during training.  When a new dataset is given, GLRM will perform Anew = Xnew*Y.  When
+        predict is called, Xnew*Y is returned.  When transform_frame is called, Xnew is returned instead.
+        :return: an H2OFrame that contains Xnew.
+        """
+        return H2OFrame._expr(expr=ExprNode("transform", ASTId(self.key), ASTId(fr.key)))._frame(fill_cache=True)

--- a/h2o-py/tests/testdir_algos/glrm/pyunit_pubdev_8750_glrm_transform.py
+++ b/h2o-py/tests/testdir_algos/glrm/pyunit_pubdev_8750_glrm_transform.py
@@ -1,0 +1,43 @@
+from __future__ import print_function
+from builtins import str
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+import numpy as np
+from h2o.estimators.glrm import H2OGeneralizedLowRankEstimator
+
+
+def test_glrm_transform():
+  # generate training and test frames
+  m = 1000
+  n = 100
+  k = 8
+  np.random.seed(12345)
+
+  print("Uploading random uniform matrix with rows = " + str(m) + " and cols = " + str(n))
+  Y = np.random.rand(k,n)
+  X = np.random.rand(m, k)
+  train = np.dot(X,Y)
+  train_h2o = h2o.H2OFrame(train.tolist())
+  frames = train_h2o.split_frame(ratios=[0.9])
+  train = frames[0]
+  test = frames[1]
+
+  glrm_h2o = H2OGeneralizedLowRankEstimator(k=k, loss="Quadratic", seed=12345)
+  glrm_h2o.train(x=train_h2o.names, training_frame=train)
+  predFrame = glrm_h2o.predict(test)
+  xFrame = glrm_h2o.transform_frame(test)
+
+  glrm_h2o2 = H2OGeneralizedLowRankEstimator(k=k, loss="Quadratic", seed=12345)
+  glrm_h2o2.train(x=train_h2o.names, training_frame=train)
+  xFrame2 = glrm_h2o2.transform_frame(test)
+  
+  assert predFrame.nrows==xFrame.nrows, "predictor frame number of row: {0}, transform frame number of row: " \
+                                              "{1}".format(predFrame.nrows,xFrame.nrows)
+  pyunit_utils.compare_frames_local(xFrame, xFrame2, prob=1.0, tol=1e-6)
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(test_glrm_transform)
+else:
+  test_glrm_transform()

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -754,9 +754,14 @@ predict_leaf_node_assignment.H2OModel <- function(object, newdata, type = c("Pat
 #' @export
 h2o.predict_leaf_node_assignment <- predict_leaf_node_assignment.H2OModel
 
+h2o.transform_frame <- function(model, fr) {
+  if (!is(model, "H2OModel") || (is(model, "H2OModel") && model@algorithm != "glrm")) stop("h2o.transform_frame can only be applied to GLRM H2OModel instance.")
+  return(.newExpr("transform", model@model_id, h2o.getId(fr)))
+}
+
 h2o.result <- function(model) {
   if (!is(model, "H2OModel")) stop("h2o.result can only be applied to H2OModel instances with constant results")
-  return(as.data.frame(.newExpr("result", model@model_id)))
+  return(.newExpr("result", model@model_id))
 }
 
 h2o.crossValidate <- function(model, nfolds, model.type = c("gbm", "glm", "deeplearning"), params, strategy = c("mod1", "random")) {

--- a/h2o-r/h2o-package/pkgdown/_pkgdown.yml
+++ b/h2o-r/h2o-package/pkgdown/_pkgdown.yml
@@ -334,6 +334,7 @@ reference:
       - h2o.toupper
       - h2o.train_segments
       - h2o.transform
+      - h2o.transform_frame
       - h2o.transform_word2vec
       - h2o.transform,H2OTargetEncoderModel-method
       - h2o.transform,H2OWordEmbeddingModel-method

--- a/h2o-r/tests/testdir_algos/glrm/runit_pubdev_8750_glrm_transform.R
+++ b/h2o-r/tests/testdir_algos/glrm/runit_pubdev_8750_glrm_transform.R
@@ -1,0 +1,22 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+test.glrm.transform <- function() {
+  m <- 1000; n <- 100; k <- 10
+  Log.info(paste("Uploading random uniform matrix with rows =", m, "and cols =", n))
+  Y <- matrix(runif(k*n), nrow = k, ncol = n)
+  X <- matrix(runif(m*k), nrow = m, ncol = k)
+  train <- X %*% Y
+  train.h2o <- as.h2o(train)
+  test.h2o <- as.h2o(train)
+
+  fitH2O <- h2o.glrm(training_frame=train.h2o, k = k, loss = "Quadratic", seed=12345)
+  pred1 <- h2o.predict(fitH2O, test.h2o)
+  transform1 <- h2o.transform_frame(fitH2O, test.h2o)
+  fitH2O2 <- h2o.glrm(training_frame=train.h2o, k = k, loss = "Quadratic", seed=12345)
+  transform2 <- h2o.transform_frame(fitH2O2, test.h2o)
+  
+  compareFrames(transform1, transform2, prob=1, tolerance=1e-6)
+}
+
+doTest("GLRM Test: transform_frame - return X part of prediction", test.glrm.transform)


### PR DESCRIPTION
This PR add the function described in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8750 .
For GLRM, we perform A = X*Y.

When a new dataset is encountered, the GLRM model will do Anew = Xnew *Y using the old Y from training dataset.  While the h2o.predict will return Xnew*Y, many users want to obtain Xnew.  I added the transform_frame function in Python/R and tranform method in Java to return Xnew.

The function transform has been taken and therefore I can only do transform_frame.