### PR TITLE
PUBDEV-8840: Exclude shaded protobuf with vulnerabilities from steam assembly

### DIFF
--- a/h2o-assemblies/steam/build.gradle
+++ b/h2o-assemblies/steam/build.gradle
@@ -40,6 +40,7 @@ dependencies {
         exclude group: "org.apache.curator"
         exclude group: "org.apache.zookeeper"
         exclude group: "org.eclipse.jetty"
+        exclude group: "org.apache.hadoop.thirdparty", module: "hadoop-shaded-protobuf_3_7"
     }
     api("org.apache.hadoop:hadoop-aws:3.3.3") {
         exclude group: "com.amazonaws", module: "aws-java-sdk-bundle"


### PR DESCRIPTION
rel-zumbo