### PR TITLE
PUBDEV-8862: Switch to Java 17 (GraalVM) in H2O docker images (from Java 11/openjdk)

### DIFF
--- a/docker/public/Dockerfile-h2o-release
+++ b/docker/public/Dockerfile-h2o-release
@@ -9,11 +9,21 @@ LABEL "release"=${H2O_VERSION}
 LABEL "summary"="H2O Open Source Machine Learning platform"
 LABEL "description"="H2O is an Open Source, Distributed, Fast & Scalable Machine Learning Platform: Deep Learning, Gradient Boosting (GBM) & XGBoost, Random Forest, Generalized Linear Modeling (GLM with Elastic Net), K-Means, PCA, Generalized Additive Models (GAM), RuleFit, Support Vector Machine (SVM), Stacked Ensembles, Automatic Machine Learning (AutoML), etc."
 
-# Install OpenJDK 11 (to use JVM with "UseContainerSupport" flags)
 # Install libgomp - to enable XGBoost multithreading
-RUN microdnf install java-11-openjdk-headless \
+RUN microdnf install wget tar gzip \
     && microdnf install libgomp
 RUN microdnf clean all
+
+# Install Java 17 (GraalVM Community Edition 22.2.0)
+RUN wget -O /tmp/graalvm-ce.tar.gz https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.2.0/graalvm-ce-java17-linux-amd64-22.2.0.tar.gz \
+    && mkdir /tmp/graalvm/ \
+    && cd /tmp/graalvm/ \
+    && tar xfz /tmp/graalvm-ce.tar.gz \
+    && mkdir /opt/java/ \
+    && cp -r graalvm-ce-* /opt/java/ \
+    && cd /opt/java/graalvm-ce-* \
+    && /bin/bash -c 'for cmd in $(ls bin/); do alternatives --install /usr/bin/$cmd $cmd $PWD/bin/$cmd 1; done' \
+    && rm -r /tmp/graalvm-ce.tar.gz /tmp/graalvm/
 
 # Copy H2O-3 artifact into the container
 RUN mkdir -p /opt/h2oai/h2o-3/
@@ -21,7 +31,7 @@ COPY h2o.jar /opt/h2oai/h2o-3/
 
 # Extract native XGBoost libraries to avoid extract on H2O boot-up
 RUN mkdir /opt/h2oai/h2o-3/xgb_lib_dir \
-    && java --illegal-access=permit -cp /opt/h2oai/h2o-3/h2o.jar water.tools.XGBoostLibExtractTool /opt/h2oai/h2o-3/xgb_lib_dir
+    && java -cp /opt/h2oai/h2o-3/h2o.jar water.tools.XGBoostLibExtractTool /opt/h2oai/h2o-3/xgb_lib_dir
 
 # Copy project's license into the container (required by Red Hat for certification)
 RUN mkdir /licenses


### PR DESCRIPTION
This pull request switches our docker images to use Java 17 instead of Java 11. We used Java 11 originally because we needed JVM flags that were only available in Java 11 ("UseContainerSupport"). Java 11 had/has known performance issues (at the time of release was slower than Java 8) and Java 17 is much faster for workloads that we have, see eg: https://www.optaplanner.org/blog/2021/09/15/HowMuchFasterIsJava17.html

The choice of Java 17 is thus a nobrainer. The question is what distribution to select. In this PR I am proposing a switch to GraalVM. In benchmarks, GraalVM performs similarly or better on our reference benchmark dataset. The only issue is observed on Springleaf dataset where performance drops by 13% for 200 trees use case. This is definitely an outlier and looks like a result of targeted optimizations we did specifically to Springleaf that apply to openJDK but don't apply to GraalVM.

Other notable points:

GraalVM performs better in GLM on Higgs dataset:
```
train_time for higgs with solver = COORDINATE_DESCENT. The expected interval is 47..54. Actual value is 42.617
train_time for higgs with solver = IRLSM. The expected interval is 65..73. Actual value is 52.44
```
(We see similar improvements in GAM for Higgs, which is not surprising since GAM is based on GLM code).

Performance on GBM is similar with slight improvements on certain datasets. As noted only Springleaf 200 is problematic, Springleaf 50 performs as expected.

Full results: http://mr-0xc1:8080/view/H2O-3/job/h2o-3-benchmark-pipeline/job/michalk_graalvm-bench/5/

The other reason to switch to GraalVM is to be abe to use Polyglot API and leverage Python code inside JVM for ease up development and integration efforts (HAIC).
