### PR TITLE
PUBDEV-8775: Force GLM to build null model for gamma, negativebinomial and tweedie

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -931,6 +931,12 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       }
     }
     if (expensive) {
+      if (_parms._build_null_model) {
+        if (!(tweedie.equals(_parms._family) || gamma.equals(_parms._family) || negativebinomial.equals(_parms._family)))
+          error("build_null_model", " is only supported for tweedie, gamma and negativebinomial familes");
+        else
+          removePredictors(_parms, _train);
+      }
       if (_parms._max_iterations == 0)
         error("_max_iterations", H2O.technote(2, "if specified, must be >= 1."));
       if (error_count() > 0) return;

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -315,7 +315,8 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     public GLMType _glmType = GLMType.glm;
     public boolean _generate_scoring_history = false; // if true, will generate scoring history but will slow algo down
     public DispersionMethod _dispersion_factor_method = DispersionMethod.pearson;
-    public double _init_dispersion_factor=1.0;
+    public double _init_dispersion_factor = 1.0;
+    public boolean _build_null_model = false;
     
     public void validate(GLM glm) {
       if (_remove_collinear_columns) {

--- a/h2o-algos/src/main/java/hex/glm/GLMUtils.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMUtils.java
@@ -12,6 +12,8 @@ import water.util.TwoDimTable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import static water.fvec.Vec.T_NUM;
 import static water.fvec.Vec.T_STR;
 
@@ -39,6 +41,14 @@ public class GLMUtils {
     return gamColIndices;
   }
 
+  public static void removePredictors(GLMModel.GLMParameters parms, Frame train) {
+    List<String> nonPredictors = Arrays.stream(parms.getNonPredictors()).collect(Collectors.toList());
+    String[] colNames = parms.train().names();
+    List<String> removeCols = Arrays.stream(colNames).filter(x -> !nonPredictors.contains(x)).collect(Collectors.toList());
+    for (String removeC : removeCols)
+      train.remove(removeC);
+  }
+  
   public static Frame expandedCatCS(Frame beta_constraints, GLMModel.GLMParameters parms) {
     byte[] csByteType = new byte[]{T_STR, T_NUM, T_NUM};
     String[] bsColNames = beta_constraints.names();

--- a/h2o-algos/src/main/java/hex/schemas/GLMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMV3.java
@@ -87,7 +87,8 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
             "generate_scoring_history",
             "auc_type",
             "dispersion_epsilon",
-            "max_iterations_dispersion"
+            "max_iterations_dispersion",
+            "build_null_model"
     };
 
     @API(help = "Seed for pseudo random number generator (if applicable)", gridable = true)
@@ -198,6 +199,9 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
 
     @API(help="Include constant term in the model", level = Level.expert)
     public boolean intercept;
+    
+    @API(help="If set, will build a model with only the intercept.  Default to false.", level = Level.expert)
+    public boolean build_null_model;
 
     @API(help="If set to true, will return HGLM model.  Otherwise, normal GLM model will be returned", level = Level.critical)
     public boolean HGLM;

--- a/h2o-algos/src/test/java/hex/glm/GLMdispersionFactorTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMdispersionFactorTest.java
@@ -10,8 +10,8 @@ import water.runner.H2ORunner;
 
 import static hex.glm.GLMModel.GLMParameters.DispersionMethod.ml;
 import static hex.glm.GLMModel.GLMParameters.DispersionMethod.pearson;
-import static hex.glm.GLMModel.GLMParameters.Family.gamma;
 import static hex.glm.GLMModel.GLMParameters;
+import static hex.glm.GLMModel.GLMParameters.Family.*;
 
 @RunWith(H2ORunner.class)
 @CloudSize(1)
@@ -25,7 +25,51 @@ public class GLMdispersionFactorTest extends TestUtil {
                 9, gamma, "resp", 0.034);
 
     }
+    
+    @Test
+    public void testGammaNullModel() {
+        assertCorrectNullModel("smalldata/glm_test/gamma_dispersion_0p5_10KRows.csv",
+                0.5, gamma, "resp", 0.012);
 
+        // uncomment this section after this is enabled for tweedie and negativebinomial families.
+/*        assertCorrectNullModel("smalldata/glm_test/gamma_dispersion_0p5_10KRows.csv",
+                0.5, tweedie, "resp", 0.012);
+
+        assertCorrectNullModel("smalldata/glm_test/gamma_dispersion_0p5_10KRows.csv",
+                0.5, negativebinomial, "resp", 0.012);*/
+    }
+
+    public static void assertCorrectNullModel(String filename, double trueDispersionFactor,
+                                              GLMModel.GLMParameters.Family family, String response, double eps) {
+        Scope.enter();
+        try {
+            final Frame train = parseAndTrackTestFile(filename);
+            GLMParameters params = new GLMParameters(family);
+            params._response_column = response;
+            params._train = train._key;
+            params._compute_p_values = true;
+            params._dispersion_factor_method = ml;
+            params._family = family;
+            params._lambda = new double[]{0.0};
+            params._build_null_model = true;
+            GLMModel glmML = new GLM(params).trainModel().get();
+            Scope.track_generic(glmML);
+            double[] mlCoeff = glmML.beta();
+            assert mlCoeff.length==1 : "GLM model should only contain one element which is just the intercept.";
+            assert glmML.coefficients().keySet().contains("Intercept"); // the one coefficient is for intercept
+
+            params._dispersion_factor_method = pearson;
+            GLMModel glmPearson = new GLM(params).trainModel().get();
+            Scope.track_generic(glmPearson);
+            double[] pearsonCoeff = glmPearson.beta();
+            assert pearsonCoeff.length==1 : "GLM model should only contain one element which is just the intercept.";
+            assert glmPearson.coefficients().keySet().contains("Intercept");
+            TestUtil.equalTwoArrays(mlCoeff, pearsonCoeff, 1e-6);
+        } finally {
+            Scope.exit();
+        }
+    }
+    
     public static void assertCorrectDispersionFactor(String filename, double trueDispersionFactor, 
                                                      GLMModel.GLMParameters.Family family, String response, double eps) {
         Scope.enter();

--- a/h2o-py/h2o/estimators/glm.py
+++ b/h2o-py/h2o/estimators/glm.py
@@ -107,6 +107,7 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
                  auc_type="auto",  # type: Literal["auto", "none", "macro_ovr", "weighted_ovr", "macro_ovo", "weighted_ovo"]
                  dispersion_epsilon=0.0001,  # type: float
                  max_iterations_dispersion=1000000,  # type: int
+                 build_null_model=False,  # type: bool
                  ):
         """
         :param model_id: Destination id for this model; auto-generated if not specified.
@@ -371,6 +372,9 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
                estimation loop using maximum likelihood
                Defaults to ``1000000``.
         :type max_iterations_dispersion: int
+        :param build_null_model: If set, will build a model with only the intercept.  Default to false.
+               Defaults to ``False``.
+        :type build_null_model: bool
         """
         super(H2OGeneralizedLinearEstimator, self).__init__()
         self._parms = {}
@@ -444,6 +448,7 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
         self.auc_type = auc_type
         self.dispersion_epsilon = dispersion_epsilon
         self.max_iterations_dispersion = max_iterations_dispersion
+        self.build_null_model = build_null_model
 
     @property
     def training_frame(self):
@@ -2213,6 +2218,20 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     def max_iterations_dispersion(self, max_iterations_dispersion):
         assert_is_type(max_iterations_dispersion, None, int)
         self._parms["max_iterations_dispersion"] = max_iterations_dispersion
+
+    @property
+    def build_null_model(self):
+        """
+        If set, will build a model with only the intercept.  Default to false.
+
+        Type: ``bool``, defaults to ``False``.
+        """
+        return self._parms.get("build_null_model")
+
+    @build_null_model.setter
+    def build_null_model(self, build_null_model):
+        assert_is_type(build_null_model, None, bool)
+        self._parms["build_null_model"] = build_null_model
 
     Lambda = deprecated_property('Lambda', lambda_)
 

--- a/h2o-py/tests/testdir_algos/glm/pyunit_pubdev_8775_gamma_null_model.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_pubdev_8775_gamma_null_model.py
@@ -1,0 +1,35 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+
+def test_gamma_null_model():
+    training_data = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/glm_test/gamma_dispersion_factor_9_10kRows.csv")
+    Y = 'resp'
+    x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
+    model = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, compute_p_values=True, 
+                                          dispersion_factor_method="ml")
+    model.train(training_frame=training_data, x=x, y=Y)
+    coeffs = model.coef()
+    model_null_ml = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, compute_p_values=True, 
+                                                  dispersion_factor_method="ml", build_null_model=True)
+    model_null_ml.train(training_frame=training_data, x=x, y=Y)
+    coeffs_null_ml = model_null_ml.coef()
+    model_null_p = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, compute_p_values=True,
+                                               dispersion_factor_method="pearson", build_null_model=True)
+    model_null_p.train(training_frame=training_data, x=x, y=Y)
+    coeffs_null_p = model_null_p.coef()
+
+    assert len(coeffs) > len(coeffs_null_ml), "Full model coefficient length: {0} shall exceed null model coefficient" \
+                                           " length: {1}".format(len(coeffs), len(coeffs_null_ml))
+    assert len(coeffs_null_ml) == 1, "Null model from ml coefficient length: {0} shall be 1.".format(len(coeffs_null_ml))
+    assert len(coeffs_null_p) == 1, "Null model from pearson coefficient length: {0} shall be " \
+                                          "1.".format(len(coeffs_null_p))
+    assert 'Intercept' in coeffs_null_ml.keys(), "Null model from ml should contain Intercept as its only coefficient but did not."
+    assert 'Intercept' in coeffs_null_p.keys(), "Null model from pearson should contain Intercept as its only coefficient but did not."
+    
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(test_gamma_null_model)
+else:
+    test_gamma_null_model()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_pubdev_8775_gamma_null_model.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_pubdev_8775_gamma_null_model.py
@@ -6,6 +6,7 @@ from h2o.estimators.glm import H2OGeneralizedLinearEstimator
 
 def test_gamma_null_model():
     training_data = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/glm_test/gamma_dispersion_factor_9_10kRows.csv")
+    training_data2 = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/glm_test/gamma_dispersion_factor_9_10kRows.csv")
     Y = 'resp'
     x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
     model = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, compute_p_values=True, 
@@ -26,8 +27,15 @@ def test_gamma_null_model():
     assert len(coeffs_null_ml) == 1, "Null model from ml coefficient length: {0} shall be 1.".format(len(coeffs_null_ml))
     assert len(coeffs_null_p) == 1, "Null model from pearson coefficient length: {0} shall be " \
                                           "1.".format(len(coeffs_null_p))
-    assert 'Intercept' in coeffs_null_ml.keys(), "Null model from ml should contain Intercept as its only coefficient but did not."
-    assert 'Intercept' in coeffs_null_p.keys(), "Null model from pearson should contain Intercept as its only coefficient but did not."
+    assert 'Intercept' in coeffs_null_ml.keys(), "Null model from ml should contain Intercept as its only coefficient" \
+                                                 " but did not."
+    assert 'Intercept' in coeffs_null_p.keys(), "Null model from pearson should contain Intercept as its only" \
+                                                " coefficient but did not."
+
+    # make sure it can predict with null model
+    pred_ml = model_null_ml.predict(training_data)
+    pred_p = model_null_p.predict(training_data2)
+    pyunit_utils.compare_frames_local(pred_p[0], pred_ml[0], prob=1)
     
 if __name__ == "__main__":
   pyunit_utils.standalone_test(test_gamma_null_model)

--- a/h2o-r/h2o-package/R/glm.R
+++ b/h2o-r/h2o-package/R/glm.R
@@ -135,6 +135,7 @@
 #'        dispersion parameter estimation loop using maximum likelihood Defaults to 0.0001.
 #' @param max_iterations_dispersion control the maximum number of iterations in the dispersion parameter estimation loop using maximum likelihood
 #'        Defaults to 1000000.
+#' @param build_null_model \code{Logical}. If set, will build a model with only the intercept.  Default to false. Defaults to FALSE.
 #' @return A subclass of \code{\linkS4class{H2OModel}} is returned. The specific subclass depends on the machine
 #'         learning task at hand (if it's binomial classification, then an \code{\linkS4class{H2OBinomialModel}} is
 #'         returned, if it's regression then a \code{\linkS4class{H2ORegressionModel}} is returned). The default print-
@@ -248,7 +249,8 @@ h2o.glm <- function(x,
                     generate_scoring_history = FALSE,
                     auc_type = c("AUTO", "NONE", "MACRO_OVR", "WEIGHTED_OVR", "MACRO_OVO", "WEIGHTED_OVO"),
                     dispersion_epsilon = 0.0001,
-                    max_iterations_dispersion = 1000000)
+                    max_iterations_dispersion = 1000000,
+                    build_null_model = FALSE)
 {
   # Validate required training_frame first and other frame args: should be a valid key or an H2OFrame object
   training_frame <- .validate.H2OFrame(training_frame, required=TRUE)
@@ -415,6 +417,8 @@ h2o.glm <- function(x,
     parms$dispersion_epsilon <- dispersion_epsilon
   if (!missing(max_iterations_dispersion))
     parms$max_iterations_dispersion <- max_iterations_dispersion
+  if (!missing(build_null_model))
+    parms$build_null_model <- build_null_model
 
   if( !missing(interactions) ) {
     # interactions are column names => as-is
@@ -511,6 +515,7 @@ h2o.glm <- function(x,
                                     auc_type = c("AUTO", "NONE", "MACRO_OVR", "WEIGHTED_OVR", "MACRO_OVO", "WEIGHTED_OVO"),
                                     dispersion_epsilon = 0.0001,
                                     max_iterations_dispersion = 1000000,
+                                    build_null_model = FALSE,
                                     segment_columns = NULL,
                                     segment_models_id = NULL,
                                     parallelism = 1)
@@ -682,6 +687,8 @@ h2o.glm <- function(x,
     parms$dispersion_epsilon <- dispersion_epsilon
   if (!missing(max_iterations_dispersion))
     parms$max_iterations_dispersion <- max_iterations_dispersion
+  if (!missing(build_null_model))
+    parms$build_null_model <- build_null_model
 
   if( !missing(interactions) ) {
     # interactions are column names => as-is

--- a/h2o-r/tests/testdir_algos/glm/runit_pubdev_8775_gamma_null_model.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_pubdev_8775_gamma_null_model.R
@@ -1,0 +1,52 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+##
+# In this test, we check and make sure we can build null GLM model with coefficients for the intercept only.
+##
+
+test_gamma_null_model <- function() {
+  if (requireNamespace("tweedie")) {
+    num_rows <- 8000
+    num_cols <- 5
+    f1 <- random_dataset_real_only(num_rows, num_cols, seed=12345) # generate dataset containing the predictors.
+    f1R <- as.data.frame(h2o.abs(f1))
+    weights <- c(0.01, 0.02, 0.03, 0.04, 0.05, 0.1) # glm coefficients
+    mu <- generate_mean(f1R, num_rows, num_cols, weights)
+    dispersion_factor <- c(1)   # dispersion factor range
+    pow_factor <- 2 # tweedie with p=2 is gamma
+    y <- "resp"      # response column
+    x <- c("abs.C1.", "abs.C2.", "abs.C3.", "abs.C4.", "abs.C5.")
+    trainF <- generate_dataset(f1R, num_rows, num_cols, pow_factor, dispersion_factor[1], mu)
+    h2oModel <- h2o.glm(x=x, y=y, training_frame=trainF, family="gamma", lambda=0, compute_p_values=TRUE)
+    h2oModelNull <- h2o.glm(x=x, y=y, training_frame=trainF, family="gamma", lambda=0, compute_p_values=TRUE,
+                            build_null_model=TRUE)
+    coef <- h2o.coef(h2oModel)
+    coef_null <- h2o.coef(h2oModelNull)
+    expect_true(length(h2oModel@model$coefficients) > length(h2oModelNull@model$coefficients))
+    expect_true(length(h2oModelNull@model$coefficients)==1)
+  } else {
+    print("test_glm_gamma is skipped.  Need to install tweedie package.")
+  }
+}
+
+generate_dataset<-function(f1R, numRows, numCols, pow, phi, mu) {
+  resp <- tweedie::rtweedie(numRows, xi=pow, mu, phi, power=pow)
+  f1h2o <- as.h2o.data.frame(f1R)
+  resph2o <- as.h2o.data.frame(as.data.frame(resp))
+  finalFrame <- h2o.cbind(f1h2o, resph2o)
+  return(finalFrame)
+}
+
+generate_mean<-function(f1R, numRows, numCols, weights) {
+  y <- c(1:numRows)
+  for (rowIndex in c(1:numRows)) {
+    tempResp = 0.0
+    for (colIndex in c(1:numCols)) {
+      tempResp = tempResp+weights[colIndex]*f1R[rowIndex, colIndex]
+    }
+    y[rowIndex] = tempResp
+  }
+  return(y)
+}
+
+doTest("Confirm null model contains only 1 coefficient", test_gamma_null_model)


### PR DESCRIPTION
This PR complete the task in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8775

This PR will allow a user to specify to build a null GLM model meaning the model only returns the coefficient for the intercept.  Java/Python/R unit tests are added to make sure it works.