### PR TITLE
PUBDEV-8846: Do not warn about job not having a proper model type when no model was trained

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -844,8 +844,10 @@ final LeaderboardHolder selectionLeaderboard = makeLeaderboard(selectionKey.toSt
                     if (res instanceof Model) {
                         models.addModel(res.getKey());
                     } else if (res instanceof ModelContainer) {
-                        models.addModels(((ModelContainer)res).getModelKeys());
+                        models.addModels(((ModelContainer) res).getModelKeys());
                         res.remove(false);
+                    } else if (res == null && jModels.stop_requested()) {
+                        // Do nothing - stop was requested before we managed to train any model
                     } else {
                         throw new H2OIllegalArgumentException("Can only convert jobs producing a single Model or ModelContainer.");
                     }


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8846

Sometimes an exception like “`GBM_lr_annealing_selection_AutoML_156_20220916_171912 [GBM lr_annealing] failed: water.exceptions.H2OIllegalArgumentException: Can only convert jobs producing a single Model or ModelContainer.`” when running AutoML with `max_runtime_secs > 0`.

This is caused by stopping the training before a `SelectionStep` produces any model. Since this is can happen even when the user does everything correctly,  I think it would be good not to throw this exception in this case. It was confusing to me, I think it might be confusing to other users as well.