### PR TITLE
Fix a few typos - comunity contribution [nocheck]

### DIFF
--- a/h2o-docs/src/product/data-science/anova_glm.rst
+++ b/h2o-docs/src/product/data-science/anova_glm.rst
@@ -98,7 +98,7 @@ ANOVA GLM uses a similar set of parameters to GLM.
 
 -  `solver <algo-params/solver.html>`__: Specify the solver to use (``AUTO``, ``IRLSM`` (default), ``L_BFGS``, ``COORDINATE_DESCENT_NAIVE``, ``COORDINATE_DESCENT``, ``GRADIENT_DESCENT_LH``, or ``GRADIENT_DESCENT_SQERR``). IRLSM is fast on problems with a small number of predictors and for lambda search with L1 penalty, while `L_BFGS <http://cran.r-project.org/web/packages/lbfgs/vignettes/Vignette.pdf>`__ scales better for datasets with many columns. COORDINATE_DESCENT is IRLSM with the covariance updates version of cyclical coordinate descent in the innermost loop. COORDINATE_DESCENT_NAIVE is IRLSM with the naive updates version of cyclical coordinate descent in the innermost loop. GRADIENT_DESCENT_LH and GRADIENT_DESCENT_SQERR can only be used with the Ordinal family. AUTO will set the solver based on the given data and other parameters.
 
--  `alpha <algo-params/alpha.html>`__: Specify the regularization distribution between L1 and L2. The default value of alpha is 0 when ``solver = 'L-BFGS'``, overwise it is 0.5.
+-  `alpha <algo-params/alpha.html>`__: Specify the regularization distribution between L1 and L2. The default value of alpha is 0 when ``solver = 'L-BFGS'``, otherwise it is 0.5.
 
 -  `lambda <algo-params/lambda.html>`__: Specify the regularization strength. Defaults to ``[0.0]``.
 

--- a/h2o-docs/src/product/data-science/gam.rst
+++ b/h2o-docs/src/product/data-science/gam.rst
@@ -81,7 +81,7 @@ Defining a GAM Model
 
 -  `solver <algo-params/solver.html>`__: Specify the solver to use (AUTO, IRLSM, L_BFGS, COORDINATE_DESCENT_NAIVE, COORDINATE_DESCENT, GRADIENT_DESCENT_LH, or GRADIENT_DESCENT_SQERR). IRLSM is fast on problems with a small number of predictors and for lambda search with L1 penalty, while `L_BFGS <http://cran.r-project.org/web/packages/lbfgs/vignettes/Vignette.pdf>`__ scales better for datasets with many columns. COORDINATE_DESCENT is IRLSM with the covariance updates version of cyclical coordinate descent in the innermost loop. COORDINATE_DESCENT_NAIVE is IRLSM with the naive updates version of cyclical coordinate descent in the innermost loop. GRADIENT_DESCENT_LH and GRADIENT_DESCENT_SQERR can only be used with the Ordinal family. AUTO (default) will set the solver based on the given data and other parameters.
 
--  `alpha <algo-params/alpha.html>`__: Specify the regularization distribution between L1 and L2. The default value of alpha is 0 when ``solver = 'L-BFGS'``, overwise it is 0.5.
+-  `alpha <algo-params/alpha.html>`__: Specify the regularization distribution between L1 and L2. The default value of alpha is 0 when ``solver = 'L-BFGS'``, otherwise it is 0.5.
 
 -  `lambda <algo-params/lambda.html>`__: Specify the regularization strength.
 

--- a/h2o-py/tests/testdir_munging/pyunit_PUBDEV_5687_groupby_with_stringCols.py
+++ b/h2o-py/tests/testdir_munging/pyunit_PUBDEV_5687_groupby_with_stringCols.py
@@ -27,7 +27,7 @@ def group_by():
     grouped.mean(na="all").median(na="all").max(na="all").min(na="all").sum(na="all")
     print(grouped.get_frame())
     print("Checking number of warning messages...")
-    check_warnings(2, buffer) # make sure we receieved two warning, one per string row
+    check_warnings(2, buffer) # make sure we received two warning, one per string row
 
 def check_warnings(warnNumber, buffer):
     warn_phrase = "UserWarning"


### PR DESCRIPTION
There are small typos in:
- h2o-docs/src/product/data-science/anova_glm.rst
- h2o-docs/src/product/data-science/gam.rst
- h2o-py/tests/testdir_munging/pyunit_PUBDEV_5687_groupby_with_stringCols.py

Fixes:
- Should read `otherwise` rather than `overwise`.
- Should read `received` rather than `receieved`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md