### PR TITLE
PUBDEV-8786: add missing added predictor, deleted predictor to result frame and model summary

### DIFF
--- a/h2o-algos/src/main/java/hex/modelselection/ModelSelection.java
+++ b/h2o-algos/src/main/java/hex/modelselection/ModelSelection.java
@@ -23,6 +23,8 @@ import static hex.modelselection.ModelSelectionUtils.*;
 public class ModelSelection extends ModelBuilder<hex.modelselection.ModelSelectionModel, hex.modelselection.ModelSelectionModel.ModelSelectionParameters, hex.modelselection.ModelSelectionModel.ModelSelectionModelOutput> {
     public String[][] _bestModelPredictors; // store for each predictor number, the best model predictors
     public double[] _bestR2Values;  // store the best R2 values of the best models with fix number of predictors
+    public String[][] _predictorsAdd;
+    public String[][] _predictorsRemoved;
     DataInfo _dinfo;
     String[] _coefNames;
     int[][] _predictorIndex2CPMIndices;    // map predictor indices to the corresponding Gram matrix indices
@@ -111,6 +113,9 @@ public class ModelSelection extends ModelBuilder<hex.modelselection.ModelSelecti
         if (!backward.equals(_parms._mode)) {
             _bestR2Values = new double[_parms._max_predictor_number];
             _bestModelPredictors = new String[_parms._max_predictor_number][];
+            if (!backward.equals(_parms._mode))
+                _predictorsAdd = new String[_parms._max_predictor_number][];
+            _predictorsRemoved = new String[_parms._max_predictor_number][];
         }
     }
 
@@ -174,6 +179,7 @@ public class ModelSelection extends ModelBuilder<hex.modelselection.ModelSelecti
                 int numModelBuilt = 0;
                 model = new hex.modelselection.ModelSelectionModel(dest(), _parms, new hex.modelselection.ModelSelectionModel.ModelSelectionModelOutput(ModelSelection.this, _dinfo));
                 model.write_lock(_job);
+                model._output._mode = _parms._mode;
                 if (backward.equals(_parms._mode)) {
                     model._output._best_model_ids = new Key[_numPredictors];
                     model._output._coef_p_values = new double[_numPredictors][];
@@ -186,6 +192,8 @@ public class ModelSelection extends ModelBuilder<hex.modelselection.ModelSelecti
                     model._output._best_model_predictors = new String[_parms._max_predictor_number][];
                     model._output._coefficient_names = new String[_parms._max_predictor_number][];
                 }
+                model._output._predictors_removed_per_step = new String[_numPredictors][];
+                model._output._predictors_added_per_step = new String[_numPredictors][];
                 // build glm model with num_predictors and find one with best R2
                 if (allsubsets.equals(_parms._mode))
                     buildAllSubsetsModels(model);

--- a/h2o-algos/src/main/java/hex/modelselection/ModelSelectionUtils.java
+++ b/h2o-algos/src/main/java/hex/modelselection/ModelSelectionUtils.java
@@ -548,20 +548,18 @@ public class ModelSelectionUtils {
     }
     
     public static String[][] shrinkStringArray(String[][] array, int numModels) {
-        int arrLen = array.length-1;
-        int offset = numModels-1;
+        int offset = array.length - numModels;
         String[][] newArray =new String[numModels][];
         for (int index=0; index < numModels; index++)
-            newArray[offset-index] = array[arrLen-index].clone();
+            newArray[index] = array[offset+index].clone();
         return newArray;
     }
     
     public static double[][] shrinkDoubleArray(double[][] array, int numModels) {
-        int arrLen = array.length-1;
-        int offset = numModels-1;
+        int offset = array.length-numModels;
         double[][] newArray =new double[numModels][];
         for (int index=0; index < numModels; index++)
-            newArray[offset-index] = array[arrLen-index].clone();
+            newArray[index] = array[offset+index].clone();
         return newArray;
     }
 

--- a/h2o-algos/src/main/java/hex/schemas/ModelSelectionModelV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/ModelSelectionModelV3.java
@@ -14,8 +14,15 @@ public class ModelSelectionModelV3 extends ModelSchemaV3<ModelSelectionModel, Mo
         @API(help="Best predictor subset names for each subset size.")
         String[][] best_model_predictors; // store for each predictor number, the best model predictors
         
-        @API(help="R2 values of all possible predictor subsets.  Only for model='allsubsets' or 'maxr'.")
+        @API(help="R2 values of all possible predictor subsets.  Only for mode='allsubsets' or 'maxr'.")
         double[] best_r2_values;  // store the best R2 values of the best models with fix number of predictors
+        
+        @API(help="at each predictor subset size, the predictor added is collected in this array.  Not for mode = " +
+                "'backward'.")
+        String[][] predictors_added_per_step;
+
+        @API(help="at each predictor subset size, the predictor removed is collected in this array.")
+        String[][] predictors_removed_per_step;
 
         @API(help="p-values of chosen predictor subsets at each subset size. Only for model='backward'.")
         double[][] coef_p_values;

--- a/h2o-algos/src/test/java/hex/modelselection/BackwardSelectionTests.java
+++ b/h2o-algos/src/test/java/hex/modelselection/BackwardSelectionTests.java
@@ -2,6 +2,7 @@ package hex.modelselection;
 
 import hex.glm.GLM;
 import hex.glm.GLMModel;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import water.*;
@@ -16,7 +17,10 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static hex.gam.GamTestPiping.massageFrame;
 import static hex.glm.GLMModel.GLMParameters.Family.*;
+import static hex.modelselection.ModelSelectionMaxRTests.compareResultFModelSummary;
+import static hex.modelselection.ModelSelectionModel.ModelSelectionParameters.Mode.allsubsets;
 import static hex.modelselection.ModelSelectionModel.ModelSelectionParameters.Mode.backward;
 import static org.junit.Assert.assertTrue;
 
@@ -44,7 +48,7 @@ public class BackwardSelectionTests extends TestUtil {
             final IcedWrapper[][] modelSummary = summary.getCellValues();
             final int numRow = modelSummary.length;
             final int numCol= modelSummary[0].length;
-            final String[] frameNames = new String[]{"coefficient_names", "z_values", "p_values"};
+            final String[] frameNames = new String[]{"coefficient_names", "z_values", "p_values", "predictor(s) removed"};
             for (int rInd = 0; rInd < numRow; rInd++)
                 for (int cInd = 0; cInd < numCol; cInd++) {
                     String cellValue = String.valueOf(modelSummary[rInd][cInd]);
@@ -341,5 +345,32 @@ public class BackwardSelectionTests extends TestUtil {
         if (ignoredCols != null)
             parms._ignored_columns = ignoredCols;
         return new hex.modelselection.ModelSelection(parms).trainModel().get();
+    }
+
+    /**
+     * Test and make sure the added and removed predictors are captured in both the result frame and the model summary.
+     * In particular, I want to make sure that they agree.  The correctness of the added/removed predictors are tested
+     * in Python unit test and won't be repeated here.
+     */
+    @Test
+    public void testAddedRemovedCols() {
+        Scope.enter();
+        try {
+            Frame train = Scope.track(massageFrame(parseTestFile("smalldata/glm_test/gaussian_20cols_10000Rows.csv"),
+                    gaussian));
+            DKV.put(train);
+            ModelSelectionModel.ModelSelectionParameters parms = new ModelSelectionModel.ModelSelectionParameters();
+            parms._response_column = "C21";
+            parms._family = gaussian;
+            parms._max_predictor_number = 3;
+            parms._seed=12345;
+            parms._train = train._key;
+            parms._mode = backward;
+            ModelSelectionModel modelBackward = new hex.modelselection.ModelSelection(parms).trainModel().get();
+            Scope.track_generic(modelBackward); //  model with validation dataset
+            compareResultFModelSummary(modelBackward);
+        } finally {
+            Scope.exit();
+        }
     }
 }

--- a/h2o-algos/src/test/java/hex/modelselection/BackwardSelectionTests.java
+++ b/h2o-algos/src/test/java/hex/modelselection/BackwardSelectionTests.java
@@ -48,7 +48,7 @@ public class BackwardSelectionTests extends TestUtil {
             final IcedWrapper[][] modelSummary = summary.getCellValues();
             final int numRow = modelSummary.length;
             final int numCol= modelSummary[0].length;
-            final String[] frameNames = new String[]{"coefficient_names", "z_values", "p_values", "predictor(s) removed"};
+            final String[] frameNames = new String[]{"coefficient_names", "z_values", "p_values", "predictor(s)_removed"};
             for (int rInd = 0; rInd < numRow; rInd++)
                 for (int cInd = 0; cInd < numCol; cInd++) {
                     String cellValue = String.valueOf(modelSummary[rInd][cInd]);

--- a/h2o-algos/src/test/java/hex/modelselection/ModelSelectionMaxRTests.java
+++ b/h2o-algos/src/test/java/hex/modelselection/ModelSelectionMaxRTests.java
@@ -2,12 +2,10 @@ package hex.modelselection;
 
 import hex.SplitFrame;
 import hex.glm.GLMModel;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import water.DKV;
-import water.Key;
-import water.Scope;
-import water.TestUtil;
+import water.*;
 import water.fvec.Frame;
 import water.fvec.Vec;
 import water.runner.CloudSize;
@@ -16,13 +14,13 @@ import water.runner.H2ORunner;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static hex.gam.GamTestPiping.massageFrame;
 import static hex.glm.GLMModel.GLMParameters.Family.gaussian;
 import static hex.modelselection.ModelSelection.forwardStep;
 import static hex.modelselection.ModelSelection.replacement;
-import static hex.modelselection.ModelSelectionModel.ModelSelectionParameters.Mode.allsubsets;
-import static hex.modelselection.ModelSelectionModel.ModelSelectionParameters.Mode.maxr;
+import static hex.modelselection.ModelSelectionModel.ModelSelectionParameters.Mode.*;
 import static hex.modelselection.ModelSelectionUtils.generateMaxRTrainingFrames;
 import static hex.modelselection.ModelSelectionUtils.removeTrainingFrames;
 import static org.junit.Assert.assertArrayEquals;
@@ -271,6 +269,56 @@ public class ModelSelectionMaxRTests extends TestUtil {
             Scope.exit();
         }
     }
+
+    /**
+     * Test and make sure the added and removed predictors are captured in both the result frame and the model summary.
+     * In particular, I want to make sure that they agree.  The correctness of the added/removed predictors are tested
+     * in Python unit test and won't be repeated here.
+     */
+    @Test
+    public void testAddedRemovedCols() {
+        Scope.enter();
+        try {
+            Frame train = Scope.track(massageFrame(parseTestFile("smalldata/glm_test/gaussian_20cols_10000Rows.csv"),
+                    gaussian));
+            DKV.put(train);
+            ModelSelectionModel.ModelSelectionParameters parms = new ModelSelectionModel.ModelSelectionParameters();
+            parms._response_column = "C21";
+            parms._family = gaussian;
+            parms._max_predictor_number = 3;
+            parms._seed=12345;
+            parms._train = train._key;
+            parms._mode = maxr;
+            ModelSelectionModel modelMaxr = new hex.modelselection.ModelSelection(parms).trainModel().get();
+            Scope.track_generic(modelMaxr); //  model with validation dataset
+            compareResultFModelSummary(modelMaxr);
+        } finally {
+            Scope.exit();
+        }
+    }
+
+    /***
+     * make sure model summary and result frame contains the same contents for removed or added predictors
+     * @param model
+     */
+    public static void compareResultFModelSummary(ModelSelectionModel model) {
+        Frame resultF = model.result();
+        Scope.track(resultF);
+        int numRows = (int) resultF.numRows();
+        String[] frameNames = new String[]{"predictor(s)_removed", "predictor(s)_added"};
+        IcedWrapper[][] cellValues = model._output._model_summary.getCellValues();
+        List<String> colHeaders = Stream.of(model._output._model_summary.getColHeaders()).collect(Collectors.toList());
+        int removedInd = colHeaders.indexOf("predictor(s)_removed");
+        int addedInd = !backward.equals(model._parms._mode) ? colHeaders.indexOf("predictor(s)_added") : 0;
+        for (int rInd = 0; rInd < numRows; rInd++) {
+            // removed predictor
+            Assert.assertTrue(cellValues[rInd][removedInd].toString().equals(resultF.vec(frameNames[0]).stringAt(rInd)));
+            // added predictor
+            if (!backward.equals(model._parms._mode))
+                Assert.assertTrue(cellValues[rInd][addedInd].toString().equals(resultF.vec(frameNames[1]).stringAt(rInd)));
+        }
+    }
+    
 
     /**
      * check cv runs correctly with maxr by comparing R2 with those from allsubsets

--- a/h2o-bindings/bin/custom/R/gen_modelselection.py
+++ b/h2o-bindings/bin/custom/R/gen_modelselection.py
@@ -12,7 +12,31 @@ parms$response_column <- args$y
 #' @export   
 h2o.get_best_r2_values<- function(model) {
   if( is(model, "H2OModel") && (model@algorithm=='modelselection'))
-    return(return(model@model$best_r2_values))
+    return(model@model$best_r2_values)
+}
+
+#' Extracts the predictor added to model at each step.
+#'
+#' @param model is a H2OModel with algorithm name of modelselection
+#' @export   
+h2o.get_predictors_added_per_step<- function(model) {
+  if( is(model, "H2OModel") && (model@algorithm=='modelselection')) {
+    if (model@allparameters$mode != 'backard') {
+      return(model@model$predictors_added_per_step)
+    } else {
+      stop("h2o.get_predictors_added_per_step can not be called with model = backward")
+    }
+  }
+}
+
+#' Extracts the predictor removed to model at each step.
+#'
+#' @param model is a H2OModel with algorithm name of modelselection
+#' @export   
+h2o.get_predictors_removed_per_step<- function(model) {
+  if( is(model, "H2OModel") && (model@algorithm=='modelselection')) {
+    return(model@model$predictors_removed_per_step)
+  }
 }
 
 #' Extracts the subset of predictor names that yield the best R2 value for each predictor subset size.

--- a/h2o-bindings/bin/custom/python/gen_modelselection.py
+++ b/h2o-bindings/bin/custom/python/gen_modelselection.py
@@ -85,6 +85,25 @@ def class_extensions():
         :return: a list of best r2 values
         """
         return self._model_json["output"]["best_r2_values"]
+    
+    def get_predictors_added_per_step(self):
+        """
+        Get list of predictors added at each step of the model building process
+
+        :return: a list of predictors added at each step
+        """ 
+        if not(self.get_params()["mode"] == "backward"):
+            return self._model_json["output"]["predictors_added_per_step"]
+        else:
+            print("backward mode does not have list predictor_added_per_step")
+
+    def get_predictors_removed_per_step(self):
+        """
+        Get list of predictors removed at each step of the model building process
+
+        :return: a list of predictors removed at each step
+        """
+        return self._model_json["output"]["predictors_removed_per_step"]           
 
     def get_best_model_predictors(self):
         """

--- a/h2o-py/h2o/estimators/model_selection.py
+++ b/h2o-py/h2o/estimators/model_selection.py
@@ -1279,6 +1279,25 @@ class H2OModelSelectionEstimator(H2OEstimator):
         """
         return self._model_json["output"]["best_r2_values"]
 
+    def get_predictors_added_per_step(self):
+        """
+        Get list of predictors added at each step of the model building process
+
+        :return: a list of predictors added at each step
+        """ 
+        if not(self.get_params()["mode"] == "backward"):
+            return self._model_json["output"]["predictors_added_per_step"]
+        else:
+            print("backward mode does not have list predictor_added_per_step")
+
+    def get_predictors_removed_per_step(self):
+        """
+        Get list of predictors removed at each step of the model building process
+
+        :return: a list of predictors removed at each step
+        """
+        return self._model_json["output"]["predictors_removed_per_step"]           
+
     def get_best_model_predictors(self):
         """
         Get list of best models with 1 predictor, 2 predictors, ..., max_predictor_number of predictors that have the

--- a/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8786_modelselection_result_frame_added_removed_preds.py
+++ b/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8786_modelselection_result_frame_added_removed_preds.py
@@ -1,0 +1,88 @@
+from __future__ import print_function
+from __future__ import division
+import sys
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.model_selection import H2OModelSelectionEstimator as modelSelection
+
+# test modelselection algorithm for regression only.  Make sure the result frame contains the correct information 
+# regarding added and deleted predictors
+def test_gaussian_result_frame_model_id():
+    d = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    my_y = "GLEASON"
+    my_x = ["AGE","RACE","CAPSULE","DCAPS","PSA","VOL","DPROS"]
+    
+    maxr_model = modelSelection(seed=12345, max_predictor_number=7, mode="maxr")
+    maxr_model.train(training_frame=d, x=my_x, y=my_y)
+    verifyCorrectAddedRemovedPreds(maxr_model, 'maxr')
+        
+    maxrsweep_model = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep")
+    maxrsweep_model.train(training_frame=d, x=my_x, y=my_y)
+    verifyCorrectAddedRemovedPreds(maxrsweep_model, 'maxrsweep')
+
+    allsubsets_model = modelSelection(seed=12345, max_predictor_number=7, mode="allsubsets")
+    allsubsets_model.train(training_frame=d, x=my_x, y=my_y)
+    verifyCorrectAddedRemovedPreds(allsubsets_model, 'allsubsets')
+        
+    backward_model = modelSelection(seed=12345, min_predictor_number=3, mode="backward")
+    backward_model.train(training_frame=d, x=my_x, y=my_y)
+    verifyCorrectAddedRemovedPreds(backward_model, 'backward')
+
+def verifyCorrectAddedRemovedPreds(model, mode):
+    resultFrame = model.result()
+    best_predictors = model.get_best_model_predictors()
+    removed_predictors = model.get_predictors_removed_per_step()
+    
+    # assert result frame and model summary results are the same
+    compareFrameNTuple(resultFrame[3], best_predictors)
+    compareFrameNTuple(resultFrame[4], removed_predictors)
+    if not(mode=='backward'):
+        added_predictors = model.get_predictors_added_per_step()
+        compareFrameNTuple(resultFrame[5], added_predictors)
+    else:
+        added_predictors = None
+
+    # verify added and removed predictors are correctly derived
+    assertCorrectAddedDeletedPreds(best_predictors, added_predictors, removed_predictors, mode)
+
+def assertCorrectAddedDeletedPreds(best_predictors, added_predictors, removed_predictors, mode):
+    numRow = len(best_predictors)
+    for index in range(numRow):
+        if not(mode=='backward'): # assert predictors are added correctly
+            add_pred = added_predictors[index]
+            if index==0:
+                for indexB in range(len(add_pred)):
+                    assert add_pred[indexB] in best_predictors[index], \
+                        "Current model predictors: {0}, predictor: {1} is added " \
+                        "incorrectly".format(best_predictors[index], add_pred[indexB])
+            else:
+                for indexB in range(len(add_pred)):
+                    assert not(add_pred[indexB] in best_predictors[index-1]) and (add_pred[indexB] in best_predictors[index]), \
+                        "Smaller model predictors: {0}, current model predictors: {1}, predictor: {2} is added " \
+                        "incorrectly.".format(best_predictors[index-1], best_predictors[index], add_pred[indexB])
+
+        del_pred = removed_predictors[index]
+        if index > 0:
+            for indexB in range(len(del_pred)):
+                if not(del_pred[indexB]==''):
+                    if mode == 'backward':
+                        assert (del_pred[indexB] in best_predictors[index]) and not(del_pred[indexB] in best_predictors[index-1]), \
+                        "Smaller model predictors: {0}, current model predictors: {1}, predictor: {2} is removed " \
+                        "incorrectly.".format(best_predictors[index-1], best_predictors[index], del_pred[indexB])
+                    else:
+                        assert (del_pred[indexB] in best_predictors[index-1]) and not(del_pred[indexB] in best_predictors[index]), \
+                            "Smaller model predictors: {0}, current model predictors: {1}, predictor: {2} is removed " \
+                            "incorrectly.".format(best_predictors[index-1], best_predictors[index], del_pred[indexB])
+                                                                                           
+def compareFrameNTuple(oneCol, oneList):
+    temp = oneCol.as_data_frame(use_pandas=False)
+    numRow = oneCol.nrows
+    for index in range(numRow):
+        assert temp[index+1].sort() == oneList[index].sort(), "Expected: {0}, Actual: {1}.  They are " \
+                                                              "different".format(temp[index], oneList[index])
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_gaussian_result_frame_model_id)
+else:
+    test_gaussian_result_frame_model_id()

--- a/h2o-r/h2o-package/R/modelselection.R
+++ b/h2o-r/h2o-package/R/modelselection.R
@@ -528,7 +528,31 @@ h2o.modelSelection <- function(x,
 #' @export   
 h2o.get_best_r2_values<- function(model) {
   if( is(model, "H2OModel") && (model@algorithm=='modelselection'))
-    return(return(model@model$best_r2_values))
+    return(model@model$best_r2_values)
+}
+
+#' Extracts the predictor added to model at each step.
+#'
+#' @param model is a H2OModel with algorithm name of modelselection
+#' @export   
+h2o.get_predictors_added_per_step<- function(model) {
+  if( is(model, "H2OModel") && (model@algorithm=='modelselection')) {
+    if (model@allparameters$mode != 'backard') {
+      return(model@model$predictors_added_per_step)
+    } else {
+      stop("h2o.get_predictors_added_per_step can not be called with model = backward")
+    }
+  }
+}
+
+#' Extracts the predictor removed to model at each step.
+#'
+#' @param model is a H2OModel with algorithm name of modelselection
+#' @export   
+h2o.get_predictors_removed_per_step<- function(model) {
+  if( is(model, "H2OModel") && (model@algorithm=='modelselection')) {
+    return(model@model$predictors_removed_per_step)
+  }
 }
 
 #' Extracts the subset of predictor names that yield the best R2 value for each predictor subset size.

--- a/h2o-r/h2o-package/pkgdown/_pkgdown.yml
+++ b/h2o-r/h2o-package/pkgdown/_pkgdown.yml
@@ -148,6 +148,8 @@ reference:
       - h2o.anovaglm
       - h2o.get_best_r2_values
       - h2o.get_best_model_predictors
+      - h2o.get_predictor_added_per_step
+      - h2o.get_predictor_removed_per_step
       - h2o.glm
       - h2o.glrm
       - h2o.grep

--- a/h2o-r/tests/testdir_algos/modelselection/runit_PUBDEV_8786_added_deleted_preds.R
+++ b/h2o-r/tests/testdir_algos/modelselection/runit_PUBDEV_8786_added_deleted_preds.R
@@ -1,0 +1,41 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# check we can get added and removed predictors in the result frame and call from model
+testAddedRemovedPreds <- function() {
+  bhexFV <- h2o.uploadFile(locate("smalldata/logreg/prostate.csv"))
+  Y <- "GLEASON"
+  X <- c("AGE","RACE","CAPSULE","DCAPS","PSA","VOL","DPROS")
+  Log.info("Build the MaxRGLM model")
+  numModel <- 7
+  allsubsetsModel <- h2o.modelSelection(y=Y, x=X, seed=12345, training_frame = bhexFV, max_predictor_number=numModel, mode="allsubsets")
+  assertAddedRemovedPreds(allsubsetsModel)
+  maxrModel <- h2o.modelSelection(y=Y, x=X, seed=12345, training_frame = bhexFV, max_predictor_number=numModel, mode="maxr")
+  assertAddedRemovedPreds(maxrModel)
+  maxrsweepModel <- h2o.modelSelection(y=Y, x=X, seed=12345, training_frame = bhexFV, max_predictor_number=numModel, mode="maxrsweep")
+  assertAddedRemovedPreds(maxrsweepModel)
+  backwardModel <- h2o.modelSelection(y=Y, x=X, seed=12345, training_frame = bhexFV, mode="backward")
+  assertAddedRemovedPreds(backwardModel)
+}
+
+assertAddedRemovedPreds <- function(model) {
+  resultFrame <- h2o.result(model)
+  removedPF <- resultFrame["predictor(s)_removed"]
+  removedPreds <- h2o.get_predictors_removed_per_step(model)
+  assertFrameListEquals(removedPF, removedPreds)
+  
+  if (model@allparameters$mode != 'backward') {
+    addPreds <- h2o.get_predictors_added_per_step(model)
+    addPredsF <- resultFrame["predictor(s)_added"]
+    assertFrameListEquals(addPredsF, addPreds)
+  }
+}
+
+assertFrameListEquals <- function(colFrame, oneList) {
+  numEle <- h2o.nrow(colFrame)
+  for (ind in c(1:numEle)) {
+    expect_true(oneList[ind] == colFrame[ind,1])
+  }
+}
+
+doTest("ModelSelection: test added and removed predictors in result frame", testAddedRemovedPreds)


### PR DESCRIPTION
This PR completes the task in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8786

Added predictors added/removed per step to modelselection toolbox in the result frame and the model summary.

Added client functions to access the predictors added/removed per step in Python and R.

Added Java, Python, R tests to access the different fields and make sure the predictors are added and removed correctly.