### PR TITLE
[nocheck] fix r cmd check as cran

### DIFF
--- a/h2o-bindings/bin/custom/R/gen_deeplearning.py
+++ b/h2o-bindings/bin/custom/R/gen_deeplearning.py
@@ -29,7 +29,7 @@ parms$response_column <- args$y
 #' prostate_path = system.file("extdata", "prostate.csv", package = "h2o")
 #' prostate = h2o.importFile(path = prostate_path)
 #' prostate_dl = h2o.deeplearning(x = 3:9, training_frame = prostate, autoencoder = TRUE,
-#'                                hidden = c(10, 10), epochs = 5)
+#'                                hidden = c(10, 10), epochs = 5, seed = 1)
 #' prostate_anon = h2o.anomaly(prostate_dl, prostate)
 #' head(prostate_anon)
 #' prostate_anon_per_feature = h2o.anomaly(prostate_dl, prostate, per_feature = TRUE)

--- a/h2o-r/h2o-package/R/deeplearning.R
+++ b/h2o-r/h2o-package/R/deeplearning.R
@@ -773,7 +773,7 @@ h2o.deeplearning <- function(x,
 #' prostate_path = system.file("extdata", "prostate.csv", package = "h2o")
 #' prostate = h2o.importFile(path = prostate_path)
 #' prostate_dl = h2o.deeplearning(x = 3:9, training_frame = prostate, autoencoder = TRUE,
-#'                                hidden = c(10, 10), epochs = 5)
+#'                                hidden = c(10, 10), epochs = 5, seed = 1)
 #' prostate_anon = h2o.anomaly(prostate_dl, prostate)
 #' head(prostate_anon)
 #' prostate_anon_per_feature = h2o.anomaly(prostate_dl, prostate, per_feature = TRUE)

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -170,7 +170,7 @@ test-r-cmd-check:
 test-r-cmd-check-as-cran:
 	cd h2o-r/R/src/contrib && OPENBLAS_MAIN_FREE=1 H2O_R_CMD_CHECK_DOC_EXAMPLES_IP=127.0.0.1 H2O_R_CMD_CHECK_DOC_EXAMPLES_PORT=59999 _R_CHECK_FORCE_SUGGESTS_=FALSE R CMD check --as-cran h2o_*.*.*.*.tar.gz
 	cd h2o-r/R/src/contrib && OPENBLAS_MAIN_FREE=1 H2O_R_CMD_CHECK_DOC_EXAMPLES_IP=127.0.0.1 H2O_R_CMD_CHECK_DOC_EXAMPLES_PORT=59999 _R_CHECK_FORCE_SUGGESTS_=FALSE [ -f ../../../../scripts/validate_r_cmd_check_output.R ] && Rscript ../../../../scripts/validate_r_cmd_check_output.R
-	cd h2o-r/R/src/contrib && OPENBLAS_MAIN_FREE=1 H2O_R_CMD_CHECK_DOC_EXAMPLES_IP=127.0.0.1 H2O_R_CMD_CHECK_DOC_EXAMPLES_PORT=59999 _R_CHECK_FORCE_SUGGESTS_=FALSE python ../../../../scripts/validate_r_cmd_check_output.py || true
+	cd h2o-r/R/src/contrib && OPENBLAS_MAIN_FREE=1 H2O_R_CMD_CHECK_DOC_EXAMPLES_IP=127.0.0.1 H2O_R_CMD_CHECK_DOC_EXAMPLES_PORT=59999 _R_CHECK_FORCE_SUGGESTS_=FALSE python ../../../../scripts/validate_r_cmd_check_output.py
 	fuser -k 59999/tcp || /bin/true
 
 test-r-booklets:

--- a/scripts/validate_r_cmd_check_output.R
+++ b/scripts/validate_r_cmd_check_output.R
@@ -24,7 +24,8 @@ whitelist = list(
   "installed package size" = c("installed size is .*Mb", # h2o.jar is installed
                                "sub-directories of 1Mb or more",
                                "java .*Mb",
-                               "R .*Mb"),
+                               "R .*Mb",
+                               "help .*Mb"),
   "Rd cross-references" = "Package unavailable to check Rd xrefs", # when linking documentation to optional deps not present at check time
   "for future file timestamps" = "unable to verify current time" # unable to verify time when worldclock is down
 )

--- a/scripts/validate_r_cmd_check_output.py
+++ b/scripts/validate_r_cmd_check_output.py
@@ -40,6 +40,7 @@ class Check:
             r"^\* using option .*",
             r"^\* checking .* \.\.\. OK",
 
+            r"^\* checking extension type ... Package",
             r"^\* this is package",
             r"^\* checking CRAN incoming feasibility \.\.\.",
             r"^\*\* found \\donttest examples: .*",
@@ -70,6 +71,8 @@ class Check:
             r"^  installed size is .*Mb",
             r"^  sub-directories of 1Mb or more:",
             r"^    java  .*Mb",
+            r"^    R  .*Mb",
+            r"^    help  .*Mb",
             r"^NOTE: There were 2 notes.",
             #r"^Status: 1 WARNING, 1 NOTE",
             #r"^Status: 1 WARNING, .* NOTEs",


### PR DESCRIPTION
I removed `|| true` in the makefile to make sure failure from `validate_r_cmd_check_output.py` is propagated and added new messages that are expected:
```python
            r"^\* checking extension type ... Package",
            r"^    R  .*Mb", # since the size is >= 1MB (around 2MB now on rel-zumbo)
            r"^    help  .*Mb", # since the size is >= 1MB (around 1MB now on master) 
```