### PR TITLE
PUBDEV-8742: Using the model performance API to avoid unnecessary transforms in the scikit-learn wrapper

### DIFF
--- a/h2o-py/h2o/sklearn/wrapper.py
+++ b/h2o-py/h2o/sklearn/wrapper.py
@@ -773,15 +773,24 @@ class H2OEstimatorScoreSupport(BaseEstimatorMixin):
             return delegate.score(_to_numpy(X), y=(_vector_to_1d_array(y)), sample_weight=sample_weight)
 
         # delegate to default sklearn scoring methods
-        parent = super(H2OEstimatorScoreSupport, self)
-        if hasattr(parent, 'score') and callable(parent.score):
-            return delegate_score(parent)
-        elif self.is_classifier():
-            with Mixin(self, ClassifierMixin) as delegate:
-                return delegate_score(delegate)
-        elif self.is_regressor():
-            with Mixin(self, RegressorMixin) as delegate:
-                return delegate_score(delegate)
+        if sample_weight is None and hasattr(self._estimator, 'model_performance'):
+            scoring_frame = X if y is None else X.concat(y)
+            if self.is_classifier():
+                # sklearn default classification metric is accuracy
+                return self._estimator.model_performance(scoring_frame).accuracy()
+            elif self.is_regressor():
+                # sklearn default regression metric is r2
+                return self._estimator.model_performance(scoring_frame).r2()
+        else:
+            parent = super(H2OEstimatorScoreSupport, self)
+            if hasattr(parent, 'score') and callable(parent.score):
+                    return delegate_score(parent)
+            elif self.is_classifier():
+                with Mixin(self, ClassifierMixin) as delegate:
+                    return delegate_score(delegate)
+            elif self.is_regressor():
+                with Mixin(self, RegressorMixin) as delegate:
+                    return delegate_score(delegate)
 
 
 class H2OEstimatorTransformSupport(BaseSklearnEstimator, TransformerMixin):


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8742

migration of https://github.com/h2oai/h2o-3/pull/6231 into `h2o-3` repo so it can go through our Jenkins pipeline

```
* Adding support for the model performance API in the scikit-learn wrappers.

Co-authored-by: Nikhil Arora <nikhiljarora@outlook.com>

* Fixing issues brought up in PR review

Co-authored-by: Nikhil Arora <nikhiljarora@outlook.com>
```