### PR TITLE
[ITA-1504] Avoid using egg files during conda package build

### DIFF
--- a/h2o-py/conda/h2o-client/bld.bat
+++ b/h2o-py/conda/h2o-client/bld.bat
@@ -1,2 +1,2 @@
-"%PYTHON%" setup.py install --client
+"%PYTHON%" setup.py install --client --single-version-externally-managed --record=record.txt
 if errorlevel 1 exit 1

--- a/h2o-py/conda/h2o-client/build.sh
+++ b/h2o-py/conda/h2o-client/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install --client
+$PYTHON setup.py install --client --single-version-externally-managed --record=record.txt

--- a/h2o-py/conda/h2o-main/bld.bat
+++ b/h2o-py/conda/h2o-main/bld.bat
@@ -1,2 +1,2 @@
-"%PYTHON%" setup.py install
+"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
 if errorlevel 1 exit 1

--- a/h2o-py/conda/h2o-main/build.sh
+++ b/h2o-py/conda/h2o-main/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt


### PR DESCRIPTION
Before the change:
```
ls  /usr/local/conda-bld/h2o_client_1663848578475/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/lib/python3.8/site-packages/
OpenSSL                                       certifi                             cryptography                       h2o_client-3.36.1.99999-py3.8.egg-info  pkg_resources                      socks.py
PySocks-1.7.1.dist-info                       certifi-2022.9.14-py3.10.egg-info   cryptography-37.0.4.dist-info      idna                                    pyOpenSSL-22.0.0.dist-info         sockshandler.py
README.txt                                    certifi-2022.9.14-py3.8.egg         distutils-precedence.pth           idna-3.4.dist-info                      pycparser                          tabulate-0.8.10.dist-info
__pycache__                                   certifi-2022.9.14-py3.8.egg-info    easy-install.pth                   libfuturize                             pycparser-2.21.dist-info           tabulate.py
_cffi_backend.cpython-38-x86_64-linux-gnu.so  cffi                                future                             libpasteurize                           requests                           urllib3
_distutils_hack                               cffi-1.15.1.dist-info               future-0.18.2.dist-info            past                                    requests-2.28.1.dist-info          urllib3-1.26.11.dist-info
brotli                                        charset_normalizer                  h2o                                pip                                     setuptools                         wheel
brotlipy-0.7.0.dist-info                      charset_normalizer-2.1.1.dist-info  h2o_client-3.36.1.99999-py3.8.egg  pip-22.2.2-py3.10.egg-info              setuptools-65.3.0-py3.10.egg-info  wheel-0.37.1-py3.8.egg-info
```

After the change:
```
ls /usr/local/conda-bld/h2o_client_1663858179758/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/lib/python3.8/site-packages/
OpenSSL                                       brotli                             charset_normalizer                  future-0.18.2.dist-info  pip                         requests                           tabulate-0.8.10.dist-info
PySocks-1.7.1.dist-info                       brotlipy-0.7.0.dist-info           charset_normalizer-2.1.1.dist-info  idna                     pip-22.2.2-py3.10.egg-info  requests-2.28.1.dist-info          tabulate.py
README.txt                                    certifi                            cryptography                        idna-3.4.dist-info       pkg_resources               setuptools                         urllib3
__pycache__                                   certifi-2022.9.14-py3.10.egg-info  cryptography-37.0.4.dist-info       libfuturize              pyOpenSSL-22.0.0.dist-info  setuptools-65.3.0-py3.10.egg-info  urllib3-1.26.11.dist-info
_cffi_backend.cpython-38-x86_64-linux-gnu.so  cffi                               distutils-precedence.pth            libpasteurize            pycparser                   socks.py                           wheel
_distutils_hack                               cffi-1.15.1.dist-info              future                              past                     pycparser-2.21.dist-info    sockshandler.py                    wheel-0.37.1-py3.8.egg-info
```

The command `conda build h2o-client --output-folder "." --no-anaconda-upload --py 3.8 --channel conda-forge` finishes without error.