### PR TITLE
PUBDEV-8572: added Java to calculate variable inflation factors

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -534,6 +534,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
 
   DataInfo _dinfo;
   String[] _validPredictors;  // valid predictors are numerical columns only
+  String[] _predictorNames;
   private transient DataInfo _validDinfo;
   // time per iteration in ms
 
@@ -1028,9 +1029,9 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
               false, hasWeightCol(), hasOffsetCol(), hasFoldCol(), _parms.interactionSpec());
 
       if (_parms._generate_variable_inflation_factors) {
-        String[] predictorNames = extractPredictorNames(_parms, _dinfo, null);
+        _predictorNames = extractPredictorNames(_parms, _dinfo, _parms._fold_column);
         // only calculate VIF for numerical columns
-        _validPredictors = Stream.of(predictorNames).filter(x -> _parms.train().vec(x).isNumeric()).
+        _validPredictors = Stream.of(_predictorNames).filter(x -> _parms.train().vec(x).isNumeric()).
                 collect(Collectors.toList()).stream().toArray(String[]::new);
         if (_validPredictors == null || _validPredictors.length == 0)
           error("generate_variable_inflation_factors", " cannot be enabled for GLM models with " +
@@ -3045,7 +3046,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
         scoreAndUpdateModel();
       if (_parms._generate_variable_inflation_factors) {
         _model._output._vif_predictor_names = _validPredictors.clone();
-        _model.buildVariableInflationFactors(_parms, _validPredictors);
+        _model.buildVariableInflationFactors(_parms, _validPredictors, _predictorNames);
       }// build variable inflation factors for numerical predictors
       TwoDimTable scoring_history_early_stop = ScoringInfo.createScoringHistoryTable(_model.getScoringInfo(),
               (null != _parms._valid), false, _model._output.getModelCategory(), false);

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -533,8 +533,6 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
   }
 
   DataInfo _dinfo;
-  String[] _validPredictors;  // valid predictors are numerical columns only
-  String[] _predictorNames;
   private transient DataInfo _validDinfo;
   // time per iteration in ms
 
@@ -1027,11 +1025,8 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
               false, hasWeightCol(), hasOffsetCol(), hasFoldCol(), _parms.interactionSpec());
 
       if (_parms._generate_variable_inflation_factors) {
-        _predictorNames = extractPredictorNames(_parms, _dinfo, _parms._fold_column);
-        // only calculate VIF for numerical columns
-        _validPredictors = Stream.of(_predictorNames).filter(x -> _parms.train().vec(x).isNumeric()).
-                collect(Collectors.toList()).stream().toArray(String[]::new);
-        if (_validPredictors == null || _validPredictors.length == 0)
+        String[] vifPredictors = GLMModel.getVifPredictors(_train, _parms, _dinfo);
+        if (vifPredictors == null || vifPredictors.length == 0)
           error("generate_variable_inflation_factors", " cannot be enabled for GLM models with " +
                   "only non-numerical predictors.");
       }
@@ -3043,8 +3038,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       if (!_parms._HGLM)  // no need to do for HGLM
         scoreAndUpdateModel();
       if (_parms._generate_variable_inflation_factors) {
-        _model._output._vif_predictor_names = _validPredictors.clone();
-        _model.buildVariableInflationFactors(_parms, _validPredictors, _predictorNames);
+        _model._output._vif_predictor_names = _model.buildVariableInflationFactors(_train, _dinfo);
       }// build variable inflation factors for numerical predictors
       TwoDimTable scoring_history_early_stop = ScoringInfo.createScoringHistoryTable(_model.getScoringInfo(),
               (null != _parms._valid), false, _model._output.getModelCategory(), false);

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -933,8 +933,6 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       }
     }
     if (expensive) {
-      if (_parms._nparallelism == 0)
-        _parms._nparallelism = H2O.NUMCPUS;
       if (_parms._build_null_model) {
         if (!(tweedie.equals(_parms._family) || gamma.equals(_parms._family) || negativebinomial.equals(_parms._family)))
           error("build_null_model", " is only supported for tweedie, gamma and negativebinomial familes");

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -113,11 +113,11 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
    * factors are generated for non-numerical predictors.
    * 
    */
-  public void buildVariableInflationFactors(GLMParameters parms, String[] validPredictors) {
+  public void buildVariableInflationFactors(GLMParameters parms, String[] validPredictors, String[] predictorNames) {
     // set variable inflation factors to NaN to start with
     _output._variable_inflation_factors = IntStream.range(0, validPredictors.length).mapToDouble(x -> Double.NaN).boxed().
             collect(Collectors.toList()).stream().mapToDouble(Double::doubleValue).toArray();
-    GLMParameters[] allParams = genGLMParameters(parms, validPredictors);
+    GLMParameters[] allParams = genGLMParameters(parms, validPredictors, predictorNames);
     GLM[] glmBuilder = Stream.of(allParams).map(x -> new GLM(x)).collect(Collectors.toList()).stream().toArray(GLM[]::new);
     GLM[] glmResults = ModelBuilderHelper.trainModelsParallel(glmBuilder, parms._nparallelism);
     Double[] r2 = Arrays.stream(glmResults).mapToDouble(x ->x.get().r2()).boxed().collect(Collectors.toList()).stream()

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -23,13 +23,20 @@ import water.util.*;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static hex.genmodel.utils.ArrayUtils.flat;
 import static hex.glm.ComputationState.expandToFullArray;
+import static hex.glm.GLMUtils.genGLMParameters;
 import static hex.schemas.GLMModelV3.GLMModelOutputV3.calculateVarimpMultinomial;
 import static hex.schemas.GLMModelV3.calculateVarimpBase;
 import static hex.util.DistributionUtils.distributionToFamily;
 import static hex.util.DistributionUtils.familyToDistribution;
+import static java.util.stream.Collectors.toMap;
 
 /**
  * Created by tomasnykodym on 8/27/14.
@@ -94,6 +101,34 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
   
   public void setVcov(double[][] inv) {_output._vcov = inv;}
 
+  /***
+   * This method will calculate the variable inflation factor of each numerical predictor using the following
+   * procedure:
+   * 1. For each numerical predictor, choose it as the response variable and leave all the other predictors as the
+   * predictors;
+   * 2. Build a GLM model and obtained the R2 of the model;
+   * 3. the variable inflation factor for that predictor is calculated as 1.0/(1.0-R2).
+   * 
+   * All the variable inflation factors for all valid predictors are saved in a double array.  No variable inflation
+   * factors are generated for non-numerical predictors.
+   * 
+   */
+  public void buildVariableInflationFactors(GLMParameters parms, String[] validPredictors) {
+    // set variable inflation factors to NaN to start with
+    _output._variable_inflation_factors = IntStream.range(0, validPredictors.length).mapToDouble(x -> Double.NaN).boxed().
+            collect(Collectors.toList()).stream().mapToDouble(Double::doubleValue).toArray();
+    GLMParameters[] allParams = genGLMParameters(parms, validPredictors);
+    GLM[] glmBuilder = Stream.of(allParams).map(x -> new GLM(x)).collect(Collectors.toList()).stream().toArray(GLM[]::new);
+    GLM[] glmResults = ModelBuilderHelper.trainModelsParallel(glmBuilder, parms._nparallelism);
+    Double[] r2 = Arrays.stream(glmResults).mapToDouble(x ->x.get().r2()).boxed().collect(Collectors.toList()).stream()
+            .toArray(Double[]::new);
+    for (GLM glm : glmResults)
+      glm.get().remove();
+    _output._variable_inflation_factors = IntStream.range(0, validPredictors.length)
+            .mapToDouble(x -> 1.0 / (1.0 - r2[x])).boxed().collect(Collectors.toList()).stream()
+            .mapToDouble(Double::doubleValue).toArray();
+  }
+  
   public static class RegularizationPath extends Iced {
     public double []   _lambdas;
     public double[] _alphas;
@@ -318,6 +353,8 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     public double _init_dispersion_parameter = 1.0;
     public boolean _fix_dispersion_parameter = false;
     public boolean _build_null_model = false;
+    public boolean _generate_variable_inflation_factors = false; // if enabled, will generate variable_inflation_factors for numeric predictors
+    public int _nparallelism = 0;
     
     public void validate(GLM glm) {
       if (_remove_collinear_columns) {
@@ -1217,11 +1254,14 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     double[] _global_beta;
     double[] _ubeta;  // HGLM:  random coefficients
     private double[] _zvalues;
+    double[] _variable_inflation_factors;
+    String[] _vif_predictor_names; // predictor names corresponding to the variableInflationFactors
     double [][] _vcov;
     private double _dispersion;
     private boolean _dispersionEstimated;
     public int[] _activeColsPerClass;
     public boolean hasPValues(){return _zvalues != null;}
+    public boolean hasVIF() { return _vif_predictor_names != null; }
     public double [] stdErr(){
       double [] res = _zvalues.clone();
       for(int i = 0; i < res.length; ++i)
@@ -1231,6 +1271,14 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     
     public double[] getZValues() {
       return _zvalues;
+    }
+    public double[] getVariableInflationFactors() { return _variable_inflation_factors; }
+    public String[] getVIFPredictorNames() { return _vif_predictor_names; }
+    public Map<String, Double> getVIFAndNames() { 
+      if (_variable_inflation_factors != null)
+        return IntStream.range(0, _vif_predictor_names.length).boxed().collect(toMap(s ->_vif_predictor_names[s], s -> _variable_inflation_factors[s]));
+      else
+        return null;
     }
 
     @Override
@@ -1253,6 +1301,9 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
       for(int i = 0; i < res.length; ++i)
         res[i] = 2*rd.cumulativeProbability(-Math.abs(res[i]));
       return res;
+    }
+    public double[] variableInflationFactors() {
+      return _variable_inflation_factors; // predictor orders the same as in coefficientNames
     }
     double[][] _global_beta_multinomial;
     final int _nclasses;

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -122,8 +122,9 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
 
   static String[] getVifPredictors(Frame train, GLMParameters parms, DataInfo dinfo) {
     String[] predictorNames = extractPredictorNames(parms, dinfo, parms._fold_column);
-    return Stream.of(predictorNames).filter(x -> train.vec(x).isNumeric()).
-            collect(Collectors.toList()).stream().toArray(String[]::new);
+    return Stream.of(predictorNames)
+            .filter(x -> train.find(x) >= 0 && train.vec(x).isNumeric())
+            .toArray(String[]::new);
   }
 
   public String[] buildVariableInflationFactors(GLMParameters parms, String[] validPredictors, String[] predictorNames) {

--- a/h2o-algos/src/main/java/hex/glm/GLMUtils.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMUtils.java
@@ -9,11 +9,10 @@ import water.util.ArrayUtils;
 import water.util.FrameUtils;
 import water.util.TwoDimTable;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
+import static hex.glm.GLMModel.GLMParameters.Family.gaussian;
 import static water.fvec.Vec.T_NUM;
 import static water.fvec.Vec.T_STR;
 
@@ -39,6 +38,24 @@ public class GLMUtils {
       }
     }
     return gamColIndices;
+  }
+  
+  public static GLMModel.GLMParameters[] genGLMParameters(GLMModel.GLMParameters parms, String[] validPreds) {
+    int numPreds = validPreds.length;
+    if (numPreds > 0) {
+      GLMModel.GLMParameters[] params = new GLMModel.GLMParameters[numPreds];
+      for (int index=0; index < numPreds; index++) {
+        params[index] = new GLMModel.GLMParameters(gaussian);
+        params[index]._response_column = validPreds[index];
+        params[index]._train = parms.train()._key;
+        params[index]._lambda = new double[]{0.0};
+        params[index]._alpha = new double[]{0.0};
+        params[index]._compute_p_values = true;
+      }
+      return params;
+    } else {
+      return null;
+    }
   }
 
   public static void removePredictors(GLMModel.GLMParameters parms, Frame train) {

--- a/h2o-algos/src/main/java/hex/glm/GLMUtils.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMUtils.java
@@ -11,6 +11,7 @@ import water.util.TwoDimTable;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static hex.glm.GLMModel.GLMParameters.Family.gaussian;
 import static water.fvec.Vec.T_NUM;
@@ -40,10 +41,14 @@ public class GLMUtils {
     return gamColIndices;
   }
   
-  public static GLMModel.GLMParameters[] genGLMParameters(GLMModel.GLMParameters parms, String[] validPreds) {
+  public static GLMModel.GLMParameters[] genGLMParameters(GLMModel.GLMParameters parms, String[] validPreds,
+                                                          String[] predictorNames) {
     int numPreds = validPreds.length;
     if (numPreds > 0) {
       GLMModel.GLMParameters[] params = new GLMModel.GLMParameters[numPreds];
+      String[] frameNames = parms.train().names();
+      List<String> predList = Stream.of(predictorNames).collect(Collectors.toList());
+      String[] ignoredCols = Arrays.stream(frameNames).filter(x -> !predList.contains(x)).collect(Collectors.toList()).toArray(new String[0]);
       for (int index=0; index < numPreds; index++) {
         params[index] = new GLMModel.GLMParameters(gaussian);
         params[index]._response_column = validPreds[index];
@@ -51,6 +56,7 @@ public class GLMUtils {
         params[index]._lambda = new double[]{0.0};
         params[index]._alpha = new double[]{0.0};
         params[index]._compute_p_values = true;
+        params[index]._ignored_columns = ignoredCols;
       }
       return params;
     } else {

--- a/h2o-algos/src/main/java/hex/glm/GLMUtils.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMUtils.java
@@ -48,6 +48,8 @@ public class GLMUtils {
       GLMModel.GLMParameters[] params = new GLMModel.GLMParameters[numPreds];
       String[] frameNames = parms.train().names();
       List<String> predList = Stream.of(predictorNames).collect(Collectors.toList());
+      if (parms._weights_column != null)
+        predList.add(parms._weights_column);
       String[] ignoredCols = Arrays.stream(frameNames).filter(x -> !predList.contains(x)).collect(Collectors.toList()).toArray(new String[0]);
       for (int index=0; index < numPreds; index++) {
         params[index] = new GLMModel.GLMParameters(gaussian);
@@ -57,6 +59,7 @@ public class GLMUtils {
         params[index]._alpha = new double[]{0.0};
         params[index]._compute_p_values = true;
         params[index]._ignored_columns = ignoredCols;
+        params[index]._weights_column = parms._weights_column;
       }
       return params;
     } else {

--- a/h2o-algos/src/main/java/hex/modelselection/ModelSelectionUtils.java
+++ b/h2o-algos/src/main/java/hex/modelselection/ModelSelectionUtils.java
@@ -702,7 +702,6 @@ public class ModelSelectionUtils {
         if (foldColumn != null && frameNames.contains(foldColumn))
             frameNames.remove(foldColumn);
         return frameNames.stream().toArray(String[]::new);
-        
     }
     
     public static int findMinZValue(GLMModel model, List<String> numPredNames, List<String> catPredNames, 

--- a/h2o-algos/src/main/java/hex/modelselection/ModelSelectionUtils.java
+++ b/h2o-algos/src/main/java/hex/modelselection/ModelSelectionUtils.java
@@ -78,7 +78,7 @@ public class ModelSelectionUtils {
      * @param predNames
      * @return
      */
-    public static Frame generateOneFrame(int[] predIndices, ModelSelectionModel.ModelSelectionParameters parms, String[] predNames,
+    public static Frame generateOneFrame(int[] predIndices, Model.Parameters parms, String[] predNames,
                                          String foldColumn) {
         final Frame predVecs = new Frame(Key.make());
         final Frame train = parms.train();
@@ -693,8 +693,8 @@ public class ModelSelectionUtils {
         return bestModel;
     }
 
-    public static String[] extractPredictorNames(ModelSelectionModel.ModelSelectionParameters parms, DataInfo dinfo, 
-                                            String foldColumn) {
+    public static String[] extractPredictorNames(Model.Parameters parms, DataInfo dinfo,
+                                                 String foldColumn) {
         List<String> frameNames = Arrays.stream(dinfo._adaptedFrame.names()).collect(Collectors.toList());
         String[] nonResponseCols = parms.getNonPredictors();
         for (String col : nonResponseCols)

--- a/h2o-algos/src/main/java/hex/schemas/GLMModelV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMModelV3.java
@@ -11,6 +11,9 @@ import water.util.ArrayUtils;
 import water.util.TwoDimTable;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static water.util.ArrayUtils.sort;
 //import water.util.DocGen.HTML;
@@ -56,6 +59,12 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
 
     @API(help = "Dispersion parameter, only applicable to Tweedie family (input/output) and fractional Binomial (output only)")
     double dispersion;
+    
+    @API(help = "Predictor names where variable inflation factors are calculated.")
+    String[] vif_predictor_names;
+    
+    @API(help = "predictor variable inflation factors.")
+    double[] variable_inflation_factors;
 
     private GLMModelOutputV3 fillMultinomial(GLMOutput impl) {
       if(impl.get_global_beta_multinomial() == null)
@@ -74,20 +83,24 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
         coefficients_table_multinomials_with_class_names = new TwoDimTableV3();
       
         int n = impl.nclasses();
-        String[] cols = new String[n*2];
+        String[] cols = impl.hasVIF() ? new String[2*n+1] : new String[n*2]; // coefficients per class and standardized coefficients
         String[] cols2=null;
         if (n>2) {
-          cols2 = new String[n*2];
+          cols2 = impl.hasVIF() ? new String[n*2+1] : new String[n*2];
           String[] classNames = impl._domains[impl.responseIdx()];
           for (int i = 0; i < n; ++i) {
             cols2[i] = "coefs_class_" + classNames[i];
             cols2[n + i] = "std_coefs_class_" + classNames[i];
           }
+          if (impl.hasVIF())
+            cols2[2*n] = "variable_inflation_factor";
         }
         for (int i = 0; i < n; ++i) {
           cols[i] = "coefs_class_" +i;
           cols[n + i] = "std_coefs_class_" +i;
         }
+        if (impl.hasVIF())
+          cols[2*n] = "variable_inflation_factor";
 
         String [] colTypes = new String[cols.length];
         Arrays.fill(colTypes, "double");
@@ -105,6 +118,18 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
               tdt.set(i + 1, n + c, betaNorm[c][i]);
             }
           }
+          if (impl.hasVIF()) {
+            List<String> vifPredictors = Stream.of(impl.getVIFPredictorNames()).collect(Collectors.toList());
+            double[] varInFactors = impl.variableInflationFactors();
+            for (int row=0; row < ns.length; row++) {
+              if (vifPredictors.contains(ns[row])) {
+                int index = vifPredictors.indexOf(ns[row]);
+                tdt.set(row, 2*n, varInFactors[index]);
+              } else {
+                tdt.set(row, 2*n, Double.NaN);
+              }
+            }
+          }
           coefficients_table.fillFromImpl(tdt);
           if (n>2) {  // restore column names from pythonized ones
             coefficients_table_multinomials_with_class_names.fillFromImpl(tdt);
@@ -115,7 +140,9 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
 
           for(int i = 0; i < len; ++i)
             names2[i] = names[indices[i]];
-          tdt = new TwoDimTable("Standardized Coefficient Magnitudes", "standardized coefficient magnitudes", names2, new String[]{"Coefficients", "Sign"}, new String[]{"double", "string"}, new String[]{"%5f", "%s"}, "names");
+          tdt = new TwoDimTable("Standardized Coefficient Magnitudes", 
+                  "standardized coefficient magnitudes", names2, new String[]{"Coefficients", "Sign"},
+                  new String[]{"double", "string"}, new String[]{"%5f", "%s"}, "names");
           for (int i = 0; i < magnitudes.length - 1; ++i) {
             tdt.set(i, 0, magnitudes[indices[i]]);
             tdt.set(i, 1, "POS");
@@ -170,6 +197,9 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
       alpha_best = impl.alpha_best();
       best_submodel_index = impl.bestSubmodelIndex();
       dispersion = impl.dispersion();
+      variable_inflation_factors = impl.getVariableInflationFactors();
+      vif_predictor_names = impl.hasVIF() ? impl.getVIFPredictorNames() : null;
+      List<String> validVIFNames = impl.hasVIF() ? Stream.of(vif_predictor_names).collect(Collectors.toList()) : null;
       if(impl._multinomial || impl._ordinal)
         return fillMultinomial(impl);
       String [] names = impl.coefficientNames().clone();
@@ -193,14 +223,25 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
       String [] colnames = new String[]{"Coefficients"};
 
       if(impl.hasPValues()){
-        colTypes = new String[]{"double","double","double","double"};
-        colFormats = new String[]{"%5f","%5f","%5f","%5f"};
-        colnames = new String[]{"Coefficients","Std. Error","z value","p value"};
+        if (impl.hasVIF()) {
+          colTypes = new String[]{"double", "double", "double", "double","double"};
+          colFormats = new String[]{"%5f", "%5f", "%5f", "%5f", "%5f"};
+          colnames = new String[]{"Coefficients", "Std. Error", "z value", "p value", "variable_inflation_factor"};
+        } else {
+          colTypes = new String[]{"double", "double", "double", "double"};
+          colFormats = new String[]{"%5f", "%5f", "%5f", "%5f"};
+          colnames = new String[]{"Coefficients", "Std. Error", "z value", "p value"};
+        }
+      } else if (impl.hasVIF()) {
+        colTypes = new String[]{"double", "double"};
+        colFormats = new String[]{"%5f", "%5f"};
+        colnames = new String[]{"Coefficients", "variable_inflation_factor"};
       }
+
       int stdOff = colnames.length;
       colTypes = ArrayUtils.append(colTypes,"double");
       colFormats = ArrayUtils.append(colFormats,"%5f");
-      colnames = ArrayUtils.append(colnames,"Standardized Coefficients");
+      colnames = ArrayUtils.append(colnames,"Standardized Coefficients"); // as last column
       TwoDimTable tdt = new TwoDimTable("Coefficients","glm coefficients", ns, colnames, colTypes, colFormats, "names");
       tdt.set(0, 0, beta[beta.length - 1]);
       for (int i = 0; i < beta.length - 1; ++i) {
@@ -224,6 +265,24 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
           tdt.set(i + 1, 1, stdErr[i]);
           tdt.set(i + 1, 2, zVals[i]);
           tdt.set(i + 1, 3, pVals[i]);
+        }
+        if (impl.hasVIF()) {
+          for (int i=0; i < stdErr.length; i++)
+            if (validVIFNames.contains(ns[i])) {
+              int index = validVIFNames.indexOf(ns[i]);
+              tdt.set(i, 4, variable_inflation_factors[index]);
+            } else {
+              tdt.set(i, 4, Double.NaN);
+            }
+        }
+      } else if (impl.hasVIF()) { // has VIF but without p-values and stuff
+        for (int i=0; i<ns.length; i++) {
+          if (validVIFNames.contains(ns[i])) {
+            int index = validVIFNames.indexOf(ns[i]);
+            tdt.set(i, 1, variable_inflation_factors[index]);
+          } else {
+            tdt.set(i, 1, Double.NaN);
+          }
         }
       }
       coefficients_table.fillFromImpl(tdt);

--- a/h2o-algos/src/main/java/hex/schemas/GLMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMV3.java
@@ -89,7 +89,9 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
             "dispersion_epsilon",
             "max_iterations_dispersion",
             "build_null_model",
-            "fix_dispersion_parameter"
+            "fix_dispersion_parameter",
+            "generate_variable_inflation_factors",
+            "nparallelism"
     };
 
     @API(help = "Seed for pseudo random number generator (if applicable)", gridable = true)
@@ -197,9 +199,17 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
 
     @API(help = "if true, will return likelihood function value for HGLM.") // not gridable
     public boolean calc_like;
+    
+    @API(help="if true, will generate variable inflation factors for numerical predictors.  Default to false.", 
+            level = Level.expert)
+    public boolean generate_variable_inflation_factors;
 
     @API(help="Include constant term in the model", level = Level.expert)
     public boolean intercept;
+
+    @API(help = "number of models to build in parallel.  Defaults to 0.0 which is adaptive to the system capability",
+            level = API.Level.secondary, gridable = true)
+    public int nparallelism;
     
     @API(help="If set, will build a model with only the intercept.  Default to false.", level = Level.expert)
     public boolean build_null_model;

--- a/h2o-algos/src/main/java/hex/schemas/GLMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMV3.java
@@ -90,8 +90,7 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
             "max_iterations_dispersion",
             "build_null_model",
             "fix_dispersion_parameter",
-            "generate_variable_inflation_factors",
-            "nparallelism"
+            "generate_variable_inflation_factors"
     };
 
     @API(help = "Seed for pseudo random number generator (if applicable)", gridable = true)
@@ -207,10 +206,6 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
     @API(help="Include constant term in the model", level = Level.expert)
     public boolean intercept;
 
-    @API(help = "number of models to build in parallel.  Defaults to 0.0 which is adaptive to the system capability",
-            level = API.Level.secondary, gridable = true)
-    public int nparallelism;
-    
     @API(help="If set, will build a model with only the intercept.  Default to false.", level = Level.expert)
     public boolean build_null_model;
 

--- a/h2o-algos/src/test/java/hex/glm/GLMModelTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMModelTest.java
@@ -1,0 +1,74 @@
+package hex.glm;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import water.DKV;
+import water.H2O;
+import water.Key;
+import water.TestUtil;
+import water.fvec.Frame;
+import water.runner.H2ORunner;
+
+import static org.junit.Assert.*;
+
+@RunWith(H2ORunner.class)
+public class GLMModelTest extends TestUtil {
+
+    @Test
+    public void testNVIFModelsInParallel() {
+        Key<Frame> smolFKey = Key.make();
+        Key<Frame> bigFKey = Key.make();
+        try {
+            { // case small
+                DKV.put(new DummySizedFrame(smolFKey, (long) 1e6 - 1));
+                GLMModel.GLMParameters parms = new GLMModel.GLMParameters();
+                parms._train = smolFKey;
+                assertEquals(H2O.ARGS.nthreads, GLMModel.nVIFModelsInParallel(parms));
+            }
+            { // case big data (> 1e6)
+                DKV.put(new DummySizedFrame(bigFKey, (long) 1e6));
+                GLMModel.GLMParameters parms = new GLMModel.GLMParameters();
+                parms._train = bigFKey;
+                assertEquals(2, GLMModel.nVIFModelsInParallel(parms));
+            }
+            { // case CV
+                GLMModel.GLMParameters parms = new GLMModel.GLMParameters();
+                parms._is_cv_model = true;
+                assertEquals(1, GLMModel.nVIFModelsInParallel(parms));
+            }
+        } finally {
+            DKV.remove(smolFKey);
+            DKV.remove(bigFKey);
+        }
+    }
+
+    @Test
+    public void testNVIFModelsInParallel_userSpec() {
+        final Key<Frame> key = Key.make();
+        final String propertyKey = "sys.ai.h2o." + "glm.vif." + key + ".nparallelism";
+        try {
+            System.setProperty(propertyKey, "42");
+            GLMModel.GLMParameters parms = new GLMModel.GLMParameters();
+            parms._train = key;
+            assertEquals(42, GLMModel.nVIFModelsInParallel(parms));
+        } finally {
+            System.getProperties().remove(propertyKey);
+        }
+    }
+
+    private static class DummySizedFrame extends Frame {
+
+        private final long _byteSize;
+
+        private DummySizedFrame(Key<Frame> key, long byteSize) {
+            super(key);
+            _byteSize = byteSize;
+        }
+
+        @Override
+        public long byteSize() {
+            return _byteSize;
+        }
+    }
+
+}

--- a/h2o-algos/src/test/java/hex/glm/GLMTestVariableInflationFactors.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMTestVariableInflationFactors.java
@@ -102,6 +102,7 @@ public class GLMTestVariableInflationFactors extends TestUtil {
                 tParms._compute_p_values = true;
                 tParms._response_column = vifNames[index];
                 tParms._train = train._key;
+                tParms._ignored_columns = new String[]{response};
                 GLMModel tModel = new GLM(tParms).trainModel().get();
                 Scope.track_generic(tModel);
                 double vif = 1.0 / (1.0 - tModel.r2());

--- a/h2o-algos/src/test/java/hex/glm/GLMTestVariableInflationFactors.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMTestVariableInflationFactors.java
@@ -1,0 +1,116 @@
+package hex.glm;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import water.DKV;
+import water.Scope;
+import water.TestUtil;
+import water.fvec.Frame;
+import water.runner.CloudSize;
+import water.runner.H2ORunner;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static hex.glm.GLMModel.GLMParameters.Family.*;
+
+@RunWith(H2ORunner.class)
+@CloudSize(1)
+public class GLMTestVariableInflationFactors extends TestUtil {
+    @Test
+    public void testVIFactorGaussian() {
+        Scope.enter();
+        try {
+            Frame train = parseAndTrackTestFile("smalldata/prostate/prostate_complete.csv.zip");
+            assertCorrectVIF(train, "GLEASON", 1e-6, gaussian);
+        } finally {
+            Scope.exit();
+        }
+    }
+    
+    @Test
+    public void testVIFactorBinomial() {
+        Scope.enter();
+        try {
+            Frame train = parseAndTrackTestFile("smalldata/prostate/prostate_complete.csv.zip");
+            List<String> predNames = Stream.of(train.names()).collect(Collectors.toList());
+            String resp = "CAPSULE";
+            int indexOfResp = predNames.indexOf(resp);
+            train.replace(indexOfResp, train.vec(indexOfResp).toCategoricalVec()).remove();
+            DKV.put(train);
+            assertCorrectVIF(train, "CAPSULE", 1e-6, binomial);
+        } finally {
+            Scope.exit();
+        }
+    }
+    
+    @Test
+    public void testVIFactorPoisson() {
+        Scope.enter();
+        try {
+            Frame df = parseAndTrackTestFile("smalldata/prostate/prostate_complete.csv.zip");
+            assertCorrectVIF(df, "GLEASON", 1e-6, poisson);
+        } finally {
+            Scope.exit();
+        }
+    }
+
+    @Test
+    public void testVIFactorMultinomial() {
+        Scope.enter();
+        try {
+            Frame df = parseAndTrackTestFile("smalldata/glm_test/rollup_stat_test.csv");
+            df.replace(df.numCols() - 1, df.vec("RACE").toCategoricalVec()).remove();
+            DKV.put(df);
+            assertCorrectVIF(df, "RACE", 1e-6, multinomial);
+        } finally {
+            Scope.exit();
+        }
+    }
+    
+    @Test
+    public void testNumNEnumPredictors() {
+        Scope.enter();
+        try {
+            Frame train = parseAndTrackTestFile(("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"));
+            List<String> colNames = Stream.of(train.names()).collect(Collectors.toList());
+            String[] enumCols = new String[]{"C1", "C2", "C3", "C4", "C5", "C11"};
+            Stream.of(enumCols).forEach(x -> train.replace(colNames.indexOf(x), train.vec(x).toCategoricalVec()).remove());
+            DKV.put(train);
+            assertCorrectVIF(train, "C11", 1e-6, multinomial);
+        } finally {
+            Scope.exit();
+        }
+    }
+
+    public void assertCorrectVIF(Frame train, String response, double tot, GLMModel.GLMParameters.Family family) {
+        GLMModel.GLMParameters params = new GLMModel.GLMParameters();
+        params._response_column = response;
+        params._train = train._key;
+        params._family = family;
+        params._generate_variable_inflation_factors = true;
+        GLMModel model = new GLM(params).trainModel().get();
+        Scope.track_generic(model);
+        double[] varInfFactors = model._output.variableInflationFactors();
+        String[] vifNames = model._output.getVIFPredictorNames();
+        for (int index = 0; index < vifNames.length; index++) {
+                GLMModel.GLMParameters tParms = new GLMModel.GLMParameters(gaussian);
+                tParms._lambda = new double[]{0};
+                tParms._alpha = new double[]{0};
+                tParms._compute_p_values = true;
+                tParms._response_column = vifNames[index];
+                tParms._train = train._key;
+                GLMModel tModel = new GLM(tParms).trainModel().get();
+                Scope.track_generic(tModel);
+                double vif = 1.0 / (1.0 - tModel.r2());
+                Assert.assertTrue(Math.abs(vif - varInfFactors[index]) < tot);
+        }
+        // make sure VIF is calculated for the correct number of predictors
+        List<String> names = Stream.of(model.names()).collect(Collectors.toList());
+        names.remove(names.indexOf(response)); 
+        int numNumericalCols = names.stream().filter(x -> train.vec(x).isNumeric()).collect(Collectors.toList()).size();
+        Assert.assertTrue(numNumericalCols == varInfFactors.length);
+    }
+}

--- a/h2o-py/h2o/estimators/glm.py
+++ b/h2o-py/h2o/estimators/glm.py
@@ -110,7 +110,6 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
                  build_null_model=False,  # type: bool
                  fix_dispersion_parameter=False,  # type: bool
                  generate_variable_inflation_factors=False,  # type: bool
-                 nparallelism=0,  # type: int
                  ):
         """
         :param model_id: Destination id for this model; auto-generated if not specified.
@@ -388,10 +387,6 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
                predictors.  Default to false.
                Defaults to ``False``.
         :type generate_variable_inflation_factors: bool
-        :param nparallelism: number of models to build in parallel.  Defaults to 0.0 which is adaptive to the system
-               capability
-               Defaults to ``0``.
-        :type nparallelism: int
         """
         super(H2OGeneralizedLinearEstimator, self).__init__()
         self._parms = {}
@@ -468,7 +463,6 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
         self.build_null_model = build_null_model
         self.fix_dispersion_parameter = fix_dispersion_parameter
         self.generate_variable_inflation_factors = generate_variable_inflation_factors
-        self.nparallelism = nparallelism
 
     @property
     def training_frame(self):
@@ -2282,20 +2276,6 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     def generate_variable_inflation_factors(self, generate_variable_inflation_factors):
         assert_is_type(generate_variable_inflation_factors, None, bool)
         self._parms["generate_variable_inflation_factors"] = generate_variable_inflation_factors
-
-    @property
-    def nparallelism(self):
-        """
-        number of models to build in parallel.  Defaults to 0.0 which is adaptive to the system capability
-
-        Type: ``int``, defaults to ``0``.
-        """
-        return self._parms.get("nparallelism")
-
-    @nparallelism.setter
-    def nparallelism(self, nparallelism):
-        assert_is_type(nparallelism, None, int)
-        self._parms["nparallelism"] = nparallelism
 
     Lambda = deprecated_property('Lambda', lambda_)
 

--- a/h2o-py/h2o/estimators/glm.py
+++ b/h2o-py/h2o/estimators/glm.py
@@ -109,6 +109,8 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
                  max_iterations_dispersion=1000000,  # type: int
                  build_null_model=False,  # type: bool
                  fix_dispersion_parameter=False,  # type: bool
+                 generate_variable_inflation_factors=False,  # type: bool
+                 nparallelism=0,  # type: int
                  ):
         """
         :param model_id: Destination id for this model; auto-generated if not specified.
@@ -382,6 +384,14 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
                p-values. Default to false.
                Defaults to ``False``.
         :type fix_dispersion_parameter: bool
+        :param generate_variable_inflation_factors: if true, will generate variable inflation factors for numerical
+               predictors.  Default to false.
+               Defaults to ``False``.
+        :type generate_variable_inflation_factors: bool
+        :param nparallelism: number of models to build in parallel.  Defaults to 0.0 which is adaptive to the system
+               capability
+               Defaults to ``0``.
+        :type nparallelism: int
         """
         super(H2OGeneralizedLinearEstimator, self).__init__()
         self._parms = {}
@@ -457,6 +467,8 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
         self.max_iterations_dispersion = max_iterations_dispersion
         self.build_null_model = build_null_model
         self.fix_dispersion_parameter = fix_dispersion_parameter
+        self.generate_variable_inflation_factors = generate_variable_inflation_factors
+        self.nparallelism = nparallelism
 
     @property
     def training_frame(self):
@@ -2256,6 +2268,34 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     def fix_dispersion_parameter(self, fix_dispersion_parameter):
         assert_is_type(fix_dispersion_parameter, None, bool)
         self._parms["fix_dispersion_parameter"] = fix_dispersion_parameter
+
+    @property
+    def generate_variable_inflation_factors(self):
+        """
+        if true, will generate variable inflation factors for numerical predictors.  Default to false.
+
+        Type: ``bool``, defaults to ``False``.
+        """
+        return self._parms.get("generate_variable_inflation_factors")
+
+    @generate_variable_inflation_factors.setter
+    def generate_variable_inflation_factors(self, generate_variable_inflation_factors):
+        assert_is_type(generate_variable_inflation_factors, None, bool)
+        self._parms["generate_variable_inflation_factors"] = generate_variable_inflation_factors
+
+    @property
+    def nparallelism(self):
+        """
+        number of models to build in parallel.  Defaults to 0.0 which is adaptive to the system capability
+
+        Type: ``int``, defaults to ``0``.
+        """
+        return self._parms.get("nparallelism")
+
+    @nparallelism.setter
+    def nparallelism(self, nparallelism):
+        assert_is_type(nparallelism, None, int)
+        self._parms["nparallelism"] = nparallelism
 
     Lambda = deprecated_property('Lambda', lambda_)
 

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -672,6 +672,19 @@ class ModelBase(h2o_meta(Keyed, H2ODisplay)):
         """Pretty print the coefficents table (includes normalized coefficients)."""
         print(self._model_json["output"]["coefficients_table"])  # will return None if no coefs!
 
+    def get_variable_inflation_factors(self):
+        if self.algo == 'glm':
+            if self.parms['generate_variable_inflation_factors']:
+                tbl = self._model_json["output"]["coefficients_table"]
+                if tbl is None:
+                    return None
+                return {name: vif for name, vif in zip(tbl["names"], tbl["variable_inflation_factor"])}
+            else:
+                raise ValueError("variable inflation factors are generated only when "
+                                 "generate_variable_inflation_factors is enabled.")
+        else:
+            raise ValueError("variable inflation factors are only found in GLM models for numerical predictors.")
+        
     def coef(self):
         """
         Return the coefficients which can be applied to the non-standardized data.
@@ -710,7 +723,7 @@ class ModelBase(h2o_meta(Keyed, H2ODisplay)):
                                  "compute_p_values=True.")
         else:
             raise ValueError("p-values, z-values and std_error are only found in GLM.")
-            
+        
     def _fillMultinomialDict(self, standardize=False):
         if self.algo == 'gam':
             tbl = self._model_json["output"]["coefficients_table"]

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8572_glm_VIF.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8572_glm_VIF.py
@@ -1,0 +1,37 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+import math
+
+def test_vif_tweedie():
+    training_data = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/glm_test/gamma_dispersion_factor_9_10kRows.csv")
+    Y = 'resp'
+    x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
+    model = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, generate_variable_inflation_factors=True)
+    model.train(training_frame=training_data, x=x, y=Y)
+    vif_names = model.get_variable_inflation_factors()
+    vif = model._model_json["output"]["variable_inflation_factors"]
+    vif_predictor_names = model._model_json["output"]["vif_predictor_names"]
+    # check variable inflation factors are the same gotten from the coefficient tables and from the variables directly
+    count = 0
+    for pred in vif_predictor_names:
+        if math.isnan(vif[count]):
+            assert math.isnan(vif_names[pred]), "For predictor: {0}, expected inflation variable factor is NaN but" \
+                                                " actual value is {1} and is not NaN.".format(pred, vif_names[pred])
+        else:
+            assert abs(vif[count]-vif_names[pred]) < 1e-6, "For predictor: {0}, expected inflation variable factor:" \
+                                                           " {1}, actual value: {2}".format(pred, vif_names[pred], vif[count])
+        count = count+1
+    count_non_nan = 0
+    for pred in vif_names.keys():
+        if not(math.isnan(vif_names[pred])):
+            count_non_nan += 1
+    assert count_non_nan == len(vif), "Expected numerical predictor length: {0}, actual: {1}.  They do not " \
+                                          "match!".format(len(vif), count_non_nan)
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(test_vif_tweedie)
+else:
+    test_vif_tweedie()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8572_glm_VIF_CV.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8572_glm_VIF_CV.py
@@ -1,0 +1,48 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+import math
+
+def test_vif_tweedie_CV():
+    nfold = 3
+    training_data = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/glm_test/gamma_dispersion_factor_9_10kRows.csv")
+    Y = 'resp'
+    x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
+    model = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, generate_variable_inflation_factors=True,
+                                          fold_assignment='modulo', nfolds = nfold, keep_cross_validation_models=True)
+    model.train(training_frame=training_data, x=x, y=Y)
+
+    # create a fold column for train
+    fold_numbers = training_data.modulo_kfold_column(n_folds=3)
+    # rename the column "fold_numbers"
+    fold_numbers.set_names(["fold_numbers"])
+    train = training_data.cbind(fold_numbers)
+    model_fold_col = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, generate_variable_inflation_factors=True, 
+                                                   fold_column="fold_numbers", keep_cross_validation_models=True)
+    model_fold_col.train(training_frame=train, x=x, y=Y)
+    # check cross validation models from both GLM models should be the same
+    xval_models =  model.get_xval_models()
+    xval_models_fold_col = model_fold_col.get_xval_models()
+    # compare VIF from cross-validation models and make sure they are the same
+    for index in range(0, nfold):
+        assertEqualVIF(xval_models[index].get_variable_inflation_factors(), 
+                       xval_models_fold_col[index].get_variable_inflation_factors())
+        
+    # check that variable inflation factors from both GLM models
+    assertEqualVIF(model.get_variable_inflation_factors(), model_fold_col.get_variable_inflation_factors())
+            
+def assertEqualVIF(vif1, vif2):
+    keys = vif1.keys()
+    for key in keys:
+        if (math.isnan(vif1[key])):
+            assert math.isnan(vif2[key])
+        else:
+            assert abs(vif1[key]-vif2[key]) < 1e-6, "Expected VIF: {0}, Actual VIF: {1}.  They are " \
+                                                       "different".format(vif1[key], vif2[key])
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(test_vif_tweedie_CV)
+else:
+    test_vif_tweedie_CV()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8572_glm_VIF_enumPreds.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8572_glm_VIF_enumPreds.py
@@ -1,0 +1,32 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+
+def test_vif_with_enum_only():
+    print("Testing glm cross-validation with alpha array, default lambda values for binomial models.")
+    h2o_data = h2o.import_file(pyunit_utils.locate("smalldata/glm_test/binomial_20_cols_10KRows.csv"))
+    enum_columns = ["C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"]
+    for cname in enum_columns:
+        h2o_data[cname] = h2o_data[cname].asfactor()
+    myY = "C21"
+    h2o_data["C21"] = h2o_data["C21"].asfactor()
+    myX = ["C1", "C2", "C3", "C4", "C5"]
+    try:
+        model = H2OGeneralizedLinearEstimator(family='binomial', lambda_=0, generate_variable_inflation_factors=True)
+        model.train(training_frame=h2o_data, x=myX, y=myY)
+        assert False, "Should have thrown an exception!"
+    except Exception as ex:
+        print(ex)
+        temp = str(ex)
+        assert ("generate_variable_inflation_factors:  cannot be enabled for GLM models with only non-numerical predictors." in temp), \
+            "Wrong exception was received."
+
+    print("glm Multinomial makeGLMModel test completed!")
+
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(test_vif_with_enum_only)
+else:
+    test_vif_with_enum_only()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8572_glm_VIF_p_values.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8572_glm_VIF_p_values.py
@@ -1,0 +1,38 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+import math
+
+def test_vif_tweedie_p_values():
+    training_data = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/glm_test/gamma_dispersion_factor_9_10kRows.csv")
+    Y = 'resp'
+    x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
+    model = H2OGeneralizedLinearEstimator(family='gamma', lambda_=0, generate_variable_inflation_factors=True, 
+                                          compute_p_values=True)
+    model.train(training_frame=training_data, x=x, y=Y)
+    vif_names = model.get_variable_inflation_factors()
+    vif = model._model_json["output"]["variable_inflation_factors"]
+    vif_predictor_names = model._model_json["output"]["vif_predictor_names"]
+    # check variable inflation factors are the same gotten from the coefficient tables and from the variables directly
+    count = 0
+    for pred in vif_predictor_names:
+        if math.isnan(vif[count]):
+            assert math.isnan(vif_names[pred]), "For predictor: {0}, expected inflation variable factor is NaN but" \
+                                                " actual value is {1} and is not NaN.".format(pred, vif_names[pred])
+        else:
+            assert abs(vif[count]-vif_names[pred]) < 1e-6, "For predictor: {0}, expected inflation variable factor:" \
+                                                           " {1}, actual value: {2}".format(pred, vif_names[pred], vif[count])
+        count = count+1
+    count_non_nan = 0
+    for pred in vif_names.keys():
+        if not(math.isnan(vif_names[pred])):
+            count_non_nan += 1
+    assert count_non_nan == len(vif), "Expected numerical predictor length: {0}, actual: {1}.  They do not " \
+                                          "match!".format(len(vif), count_non_nan)
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(test_vif_tweedie_p_values)
+else:
+    test_vif_tweedie_p_values()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8572_glm_multinomial_VIF.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8572_glm_multinomial_VIF.py
@@ -1,0 +1,48 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+import math
+
+# make sure variable inflation factors are calculated correctly for polynomials because multinomials and ordinals
+# are processed separately from other families
+def test_vif_multinomial():
+    h2o_data = h2o.import_file(
+        pyunit_utils.locate("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"))
+    h2o_data["C1"] = h2o_data["C1"].asfactor()
+    h2o_data["C2"] = h2o_data["C2"].asfactor()
+    h2o_data["C3"] = h2o_data["C3"].asfactor()
+    h2o_data["C4"] = h2o_data["C4"].asfactor()
+    h2o_data["C5"] = h2o_data["C5"].asfactor()
+    h2o_data["C11"] = h2o_data["C11"].asfactor()
+    X = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    Y = "C11"
+    model = H2OGeneralizedLinearEstimator(family='multinomial', lambda_=0, generate_variable_inflation_factors=True)
+    model.train(training_frame=h2o_data, x=X, y=Y)
+
+    vif_names = model.get_variable_inflation_factors()
+    vif = model._model_json["output"]["variable_inflation_factors"]
+    vif_predictor_names = model._model_json["output"]["vif_predictor_names"]
+    # check variable inflation factors are the same gotten from the coefficient tables and from the variables directly
+    count = 0
+    for pred in vif_predictor_names:
+        if math.isnan(vif[count]):
+            assert math.isnan(vif_names[pred]), "For predictor: {0}, expected inflation variable factor is NaN but" \
+                                            " actual value is {1} and is not NaN.".format(pred, vif_names[pred])
+        else:
+            assert abs(vif[count]-vif_names[pred]) < 1e-6, "For predictor: {0}, expected inflation variable factor:" \
+                                                       " {1}, actual value: {2}".format(pred, vif_names[pred], vif[count])
+        count = count+1
+    count_non_nan = 0
+    for pred in vif_names.keys():
+        if not(math.isnan(vif_names[pred])):
+            count_non_nan += 1
+    assert count_non_nan == len(vif), "Expected numerical predictor length: {0}, actual: {1}.  They do not " \
+                                      "match!".format(len(vif), count_non_nan)
+
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(test_vif_multinomial)
+else:
+    test_vif_multinomial()

--- a/h2o-r/h2o-package/R/glm.R
+++ b/h2o-r/h2o-package/R/glm.R
@@ -143,8 +143,6 @@
 #'        false. Defaults to FALSE.
 #' @param generate_variable_inflation_factors \code{Logical}. if true, will generate variable inflation factors for numerical predictors.  Default to false.
 #'        Defaults to FALSE.
-#' @param nparallelism number of models to build in parallel.  Defaults to 0.0 which is adaptive to the system capability Defaults to
-#'        0.
 #' @return A subclass of \code{\linkS4class{H2OModel}} is returned. The specific subclass depends on the machine
 #'         learning task at hand (if it's binomial classification, then an \code{\linkS4class{H2OBinomialModel}} is
 #'         returned, if it's regression then a \code{\linkS4class{H2ORegressionModel}} is returned). The default print-
@@ -261,8 +259,7 @@ h2o.glm <- function(x,
                     max_iterations_dispersion = 1000000,
                     build_null_model = FALSE,
                     fix_dispersion_parameter = FALSE,
-                    generate_variable_inflation_factors = FALSE,
-                    nparallelism = 0)
+                    generate_variable_inflation_factors = FALSE)
 {
   # Validate required training_frame first and other frame args: should be a valid key or an H2OFrame object
   training_frame <- .validate.H2OFrame(training_frame, required=TRUE)
@@ -435,8 +432,6 @@ h2o.glm <- function(x,
     parms$fix_dispersion_parameter <- fix_dispersion_parameter
   if (!missing(generate_variable_inflation_factors))
     parms$generate_variable_inflation_factors <- generate_variable_inflation_factors
-  if (!missing(nparallelism))
-    parms$nparallelism <- nparallelism
 
   if( !missing(interactions) ) {
     # interactions are column names => as-is
@@ -536,7 +531,6 @@ h2o.glm <- function(x,
                                     build_null_model = FALSE,
                                     fix_dispersion_parameter = FALSE,
                                     generate_variable_inflation_factors = FALSE,
-                                    nparallelism = 0,
                                     segment_columns = NULL,
                                     segment_models_id = NULL,
                                     parallelism = 1)
@@ -714,8 +708,6 @@ h2o.glm <- function(x,
     parms$fix_dispersion_parameter <- fix_dispersion_parameter
   if (!missing(generate_variable_inflation_factors))
     parms$generate_variable_inflation_factors <- generate_variable_inflation_factors
-  if (!missing(nparallelism))
-    parms$nparallelism <- nparallelism
 
   if( !missing(interactions) ) {
     # interactions are column names => as-is

--- a/h2o-r/h2o-package/R/glm.R
+++ b/h2o-r/h2o-package/R/glm.R
@@ -141,6 +141,10 @@
 #' @param fix_dispersion_parameter \code{Logical}. Only used for Tweedie, Gamma and Negative Binomial GLM.  If set, will use the dispsersion
 #'        parameter in init_dispersion_parameter as the standard error and use it to calculate the p-values. Default to
 #'        false. Defaults to FALSE.
+#' @param generate_variable_inflation_factors \code{Logical}. if true, will generate variable inflation factors for numerical predictors.  Default to false.
+#'        Defaults to FALSE.
+#' @param nparallelism number of models to build in parallel.  Defaults to 0.0 which is adaptive to the system capability Defaults to
+#'        0.
 #' @return A subclass of \code{\linkS4class{H2OModel}} is returned. The specific subclass depends on the machine
 #'         learning task at hand (if it's binomial classification, then an \code{\linkS4class{H2OBinomialModel}} is
 #'         returned, if it's regression then a \code{\linkS4class{H2ORegressionModel}} is returned). The default print-
@@ -256,7 +260,9 @@ h2o.glm <- function(x,
                     dispersion_epsilon = 0.0001,
                     max_iterations_dispersion = 1000000,
                     build_null_model = FALSE,
-                    fix_dispersion_parameter = FALSE)
+                    fix_dispersion_parameter = FALSE,
+                    generate_variable_inflation_factors = FALSE,
+                    nparallelism = 0)
 {
   # Validate required training_frame first and other frame args: should be a valid key or an H2OFrame object
   training_frame <- .validate.H2OFrame(training_frame, required=TRUE)
@@ -427,6 +433,10 @@ h2o.glm <- function(x,
     parms$build_null_model <- build_null_model
   if (!missing(fix_dispersion_parameter))
     parms$fix_dispersion_parameter <- fix_dispersion_parameter
+  if (!missing(generate_variable_inflation_factors))
+    parms$generate_variable_inflation_factors <- generate_variable_inflation_factors
+  if (!missing(nparallelism))
+    parms$nparallelism <- nparallelism
 
   if( !missing(interactions) ) {
     # interactions are column names => as-is
@@ -525,6 +535,8 @@ h2o.glm <- function(x,
                                     max_iterations_dispersion = 1000000,
                                     build_null_model = FALSE,
                                     fix_dispersion_parameter = FALSE,
+                                    generate_variable_inflation_factors = FALSE,
+                                    nparallelism = 0,
                                     segment_columns = NULL,
                                     segment_models_id = NULL,
                                     parallelism = 1)
@@ -700,6 +712,10 @@ h2o.glm <- function(x,
     parms$build_null_model <- build_null_model
   if (!missing(fix_dispersion_parameter))
     parms$fix_dispersion_parameter <- fix_dispersion_parameter
+  if (!missing(generate_variable_inflation_factors))
+    parms$generate_variable_inflation_factors <- generate_variable_inflation_factors
+  if (!missing(nparallelism))
+    parms$nparallelism <- nparallelism
 
   if( !missing(interactions) ) {
     # interactions are column names => as-is

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -2230,6 +2230,45 @@ h2o.coef_with_p_values <- function(object) {
 }
 
 #'
+#' Return the variable inflation factors associated with numerical predictors for GLM models.
+#'
+#' @param object An \linkS4class{H2OModel} object.
+#' @examples 
+#' \dontrun{
+#' library(h2o)
+#' h2o.init()
+#' 
+#' f <- "https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv"
+#' cars <- h2o.importFile(f)
+#' predictors <- c("displacement", "power", "weight", "acceleration", "year")
+#' response <- "cylinders"
+#' cars_split <- h2o.splitFrame(data = cars, ratios = 0.8, seed = 1234)
+#' train <- cars_split[[1]]
+#' valid <- cars_split[[2]]
+#' cars_glm <- h2o.glm(seed = 1234, 
+#'                     lambda=0.0,
+#'                     compute_p_values=TRUE,
+#'                     generate_variable_inflation_factors=TRUE,     
+#'                     x = predictors, 
+#'                     y = response, 
+#'                     training_frame = train, 
+#'                     validation_frame = valid)
+#' h2o.get_variable_inflation_factors(cars_glm)
+#' }
+#' @export
+h2o.get_variable_inflation_factors <- function(object) {
+  if (is(object, "H2OModel") && object@algorithm %in% c("glm")) {
+    if (object@parameters$generate_variable_inflation_factors) {
+      structure(object@model$variable_inflation_factors, names = object@model$vif_predictor_names)
+    } else {
+      stop("variable inflation factors are not found in model.  Make sure to set enable_variable_inflation_factors=TRUE.")
+    }
+  } else {
+    stop("variable inflation factors are only found in GLM models with numerical predictors.")
+  }
+}
+
+#'
 #' Return the coefficients that can be applied to the non-standardized data.
 #'
 #' Note: standardize = True by default. If set to False, then coef() returns the coefficients that are fit directly.

--- a/h2o-r/h2o-package/pkgdown/_pkgdown.yml
+++ b/h2o-r/h2o-package/pkgdown/_pkgdown.yml
@@ -150,6 +150,7 @@ reference:
       - h2o.get_best_model_predictors
       - h2o.get_predictor_added_per_step
       - h2o.get_predictor_removed_per_step
+      - h2o.get_variable_inflation_factors
       - h2o.glm
       - h2o.glrm
       - h2o.grep

--- a/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_8572_glm_VIF.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_8572_glm_VIF.R
@@ -1,0 +1,22 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+testGLMVIF <- function() {
+	bhexFV <- h2o.importFile(locate("smalldata/logreg/benign.csv"))
+	maxX <- 11
+	Y <- 4
+	X   <- 3:maxX
+	X   <- X[ X != Y ]
+	bhexFV$FNDX <- h2o.asfactor(bhexFV$FNDX)
+	mFV <- h2o.glm(y=Y, x=colnames(bhexFV)[X], training_frame=bhexFV, family="binomial", lambda=0.0, compute_p_values=TRUE,
+	               generate_variable_inflation_factors=TRUE)
+  glmVIF <- h2o.get_variable_inflation_factors(mFV) # get variable inflation factors
+  glmCoefName <- mFV@model$coefficients_table$names
+  glmCoefVal <- mFV@model$coefficients_table$variable_inflation_factor
+  for (ind in c(1:8)) {
+    expect_true(abs(glmVIF[[ind]]-glmCoefVal[ind+1])<1e-6)
+  }
+}
+
+doTest("GLM: test variable inflation factors", testGLMVIF)
+


### PR DESCRIPTION
This PR completes the task in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8572

The variable inflation factor for numerical predictor x is built as follows:
1. Set numerical predictor x as the response and use the same predictors as before except x.
2. Build a GLM regression model.
3. Take the R2 of the in 2 and the variable inflation factor is 1.0/(1.0-R2).
4. VIF can be calculated with cross-validation turned on.

Repeat the above for all the other numerical predictors to get the variable inflation factors for them as well.

The variable inflation factors are added to the coefficient tables.  Individual functions are added to allow user access to the variable inflation factors.

Java/R/Python tests are added to make sure the implementation correct.