### PR TITLE
ITA-1507: Add GraalVM to H2O benchmarks

### DIFF
--- a/docker/jenkins-images/Dockerfile-graalvm
+++ b/docker/jenkins-images/Dockerfile-graalvm
@@ -1,0 +1,13 @@
+# This is not part of the automated system (Will be fixed by https://h2oai.atlassian.net/browse/ITA-1506)
+# The corresponding image harbor.h2o.ai/opsh2oai/h2o-3/dev-r-3.5.3-graalvm-17:42 was build manually from this file
+
+
+FROM harbor.h2o.ai/opsh2oai/h2o-3/dev-r-3.5.3:42
+
+RUN \
+    wget https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.2.0/graalvm-ce-java17-linux-amd64-22.2.0.tar.gz && \
+    tar xfz graalvm-ce-java17-linux-amd64-22.2.0.tar.gz && \
+    rm graalvm-ce-java17-linux-amd64-22.2.0.tar.gz && \
+    mkdir /usr/opt/java-17-22.2.0/ && \
+    mv graalvm-ce-java17-22.2.0 /usr/opt/java-17-22.2.0/ && \
+    ln -s /usr/opt/java-17-22.2.0/graalvm-ce-java17-22.2.0 /usr/lib/jvm/java-17-graalvm

--- a/scripts/jenkins/groovy/compareBenchmarksStage.groovy
+++ b/scripts/jenkins/groovy/compareBenchmarksStage.groovy
@@ -320,6 +320,21 @@ def call(final pipelineContext, final stageConfig, final benchmarkFolderConfig) 
             ]
         ]    
     ]
+    // this is a starting point: we need to collect enough data to establish reasonable ranges first
+    // for the lower bound we just use 0, for the upper bound we use the upper bound of the regular 'gbm' benchmark
+    EXPECTED_VALUES['gbm-noscoring'] = new LinkedHashMap<String, LinkedHashMap<Serializable, LinkedHashMap<String, Integer>>>()
+    EXPECTED_VALUES['gbm'].each { dataset, cases ->
+        EXPECTED_VALUES['gbm-noscoring'][dataset] = [
+                50: [
+                        train_time_min: 0,
+                        train_time_max: cases[50].train_time_max
+                ],
+                200: [
+                        train_time_min: 0,
+                        train_time_max: cases[200].train_time_max
+                ]
+        ]
+    }
 
     def TESTED_COLUMNS = ['train_time']
 

--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -254,6 +254,24 @@ def call(final pipelineContext) {
       additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_R],
       customData: [algorithm: 'gbm'], makefilePath: pipelineContext.getBuildConfig().BENCHMARK_MAKEFILE_PATH,
       nodeLabel: pipelineContext.getBuildConfig().getBenchmarkNodeLabel(),
+      healthCheckSuppressed: true,
+    ],
+    [
+      stageName: 'GBM Benchmark noscoring-graalvm', executionScript: 'h2o-3/scripts/jenkins/groovy/benchmarkStage.groovy',
+      timeoutValue: 120, target: 'benchmark', component: pipelineContext.getBuildConfig().COMPONENT_ANY,
+      additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_R],
+      customData: [algorithm: 'gbm-noscoring'], makefilePath: pipelineContext.getBuildConfig().BENCHMARK_MAKEFILE_PATH,
+      nodeLabel: pipelineContext.getBuildConfig().getBenchmarkNodeLabel(),
+      healthCheckSuppressed: true,
+      image: 'harbor.h2o.ai/opsh2oai/h2o-3/dev-r-3.5.3-graalvm-17:42', // manually build, see Dockerfile-graalvm
+      javaVersion: 17
+    ],
+    [
+      stageName: 'GBM Benchmark noscoring-java8', executionScript: 'h2o-3/scripts/jenkins/groovy/benchmarkStage.groovy',
+      timeoutValue: 120, target: 'benchmark', component: pipelineContext.getBuildConfig().COMPONENT_ANY,
+      additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_R],
+      customData: [algorithm: 'gbm-noscoring'], makefilePath: pipelineContext.getBuildConfig().BENCHMARK_MAKEFILE_PATH,
+      nodeLabel: pipelineContext.getBuildConfig().getBenchmarkNodeLabel(),
       healthCheckSuppressed: true
     ],
     [


### PR DESCRIPTION
We want to see the performance of GraalVM in H2O benchmarks in addition to Java 8.

In prior experiments, GraalVM showed a better performance in all benchmarks, except for GBM. We want to monitor GBM performance as we expect to implement changes that will improve performance on GraalVM. 

For a correct comparison, we need to eliminate the non-deterministic behavior of the GBM benchmark (caused by time-based scoring). We add a new stage with in-training scoring disabled for both Java 8 (default) and GraalVM. This makes the timing comparable to each other.