### PR TITLE
PUBDEV-8852: POC of using Python and GraalVM to integrate with h2o-drive

### DIFF
--- a/h2o-persist-drive/bootstrap.sh
+++ b/h2o-persist-drive/bootstrap.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+wget https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.2.0/graalvm-ce-java17-linux-amd64-22.2.0.tar.gz
+tar xfz graalvm-ce-java17-linux-amd64-22.2.0.tar.gz
+GRAALVM_HOME="$PWD/$(ls -d graalvm-* | grep -F -v .tar.gz | tail -1)"
+$GRAALVM_HOME/bin/gu install python
+$GRAALVM_HOME/bin/graalpython -m venv venv
+(source venv/bin/activate && pip install boto3)
+ln -s $GRAALVM_HOME graalvm

--- a/h2o-persist-drive/bootstrap.sh
+++ b/h2o-persist-drive/bootstrap.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -ex
+
 wget https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.2.0/graalvm-ce-java17-linux-amd64-22.2.0.tar.gz
 tar xfz graalvm-ce-java17-linux-amd64-22.2.0.tar.gz
 GRAALVM_HOME="$PWD/$(ls -d graalvm-* | grep -F -v .tar.gz | tail -1)"

--- a/h2o-persist-drive/build.gradle
+++ b/h2o-persist-drive/build.gradle
@@ -1,0 +1,23 @@
+description = "H2O Persist Drive"
+
+repositories {
+    mavenCentral()
+}
+
+apply plugin: 'java-library'
+
+sourceCompatibility = 17
+targetCompatibility = 17
+
+compileJava {
+  options.debug = true
+  options.encoding = "UTF-8"
+}
+
+dependencies {
+  api fileTree(dir: "$rootDir/../h2o-core/build/libs", include: '*.jar')
+  api fileTree(dir: "$rootDir/../h2o-logger/build/libs", include: '*.jar')
+  compileOnly "org.graalvm.sdk:graal-sdk:22.2.0"
+
+  testImplementation group: 'junit', name: 'junit', version: '4.12'
+}

--- a/h2o-persist-drive/build.gradle
+++ b/h2o-persist-drive/build.gradle
@@ -10,7 +10,6 @@ sourceCompatibility = 17
 targetCompatibility = 17
 
 compileJava {
-  options.debug = true
   options.encoding = "UTF-8"
 }
 

--- a/h2o-persist-drive/readme.txt
+++ b/h2o-persist-drive/readme.txt
@@ -1,0 +1,28 @@
+This is an experimental support for custom persist implementation relying on python and GraalVM
+
+Currently, our example uses S3 and boto3 python library to download file locally and parse into H2O.
+
+Installation Steps:
+
+1) Download GraalVM
+wget https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.2.0/graalvm-ce-java17-linux-amd64-22.2.0.tar.gz
+tar xfz graalvm-ce-java17-linux-amd64-22.2.0.tar.gz
+export GRAAL_HOME=$(ls -d graalvm-*)
+
+2) Create Python environment with boto3 
+$GRAAL_HOME/bin/gu install python
+$GRAAL_HOME/bin/graalpython -m venv venv
+(source venv/bin/activate && pip install boto3)
+
+3) Set AWS credentials into environment variables
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+
+4) Run H2O with GraalVM
+$GRAAL_HOME/bin/java -jar ../../build/h2o.jar
+
+5) Import data from "drive" (in our case backed by S3)
+python
+> import h2o
+> h2o.connect()
+> h2o.import_file("drive://h2o-public-test-data/smalldata/iris/iris.csv")

--- a/h2o-persist-drive/settings.gradle
+++ b/h2o-persist-drive/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'h2o-persist-drive'

--- a/h2o-persist-drive/src/main/java/water/persist/DriveClient.java
+++ b/h2o-persist-drive/src/main/java/water/persist/DriveClient.java
@@ -1,0 +1,55 @@
+package water.persist;
+
+/**
+ * This class is here to wrap around the actual Polyglot proxy object and delegate
+ * all calls directly to it. The only reason this class exists is that we want to
+ * keep things nice on the python side and have `self` reference and also respect
+ * naming conventions in both worlds.
+ */
+public final class DriveClient {
+    private final DriveClientDelegate _delegate;
+
+    DriveClient(DriveClientDelegate delegate) {
+        _delegate = delegate;
+    }
+
+    /**
+     * Does the underlying implementation generate a presigned-URL to access
+     * the data?
+     * @return true, if pre-signed URLs can be generated
+     */
+    boolean supportsPresignedUrls() {
+        return _delegate.supports_presigned_urls(_delegate);
+    }
+
+    /**
+     * Download dataset located at given path to a local file.
+     * @param path dataset location
+     * @param file local file path
+     */
+    void downloadFile(String path, String file) {
+        _delegate.download_file(_delegate, path, file);
+    }
+
+    /**
+     * For a given path generate a pre-signed URL to access it by
+     * HTTP.
+     * @param path path specification
+     * @return HTTP/HTTPS URL
+     */
+    String generatePresignedUrls(String path) {
+        return _delegate.generate_presigned_url(_delegate, path);
+    }
+
+    /**
+     * For auto-complete suggestions in Flow: take a given path and suggest
+     * a list of path that could complete the path.
+     * @param path Path prefix or a path to a directory.
+     * @param limit maximum number of returned suggestions
+     * @return array of suggested paths
+     */
+    String[] calcTypeaheadMatches(String path, int limit) {
+        return _delegate.calc_typeahead_matches(_delegate, path, limit);
+    }
+
+}

--- a/h2o-persist-drive/src/main/java/water/persist/DriveClientDelegate.java
+++ b/h2o-persist-drive/src/main/java/water/persist/DriveClientDelegate.java
@@ -1,0 +1,17 @@
+package water.persist;
+
+/**
+ * This is the main interface for talking to the underlying python implementation.
+ * It is Pythonic to keep things nice on the Python side.
+ */
+public interface DriveClientDelegate {
+
+    boolean supports_presigned_urls(DriveClientDelegate self);
+
+    void download_file(DriveClientDelegate self, String path, String file);
+
+    String generate_presigned_url(DriveClientDelegate self, String path);
+
+    String[] calc_typeahead_matches(DriveClientDelegate self, String partial_path, int limit);
+
+}

--- a/h2o-persist-drive/src/main/java/water/persist/DriveClientFactory.java
+++ b/h2o-persist-drive/src/main/java/water/persist/DriveClientFactory.java
@@ -1,0 +1,37 @@
+package water.persist;
+
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Source;
+
+import java.io.IOException;
+import java.net.URL;
+
+public abstract class DriveClientFactory {
+
+    /**
+     * Creates a new instance of a DriveClient backed by a Python backend
+     * @param venvExePath path to Python executable (presumably located in a virtual environment)
+     * @return instance of DriveClient
+     * @throws IOException if Python client script cannot be found
+     */
+    public static DriveClient createDriveClient(String venvExePath) throws IOException {
+        Context context = Context.newBuilder("python").
+                allowIO(true).
+                allowAllAccess(true).
+                option("python.Executable", venvExePath).
+                build();
+        URL scriptURL = DriveClientFactory.class.getResource("/drive_client.py");
+        if (scriptURL == null) {
+            throw new IllegalStateException("Drive client (drive_client.py) not bundled in the jar.");
+        }
+        Source scriptSource = Source.newBuilder("python", scriptURL)
+                .build();
+        context.eval("python", "import site");
+        context.eval(scriptSource);
+        DriveClientDelegate delegate = context.getBindings("python")
+                .getMember("DriveClient")
+                .as(DriveClientDelegate.class);
+        return new DriveClient(delegate);
+    }
+
+}

--- a/h2o-persist-drive/src/main/java/water/persist/PersistDrive.java
+++ b/h2o-persist-drive/src/main/java/water/persist/PersistDrive.java
@@ -1,0 +1,103 @@
+package water.persist;
+
+import water.H2O;
+import water.Key;
+import water.Value;
+import water.util.FrameUtils;
+import water.util.Log;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.*;
+
+public class PersistDrive extends EagerPersistBase {
+
+  private static final Object _lock = new Object();
+  private static volatile DriveClient _driveClient;
+
+  @Override
+  public final byte[] load(Value v) {
+    throw new UnsupportedOperationException("PersistDrive#load should never be called");
+  }
+
+  @Override
+  public void importFiles(String path, String pattern,
+                          /*OUT*/ ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels) {
+    final boolean useHttp = getClient().supportsPresignedUrls();
+    if (useHttp) {
+      importFileHttp(path, files, keys, fails);
+    } else {
+      importFileDiskCache(path, files, keys, fails);
+    }
+  }
+
+  void importFileHttp(String path,
+                      /*OUT*/ ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails) {
+    try {
+      String presigned = getClient().generatePresignedUrls(path);
+      Key<?> destKey = FrameUtils.eagerLoadFromURL(path, new URL(presigned));
+      files.add(path);
+      keys.add(destKey.toString());
+    } catch (Exception e) {
+      Log.err("Generating pre-signed URL for `" + path + "` failed.", e);
+      fails.add(path);
+    }
+  }
+
+  void importFileDiskCache(String path,
+                           /*OUT*/ ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails) {
+    File temp = null;
+    try {
+      temp = Files.createTempFile("drive", ".data").toFile();
+      getClient().downloadFile(path, temp.getAbsolutePath());
+      assert temp.isFile();
+      Key<?> destKey = FrameUtils.eagerLoadFromURL(path, temp.toURI().toURL());
+      files.add(path);
+      keys.add(destKey.toString());
+    } catch (Exception e) {
+      Log.err("Loading from `" + path + "` failed.", e);
+      fails.add(path);
+    } finally {
+      if (temp != null) {
+        if (!temp.delete()) {
+          Log.warn("Unable to delete temporary file " + temp);
+        }
+      }
+    }
+  }
+
+  @Override
+  public List<String> calcTypeaheadMatches(String filter, int limit) {
+    return Arrays.asList(getClient().calcTypeaheadMatches(filter, limit));
+  }
+
+  static DriveClient getClient() {
+    if (_driveClient == null) {
+      synchronized (_lock) {
+        if (_driveClient == null) {
+          String venvExePath = H2O.getSysProperty("persist.drive.venv", lookupDefaultVenv());
+          try {
+            _driveClient = DriveClientFactory.createDriveClient(venvExePath);
+          } catch (IOException e) {
+            throw new RuntimeException("Failed creating a Drive client", e);
+          }
+          assert _driveClient != null;
+        }
+      }
+    }
+    return _driveClient;
+  }
+
+  private static String lookupDefaultVenv() {
+    String def = "venv/bin/graalpython";
+    for (int i = 0; i < 2; i++) {
+      if (new File(def).isFile())
+        return def;
+      def = "../" + def;
+    }
+    return def;
+  }
+  
+}

--- a/h2o-persist-drive/src/main/resources/drive_client.py
+++ b/h2o-persist-drive/src/main/resources/drive_client.py
@@ -1,0 +1,49 @@
+import boto3
+import itertools
+
+
+def decode_path(path, fail_on_bucket_only=True):
+    if not path.startswith("drive://"):
+        raise ValueError("Path is not a Drive path (path='%s')" % path)
+    parts = path.split("/", maxsplit=3)
+    if len(parts) != 4:
+        if fail_on_bucket_only:
+            raise ValueError("Path needs to include both bucket name and object key (path='%s')" % path)
+        else:
+            return parts[2], None
+    return parts[2], parts[3]
+
+
+class DriveClient:
+    """
+    Example implementation of S3-like persistence client
+    """
+
+    def __init__(self):
+        pass
+
+    def supports_presigned_urls(self):
+        return True
+
+    def download_file(self, path, file):
+        s3 = boto3.client('s3')
+        bucket, objectKey = decode_path(path)
+        s3.download_file(self, bucket, objectKey, file)
+
+    def generate_presigned_url(self, path):
+        s3 = boto3.client('s3')
+        bucket, objectKey = decode_path(path)
+        response = s3.generate_presigned_url('get_object',
+                                             Params={'Bucket': bucket,
+                                                     'Key': objectKey},
+                                             ExpiresIn=3600)
+        return response
+
+    def calc_typeahead_matches(self, partial_path, limit):
+        bucket, objectKeyPrefix = decode_path(partial_path, fail_on_bucket_only=False)
+        if objectKeyPrefix is None:
+            return []
+        s3 = boto3.client('s3')
+        contents = s3.list_objects(Bucket=bucket, Prefix=objectKeyPrefix)['Contents']
+        keys = map(lambda it: "drive://" + bucket + "/" + it["Key"], contents)
+        return list(itertools.islice(keys, limit))

--- a/h2o-persist-drive/src/test/java/water/persist/PersistDriveTest.java
+++ b/h2o-persist-drive/src/test/java/water/persist/PersistDriveTest.java
@@ -1,0 +1,19 @@
+package water.persist;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PersistDriveTest {
+
+    @Test
+    public void load() {
+        try {
+            new PersistDrive().load(null);
+            fail();
+        } catch (UnsupportedOperationException e) {
+            assertEquals("PersistDrive#load should never be called", e.getMessage());
+        }
+    }
+
+}

--- a/h2o-persist-drive/tests/python/pyunit_import_drive.py
+++ b/h2o-persist-drive/tests/python/pyunit_import_drive.py
@@ -1,0 +1,22 @@
+#! /usr/env/python
+
+import sys, os
+sys.path.insert(1, os.path.join("..", "..", "..", "h2o-py"))
+from tests import pyunit_utils
+import h2o
+from pandas.util.testing import assert_frame_equal
+
+
+def test_drive_import():
+    local_frame = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    drive_frame = h2o.import_file("drive://h2o-public-test-data/smalldata/logreg/prostate.csv")
+    assert_frame_equal(local_frame.as_data_frame(), drive_frame.as_data_frame())
+
+    resp = h2o.api("GET /3/Typeahead/files?src=drive://h2o-public-test-data/smalldata/logre&limit=3")
+    assert len(resp["matches"]) == 3
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_drive_import)
+else:
+    test_drive_import()

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -92,6 +92,28 @@ test-py-changed:
 test-py-persist-s3: lookup-persist-s3-tests
 	export NO_GCE_CHECK=True && cd h2o-py/tests/ && ../../scripts/run.py --wipeall --geterrs --testlist .lookup.txt --numclouds 1 --jvm.xmx 3g
 
+build-h2o-persist-drive:
+	@echo "+--Building H2O Persit Drive--+"
+	@echo
+	cd h2o-persist-drive && ../gradlew clean build
+
+bootstrap-persist-drive-env:
+	mkdir -p h2o-persist-drive/build/graal && cd h2o-persist-drive/build/graal && ../../bootstrap.sh
+
+test-py-persist-drive:
+	export NO_GCE_CHECK=True \
+	 && export JAVA_HOME="$$PWD/h2o-persist-drive/build/graal/graalvm" \
+	 && cd h2o-persist-drive/tests/ \
+	 && ../../scripts/run.py --wipeall --geterrs --numclouds 1 --jvm.xmx 3g \
+	                         --jvm.cp "$(shell pwd)/$(wildcard h2o-persist-drive/build/libs/h2o-persist-drive*.jar)" \
+	                         --jvm.opt "--add-opens=java.base/java.lang=ALL-UNNAMED" \
+	                         --jvm.opt "-Dsys.ai.h2o.persist.drive.venv=../../build/graal/venv/bin/graalpython"
+
+test-py-persist-drive-jenkins:
+	@$(MAKE) -f $(THIS_FILE) build-h2o-persist-drive
+	@$(MAKE) -f $(THIS_FILE) bootstrap-persist-drive-env
+	@$(MAKE) -f $(THIS_FILE) test-py-persist-drive
+
 test-py-init:
 	export NO_GCE_CHECK=True && cd h2o-py/tests/testdir_apis/H2O_Init \
 	 && python h2o.init_test.py \
@@ -314,6 +336,7 @@ test-package-java:
 		h2o-persist-s3/build/libs/h2o-persist-s3-*.jar \
 		h2o-persist-http/src/ \
 		h2o-persist-http/build/libs/h2o-persist-http-*.jar \
+		h2o-persist-drive/ \
 		h2o-security/src/ \
 		h2o-security/build/libs/h2o-security-*.jar \
 		h2o-extensions/xgboost/src/ \

--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -60,6 +60,11 @@ def call(final pipelineContext) {
     [
       stageName: 'Java 8 Smoke', target: 'test-junit-smoke-jenkins', javaVersion: 8, timeoutValue: 20,
       component: pipelineContext.getBuildConfig().COMPONENT_JAVA
+    ],
+    [
+      stageName: 'Persist Drive (GraalVM)', target: 'test-py-persist-drive-jenkins', javaVersion: 17, timeoutValue: 20,
+      component: pipelineContext.getBuildConfig().COMPONENT_JAVA,
+      additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY]
     ]
   ]
 

--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -60,11 +60,6 @@ def call(final pipelineContext) {
     [
       stageName: 'Java 8 Smoke', target: 'test-junit-smoke-jenkins', javaVersion: 8, timeoutValue: 20,
       component: pipelineContext.getBuildConfig().COMPONENT_JAVA
-    ],
-    [
-      stageName: 'Persist Drive (GraalVM)', target: 'test-py-persist-drive-jenkins', javaVersion: 17, timeoutValue: 20,
-      component: pipelineContext.getBuildConfig().COMPONENT_JAVA,
-      additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY]
     ]
   ]
 
@@ -497,6 +492,11 @@ def call(final pipelineContext) {
     [ // These run with reduced number of file descriptors for early detection of FD leaks
       stageName: 'XGBoost Stress tests', target: 'test-pyunit-xgboost-stress', pythonVersion: '3.6', timeoutValue: 40,
       component: pipelineContext.getBuildConfig().COMPONENT_PY, customDockerArgs: [ '--ulimit nofile=150:150' ]
+    ],
+    [
+      stageName: 'Persist Drive (GraalVM)', target: 'test-py-persist-drive-jenkins', javaVersion: 17, timeoutValue: 20,
+      component: pipelineContext.getBuildConfig().COMPONENT_JAVA,
+      additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY]
     ]
   ]
 

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -2190,6 +2190,8 @@ def usage():
     print("")
     print("    --jvm.opts       Additional JVM options.")
     print("")
+    print("    --jvm.opt        Additional JVM option - can be added more than once.")
+    print("")
     print("    --restLog        If set, enable REST API logging. Logs will be available at <resultsDir>/rest.log.")
     print("                     Please note, that enablig REST API logging will increase the execution time and that")
     print("                     the log file might be large (> 2GB).")
@@ -2516,6 +2518,16 @@ def parse_args(argv):
             if i >= len(argv):
                 usage()
             g_jvm_opts = argv[i]
+        elif s == '--jvm.opt':
+            i += 1
+            if i >= len(argv):
+                usage()
+            if g_jvm_opts is None:
+                g_jvm_opts = argv[i]
+            elif isinstance(g_jvm_opts, list):
+                g_jvm_opts += argv[i]
+            else:
+                g_jvm_opts = [g_jvm_opts, argv[i]]
         elif s == '--restLog':
             g_rest_log = True
         else:


### PR DESCRIPTION
h2o-drive currently only has Python API. While we could re-implement what the library is doing, we want to explore the option of just using this library directly from Java. One way to do so is by using Polyglot APIs in GraalVM. There are numerous advantages of GraalVM, including the ability to speed up user-defined functions for custom metrics/custom objective functions and in the future allow any transformations of H2O frames defined in Python.

This code is experimental and because it depends on Java 17, it needs to stand outside of the main h2o-3 project. This creates some challenges in our build process.

We use boto3 to approximate h2o-drive's behavior. Thanks to that we can keep tests public and independent of HAIC.

In this POC we focus only on data import. We enable the basic flow of listing files in H2O Flow and importing a dataset. Same works in Python (and R).