### PR TITLE
TestFrameBuilder - fix chunkLayout [nocheck]

### DIFF
--- a/h2o-test-support/src/main/java/water/fvec/TestFrameBuilder.java
+++ b/h2o-test-support/src/main/java/water/fvec/TestFrameBuilder.java
@@ -448,7 +448,10 @@ public class TestFrameBuilder {
       for (long numPerChunk : chunkLayout) {
         sum += numPerChunk;
       }
-      throwIf(sum > numRows, "Chunk layout contains bad elements. Total sum is higher then available number of elements.");
+      throwIf(sum > numRows, "Total chunk capacity is higher then available number of elements. " +
+              "Check withChunkLayout() and make sure that sum of the arguments is equal to number of the rows in frame.");
+      throwIf(sum < numRows, "Not enough chunk capacity to store " + numRows + " rows. " +
+              "Check withChunkLayout() and make sure that sum of the arguments is equal to number of the rows in frame.");
     } else {
       // create chunk layout - by default 1 chunk
       chunkLayout = new long[]{numRows};

--- a/h2o-test-support/src/main/java/water/fvec/TestFrameBuilderTest.java
+++ b/h2o-test-support/src/main/java/water/fvec/TestFrameBuilderTest.java
@@ -112,6 +112,23 @@ public class TestFrameBuilderTest extends TestUtil {
     fr.remove();
   }
 
+  /**
+   *  This test throws exception because it gets more data than the chunks can contain (Total size of chunks is less 
+   *  than the size of provided data) and it would result with frame with missing data in last rows
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testSetChunksFewerThanProvidedData(){
+    Frame fr = new TestFrameBuilder()
+            .withVecTypes(Vec.T_CAT, Vec.T_NUM)
+            .withColNames("A", "B")
+            .withDataForCol(0, ar("A", "B", "B", null, "F", "I"))
+            .withDataForCol(1, ard(Double.NaN, 1, 2, 3, 4, 5.6))
+            .withChunkLayout(1, 1, 2, 1) // we are requesting chunk capacity for 5 rows but provide 6 rows
+            .build();
+
+    fr.remove();
+  }
+
   @Test
   public void testSetChunks(){
     final Frame fr = new TestFrameBuilder()


### PR DESCRIPTION
Throw exception when user provide chunkLayout with…fewer capacity than numRows of the frame.

The previous implementation leads to discard the tail rows without any warning for user.