### PR TITLE
PUBDEV-8763 maxrsweep NPE

### DIFF
--- a/h2o-algos/src/main/java/hex/modelselection/ModelSelection.java
+++ b/h2o-algos/src/main/java/hex/modelselection/ModelSelection.java
@@ -511,7 +511,7 @@ public class ModelSelection extends ModelBuilder<hex.modelselection.ModelSelecti
                 bestInd = index;
             }
         }
-        if (bestInd == -1) {
+        if (bestInd == -1) { // Predictor sets are duplicates.  Return SweepModel for findBestMSEModel stream operations
             return new SweepModel(null, null, null, errorVarianceMin);
         } else {    // set new predictor subset to curSubsetIndices, 
             currSubsetIndices.clear();

--- a/h2o-algos/src/main/java/hex/modelselection/ModelSelectionUtils.java
+++ b/h2o-algos/src/main/java/hex/modelselection/ModelSelectionUtils.java
@@ -10,6 +10,8 @@ import jsr166y.RecursiveAction;
 import water.DKV;
 import water.Key;
 import water.fvec.Frame;
+import water.util.Log;
+
 import java.lang.reflect.Field;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -824,9 +826,9 @@ public class ModelSelectionUtils {
     public static List<Integer> findLastModelpredSub(int modIndex, ModelSelection.SweepModel[] bestModels, 
                                                      List<Integer> currSubsetIndices) {
         for (int index=modIndex-1; index >= 0; index--)
-            if (bestModels[index] != null) {
+            if (bestModels[index] != null && bestModels[index]._predSubset != null) {
                 List<Integer> predList = IntStream.of(bestModels[index]._predSubset).boxed().collect(Collectors.toList());
-                Integer lastSubIndex = predList.remove(predList.size()-1);
+                Integer lastSubIndex = predList.remove(predList.size() - 1);
                 predList.add(index, lastSubIndex);
                 return predList;
             }

--- a/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8763_maxrSweep_NPE_large.py
+++ b/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8763_maxrSweep_NPE_large.py
@@ -1,0 +1,23 @@
+import sys
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.model_selection import H2OModelSelectionEstimator
+
+def test_maxrsweep_NPE():
+    train = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/bigdata/laptop/model_selection/maxrglm200Cols50KRows.csv")
+    response="response"
+    predictors = train.names
+    predictors.remove(response)
+    npred = 100
+    maxrsweep_model = H2OModelSelectionEstimator(mode="maxrsweep", max_predictor_number=npred, intercept=True)
+    maxrsweep_model.train(x=predictors, y=response, training_frame=train)
+    bestPredictorSubsets = maxrsweep_model.get_best_model_predictors()
+    assert len(bestPredictorSubsets) == npred, "Expected number of predictors: {0}, Actual: " \
+                                               "{1}".format(npred, len(bestPredictorSubsets))
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_maxrsweep_NPE)
+else:
+    test_maxrsweep_NPE()


### PR DESCRIPTION
This PR fixes the problem in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8763 .

During forward search, if all the subcarrier subsets are duplicates of previous, a sweepmodel with null predSubset is returned.

During the replacement step, I only check to make sure the sweepmodel is not null but failed to check if the predSubset is not added.  This is what causes the NPE.  