### PR TITLE
PUBDEV-8315: restoring the full model rendering by default

### DIFF
--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -1789,7 +1789,7 @@ class ModelBase(h2o_meta(Keyed, H2ODisplay)):
     # --------------------------------
     
     def _str_items(self, verbosity=None):
-        verbosity = verbosity or 'medium'  # default verbosity when printing model
+        verbosity = verbosity or 'full'  # default verbosity when printing model
         # edge cases
         if self._future:
             self._job.poll_once()
@@ -1833,7 +1833,7 @@ class ModelBase(h2o_meta(Keyed, H2ODisplay)):
         return items
     
     def _str_usage(self, verbosity=None, fmt=None):
-        verbosity = verbosity or 'medium'  # default verbosity when printing model
+        verbosity = verbosity or 'full'  # default verbosity when printing model
         if not self._model_json or verbosity == 'short':
             return ""
         lines = []


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8315

Restoring the full model rendering for default output or `print(model)` in iPython/Jupyter or Py REPL