### PR TITLE
[nocheck] Fix S3 syncData in gradle

### DIFF
--- a/gradle/s3sync.gradle
+++ b/gradle/s3sync.gradle
@@ -70,6 +70,7 @@ def syncData(subdir) {
   boolean needMoreData = true
   String lastKey = ""
   while (needMoreData) {
+      lastKey = java.net.URLEncoder.encode(lastKey, "UTF-8")
       def remoteFiles = new XmlSlurper().parseText(new URL("https://h2o-public-test-data.s3.amazonaws.com/?marker=$lastKey").getText())
       if (!remoteFiles.Contents) {
         break


### PR DESCRIPTION
Fixes issue caused by either spaces or parentheses when running `./gradlew syncSmalldata`:
```
Server returned HTTP response code: 505 for URL: https://h2o-public-test-data.s3.amazonaws.com/?marker=.../... (...).jpg
```