### PR TITLE
[nocheck] Fix explain in R 3.3 

### DIFF
--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -3331,7 +3331,7 @@ h2o.learning_curve_plot <- function(model,
   }
   decreasing <- c(endsWith(optimum, "right"), startsWith(optimum, "top"))
 
-  reordered_df <- df[order(df[[x]], df[[y]], decreasing = decreasing), ]
+  reordered_df <- df[order(df[[x]], df[[y]], decreasing = decreasing, method = "radix"), ]
   reordered_df <- reordered_df[which(!duplicated(cum_agg(reordered_df[[y]]))), ]
   reordered_df
 }


### PR DESCRIPTION
Set order method to radix as the default in 3.3 does not support multiple decreasing criteria.

~**TODO**:~
* ~remove R3.3 from PR stage~