### PR TITLE
PUBDEV-8833 sorting in cross-validation fails

### DIFF
--- a/h2o-core/src/main/java/water/rapids/BinaryMerge.java
+++ b/h2o-core/src/main/java/water/rapids/BinaryMerge.java
@@ -37,6 +37,7 @@ class BinaryMerge extends DTask<BinaryMerge> {
   private final boolean _allLeft, _allRight;
   private boolean[] _stringCols;
   private boolean[] _intCols;
+  final long _randomDigits;
 
   // does any left row match to more than 1 right row?  If not, can allocate
   // and loop more efficiently, and mark the resulting key'd frame with a
@@ -83,8 +84,9 @@ class BinaryMerge extends DTask<BinaryMerge> {
   }
 
   // In X[Y], 'left'=i and 'right'=x
-  BinaryMerge(FFSB leftSB, FFSB riteSB, boolean allLeft) {
+  BinaryMerge(FFSB leftSB, FFSB riteSB, boolean allLeft, long randomDigits) {
     assert riteSB._msb!=-1 || allLeft;
+    _randomDigits = randomDigits;
     _leftSB = leftSB;
     _riteSB = riteSB;
     _onlyLeftFrame = (_leftSB._frame.numCols() > 0 && _riteSB._frame.numCols()==0);
@@ -128,21 +130,23 @@ class BinaryMerge extends DTask<BinaryMerge> {
     _timings = MemoryManager.malloc8d(20);
     long t0 = System.nanoTime();
 
-    SingleThreadRadixOrder.OXHeader leftSortedOXHeader = DKV.getGet(getSortedOXHeaderKey(/*left=*/true, _leftSB._msb));
+    SingleThreadRadixOrder.OXHeader leftSortedOXHeader = DKV.getGet(getSortedOXHeaderKey(/*left=*/true,
+            _leftSB._msb, _randomDigits));
     if (leftSortedOXHeader == null) {
       if( !_allRight ) { tryComplete(); return; }
       throw H2O.unimpl();  // TODO pass through _allRight and implement
     }
-    _leftKO = new KeyOrder(leftSortedOXHeader);
+    _leftKO = new KeyOrder(leftSortedOXHeader, _randomDigits);
 
-    SingleThreadRadixOrder.OXHeader rightSortedOXHeader = DKV.getGet(getSortedOXHeaderKey(/*left=*/false, _riteSB._msb));
+    SingleThreadRadixOrder.OXHeader rightSortedOXHeader = DKV.getGet(getSortedOXHeaderKey(/*left=*/false,
+            _riteSB._msb, _randomDigits));
     //if (_riteSB._msb==-1) assert _allLeft && rightSortedOXHeader == null; // i.e. it's known nothing on right can join
     if (rightSortedOXHeader == null) {
       if( !_allLeft ) { tryComplete(); return; }
       // enables general case code to run below without needing new special case code
       rightSortedOXHeader = new SingleThreadRadixOrder.OXHeader(0, 0, 0);
     }
-    _riteKO = new KeyOrder(rightSortedOXHeader);
+    _riteKO = new KeyOrder(rightSortedOXHeader, _randomDigits);
 
     // get left batches
     _leftKO.initKeyOrder(_leftSB._msb,/*left=*/true);
@@ -241,18 +245,20 @@ class BinaryMerge extends DTask<BinaryMerge> {
     private final transient byte _key  [/*n2GB*/][/*i mod 2GB * _keySize*/];
     private final transient long _order[/*n2GB*/][/*i mod 2GB * _keySize*/];
     private final transient long _perNodeNumRowsToFetch[];
+    final long _randomDigits;
 
-    KeyOrder( SingleThreadRadixOrder.OXHeader sortedOXHeader ) {
+    KeyOrder( SingleThreadRadixOrder.OXHeader sortedOXHeader , long bTime) {
       _batchSize = sortedOXHeader._batchSize;
       final int nBatch = sortedOXHeader._nBatch;
       _key   = new byte[nBatch][];
       _order = new long[nBatch][];
       _perNodeNumRowsToFetch = new long[H2O.CLOUD.size()];
+      _randomDigits = bTime;
     }
 
     void initKeyOrder( int msb, boolean isLeft ) {
       for( int b=0; b<_key.length; b++ ) {
-        Value v = DKV.get(SplitByMSBLocal.getSortedOXbatchKey(isLeft, msb, b));
+        Value v = DKV.get(SplitByMSBLocal.getSortedOXbatchKey(isLeft, msb, b, _randomDigits));
         SplitByMSBLocal.OXbatch ox = v.get(); //mem version (obtained from remote) of the Values gets turned into POJO version
         v.freeMem(); //only keep the POJO version of the Value
         _key  [b] = ox._x;
@@ -600,7 +606,7 @@ class BinaryMerge extends DTask<BinaryMerge> {
           for (int index = 0; index < frameLikeChunks4String[col][b].length; index++)
             nc.addStr(frameLikeChunks4String[col][b][index]);
           Chunk ck = nc.compress();
-          DKV.put(getKeyForMSBComboPerCol(_leftSB._msb, _riteSB._msb, col, b), ck, fs, true);
+          DKV.put(getKeyForMSBComboPerCol(_leftSB._msb, _riteSB._msb, col, b, _randomDigits), ck, fs, true);
           frameLikeChunks4String[col][b] = null; //free mem as early as possible (it's now in the store)
         }
       } else if( _intCols[col] ) {
@@ -612,13 +618,13 @@ class BinaryMerge extends DTask<BinaryMerge> {
             else                    nc.addNum(l, 0);
           }
           Chunk ck = nc.compress();
-          DKV.put(getKeyForMSBComboPerCol(_leftSB._msb, _riteSB._msb, col, b), ck, fs, true);
+          DKV.put(getKeyForMSBComboPerCol(_leftSB._msb, _riteSB._msb, col, b, _randomDigits), ck, fs, true);
           frameLikeChunksLong[col][b] = null; //free mem as early as possible (it's now in the store)
         }
       } else {
         for (int b = 0; b < nbatch; b++) {
           Chunk ck = new NewChunk(frameLikeChunks[col][b]).compress();
-          DKV.put(getKeyForMSBComboPerCol(_leftSB._msb, _riteSB._msb, col, b), ck, fs, true);
+          DKV.put(getKeyForMSBComboPerCol(_leftSB._msb, _riteSB._msb, col, b, _randomDigits), ck, fs, true);
           frameLikeChunks[col][b] = null; //free mem as early as possible (it's now in the store)
         }
       }
@@ -1004,7 +1010,7 @@ class BinaryMerge extends DTask<BinaryMerge> {
           for (int index = 0; index < frameLikeChunks4String[col][b].length; index++)
             nc.addStr(frameLikeChunks4String[col][b][index]);
           Chunk ck = nc.compress();
-          DKV.put(getKeyForMSBComboPerCol(_leftSB._msb, _riteSB._msb, col, b), ck, fs, true);
+          DKV.put(getKeyForMSBComboPerCol(_leftSB._msb, _riteSB._msb, col, b, _randomDigits), ck, fs, true);
           frameLikeChunks4String[col][b] = null; //free mem as early as possible (it's now in the store)
       } else if( _intCols[col] ) {
           NewChunk nc = new NewChunk(null,-1);
@@ -1013,11 +1019,11 @@ class BinaryMerge extends DTask<BinaryMerge> {
             else                    nc.addNum(l, 0);
           }
           Chunk ck = nc.compress();
-          DKV.put(getKeyForMSBComboPerCol(_leftSB._msb, _riteSB._msb, col, b), ck, fs, true);
+          DKV.put(getKeyForMSBComboPerCol(_leftSB._msb, _riteSB._msb, col, b, _randomDigits), ck, fs, true);
           frameLikeChunksLong[col][b] = null; //free mem as early as possible (it's now in the store)
       } else {
           Chunk ck = new NewChunk(frameLikeChunks[col][b]).compress();
-          DKV.put(getKeyForMSBComboPerCol(_leftSB._msb, _riteSB._msb, col, b), ck, fs, true);
+          DKV.put(getKeyForMSBComboPerCol(_leftSB._msb, _riteSB._msb, col, b, _randomDigits), ck, fs, true);
           frameLikeChunks[col][b] = null; //free mem as early as possible (it's now in the store)
       }
     }
@@ -1025,10 +1031,10 @@ class BinaryMerge extends DTask<BinaryMerge> {
   }
 
 
-  static Key getKeyForMSBComboPerCol(/*Frame leftFrame, Frame rightFrame,*/ int leftMSB, int rightMSB, int col /*final table*/, int batch) {
+  static Key getKeyForMSBComboPerCol(/*Frame leftFrame, Frame rightFrame,*/ int leftMSB, int rightMSB, int col /*final table*/, int batch, long randomDigits) {
     return Key.make("__binary_merge__Chunk_for_col" + col + "_batch" + batch
         // + rightFrame._key.toString() + "_joined_with" + leftFrame._key.toString()
-        + "_leftSB._msb" + leftMSB + "_riteSB._msb" + rightMSB,
+        + "_leftSB._msb" + leftMSB + "_riteSB._msb" + rightMSB + "_" + randomDigits,
       Key.HIDDEN_USER_KEY, false, SplitByMSBLocal.ownerOfMSB(rightMSB==-1 ? leftMSB : rightMSB)
     ); //TODO home locally
   }

--- a/h2o-core/src/main/java/water/rapids/RadixCount.java
+++ b/h2o-core/src/main/java/water/rapids/RadixCount.java
@@ -22,16 +22,16 @@ class RadixCount extends MRTask<RadixCount> {
   private final boolean _isLeft; 
   private final int _id_maps[][];
   private final int _ascending;
-  final long _randomDigits;
+  final long _mergeId;
 
-  RadixCount(boolean isLeft, BigInteger base, int shift, int col, int id_maps[][], int ascending, long randomDigits) {
+  RadixCount(boolean isLeft, BigInteger base, int shift, int col, int id_maps[][], int ascending, long mergeId) {
     _isLeft = isLeft;
     _base = base;
     _col = col;
     _shift = shift;
     _id_maps = id_maps;
     _ascending = ascending;
-    _randomDigits = randomDigits;
+    _mergeId = mergeId;
   }
 
   // make a unique deterministic key as a function of frame, column and node
@@ -42,8 +42,8 @@ class RadixCount extends MRTask<RadixCount> {
    * make a unique deterministic key as a function of frame, column and node make it homed to the owning node. 
    * Add current system time to make it not repeatable.  This can cause problem if sort is used in cross-validation
    */
-  static Key getKey(boolean isLeft, int col, long randomDigits, H2ONode node) {
-    return Key.make("__radix_order__MSBNodeCounts_col" + col + "_node" + node.index() + "_" + randomDigits + 
+  static Key getKey(boolean isLeft, int col, long mergeId, H2ONode node) {
+    return Key.make("__radix_order__MSBNodeCounts_col" + col + "_node" + node.index() + "_" + mergeId + 
             (isLeft ? "_LEFT" : "_RIGHT"));
     // Each node's contents is different so the node number needs to be in the key
     // TODO: need the biggestBit in here too, that the MSB is offset from
@@ -108,7 +108,7 @@ class RadixCount extends MRTask<RadixCount> {
   }
 
   @Override protected void closeLocal() {
-    DKV.put(getKey(_isLeft, _col, _randomDigits, H2O.SELF), _counts, _fs, true);
+    DKV.put(getKey(_isLeft, _col, _mergeId, H2O.SELF), _counts, _fs, true);
     // just the MSB counts per chunk on this node.  Most of this spine will be empty here.  
     // TODO: could condense to just the chunks on this node but for now, leave sparse.
     // We'll use this sparse spine right now on this node and the reduce happens on _o and _x later

--- a/h2o-core/src/main/java/water/rapids/RadixOrder.java
+++ b/h2o-core/src/main/java/water/rapids/RadixOrder.java
@@ -27,8 +27,9 @@ class RadixOrder extends H2O.H2OCountedCompleter<RadixOrder> {
   final int _bytesUsed[];
   final BigInteger _base[];
   final int[] _ascending;  // 0 to sort ASC, 1 to sort DESC
+  final long _randomDigits;
 
-  RadixOrder(Frame DF, boolean isLeft, int whichCols[], int id_maps[][], int[] ascending) {
+  RadixOrder(Frame DF, boolean isLeft, int whichCols[], int id_maps[][], int[] ascending, long randomDigits) {
     _DF = DF;
     _isLeft = isLeft;
     _whichCols = whichCols;
@@ -40,6 +41,7 @@ class RadixOrder extends H2O.H2OCountedCompleter<RadixOrder> {
     _isInt = new boolean[_whichCols.length];
     _isCategorical = new boolean[_whichCols.length];
     _ascending = ascending;
+    _randomDigits =  randomDigits;
   }
 
   @Override
@@ -57,7 +59,7 @@ class RadixOrder extends H2O.H2OCountedCompleter<RadixOrder> {
     Log.debug("Time to use rollup stats to determine biggestBit: " + ((t1=System.nanoTime()) - t0) / 1e9+" seconds."); t0=t1;
 
     if( _whichCols.length > 0 )
-      new RadixCount(_isLeft, _base[0], _shift[0], _whichCols[0], _id_maps, _ascending[0]).doAll(_DF.vec(_whichCols[0]));
+      new RadixCount(_isLeft, _base[0], _shift[0], _whichCols[0], _id_maps, _ascending[0], _randomDigits).doAll(_DF.vec(_whichCols[0]));
     Log.debug("Time of MSB count MRTask left local on each node (no reduce): " + ((t1=System.nanoTime()) - t0) / 1e9+" seconds."); t0=t1;
 
     // NOT TO DO:  we do need the full allocation of x[] and o[].  We need o[] anyway.  x[] will be compressed and dense.
@@ -71,7 +73,8 @@ class RadixOrder extends H2O.H2OCountedCompleter<RadixOrder> {
     // TODO: fix closeLocal() blocking issue and revert to simpler usage of closeLocal()
     Key linkTwoMRTask = Key.make();
     if( _whichCols.length > 0 )
-      new SplitByMSBLocal(_isLeft, _base, _shift[0], keySize, batchSize, _bytesUsed, _whichCols, linkTwoMRTask, _id_maps, _ascending).doAll(_DF.vecs(_whichCols)); // postLocal needs DKV.put()
+      new SplitByMSBLocal(_isLeft, _base, _shift[0], keySize, batchSize, _bytesUsed, _whichCols, linkTwoMRTask, 
+              _id_maps, _ascending, _randomDigits).doAll(_DF.vecs(_whichCols)); // postLocal needs DKV.put()
     Log.debug("SplitByMSBLocal MRTask (all local per node, no network) took : " + ((t1=System.nanoTime()) - t0) / 1e9+" seconds."); t0=t1;
 
     if( _whichCols.length > 0 )
@@ -82,7 +85,8 @@ class RadixOrder extends H2O.H2OCountedCompleter<RadixOrder> {
     RPC[] radixOrders = new RPC[256];
     Log.info("Sending SingleThreadRadixOrder async RPC calls ... ");
     for (int i = 0; i < 256; i++)
-      radixOrders[i] = new RPC<>(SplitByMSBLocal.ownerOfMSB(i), new SingleThreadRadixOrder(_DF, _isLeft, batchSize, keySize, /*nGroup,*/ i)).call();
+      radixOrders[i] = new RPC<>(SplitByMSBLocal.ownerOfMSB(i), new SingleThreadRadixOrder(_DF, _isLeft, batchSize,
+              keySize, /*nGroup,*/ i, _randomDigits)).call();
     Log.debug("took : " + ((t1=System.nanoTime()) - t0) / 1e9); t0=t1;
 
     Log.info("Waiting for RPC SingleThreadRadixOrder to finish ... ");

--- a/h2o-core/src/main/java/water/rapids/RadixOrder.java
+++ b/h2o-core/src/main/java/water/rapids/RadixOrder.java
@@ -27,9 +27,9 @@ class RadixOrder extends H2O.H2OCountedCompleter<RadixOrder> {
   final int _bytesUsed[];
   final BigInteger _base[];
   final int[] _ascending;  // 0 to sort ASC, 1 to sort DESC
-  final long _randomDigits;
+  final long _mergeId;
 
-  RadixOrder(Frame DF, boolean isLeft, int whichCols[], int id_maps[][], int[] ascending, long randomDigits) {
+  RadixOrder(Frame DF, boolean isLeft, int whichCols[], int id_maps[][], int[] ascending, long mergeId) {
     _DF = DF;
     _isLeft = isLeft;
     _whichCols = whichCols;
@@ -41,7 +41,7 @@ class RadixOrder extends H2O.H2OCountedCompleter<RadixOrder> {
     _isInt = new boolean[_whichCols.length];
     _isCategorical = new boolean[_whichCols.length];
     _ascending = ascending;
-    _randomDigits =  randomDigits;
+    _mergeId =  mergeId;
   }
 
   @Override
@@ -59,7 +59,7 @@ class RadixOrder extends H2O.H2OCountedCompleter<RadixOrder> {
     Log.debug("Time to use rollup stats to determine biggestBit: " + ((t1=System.nanoTime()) - t0) / 1e9+" seconds."); t0=t1;
 
     if( _whichCols.length > 0 )
-      new RadixCount(_isLeft, _base[0], _shift[0], _whichCols[0], _id_maps, _ascending[0], _randomDigits).doAll(_DF.vec(_whichCols[0]));
+      new RadixCount(_isLeft, _base[0], _shift[0], _whichCols[0], _id_maps, _ascending[0], _mergeId).doAll(_DF.vec(_whichCols[0]));
     Log.debug("Time of MSB count MRTask left local on each node (no reduce): " + ((t1=System.nanoTime()) - t0) / 1e9+" seconds."); t0=t1;
 
     // NOT TO DO:  we do need the full allocation of x[] and o[].  We need o[] anyway.  x[] will be compressed and dense.
@@ -74,7 +74,7 @@ class RadixOrder extends H2O.H2OCountedCompleter<RadixOrder> {
     Key linkTwoMRTask = Key.make();
     if( _whichCols.length > 0 )
       new SplitByMSBLocal(_isLeft, _base, _shift[0], keySize, batchSize, _bytesUsed, _whichCols, linkTwoMRTask, 
-              _id_maps, _ascending, _randomDigits).doAll(_DF.vecs(_whichCols)); // postLocal needs DKV.put()
+              _id_maps, _ascending, _mergeId).doAll(_DF.vecs(_whichCols)); // postLocal needs DKV.put()
     Log.debug("SplitByMSBLocal MRTask (all local per node, no network) took : " + ((t1=System.nanoTime()) - t0) / 1e9+" seconds."); t0=t1;
 
     if( _whichCols.length > 0 )
@@ -86,7 +86,7 @@ class RadixOrder extends H2O.H2OCountedCompleter<RadixOrder> {
     Log.info("Sending SingleThreadRadixOrder async RPC calls ... ");
     for (int i = 0; i < 256; i++)
       radixOrders[i] = new RPC<>(SplitByMSBLocal.ownerOfMSB(i), new SingleThreadRadixOrder(_DF, _isLeft, batchSize,
-              keySize, /*nGroup,*/ i, _randomDigits)).call();
+              keySize, /*nGroup,*/ i, _mergeId)).call();
     Log.debug("took : " + ((t1=System.nanoTime()) - t0) / 1e9); t0=t1;
 
     Log.info("Waiting for RPC SingleThreadRadixOrder to finish ... ");

--- a/h2o-core/src/main/java/water/rapids/SingleThreadRadixOrder.java
+++ b/h2o-core/src/main/java/water/rapids/SingleThreadRadixOrder.java
@@ -38,18 +38,22 @@ class SingleThreadRadixOrder extends DTask<SingleThreadRadixOrder> {
   private transient long counts[][];
   private transient byte keytmp[];
   //public long _groupSizes[][];
+  
+  final long _randomDigits;
 
 
   // outputs ...
   // o and x are changed in-place always
   // iff _groupsToo==true then the following are allocated and returned
 
-  SingleThreadRadixOrder(Frame fr, boolean isLeft, int batchSize, int keySize, /*long nGroup[],*/ int MSBvalue) {
+  SingleThreadRadixOrder(Frame fr, boolean isLeft, int batchSize, int keySize, /*long nGroup[],*/ int MSBvalue, 
+                         long randomDigits) {
     _fr = fr;
     _isLeft = isLeft;
     _batchSize = batchSize;
     _keySize = keySize;
     _MSBvalue = MSBvalue;
+    _randomDigits = randomDigits;
   }
 
   @Override
@@ -63,7 +67,7 @@ class SingleThreadRadixOrder extends DTask<SingleThreadRadixOrder> {
     for (int n=0; n<H2O.CLOUD.size(); n++) {
       // Log.info("Getting MSB " + MSBvalue + " Node Header from node " + n + "/" + H2O.CLOUD.size() + " for Frame " + _fr._key);
       // Log.info("Getting");
-      k = SplitByMSBLocal.getMSBNodeHeaderKey(_isLeft, _MSBvalue, n);
+      k = SplitByMSBLocal.getMSBNodeHeaderKey(_isLeft, _MSBvalue, n, _randomDigits);
       MSBnodeHeader[n] = DKV.getGet(k);
       if (MSBnodeHeader[n]==null) continue;
       DKV.remove(k);
@@ -93,7 +97,7 @@ class SingleThreadRadixOrder extends DTask<SingleThreadRadixOrder> {
     SplitByMSBLocal.OXbatch ox[/*node*/] = new SplitByMSBLocal.OXbatch[H2O.CLOUD.size()];
     int oxBatchNum[/*node*/] = new int[H2O.CLOUD.size()];  // which batch of OX are we on from that node?  Initialized to 0.
     for (int node=0; node<H2O.CLOUD.size(); node++) {  //TO DO: why is this serial?  Relying on
-      k = SplitByMSBLocal.getNodeOXbatchKey(_isLeft, _MSBvalue, node, /*batch=*/0);
+      k = SplitByMSBLocal.getNodeOXbatchKey(_isLeft, _MSBvalue, node, /*batch=*/0, _randomDigits);
       // assert k.home();   // TODO: PUBDEV-3074
       ox[node] = DKV.getGet(k);   // get the first batch for each node for this MSB
       DKV.remove(k);
@@ -134,7 +138,7 @@ class SingleThreadRadixOrder extends DTask<SingleThreadRadixOrder> {
         targetOffset += thisCopy; targetBatchRemaining -= thisCopy;
         if (sourceBatchRemaining == 0) {
           // fetch the next batch :
-          k = SplitByMSBLocal.getNodeOXbatchKey(_isLeft, _MSBvalue, fromNode, ++oxBatchNum[fromNode]);
+          k = SplitByMSBLocal.getNodeOXbatchKey(_isLeft, _MSBvalue, fromNode, ++oxBatchNum[fromNode], _randomDigits);
           assert k.home();
           ox[fromNode] = DKV.getGet(k);
           DKV.remove(k);
@@ -186,11 +190,11 @@ class SingleThreadRadixOrder extends DTask<SingleThreadRadixOrder> {
     // tell the world how many batches and rows for this MSB
     OXHeader msbh = new OXHeader(_o.length, numRows, _batchSize);
     Futures fs = new Futures();
-    DKV.put(getSortedOXHeaderKey(_isLeft, _MSBvalue), msbh, fs, true);
+    DKV.put(getSortedOXHeaderKey(_isLeft, _MSBvalue, _randomDigits), msbh, fs, true);
     assert _o.length == _x.length;
     for (b=0; b<_o.length; b++) {
       SplitByMSBLocal.OXbatch tmp = new SplitByMSBLocal.OXbatch(_o[b], _x[b]);
-      Value v = new Value(SplitByMSBLocal.getSortedOXbatchKey(_isLeft, _MSBvalue, b), tmp);
+      Value v = new Value(SplitByMSBLocal.getSortedOXbatchKey(_isLeft, _MSBvalue, b, _randomDigits), tmp);
       DKV.put(v._key, v, fs, true);  // the OXbatchKey's on this node will be reused for the new keys
       v.freeMem();
     }
@@ -199,10 +203,10 @@ class SingleThreadRadixOrder extends DTask<SingleThreadRadixOrder> {
     tryComplete();
   }
 
-  static Key getSortedOXHeaderKey(boolean isLeft, int MSBvalue) {
+  static Key getSortedOXHeaderKey(boolean isLeft, int MSBvalue, long randomDigits) {
     // This guy has merges together data from all nodes and its data is not "from" 
     // any particular node.  Therefore node number should not be in the key.
-    return Key.make("__radix_order__SortedOXHeader_MSB" + MSBvalue + (isLeft ? "_LEFT" : "_RIGHT"));  // If we don't say this it's random ... (byte) 1 /*replica factor*/, (byte) 31 /*hidden user-key*/, true, H2O.SELF);
+    return Key.make("__radix_order__SortedOXHeader_MSB" + MSBvalue + "_" + randomDigits + (isLeft ? "_LEFT" : "_RIGHT"));  // If we don't say this it's random ... (byte) 1 /*replica factor*/, (byte) 31 /*hidden user-key*/, true, H2O.SELF);
   }
 
   static class OXHeader extends Iced<OXHeader> {

--- a/h2o-core/src/main/java/water/rapids/SingleThreadRadixOrder.java
+++ b/h2o-core/src/main/java/water/rapids/SingleThreadRadixOrder.java
@@ -39,7 +39,7 @@ class SingleThreadRadixOrder extends DTask<SingleThreadRadixOrder> {
   private transient byte keytmp[];
   //public long _groupSizes[][];
   
-  final long _randomDigits;
+  final long _mergeId;
 
 
   // outputs ...
@@ -47,13 +47,13 @@ class SingleThreadRadixOrder extends DTask<SingleThreadRadixOrder> {
   // iff _groupsToo==true then the following are allocated and returned
 
   SingleThreadRadixOrder(Frame fr, boolean isLeft, int batchSize, int keySize, /*long nGroup[],*/ int MSBvalue, 
-                         long randomDigits) {
+                         long mergeId) {
     _fr = fr;
     _isLeft = isLeft;
     _batchSize = batchSize;
     _keySize = keySize;
     _MSBvalue = MSBvalue;
-    _randomDigits = randomDigits;
+    _mergeId = mergeId;
   }
 
   @Override
@@ -67,7 +67,7 @@ class SingleThreadRadixOrder extends DTask<SingleThreadRadixOrder> {
     for (int n=0; n<H2O.CLOUD.size(); n++) {
       // Log.info("Getting MSB " + MSBvalue + " Node Header from node " + n + "/" + H2O.CLOUD.size() + " for Frame " + _fr._key);
       // Log.info("Getting");
-      k = SplitByMSBLocal.getMSBNodeHeaderKey(_isLeft, _MSBvalue, n, _randomDigits);
+      k = SplitByMSBLocal.getMSBNodeHeaderKey(_isLeft, _MSBvalue, n, _mergeId);
       MSBnodeHeader[n] = DKV.getGet(k);
       if (MSBnodeHeader[n]==null) continue;
       DKV.remove(k);
@@ -97,7 +97,7 @@ class SingleThreadRadixOrder extends DTask<SingleThreadRadixOrder> {
     SplitByMSBLocal.OXbatch ox[/*node*/] = new SplitByMSBLocal.OXbatch[H2O.CLOUD.size()];
     int oxBatchNum[/*node*/] = new int[H2O.CLOUD.size()];  // which batch of OX are we on from that node?  Initialized to 0.
     for (int node=0; node<H2O.CLOUD.size(); node++) {  //TO DO: why is this serial?  Relying on
-      k = SplitByMSBLocal.getNodeOXbatchKey(_isLeft, _MSBvalue, node, /*batch=*/0, _randomDigits);
+      k = SplitByMSBLocal.getNodeOXbatchKey(_isLeft, _MSBvalue, node, /*batch=*/0, _mergeId);
       // assert k.home();   // TODO: PUBDEV-3074
       ox[node] = DKV.getGet(k);   // get the first batch for each node for this MSB
       DKV.remove(k);
@@ -138,7 +138,7 @@ class SingleThreadRadixOrder extends DTask<SingleThreadRadixOrder> {
         targetOffset += thisCopy; targetBatchRemaining -= thisCopy;
         if (sourceBatchRemaining == 0) {
           // fetch the next batch :
-          k = SplitByMSBLocal.getNodeOXbatchKey(_isLeft, _MSBvalue, fromNode, ++oxBatchNum[fromNode], _randomDigits);
+          k = SplitByMSBLocal.getNodeOXbatchKey(_isLeft, _MSBvalue, fromNode, ++oxBatchNum[fromNode], _mergeId);
           assert k.home();
           ox[fromNode] = DKV.getGet(k);
           DKV.remove(k);
@@ -190,11 +190,11 @@ class SingleThreadRadixOrder extends DTask<SingleThreadRadixOrder> {
     // tell the world how many batches and rows for this MSB
     OXHeader msbh = new OXHeader(_o.length, numRows, _batchSize);
     Futures fs = new Futures();
-    DKV.put(getSortedOXHeaderKey(_isLeft, _MSBvalue, _randomDigits), msbh, fs, true);
+    DKV.put(getSortedOXHeaderKey(_isLeft, _MSBvalue, _mergeId), msbh, fs, true);
     assert _o.length == _x.length;
     for (b=0; b<_o.length; b++) {
       SplitByMSBLocal.OXbatch tmp = new SplitByMSBLocal.OXbatch(_o[b], _x[b]);
-      Value v = new Value(SplitByMSBLocal.getSortedOXbatchKey(_isLeft, _MSBvalue, b, _randomDigits), tmp);
+      Value v = new Value(SplitByMSBLocal.getSortedOXbatchKey(_isLeft, _MSBvalue, b, _mergeId), tmp);
       DKV.put(v._key, v, fs, true);  // the OXbatchKey's on this node will be reused for the new keys
       v.freeMem();
     }
@@ -203,10 +203,10 @@ class SingleThreadRadixOrder extends DTask<SingleThreadRadixOrder> {
     tryComplete();
   }
 
-  static Key getSortedOXHeaderKey(boolean isLeft, int MSBvalue, long randomDigits) {
+  static Key getSortedOXHeaderKey(boolean isLeft, int MSBvalue, long mergeId) {
     // This guy has merges together data from all nodes and its data is not "from" 
     // any particular node.  Therefore node number should not be in the key.
-    return Key.make("__radix_order__SortedOXHeader_MSB" + MSBvalue + "_" + randomDigits + (isLeft ? "_LEFT" : "_RIGHT"));  // If we don't say this it's random ... (byte) 1 /*replica factor*/, (byte) 31 /*hidden user-key*/, true, H2O.SELF);
+    return Key.make("__radix_order__SortedOXHeader_MSB" + MSBvalue + "_" + mergeId + (isLeft ? "_LEFT" : "_RIGHT"));  // If we don't say this it's random ... (byte) 1 /*replica factor*/, (byte) 31 /*hidden user-key*/, true, H2O.SELF);
   }
 
   static class OXHeader extends Iced<OXHeader> {

--- a/h2o-core/src/main/java/water/rapids/SortCombine.java
+++ b/h2o-core/src/main/java/water/rapids/SortCombine.java
@@ -28,6 +28,7 @@ class SortCombine extends DTask<SortCombine> {
   private boolean[] _stringCols;
   private boolean[] _intCols;
   final SingleThreadRadixOrder.OXHeader _leftSortedOXHeader;
+  final long _randomDigits;
   
   // around the cluster.
   static class FFSB extends Iced<FFSB> {
@@ -40,7 +41,6 @@ class SortCombine extends DTask<SortCombine> {
       assert -1 <= msb && msb <= 255; // left ranges from 0 to 255, right from -1 to 255
       _frame = frame;
       _msb = msb;
-      
       // Create fast lookups to go from chunk index to node index of that chunk
       Vec vec = _vec = frame.anyVec();
       _chunkNode = vec == null ? null : MemoryManager.malloc4(vec.nChunks());
@@ -50,8 +50,9 @@ class SortCombine extends DTask<SortCombine> {
     }
   }
   
-  SortCombine(FFSB leftSB, SingleThreadRadixOrder.OXHeader leftSortedOXHeader) {
+  SortCombine(FFSB leftSB, SingleThreadRadixOrder.OXHeader leftSortedOXHeader, long randomDigits) {
     _leftSB = leftSB;
+    _randomDigits = randomDigits;
     int columnsInResult = _leftSB._frame.numCols();
     _stringCols = MemoryManager.mallocZ(columnsInResult);
     _intCols = MemoryManager.mallocZ(columnsInResult);
@@ -71,7 +72,7 @@ class SortCombine extends DTask<SortCombine> {
   public void compute2() {
     _timings = MemoryManager.malloc8d(20);
     long t0 = System.nanoTime();
-    _leftKO = new KeyOrder(_leftSortedOXHeader);
+    _leftKO = new KeyOrder(_leftSortedOXHeader, _randomDigits);
     _leftKO.initKeyOrder(_leftSB._msb,/*left=*/true);
     final long leftN = _leftSortedOXHeader._numRows; // store number of rows in left frame for the MSB
     assert leftN >= 1;
@@ -92,7 +93,7 @@ class SortCombine extends DTask<SortCombine> {
     
     setPerNodeNumsToFetch();  // find out the number of rows to fetch from H2O nodes, number of rows to fetch per chunk
     
-    if (_numRowsInResult > 0) createChunksInDKV();
+    if (_numRowsInResult > 0) createChunksInDKV(_randomDigits);
     tryComplete();
   }
 
@@ -120,18 +121,20 @@ class SortCombine extends DTask<SortCombine> {
     private final transient byte _key[/*n2GB*/][/*i mod 2GB * _keySize*/];
     private final transient long _order[/*n2GB*/][/*i mod 2GB * _keySize*/];
     private final transient long _perNodeNumRowsToFetch[];
+    final long _randomDigits;
 
-    KeyOrder(SingleThreadRadixOrder.OXHeader sortedOXHeader) {
+    KeyOrder(SingleThreadRadixOrder.OXHeader sortedOXHeader, long randomDigits) {
       _batchSize = sortedOXHeader._batchSize;
       final int nBatch = sortedOXHeader._nBatch;
       _key = new byte[nBatch][];
       _order = new long[nBatch][];
       _perNodeNumRowsToFetch = new long[H2O.CLOUD.size()];
+      _randomDigits = randomDigits;
     }
 
     void initKeyOrder(int msb, boolean isLeft) {
       for (int b = 0; b < _key.length; b++) {
-        Value v = DKV.get(SplitByMSBLocal.getSortedOXbatchKey(isLeft, msb, b));
+        Value v = DKV.get(SplitByMSBLocal.getSortedOXbatchKey(isLeft, msb, b, _randomDigits));
         SplitByMSBLocal.OXbatch ox = v.get(); //mem version (obtained from remote) of the Values gets turned into POJO version
         v.freeMem(); //only keep the POJO version of the Value
         _key[b] = ox._x;
@@ -159,7 +162,7 @@ class SortCombine extends DTask<SortCombine> {
     }
   }
   
-  private void createChunksInDKV() {
+  private void createChunksInDKV(long randomDigits) {
     long t0 = System.nanoTime(), t1;
     // Create the chunks for the final frame from this MSB.
     final int batchSizeUUID = _retBatchSize;
@@ -203,7 +206,7 @@ class SortCombine extends DTask<SortCombine> {
       _timings[10] += ((t1 = System.nanoTime()) - t0) / 1e9;
       t0 = t1;
       // compress all chunks and store them
-      chunksCompressAndStore(b, numColsInResult, frameLikeChunks, frameLikeChunks4Strings, frameLikeChunksLongs);
+      chunksCompressAndStore(b, numColsInResult, frameLikeChunks, frameLikeChunks4Strings, frameLikeChunksLongs, randomDigits);
       if (nbatch > 1) {
         cleanUpMemory(grrrsLeftPerChunk, b);  // clean up memory used by grrrsLeftperChunk
       }
@@ -305,7 +308,8 @@ class SortCombine extends DTask<SortCombine> {
 
   // compress all chunks and store them
   private void chunksCompressAndStore(final int b, final int numColsInResult, final double[][][] frameLikeChunks,
-                                      BufferedString[][][] frameLikeChunks4String, final long[][][] frameLikeChunksLong) {
+                                      BufferedString[][][] frameLikeChunks4String, final long[][][] frameLikeChunksLong, 
+                                      long randomDigits) {
     // compress all chunks and store them
     Futures fs = new Futures();
     for (int col = 0; col < numColsInResult; col++) {
@@ -314,7 +318,7 @@ class SortCombine extends DTask<SortCombine> {
         for (int index = 0; index < frameLikeChunks4String[col][b].length; index++)
           nc.addStr(frameLikeChunks4String[col][b][index]);
         Chunk ck = nc.compress();
-        DKV.put(BinaryMerge.getKeyForMSBComboPerCol(_leftSB._msb, -1, col, b), ck, fs, true);
+        DKV.put(BinaryMerge.getKeyForMSBComboPerCol(_leftSB._msb, -1, col, b, randomDigits), ck, fs, true);
         frameLikeChunks4String[col][b] = null; //free mem as early as possible (it's now in the store)
       } else if (_intCols[col]) {
         NewChunk nc = new NewChunk(null, -1);
@@ -323,11 +327,11 @@ class SortCombine extends DTask<SortCombine> {
           else nc.addNum(l, 0);
         }
         Chunk ck = nc.compress();
-        DKV.put(BinaryMerge.getKeyForMSBComboPerCol(_leftSB._msb, -1, col, b), ck, fs, true);
+        DKV.put(BinaryMerge.getKeyForMSBComboPerCol(_leftSB._msb, -1, col, b, randomDigits), ck, fs, true);
         frameLikeChunksLong[col][b] = null; //free mem as early as possible (it's now in the store)
       } else {
         Chunk ck = new NewChunk(frameLikeChunks[col][b]).compress();
-        DKV.put(BinaryMerge.getKeyForMSBComboPerCol(_leftSB._msb, -1, col, b), ck, fs, true);
+        DKV.put(BinaryMerge.getKeyForMSBComboPerCol(_leftSB._msb, -1, col, b, randomDigits), ck, fs, true);
         frameLikeChunks[col][b] = null; //free mem as early as possible (it's now in the store)
       }
     }

--- a/h2o-core/src/main/java/water/rapids/SplitByMSBLocal.java
+++ b/h2o-core/src/main/java/water/rapids/SplitByMSBLocal.java
@@ -26,9 +26,11 @@ class SplitByMSBLocal extends MRTask<SplitByMSBLocal> {
   private transient long _o[][][];  // transient ok because there is no reduce here between nodes, and important to save shipping back to caller.
   private transient byte _x[][][];
   private long _numRowsOnThisNode;
+  final long _randomDigits;
 
   static Hashtable<Key,SplitByMSBLocal> MOVESHASH = new Hashtable<>();
-  SplitByMSBLocal(boolean isLeft, BigInteger base[], int shift, int keySize, int batchSize, int bytesUsed[], int[] col, Key linkTwoMRTask, int[][] id_maps, int[] ascending) {
+  SplitByMSBLocal(boolean isLeft, BigInteger base[], int shift, int keySize, int batchSize, int bytesUsed[], int[] col,
+                  Key linkTwoMRTask, int[][] id_maps, int[] ascending, long randomDigits) {
     _isLeft = isLeft;
     // we only currently use the shift (in bits) for the first column for the
     // MSB (which we don't know from bytesUsed[0]). Otherwise we use the
@@ -39,11 +41,12 @@ class SplitByMSBLocal extends MRTask<SplitByMSBLocal> {
     _linkTwoMRTask = linkTwoMRTask;
     _id_maps = id_maps;
     _ascending = ascending;
+    _randomDigits = randomDigits;
   }
 
   @Override protected void setupLocal() {
 
-    Key k = RadixCount.getKey(_isLeft, _col[0], H2O.SELF);
+    Key k = RadixCount.getKey(_isLeft, _col[0], _randomDigits, H2O.SELF);
     _counts = ((RadixCount.Long2DArray) DKV.getGet(k))._val;   // get the sparse spine for this node, created and DKV-put above
     DKV.remove(k);
     // First cumulate MSB count histograms across the chunks in this node
@@ -197,13 +200,15 @@ class SplitByMSBLocal extends MRTask<SplitByMSBLocal> {
     return H2O.CLOUD._memary[MSBvalue % H2O.CLOUD.size()];   // spread it around more.
   }
 
-  static Key getNodeOXbatchKey(boolean isLeft, int MSBvalue, int node, int batch) {
-    return Key.make("__radix_order__NodeOXbatch_MSB" + MSBvalue + "_node" + node + "_batch" + batch + (isLeft ? "_LEFT" : "_RIGHT"),
+  static Key getNodeOXbatchKey(boolean isLeft, int MSBvalue, int node, int batch, long randomDigits) {
+    return Key.make("__radix_order__NodeOXbatch_MSB" + MSBvalue + "_node" + node + "_batch" + batch +  "_"
+                    + randomDigits + (isLeft ? "_LEFT" : "_RIGHT"),
             Key.HIDDEN_USER_KEY, false, SplitByMSBLocal.ownerOfMSB(MSBvalue));
   }
 
-  static Key getSortedOXbatchKey(boolean isLeft, int MSBvalue, int batch) {
-    return Key.make("__radix_order__SortedOXbatch_MSB" + MSBvalue + "_batch" + batch + (isLeft ? "_LEFT" : "_RIGHT"),
+  static Key getSortedOXbatchKey(boolean isLeft, int MSBvalue, int batch, long randomDigits) {
+    return Key.make("__radix_order__SortedOXbatch_MSB" + MSBvalue + "_batch" + batch + "_"
+                    + randomDigits + (isLeft ? "_LEFT" : "_RIGHT"),
             Key.HIDDEN_USER_KEY, false, SplitByMSBLocal.ownerOfMSB(MSBvalue));
   }
 
@@ -214,8 +219,9 @@ class SplitByMSBLocal extends MRTask<SplitByMSBLocal> {
     final byte[/*batchSize or lastSize*/] _x;
   }
 
-  static Key getMSBNodeHeaderKey(boolean isLeft, int MSBvalue, int node) {
-    return Key.make("__radix_order__OXNodeHeader_MSB" + MSBvalue + "_node" + node + (isLeft ? "_LEFT" : "_RIGHT"),
+  static Key getMSBNodeHeaderKey(boolean isLeft, int MSBvalue, int node, long randomDigits) {
+    return Key.make("__radix_order__OXNodeHeader_MSB" + MSBvalue + "_node" + node + "_" + randomDigits
+                    + (isLeft ? "_LEFT" : "_RIGHT"),
             Key.HIDDEN_USER_KEY, false, SplitByMSBLocal.ownerOfMSB(MSBvalue));
   }
 
@@ -308,10 +314,10 @@ class SplitByMSBLocal extends MRTask<SplitByMSBLocal> {
       MSBNodeHeader msbh = new MSBNodeHeader(msbNodeChunkCounts);
       // Need dontCache==true, so data does not remain both locally and on remote.
       // Use private Futures so can block independent of MRTask Futures.
-      DKV.put(getMSBNodeHeaderKey(_isLeft, _msb, H2O.SELF.index()), msbh, _myfs, true);
+      DKV.put(getMSBNodeHeaderKey(_isLeft, _msb, H2O.SELF.index(), _randomDigits), msbh, _myfs, true);
       for (int b=0;b<_o[_msb].length; b++) {
         OXbatch ox = new OXbatch(_o[_msb][b], _x[_msb][b]);   // this does not copy in Java, just references
-        DKV.put(getNodeOXbatchKey(_isLeft, _msb, H2O.SELF.index(), b), ox, _myfs, true);
+        DKV.put(getNodeOXbatchKey(_isLeft, _msb, H2O.SELF.index(), b, _randomDigits), ox, _myfs, true);
       }
       tryComplete();
     }


### PR DESCRIPTION
This PR attempts to resolve the problem in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8833 .

@michalkurka reported that when he tries to run sort in cross-validation, the sort will fail.  I remembered there are many keys generated in the process.  For single thread, there is no problem.  But when we run things in parallel, the keys stored in the DKV will cause a problem because all the various processes will use the same set of keys.  As the keys being created and deleted, there will be null pointer errors.

I added a timestamp plus a randomly generated long to all keys.  This seems to resolve the issue.