### PR TITLE
PUBDEV-8209: Adding varsplits() and adding examples for varsplits() & feature_frequencies() to pydocs

### DIFF
--- a/h2o-py/docs/model_categories.rst
+++ b/h2o-py/docs/model_categories.rst
@@ -25,7 +25,7 @@ Model Categories
 :mod:`Binomial Classification`
 ------------------------------
 
-.. automodule:: h2o.model.binomial
+.. automodule:: h2o.model.models.binomial
     :members:
     :undoc-members:
     :show-inheritance:
@@ -33,7 +33,7 @@ Model Categories
 :mod:`Multinomial Classification`
 ---------------------------------
 
-.. automodule:: h2o.model.multinomial
+.. automodule:: h2o.model.models.multinomial
     :members:
     :undoc-members:
     :show-inheritance:
@@ -41,7 +41,7 @@ Model Categories
 :mod:`Regression`
 -----------------
 
-.. automodule:: h2o.model.regression
+.. automodule:: h2o.model.models.regression
     :members:
     :undoc-members:
     :show-inheritance:
@@ -49,7 +49,7 @@ Model Categories
 :mod:`Dimensionality Reduction`
 -------------------------------
 
-.. automodule:: h2o.model.dim_reduction
+.. automodule:: h2o.model.models.dim_reduction
     :members:
     :undoc-members:
     :show-inheritance:
@@ -57,7 +57,7 @@ Model Categories
 :mod:`Clustering Methods`
 -------------------------
 
-.. automodule:: h2o.model.clustering
+.. automodule:: h2o.model.models.clustering
     :members:
     :undoc-members:
     :show-inheritance:
@@ -65,14 +65,22 @@ Model Categories
 :mod:`AutoEncoders`
 -------------------
 
-.. automodule:: h2o.model.autoencoder
+.. automodule:: h2o.model.models.autoencoder
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+:mod:`Anomaly Detection`
+------------------------
+
+.. automodule:: h2o.model.models.anomaly_detection
     :members:
     :undoc-members:
     :show-inheritance:
 
 :mod:`Word Embedding`
 ---------------------
-.. automodule:: h2o.model.word_embedding
+.. automodule:: h2o.model.models.word_embedding
     :members:
     :undoc-members:
     :show-inheritance:

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -247,6 +247,17 @@ class ModelBase(h2o_meta(Keyed, H2ODisplay)):
         :param H2OFrame test_data: Data on which to calculate feature frequencies.
 
         :returns: A new H2OFrame made of feature contributions.
+
+        :examples:
+
+        >>> from h2o.estimators import H2OIsolationForestEstimator
+        >>> h2o_df = h2o.import_file("https://raw.github.com/h2oai/h2o/master/smalldata/logreg/prostate.csv")
+        >>> train,test = h2o_df.split_frame(ratios=[0.75])
+        >>> model = H2OIsolationForestEstimator(sample_rate = 0.1,
+        ...                                     max_depth = 20,
+        ...                                     ntrees = 50)
+        >>> model.train(training_frame=train)
+        >>> model.feature_frequencies(test_data = test)
         """
         if not isinstance(test_data, h2o.H2OFrame): raise ValueError("test_data must be an instance of H2OFrame")
         j = h2o.api("POST /3/Predictions/models/%s/frames/%s" % (self.model_id, test_data.frame_id),

--- a/h2o-py/h2o/model/models/anomaly_detection.py
+++ b/h2o-py/h2o/model/models/anomaly_detection.py
@@ -10,17 +10,29 @@ class H2OAnomalyDetectionModel(ModelBase):
     def varsplits(self, use_pandas=False):
         """
         Retrieve per-variable split information for a given Isolation Forest model. Output will include:
-        - count - The number of times a variable was used to make a split.
-        - aggregated_split_ratios - The split ratio is defined as "abs(#left_observations - #right_observations) / #before_split".
-                                    Even splits (#left_observations approx the same as #right_observations) contribute
-                                    less to the total aggregated split ratio value for the given feature;
-                                    highly imbalanced splits (eg. #left_observations >> #right_observations) contribute more.
-        - aggregated_split_depths - The sum of all depths of a variable used to make a split. (If a variable is used
-                                    on level N of a tree, then it contributes with N to the total aggregate.)
+        
+        **count**: The number of times a variable was used to make a split.
+        
+        **aggregated_split_ratios**: The split ratio is defined as `abs(#left_observations - #right_observations) / #before_split`.
+        Even splits (i.e., `#left_observations` approx the same as `#right_observations`) contribute
+        less to the total aggregated split ratio value for the given feature; highly imbalanced splits (e.g., `#left_observations` >> `#right_observations`) contribute more.
+            
+        **aggregated_split_depths**: The sum of all depths of a variable used to make a split. (If a variable is used on level N of a tree, then it contributes with N to the total aggregate.)
 
-        :param use_pandas: If True, then the variable splits will be returned as a Pandas data frame.
+        :param use_pandas: If ``True``, then the variable splits will be returned as a Pandas data frame.
 
         :returns: A list or Pandas DataFrame.
+
+        :examples:
+
+        >>> from h2o.estimators import H2OIsolationForestEstimator
+        >>> h2o_df = h2o.import_file("https://raw.github.com/h2oai/h2o/master/smalldata/logreg/prostate.csv")
+        >>> train,test = h2o_df.split_frame(ratios=[0.75])
+        >>> model = H2OIsolationForestEstimator(sample_rate = 0.1,
+        ...                                     max_depth = 20,
+        ...                                     ntrees = 50)
+        >>> model.train(training_frame=train)
+        >>> model.varsplits()
         """
         model = self._model_json["output"]
         if "variable_splits" in list(model.keys()) and model["variable_splits"]:


### PR DESCRIPTION
For: [PUBDEV-8209](https://h2oai.atlassian.net/browse/PUBDEV-8209)

Updated the model_categories.rst file as well to reflect moved files. Had to change the anomaly detection `varsplits()` description list to separate paragraphs because it wouldn't print properly as a list. Please let me know if anything needs to be updated.