### PR TITLE
PUBDEV-8220 - DRF with binomial_double_trees=True fail with assert

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/drf/DRFModel.java
+++ b/h2o-algos/src/main/java/hex/tree/drf/DRFModel.java
@@ -3,7 +3,9 @@ package hex.tree.drf;
 import hex.genmodel.utils.DistributionFamily;
 import hex.tree.*;
 import hex.util.EffectiveParametersUtils;
+import water.Job;
 import water.Key;
+import water.fvec.Frame;
 import water.fvec.NewChunk;
 import water.util.MathUtils;
 
@@ -43,6 +45,24 @@ public class DRFModel extends SharedTreeModelWithContributions<DRFModel, DRFMode
 
   public void initActualParamValuesAfterOutputSetup(boolean isClassifier) {
     EffectiveParametersUtils.initStoppingMetric(_parms, isClassifier);
+  }
+
+  @Override
+  public Frame scoreContributions(Frame frame, Key<Frame> destination_key, Job<Frame> j) {
+    if (_parms._binomial_double_trees) {
+      throw new UnsupportedOperationException(
+              "Calculating contributions is currently not supported for model with binomial_double_trees parameter set.");
+    }
+    return super.scoreContributions(frame, destination_key, j);
+  }
+
+  @Override
+  public Frame scoreContributions(Frame frame, Key<Frame> destination_key, Job<Frame> j, ContributionsOptions options) {
+    if (_parms._binomial_double_trees) {
+      throw new UnsupportedOperationException(
+              "Calculating contributions is currently not supported for model with binomial_double_trees parameter set.");
+    }
+    return super.scoreContributions(frame, destination_key, j, options);
   }
 
   @Override

--- a/h2o-algos/src/test/java/hex/tree/drf/DRFPredictContribsTest.java
+++ b/h2o-algos/src/test/java/hex/tree/drf/DRFPredictContribsTest.java
@@ -209,6 +209,57 @@ public class DRFPredictContribsTest extends TestUtil {
         }
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void testScoreContributionsBinomialDoubleTreesFail() {
+        try {
+            Scope.enter();
+            Frame fr = Scope.track(parseTestFile("smalldata/junit/titanic_alt.csv"));
+            fr.toCategoricalCol("survived");
+
+            DRFModel.DRFParameters parms = new DRFModel.DRFParameters();
+
+            parms._train = fr._key;
+            parms._response_column = "survived";
+            parms._ntrees = 1;
+            parms._max_depth = 4;
+            parms._binomial_double_trees = true;
+            parms._seed = 42;
+
+            DRF job = new DRF(parms);
+            DRFModel drf = job.trainModel().get();
+            Scope.track_generic(drf);
+
+            drf.scoreContributions(fr, Key.make("contributions_binomial_titanic"));
+        } finally {
+            Scope.exit();
+        }
+    }
+
+    @Test(expected = IOException.class)
+    public void testScoreContributionsBinomialDoubleTreesMojoFail() throws IOException {
+        try {
+            Scope.enter();
+            Frame fr = Scope.track(parseTestFile("smalldata/junit/titanic_alt.csv"));
+            fr.toCategoricalCol("survived");
+
+            DRFModel.DRFParameters parms = new DRFModel.DRFParameters();
+
+            parms._train = fr._key;
+            parms._response_column = "survived";
+            parms._ntrees = 1;
+            parms._max_depth = 4;
+            parms._binomial_double_trees = true;
+            parms._seed = 42;
+
+            DRFModel drf = Scope.track_generic(new DRF(parms).trainModel().get());
+
+            new EasyPredictModelWrapper.Config()
+                    .setModel(drf.toMojo())
+                    .setEnableContributions(true);
+        } finally {
+            Scope.exit();
+        }
+    }
 
     private static class CheckTreeSHAPTask extends MRTask<DRFPredictContribsTest.CheckTreeSHAPTask> {
         final DRFModel _model;

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/drf/DrfMojoModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/drf/DrfMojoModel.java
@@ -70,6 +70,10 @@ public final class DrfMojoModel extends SharedTreeMojoModelWithContributions imp
         
         private ContributionsPredictorDRF(DrfMojoModel model, TreeSHAPPredictor<double[]> treeSHAPPredictor) {
             super(model, treeSHAPPredictor);
+            if (model._binomial_double_trees) {
+                throw new UnsupportedOperationException(
+                        "Calculating contributions is currently not supported for model with binomial_double_trees parameter set.");
+            }
             if (ModelCategory.Regression.equals(model._category)) {
                 _featurePlusBiasRatio = 0;
                 _normalizer = model._ntree_groups;
@@ -90,4 +94,7 @@ public final class DrfMojoModel extends SharedTreeMojoModelWithContributions imp
         }
     }
 
+    public boolean isBinomialDoubleTrees() {
+        return _binomial_double_trees;
+    }
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
@@ -3,6 +3,7 @@ package hex.genmodel.easy;
 import hex.ModelCategory;
 import hex.genmodel.*;
 import hex.genmodel.algos.deeplearning.DeeplearningMojoModel;
+import hex.genmodel.algos.drf.DrfMojoModel;
 import hex.genmodel.algos.glrm.GlrmMojoModel;
 import hex.genmodel.algos.targetencoder.TargetEncoderMojoModel;
 import hex.genmodel.algos.tree.SharedTreeMojoModel;
@@ -200,6 +201,9 @@ public class EasyPredictModelWrapper implements Serializable {
         throw new IOException("setEnableContributions can be set to true only with DRF, GBM, or XGBoost models.");
       if (val && (ModelCategory.Multinomial.equals(model.getModelCategory()))) {
         throw new IOException("setEnableContributions is not yet supported for multinomial classification models.");
+      }
+      if (val && model instanceof DrfMojoModel && ((DrfMojoModel) model).isBinomialDoubleTrees()) {
+        throw new IOException("setEnableContributions is not yet supported for model with binomial_double_trees parameter set.");
       }
       enableContributions = val;
       return this;


### PR DESCRIPTION
DRF with binomial_double_trees=True behave like a multinomial model. Multinomial models are not supported for shap. Throw unsupported exceptions instead of assertion error before we fully support binomial_double_trees option.

Its old bug from self closed support ticket, but it came to us again from user. 

https://h2oai.atlassian.net/browse/PUBDEV-8220
https://h2oai.atlassian.net/browse/PUBDEV-8814

I put master as base branch but it should go to rel-zygmund