### PR TITLE
Build script: Fix detection of "changed-only" pyunits [nocheck]

### DIFF
--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -13,10 +13,8 @@ from contextlib import contextmanager
 import copy
 import datetime
 from decimal import *
-import fnmatch
 from functools import reduce
 import imp
-import importlib
 import io
 import json
 import math

--- a/scripts/jenkins/groovy/buildConfig.groovy
+++ b/scripts/jenkins/groovy/buildConfig.groovy
@@ -302,7 +302,7 @@ class BuildConfig {
 
   private static List<String> detectPythonTestChanges(changes) {
     changes.findAll { change ->
-      change.startsWith('h2o-py/') && change.contains("pyunit_")
+      change.startsWith('h2o-py/') && change.contains("pyunit_") && change.lastIndexOf("pyunit_") > change.lastIndexOf("/")
     }.collect {
       it.replaceFirst(".*pyunit_", "pyunit_") // Extract only filename from path
     }


### PR DESCRIPTION
- Fix build script: Only apply "changed only" to actual pyunit tests
- Remove unused imports from utilsPY.py
