### PR TITLE
Build script: Installing python wheel should not resolve new dependencies [nocheck]

### DIFF
--- a/scripts/jenkins/groovy/defaultStage.groovy
+++ b/scripts/jenkins/groovy/defaultStage.groovy
@@ -53,7 +53,7 @@ def installPythonPackage(String h2o3dir) {
     sh """
         echo "Activating Python ${env.PYTHON_VERSION}"
         . /envs/h2o_env_python${env.PYTHON_VERSION}/bin/activate
-        pip install ${h2o3dir}/h2o-py/build/dist/*.whl
+        pip install --no-dependencies ${h2o3dir}/h2o-py/build/dist/*.whl
     """
 }
 


### PR DESCRIPTION
We assume we have the correct dependencies already in the pre-packaged
virtual environment.

If the dependencies of the python package change - the test should fail and
the environment needs to be redone. Installing dependencies at this point
covers up issues with virtual environment and defeats its purpose.
