### PR TITLE
 CI: Add a new stage that runs only changed python tests [nocheck]

### DIFF
--- a/h2o-py/tests/testdir_algos/gbm/pyunit_offset_tweedie_gbm.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_offset_tweedie_gbm.py
@@ -5,12 +5,9 @@ import h2o
 from tests import pyunit_utils
 from h2o.estimators.gbm import H2OGradientBoostingEstimator
 
+
 def offset_tweedie():
-  # Connect to a pre-existing cluster
-
-
   insurance = h2o.import_file(pyunit_utils.locate("smalldata/glm_test/insurance.csv"))
-
   insurance["offset"] = insurance["Holders"].log()
 
 
@@ -37,7 +34,6 @@ def offset_tweedie():
     format(1.0255, predictions.min())
   assert abs(392.4945 - predictions.max()) < 1e-2, "expected prediction max to be {0}, but got {1}". \
     format(392.4945, predictions.max())
-
 
 
 if __name__ == "__main__":

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -83,6 +83,9 @@ test-py-smoke-minimal:
 test-py-smoke-steam: lookup-steam-assembly-tests
 	export NO_GCE_CHECK=True && cd h2o-py/tests/ && ../../scripts/run.py --wipeall --geterrs --testlist .lookup.txt --numclouds 6 --jvm.xmx 3g --h2ojar ../../h2o-assemblies/steam/build/libs/steam.jar 
 
+test-py-changed:
+	export NO_GCE_CHECK=True && cd h2o-py/tests/ && ../../scripts/run.py --wipeall --geterrs --testlist ../../tests/pyunitChangedTestList --numclouds 1 --jvm.xmx 3g
+
 test-py-init:
 	export NO_GCE_CHECK=True && cd h2o-py/tests/testdir_apis/H2O_Init \
 	 && python h2o.init_test.py \

--- a/scripts/jenkins/groovy/buildConfig.groovy
+++ b/scripts/jenkins/groovy/buildConfig.groovy
@@ -76,6 +76,7 @@ class BuildConfig {
   private List<String> additionalGradleOpts
   private String xgbVersion
   private String gradleVersion
+  private List<String> changedPythonTests
 
   void initialize(final context, final String mode, final String commitMessage, final changes,
                   final boolean ignoreChanges, final List<String> distributionsToBuild, final List<String> gradleOpts,
@@ -94,6 +95,7 @@ class BuildConfig {
       detectChanges(changes)
     }
     changesMap[COMPONENT_HADOOP] = buildHadoop
+    changedPythonTests = detectPythonTestChanges(changes)
 
     nodeLabels = NodeLabels.findByBuildURL(context.env.BUILD_URL)
     supportedXGBEnvironments = [
@@ -158,6 +160,10 @@ class BuildConfig {
       'JAVA_VERSION=8',
       "BUILD_HADOOP=false"
     ]
+  }
+
+  List<String> getChangedPythonTests() {
+    return changedPythonTests
   }
 
   void setJobProperties(final context) {
@@ -291,6 +297,14 @@ class BuildConfig {
       } else {
         markAllComponentsForTest()
       }
+    }
+  }
+
+  private static List<String> detectPythonTestChanges(changes) {
+    changes.findAll { change ->
+      change.startsWith('h2o-py/') && change.contains("pyunit_")
+    }.collect {
+      it.replaceFirst(".*pyunit_", "pyunit_") // Extract only filename from path
     }
   }
 

--- a/scripts/jenkins/groovy/defaultStage.groovy
+++ b/scripts/jenkins/groovy/defaultStage.groovy
@@ -25,6 +25,13 @@ def call(final pipelineContext, final stageConfig) {
             }
         }
 
+        if (stageConfig.component == pipelineContext.getBuildConfig().COMPONENT_PY) {
+            writeFile(
+                    file: "${h2oFolder}/tests/pyunitChangedTestList", 
+                    text: pipelineContext.getBuildConfig().getChangedPythonTests().join("\n")
+            )
+        }
+
         if (stageConfig.installRPackage && (stageConfig.component == pipelineContext.getBuildConfig().COMPONENT_R || stageConfig.additionalTestPackages.contains(pipelineContext.getBuildConfig().COMPONENT_R))) {
             installRPackage(h2oFolder)
         }

--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -63,6 +63,13 @@ def call(final pipelineContext) {
     ]
   ]
 
+  def SMOKE_PR_STAGES = [
+    [
+      stageName: 'Py3.7 Changed Only', target: 'test-py-changed', pythonVersion: '3.7',timeoutValue: 8,
+      component: pipelineContext.getBuildConfig().COMPONENT_PY
+    ]
+  ]
+
   // Stages executed after each push to PR branch.
   // for Python, mainly test with latest supported version
   def PR_STAGES = [
@@ -792,7 +799,11 @@ def call(final pipelineContext) {
       // in Nightly mode execute all jobs regardless whether smoke tests fail 
       executeInParallel(SMOKE_STAGES + jobs, pipelineContext)
     } else {
-      executeInParallel(SMOKE_STAGES, pipelineContext)
+      def smokeStages = SMOKE_STAGES
+      if (modeCode == MODE_PR_CODE) {
+        smokeStages += SMOKE_PR_STAGES
+      }
+      executeInParallel(smokeStages, pipelineContext)
       if (modeCode == MODE_PR_CODE) {
         jobs += METADATA_VALIDATION_STAGES
       }


### PR DESCRIPTION
This change adds a new smoke test stage that runs only the Python tests that were modified in your PR. This is useful because
you can immediately see the results of your tests (don't have to wait for the full python suite) and also saves HW resources - the full test suite will not run if your own tests are failing.