### PR TITLE
PUBDEV-8774: allow gamma to fix dispersion_parameter

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -314,8 +314,9 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     final static NormalDistribution _dprobit = new NormalDistribution(0,1);  // get the normal distribution
     public GLMType _glmType = GLMType.glm;
     public boolean _generate_scoring_history = false; // if true, will generate scoring history but will slow algo down
-    public DispersionMethod _dispersion_factor_method = DispersionMethod.pearson;
-    public double _init_dispersion_factor = 1.0;
+    public DispersionMethod _dispersion_parameter_method = DispersionMethod.pearson;
+    public double _init_dispersion_parameter = 1.0;
+    public boolean _fix_dispersion_parameter = false;
     public boolean _build_null_model = false;
     
     public void validate(GLM glm) {

--- a/h2o-algos/src/main/java/hex/schemas/GLMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMV3.java
@@ -52,8 +52,8 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
             "missing_values_handling",
             "plug_values",
             "compute_p_values",
-            "dispersion_factor_method",
-            "init_dispersion_factor",
+            "dispersion_parameter_method",
+            "init_dispersion_parameter",
             "remove_collinear_columns",
             "intercept",
             "non_negative",
@@ -88,7 +88,8 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
             "auc_type",
             "dispersion_epsilon",
             "max_iterations_dispersion",
-            "build_null_model"
+            "build_null_model",
+            "fix_dispersion_parameter"
     };
 
     @API(help = "Seed for pseudo random number generator (if applicable)", gridable = true)
@@ -181,9 +182,9 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
             "inverse", "tweedie", "ologit"}) //"oprobit", "ologlog": will be supported.
     public GLMParameters.Link link;
     
-    @API(help="Method used to estimate the dispersion factor for Tweedie, Gamma and Negative Binomial only.",
+    @API(help="Method used to estimate the dispersion parameter for Tweedie, Gamma and Negative Binomial only.",
             level = Level.secondary, values={"pearson", "ml"})
-    public GLMParameters.DispersionMethod dispersion_factor_method;
+    public GLMParameters.DispersionMethod dispersion_parameter_method;
     
     @API(help = "Link function array for random component in HGLM.", values = {"[identity]", "[family_default]"},level = Level.secondary, gridable=true)   
     public GLMParameters.Link[] rand_link; // link function for random components
@@ -203,14 +204,21 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
     @API(help="If set, will build a model with only the intercept.  Default to false.", level = Level.expert)
     public boolean build_null_model;
 
+    @API(help="Only used for Tweedie, Gamma and Negative Binomial GLM.  If set, will use the dispsersion parameter" +
+            " in init_dispersion_parameter as the standard error and use it to calculate the p-values. Default to" +
+            " false.", level=Level.expert)
+    public boolean fix_dispersion_parameter;
+    
+    @API(help="Only used for Tweedie, Gamma and Negative Binomial GLM.  Store the initial value of dispersion " +
+            "parameter.  If fix_dispersion_parameter is set, this value will be used in the calculation of p-values." +
+            "Default to 1.0.", level=Level.expert)
+    public double init_dispersion_parameter;
+
     @API(help="If set to true, will return HGLM model.  Otherwise, normal GLM model will be returned", level = Level.critical)
     public boolean HGLM;
     
     @API(help = "Prior probability for y==1. To be used only for logistic regression iff the data has been sampled and the mean of response does not reflect reality.", level = Level.expert)
     public double prior;
-
-    @API(help = "Initial value of disperion factor to be estimated using either pearson or ml.  Default to 1.0.", level = Level.expert)
-    public double init_dispersion_factor;
 
     @API(help = "Minimum lambda used in lambda search, specified as a ratio of lambda_max (the smallest lambda that drives all coefficients to zero)." +
     " Default indicates: if the number of observations is greater than the number of variables, then lambda_min_ratio" +

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8683_gamma_dispersion_epsilon.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8683_gamma_dispersion_epsilon.py
@@ -12,13 +12,13 @@ def test_dispersion_epsilon():
     training_data = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/glm_test/gamma_dispersion_factor_9_10kRows.csv")
     Y = 'resp'
     x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
-    model = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, compute_p_values=True, dispersion_factor_method="ml")
+    model = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, compute_p_values=True, dispersion_parameter_method="ml")
     model.train(training_frame=training_data, x=x, y=Y)
     model_short = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, compute_p_values=True,
-                                                  dispersion_factor_method="ml", dispersion_epsilon=1e-1)
+                                                  dispersion_parameter_method="ml", dispersion_epsilon=1e-1)
     model_short.train(training_frame=training_data, x=x, y=Y)
     model_long = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, compute_p_values=True,
-                                                dispersion_factor_method="ml", dispersion_epsilon=1e-4)
+                                                dispersion_parameter_method="ml", dispersion_epsilon=1e-4)
     model_long.train(training_frame=training_data, x=x, y=Y)
     true_dispersion_factor = 9
     assert abs(true_dispersion_factor-model_long._model_json["output"]["dispersion"]) <= abs(model_short._model_json["output"]["dispersion"]-true_dispersion_factor), \

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8683_gamma_dispersion_maxIter.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8683_gamma_dispersion_maxIter.py
@@ -12,11 +12,11 @@ def test_max_iterations_dispersion():
     x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
 
     model_short = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, compute_p_values=True,
-                                                  dispersion_factor_method="ml",max_iterations_dispersion=1)
+                                                  dispersion_parameter_method="ml",max_iterations_dispersion=1)
     model_short.train(training_frame=training_data, x=x, y=Y)
 
     model_long = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, compute_p_values=True,
-                                                dispersion_factor_method="ml",max_iterations_dispersion=1000000)
+                                                dispersion_parameter_method="ml",max_iterations_dispersion=1000000)
     model_long.train(training_frame=training_data, x=x, y=Y)
     true_dispersion=9
     # check model with more iterations should generate dispersion parameters closer to the true dispersion value

--- a/h2o-py/tests/testdir_algos/glm/pyunit_pubdev_8683_gamma_dispersion_factor.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_pubdev_8683_gamma_dispersion_factor.py
@@ -8,10 +8,10 @@ def test_gamma_dispersion_factor():
     training_data = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/glm_test/gamma_dispersion_factor_9_10kRows.csv")
     Y = 'resp'
     x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
-    model = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, compute_p_values=True, dispersion_factor_method="ml")
+    model = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, compute_p_values=True, dispersion_parameter_method="ml")
     model.train(training_frame=training_data, x=x, y=Y)
     model_pearson = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, compute_p_values=True, 
-                                                  dispersion_factor_method="pearson")
+                                                  dispersion_parameter_method="pearson")
     model_pearson.train(training_frame=training_data, x=x, y=Y)
     true_dispersion_factor = 9
     R_dispersion_factor = 9.3

--- a/h2o-py/tests/testdir_algos/glm/pyunit_pubdev_8683_gamma_dispersion_factor_weighted.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_pubdev_8683_gamma_dispersion_factor_weighted.py
@@ -5,14 +5,14 @@ from tests import pyunit_utils
 from h2o.estimators.glm import H2OGeneralizedLinearEstimator
 
 # add weight column
-def test_gamma_dispersion_factor():
+def test_gamma_dispersion_parameter():
     training_data = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/glm_test/gamma_dispersion_factor_9_10kRows.csv")
     weight = pyunit_utils.random_dataset_real_only(training_data.nrow, 1, realR=2, misFrac=0, randSeed=12345)
     weight = weight.abs()
     training_data = training_data.cbind(weight)
     Y = 'resp'
     x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
-    model_ml = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, compute_p_values=True, dispersion_factor_method="ml", 
+    model_ml = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, compute_p_values=True, dispersion_parameter_method="ml", 
                                           weights_column = "abs(C1)")
     model_ml.train(training_frame=training_data, x=x, y=Y)
     true_dispersion_factor = 9
@@ -25,6 +25,6 @@ def test_gamma_dispersion_factor():
         "{2}".format( dispersion_factor_ml_estimated, R_dispersion_factor, true_dispersion_factor)   
 
 if __name__ == "__main__":
-  pyunit_utils.standalone_test(test_gamma_dispersion_factor)
+  pyunit_utils.standalone_test(test_gamma_dispersion_parameter)
 else:
-    test_gamma_dispersion_factor()
+    test_gamma_dispersion_parameter()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_pubdev_8774_fix_dispersion.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_pubdev_8774_fix_dispersion.py
@@ -1,0 +1,26 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+
+def test_gamma_dispersion_factor():
+    training_data = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/glm_test/gamma_dispersion_factor_9_10kRows.csv")
+    Y = 'resp'
+    x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
+
+    try:
+        model = H2OGeneralizedLinearEstimator(family='gaussian', lambda_=0, compute_p_values=True, 
+                                          fix_dispersion_parameter=True)
+        model.train(training_frame=training_data, x=x, y=Y)
+        assert False, "Test failed:  should have thrown exception of fix_dispersion_parameter."
+    except Exception as ex:
+        print(ex)
+        temp = str(ex)
+        assert "is only supported for gamma, tweedie, negativebinomial families" in temp,"Wrong exception was received."
+        print("Test passed!")
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(test_gamma_dispersion_factor)
+else:
+    test_gamma_dispersion_factor()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_pubdev_8775_gamma_null_model.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_pubdev_8775_gamma_null_model.py
@@ -10,15 +10,15 @@ def test_gamma_null_model():
     Y = 'resp'
     x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
     model = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, compute_p_values=True, 
-                                          dispersion_factor_method="ml")
+                                          dispersion_parameter_method="ml")
     model.train(training_frame=training_data, x=x, y=Y)
     coeffs = model.coef()
     model_null_ml = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, compute_p_values=True, 
-                                                  dispersion_factor_method="ml", build_null_model=True)
+                                                  dispersion_parameter_method="ml", build_null_model=True)
     model_null_ml.train(training_frame=training_data, x=x, y=Y)
     coeffs_null_ml = model_null_ml.coef()
     model_null_p = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, compute_p_values=True,
-                                               dispersion_factor_method="pearson", build_null_model=True)
+                                               dispersion_parameter_method="pearson", build_null_model=True)
     model_null_p.train(training_frame=training_data, x=x, y=Y)
     coeffs_null_p = model_null_p.coef()
 

--- a/h2o-r/h2o-package/R/glm.R
+++ b/h2o-r/h2o-package/R/glm.R
@@ -70,9 +70,11 @@
 #'        training/validation frame, use with conjunction missing_values_handling = PlugValues)
 #' @param compute_p_values \code{Logical}. Request p-values computation, p-values work only with IRLSM solver and no regularization
 #'        Defaults to FALSE.
-#' @param dispersion_factor_method Method used to estimate the dispersion factor for Tweedie, Gamma and Negative Binomial only. Must be one of:
-#'        "pearson", "ml". Defaults to pearson.
-#' @param init_dispersion_factor Initial value of disperion factor to be estimated using either pearson or ml.  Default to 1.0. Defaults to 1.
+#' @param dispersion_parameter_method Method used to estimate the dispersion parameter for Tweedie, Gamma and Negative Binomial only. Must be one
+#'        of: "pearson", "ml". Defaults to pearson.
+#' @param init_dispersion_parameter Only used for Tweedie, Gamma and Negative Binomial GLM.  Store the initial value of dispersion parameter.  If
+#'        fix_dispersion_parameter is set, this value will be used in the calculation of p-values.Default to 1.0.
+#'        Defaults to 1.
 #' @param remove_collinear_columns \code{Logical}. In case of linearly dependent columns, remove some of the dependent columns Defaults to FALSE.
 #' @param intercept \code{Logical}. Include constant term in the model Defaults to TRUE.
 #' @param non_negative \code{Logical}. Restrict coefficients (not intercept) to be non-negative Defaults to FALSE.
@@ -136,6 +138,9 @@
 #' @param max_iterations_dispersion control the maximum number of iterations in the dispersion parameter estimation loop using maximum likelihood
 #'        Defaults to 1000000.
 #' @param build_null_model \code{Logical}. If set, will build a model with only the intercept.  Default to false. Defaults to FALSE.
+#' @param fix_dispersion_parameter \code{Logical}. Only used for Tweedie, Gamma and Negative Binomial GLM.  If set, will use the dispsersion
+#'        parameter in init_dispersion_parameter as the standard error and use it to calculate the p-values. Default to
+#'        false. Defaults to FALSE.
 #' @return A subclass of \code{\linkS4class{H2OModel}} is returned. The specific subclass depends on the machine
 #'         learning task at hand (if it's binomial classification, then an \code{\linkS4class{H2OBinomialModel}} is
 #'         returned, if it's regression then a \code{\linkS4class{H2ORegressionModel}} is returned). The default print-
@@ -216,8 +221,8 @@ h2o.glm <- function(x,
                     missing_values_handling = c("MeanImputation", "Skip", "PlugValues"),
                     plug_values = NULL,
                     compute_p_values = FALSE,
-                    dispersion_factor_method = c("pearson", "ml"),
-                    init_dispersion_factor = 1,
+                    dispersion_parameter_method = c("pearson", "ml"),
+                    init_dispersion_parameter = 1,
                     remove_collinear_columns = FALSE,
                     intercept = TRUE,
                     non_negative = FALSE,
@@ -250,7 +255,8 @@ h2o.glm <- function(x,
                     auc_type = c("AUTO", "NONE", "MACRO_OVR", "WEIGHTED_OVR", "MACRO_OVO", "WEIGHTED_OVO"),
                     dispersion_epsilon = 0.0001,
                     max_iterations_dispersion = 1000000,
-                    build_null_model = FALSE)
+                    build_null_model = FALSE,
+                    fix_dispersion_parameter = FALSE)
 {
   # Validate required training_frame first and other frame args: should be a valid key or an H2OFrame object
   training_frame <- .validate.H2OFrame(training_frame, required=TRUE)
@@ -353,10 +359,10 @@ h2o.glm <- function(x,
     parms$plug_values <- plug_values
   if (!missing(compute_p_values))
     parms$compute_p_values <- compute_p_values
-  if (!missing(dispersion_factor_method))
-    parms$dispersion_factor_method <- dispersion_factor_method
-  if (!missing(init_dispersion_factor))
-    parms$init_dispersion_factor <- init_dispersion_factor
+  if (!missing(dispersion_parameter_method))
+    parms$dispersion_parameter_method <- dispersion_parameter_method
+  if (!missing(init_dispersion_parameter))
+    parms$init_dispersion_parameter <- init_dispersion_parameter
   if (!missing(remove_collinear_columns))
     parms$remove_collinear_columns <- remove_collinear_columns
   if (!missing(intercept))
@@ -419,6 +425,8 @@ h2o.glm <- function(x,
     parms$max_iterations_dispersion <- max_iterations_dispersion
   if (!missing(build_null_model))
     parms$build_null_model <- build_null_model
+  if (!missing(fix_dispersion_parameter))
+    parms$fix_dispersion_parameter <- fix_dispersion_parameter
 
   if( !missing(interactions) ) {
     # interactions are column names => as-is
@@ -481,8 +489,8 @@ h2o.glm <- function(x,
                                     missing_values_handling = c("MeanImputation", "Skip", "PlugValues"),
                                     plug_values = NULL,
                                     compute_p_values = FALSE,
-                                    dispersion_factor_method = c("pearson", "ml"),
-                                    init_dispersion_factor = 1,
+                                    dispersion_parameter_method = c("pearson", "ml"),
+                                    init_dispersion_parameter = 1,
                                     remove_collinear_columns = FALSE,
                                     intercept = TRUE,
                                     non_negative = FALSE,
@@ -516,6 +524,7 @@ h2o.glm <- function(x,
                                     dispersion_epsilon = 0.0001,
                                     max_iterations_dispersion = 1000000,
                                     build_null_model = FALSE,
+                                    fix_dispersion_parameter = FALSE,
                                     segment_columns = NULL,
                                     segment_models_id = NULL,
                                     parallelism = 1)
@@ -623,10 +632,10 @@ h2o.glm <- function(x,
     parms$plug_values <- plug_values
   if (!missing(compute_p_values))
     parms$compute_p_values <- compute_p_values
-  if (!missing(dispersion_factor_method))
-    parms$dispersion_factor_method <- dispersion_factor_method
-  if (!missing(init_dispersion_factor))
-    parms$init_dispersion_factor <- init_dispersion_factor
+  if (!missing(dispersion_parameter_method))
+    parms$dispersion_parameter_method <- dispersion_parameter_method
+  if (!missing(init_dispersion_parameter))
+    parms$init_dispersion_parameter <- init_dispersion_parameter
   if (!missing(remove_collinear_columns))
     parms$remove_collinear_columns <- remove_collinear_columns
   if (!missing(intercept))
@@ -689,6 +698,8 @@ h2o.glm <- function(x,
     parms$max_iterations_dispersion <- max_iterations_dispersion
   if (!missing(build_null_model))
     parms$build_null_model <- build_null_model
+  if (!missing(fix_dispersion_parameter))
+    parms$fix_dispersion_parameter <- fix_dispersion_parameter
 
   if( !missing(interactions) ) {
     # interactions are column names => as-is

--- a/h2o-r/tests/testdir_algos/glm/runit_pubdev_8774_gamma_fix_dispersion_parameter.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_pubdev_8774_gamma_fix_dispersion_parameter.R
@@ -1,0 +1,93 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+##
+# In this test, I want to check and make sure that if user set fix_dispersion_parameter for gamma
+# family, the dispersion parameter should not change.
+##
+
+test_glm_gamma_fix_dispersion_parameter <- function() {
+  if (requireNamespace("tweedie")) {
+    num_rows <- 18000
+    num_cols <- 5
+    f1 <- random_dataset_real_only(num_rows, num_cols, seed=12345) # generate dataset containing the predictors.
+    f1R <- as.data.frame(h2o.abs(f1))
+    weights <- c(0.01, 0.02, 0.03, 0.04, 0.05, 0.1) # glm coefficients
+    mu <- generate_mean(f1R, num_rows, num_cols, weights)
+    dispersion_factor <- c(2)   # dispersion factor range
+    pow_factor <- 2 # tweedie with p=2 is gamma
+    y <- "resp"      # response column
+    x <- c("abs.C1.", "abs.C2.", "abs.C3.", "abs.C4.", "abs.C5.")
+
+    hdf <- generate_dataset(f1R, num_rows, num_cols, pow_factor, dispersion_factor[1], mu)
+    fixedDispersion <- 1.5
+    # use maximum likelihood to estimate dispersion parameter
+    h2omodel <-
+      h2o.glm(
+        x = x,
+        y = y,
+        training_frame = hdf,
+        family = "gamma",
+        lambda = 0,
+        nfolds = 0,
+        dispersion_parameter_method = "ml",
+        compute_p_values = TRUE
+      )
+    # fixed dispersion parameter still specify ml, should have no effect
+    h2omodel2 <-
+      h2o.glm(
+        x = x,
+        y = y,
+        training_frame = hdf,
+        family = "gamma",
+        lambda = 0,
+        nfolds = 0,
+        dispersion_parameter_method = "ml",
+        fix_dispersion_parameter = TRUE,
+        init_dispersion_parameter = fixedDispersion,
+        compute_p_values = TRUE
+      )
+    # fixed dispersion parameter, use default pearson, should have no effect
+    h2omodel3 <-
+      h2o.glm(
+        x = x,
+        y = y,
+        training_frame = hdf,
+        family = "gamma",
+        lambda = 0,
+        nfolds = 0,
+        fix_dispersion_parameter = TRUE,
+        init_dispersion_parameter = fixedDispersion,
+        compute_p_values = TRUE
+      )
+    dispersionFactor <- h2omodel@model$dispersion
+    dispersionFactor2 <- h2omodel2@model$dispersion
+    dispersionFactor3 <- h2omodel3@model$dispersion
+    expect_true(abs(dispersionFactor-dispersionFactor2) > 0.1)
+    expect_true(dispersionFactor2==dispersionFactor3)
+    expect_true(fixedDispersion==dispersionFactor2)
+  } else {
+    print("test_glm_gamma is skipped.  Need to install tweedie package.")
+  }
+}
+
+generate_dataset<-function(f1R, numRows, numCols, pow, phi, mu) {
+  resp <- tweedie::rtweedie(numRows, xi=pow, mu, phi, power=pow)
+  f1h2o <- as.h2o.data.frame(f1R)
+  resph2o <- as.h2o.data.frame(as.data.frame(resp))
+  finalFrame <- h2o.cbind(f1h2o, resph2o)
+  return(finalFrame)
+}
+
+generate_mean<-function(f1R, numRows, numCols, weights) {
+  y <- c(1:numRows)
+  for (rowIndex in c(1:numRows)) {
+    tempResp = 0.0
+    for (colIndex in c(1:numCols)) {
+      tempResp = tempResp+weights[colIndex]*f1R[rowIndex, colIndex]
+    }
+    y[rowIndex] = tempResp
+  }
+  return(y)
+}
+
+doTest("GLM gamma, check fix_dispersion_parameter works.", test_glm_gamma_fix_dispersion_parameter)


### PR DESCRIPTION
This PR fixes the problem here: https://h2oai.atlassian.net/browse/PUBDEV-8774 .

Basically, for gamma, tweedie and negative binomial, we want to be able to fix the dispersion parameter and use the value specified in parms._init_dispersion_parameter to calculate the p-values .

I added tests in R/Python/Java to make sure it is working.