### PR TITLE
PUBDEV-8788: Address high vulnerabilities in Steam assembly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,7 @@ ext {
     //
     junitVersion  = '4.12'
     jets3tVersion = '0.7.1'
-    awsJavaSdkVersion = '1.12.127'
+    awsJavaSdkVersion = '1.12.268'
 
     //
     // Optional H2O modules which can be included h2o.jar assembly

--- a/gradle.properties
+++ b/gradle.properties
@@ -67,7 +67,7 @@ jetty8version=8.2.0.v20160908
 # jetty 9 version is used in the main standalone assembly
 jetty9version=9.4.11.v20180605
 # jetty-minimal 9 version is used in the minimal standalone assembly
-jetty9MinimalVersion=9.4.44.v20210927
+jetty9MinimalVersion=9.4.48.v20220622
 servletApiVersion=3.1.0
 
 # Gson

--- a/h2o-assemblies/steam/build.gradle
+++ b/h2o-assemblies/steam/build.gradle
@@ -46,6 +46,10 @@ dependencies {
     }
     // Upgrade dependencies coming from Hadoop to address vulnerabilities 
     api "org.apache.commons:commons-compress:1.21"
+    // FasterXML force version
+    api "org.codehaus.jackson:jackson-mapper-asl:1.9.13"
+    // Google OAuth force version
+    api "com.google.oauth-client:google-oauth-client:1.33.3"
 }
 
 shadowJar {


### PR DESCRIPTION
- Fix CVEs: CVE-2021-22573 and CVE-2019-10172
- Upgrade version of AWS SDK to 1.12.268
- Upgrade Jetty in minimal assemblies to 9.4.48.v20220622
