### PR TITLE
PUBDEV-8817: Added note to explain confusion matrix calculation

### DIFF
--- a/h2o-docs/src/product/performance-and-prediction.rst
+++ b/h2o-docs/src/product/performance-and-prediction.rst
@@ -1734,6 +1734,10 @@ Examples:
         # build the confusion matrix:
         gbm.confusion_matrix(train)
 
+.. note::
+    
+    Our confusion matrix returns an approximation of the actual histogram, so the table will not match the exact values. This is because we use an online version of the algorithm to calculate the histogram of the predictors for the confusion matrix. 
+
 Variable Importances
 ''''''''''''''''''''
 

--- a/h2o-docs/src/product/performance-and-prediction.rst
+++ b/h2o-docs/src/product/performance-and-prediction.rst
@@ -1736,7 +1736,7 @@ Examples:
 
 .. note::
     
-    Our confusion matrix returns an approximation of the actual histogram, so the table will not match the exact values. This is because we use an online version of the algorithm to calculate the histogram of the predictors for the confusion matrix. 
+    Because we use an online version of the algorithm to calculate the histogram of the predictors for the confusion matrix, the confusion matrix returns an approximation of the actual histogram and, therefore, will not match the exact values.
 
 Variable Importances
 ''''''''''''''''''''


### PR DESCRIPTION
For: [PUBDEV-8817](https://h2oai.atlassian.net/browse/PUBDEV-8817)

I pulled the information from [this ticket](https://h2oai.atlassian.net/browse/PUBDEV-5243), so please let me know if I need to update anything.