### PR TITLE
PUBDEV-8811: Fix leaderboard sorting

### DIFF
--- a/h2o-core/src/main/java/water/rapids/ast/prims/models/AstMakeLeaderboard.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/models/AstMakeLeaderboard.java
@@ -91,8 +91,8 @@ public class AstMakeLeaderboard extends AstPrimitive {
                 .map(parameters -> parameters._nfolds)
                 .distinct()
                 .count() == 1;
-        final boolean allCV = Arrays.stream(models).allMatch(m -> ((Model) DKV.getGet(m))._parms._nfolds >= 2);
-        final boolean allHasValid = Arrays.stream(models).allMatch(m -> ((Model) DKV.getGet(m))._parms._valid != null);
+        final boolean allCV = Arrays.stream(models).allMatch(m -> ((Model) DKV.getGet(m))._output._cross_validation_metrics != null);
+        final boolean allHasValid = Arrays.stream(models).allMatch(m -> ((Model) DKV.getGet(m))._output._validation_metrics != null);
 
         boolean warnAboutTrain = false;
         boolean warnAboutValid = false;
@@ -139,6 +139,7 @@ public class AstMakeLeaderboard extends AstPrimitive {
         Leaderboard ldb = Leaderboard.getOrMake(projectName, logger, leaderboardFrame, sortMetric, Leaderboard.ScoreData.valueOf(scoringData));
         ldb.setExtensionsProvider(createLeaderboardExtensionProvider(leaderboardFrame));
         ldb.addModels(models);
+        ldb.ensureSorted();
         Frame leaderboard = ldb.toTwoDimTable(extensions).asFrame(Key.make());
         return new ValFrame(leaderboard);
     }


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8811

I noticed 2 bugs: 

- Leaderboard is not sorted by scoring_data but by some other logic (by the first available metrics from xval, valid, train) - this is problem when we want to see training leaderboard but it is sorted by xval metrics (if available).

- Leaderboard is not sorted  by sort_metric if it was already sorted by other metric