### PR TITLE
PUBDEV-8757: Explicitly start external xgboost cluster before CV [hotfix]

### DIFF
--- a/h2o-core/src/main/java/hex/CVModelBuilder.java
+++ b/h2o-core/src/main/java/hex/CVModelBuilder.java
@@ -28,9 +28,9 @@ public class CVModelBuilder {
         this.parallelization = parallelization;
     }
     
-    protected void prepare(ModelBuilder m) {}
+    protected void prepare(ModelBuilder<?, ?, ?> m) {}
     
-    protected void finished(ModelBuilder m) {}
+    protected void finished(ModelBuilder<?, ?, ?> m) {}
 
     public void bulkBuildModels() {
         final int N = modelBuilders.length;

--- a/h2o-core/src/main/java/hex/CVModelBuilder.java
+++ b/h2o-core/src/main/java/hex/CVModelBuilder.java
@@ -94,4 +94,8 @@ public class CVModelBuilder {
         }
     }
 
+    protected Job getJob() {
+        return job;
+    }
+    
 }

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
@@ -305,6 +305,10 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
     return H2O.getSysBoolProperty("xgboost.multinode.gpu.enabled", false);
   }
 
+  static boolean prestartExternalClusterForCV() {
+    return H2O.getSysBoolProperty("xgboost.external.cv.prestart", false);
+  }
+
   @Override
   public XGBoost getModelBuilder() {
     return this;
@@ -774,6 +778,8 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
   protected CVModelBuilder makeCVModelBuilder(ModelBuilder<?, ?, ?>[] modelBuilders, int parallelization) {
     if (XGBoostModel.getActualBackend(_parms, false) == XGBoostModel.XGBoostParameters.Backend.gpu && parallelization > 1) {
       return new XGBoostGPUCVModelBuilder(_job, modelBuilders, parallelization, _parms._gpu_id);      
+    } else if (H2O.ARGS.use_external_xgboost && prestartExternalClusterForCV()) {
+      return new XGBoostExternalCVModelBuilder(_job, modelBuilders, parallelization, SteamExecutorStarter.getInstance());
     } else {
       return super.makeCVModelBuilder(modelBuilders, parallelization);
     }

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostExternalCVModelBuilder.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostExternalCVModelBuilder.java
@@ -1,0 +1,56 @@
+package hex.tree.xgboost;
+
+import hex.CVModelBuilder;
+import hex.ModelBuilder;
+import hex.tree.xgboost.remote.SteamExecutorStarter;
+import org.apache.log4j.Logger;
+import water.Job;
+
+import java.io.IOException;
+
+public class XGBoostExternalCVModelBuilder extends CVModelBuilder {
+
+    private static final Logger LOG = Logger.getLogger(XGBoostExternalCVModelBuilder.class);
+
+    private final SteamExecutorStarter _starter;
+    private boolean _initialized;
+
+    public XGBoostExternalCVModelBuilder(
+            Job job,
+            ModelBuilder<?, ?, ?>[] modelBuilders,
+            int parallelization,
+            SteamExecutorStarter starter
+    ) {
+        super(job, modelBuilders, parallelization);
+        _starter = starter;
+    }
+
+    @Override
+    protected void prepare(ModelBuilder<?, ?, ?> m) {
+        if (!_initialized) {
+            XGBoost xgb = (XGBoost) m;
+            // We try to the cluster start just one time before CV models are executed in parallel. This way
+            // the CV models don't need to compete for who will succeed starting the cluster - the flow is more
+            // predictable and easier to debug.
+            try {
+                prepareCluster(xgb);
+            } catch (Exception e) { // ignore, give another chance to start in CV models (same as before this change)
+                LOG.error("Failed to prepare an external XGBoost cluster, " +
+                        "individual CV models will attempt to start the cluster again.", e);
+            }
+            _initialized = true;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    void prepareCluster(XGBoost xgb) {
+        LOG.info("Requesting external cluster for model " + xgb.dest());
+        try {
+            _starter.startCluster(xgb.dest(), getJob());
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to start external XGBoost cluster", e);
+        }
+        LOG.info("External cluster successfully initialized");
+    }
+    
+}

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostGPUCVModelBuilder.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostGPUCVModelBuilder.java
@@ -31,14 +31,14 @@ public class XGBoostGPUCVModelBuilder extends CVModelBuilder {
     }
 
     @Override
-    protected void prepare(ModelBuilder m) {
+    protected void prepare(ModelBuilder<?, ?, ?> m) {
         XGBoost xgb = (XGBoost) m;
         xgb._parms._gpu_id = new int[] { availableGpus.pop() };
         LOG.info("Building " + xgb.dest() + " on GPU " + xgb._parms._gpu_id[0]);
     }
 
     @Override
-    protected void finished(ModelBuilder m) {
+    protected void finished(ModelBuilder<?, ?, ?> m) {
         XGBoost xgb = (XGBoost) m;
         availableGpus.push(xgb._parms._gpu_id[0]);
     }

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTest.java
@@ -2926,4 +2926,11 @@ public class XGBoostTest extends TestUtil {
       Scope.exit();
     }
   }
+
+  @Test
+  public void checkRunningWithClusterPrestartInCI() {
+    Assume.assumeTrue(isCI());
+    assertTrue(hex.tree.xgboost.XGBoost.prestartExternalClusterForCV());
+  }
+
 }

--- a/h2o-extensions/xgboost/testMultiNode.sh
+++ b/h2o-extensions/xgboost/testMultiNode.sh
@@ -70,7 +70,7 @@ else
     COVERAGE=""
 fi
 # Force enable LeaderNodeRequestFilter to emulate XGBoost external cluster deployments on K8S
-JVM="nice $JAVA_CMD $COVERAGE -ea -Xmx${MAX_MEM} -Xms${MAX_MEM} -Dsys.ai.h2o.ext.auth.toggle.LeaderNodeRequestFilter=true -DcloudSize=4 -cp ${JVM_CLASSPATH} ${ADDITIONAL_TEST_JVM_OPTS}"
+JVM="nice $JAVA_CMD $COVERAGE -ea -Xmx${MAX_MEM} -Xms${MAX_MEM} -Dsys.ai.h2o.ext.auth.toggle.LeaderNodeRequestFilter=true -Dsys.ai.h2o.xgboost.external.cv.prestart=true -DcloudSize=4 -cp ${JVM_CLASSPATH} ${ADDITIONAL_TEST_JVM_OPTS}"
 echo "$JVM" > $OUTDIR/jvm_cmd.txt
 
 # Tests

--- a/h2o-extensions/xgboost/testSingleNode.sh
+++ b/h2o-extensions/xgboost/testSingleNode.sh
@@ -65,7 +65,7 @@ then
 else
     COVERAGE=""
 fi
-JVM="nice $JAVA_CMD $COVERAGE -ea -Xmx${MAX_MEM} -Xms${MAX_MEM} -cp $JVM_CLASSPATH ${ADDITIONAL_TEST_JVM_OPTS}"
+JVM="nice $JAVA_CMD $COVERAGE -ea -Xmx${MAX_MEM} -Xms${MAX_MEM} -Dsys.ai.h2o.xgboost.external.cv.prestart=true -cp $JVM_CLASSPATH ${ADDITIONAL_TEST_JVM_OPTS}"
 echo "$JVM" > $OUTDIR/jvm_cmd.txt
 # Ahhh... but the makefile runs the tests skipping the jar'ing step when possible.
 # Also, sometimes see test files in the main-class directory, so put the test


### PR DESCRIPTION
In this hotfix, we attempt to start the external xgboost cluster at a predictable
time before the CV models start executing. This prevents the CV model
to compete with which one will start the cluster and makes the whole flow
more deterministic.
    
This is a best-effort fix to address the common scenarios, it doesn't fully
fix PUBDEV-8757 and the new behavior needs to be explicitly enabled.