### PR TITLE
Fix "relative redirect" tests [nocheck]

### DIFF
--- a/h2o-assemblies/main/tests/.lookup.txt
+++ b/h2o-assemblies/main/tests/.lookup.txt
@@ -1,0 +1,1 @@
+pyunit_redirect_relative.py

--- a/h2o-assemblies/main/tests/python/pyunit_redirect_relative.py
+++ b/h2o-assemblies/main/tests/python/pyunit_redirect_relative.py
@@ -2,17 +2,13 @@
 # -*- encoding: utf-8 -*-
 import sys
 import os
-sys.path.insert(1, os.path.join("../../../h2o-py"))
+sys.path.insert(1, os.path.join("../../../../h2o-py"))
 import h2o
 from tests import pyunit_utils
 import requests
 
 
 def redirect_relative():
-    if os.environ.get('JOB_NAME') and os.environ.get('JOB_NAME').startswith("h2o-3-kerberos-smoke-pipeline/"): 
-        h2o.log_and_echo("Skipping test 'redirect_relative' on Kerberos pipeline (it is not configured with form_auth)")
-        return
-
     conn = h2o.connection()
 
     # get default requests arguments
@@ -22,7 +18,7 @@ def redirect_relative():
 
     # invalidate authentication
     req_args["auth"] = None
-    req_args["headers"] = headers 
+    req_args["headers"] = headers
 
     response_flow = requests.request("GET", conn._base_url + "/flow/index.html", allow_redirects=False, **req_args)
     print(response_flow)

--- a/h2o-assemblies/main/tests/python/realm.properties
+++ b/h2o-assemblies/main/tests/python/realm.properties
@@ -1,0 +1,1 @@
+jenkins_user: jenkins_pwd42

--- a/h2o-bindings/bin/gen_all.py
+++ b/h2o-bindings/bin/gen_all.py
@@ -43,7 +43,7 @@ cloud = run.H2OCloud(
     jvm_opts=h2o_jvm_opts,
     output_dir=results_dir,
     test_ssl=False,
-    ldap_config_path=None,
+    login_config=None,
     strict_port=False
 )
 atexit.register(lambda: cloud.stop())

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -74,11 +74,17 @@ lookup-steam-assembly-tests: init-lookup
 	find h2o-py/tests -name '*s3*.py' -exec basename {} \; >>h2o-py/tests/.lookup.txt
 	cat tests/pyunitSmokeTestList >>h2o-py/tests/.lookup.txt
 
+lookup-main-assembly-tests:
+	find h2o-assemblies/main/tests -name '*.py' -exec basename {} \; > h2o-assemblies/main/tests/.lookup.txt
+
 lookup-persist-s3-tests: init-lookup
 	find h2o-py/tests/testdir_persist -name '*.py' -exec basename {} \; >>h2o-py/tests/.lookup.txt
 
 test-py-smoke:
 	export NO_GCE_CHECK=True && cd h2o-py/tests/ && ../../scripts/run.py --wipeall --geterrs --testlist ../../tests/pyunitSmokeTestList --numclouds 6 --jvm.xmx 3g
+
+test-py-smoke-main: lookup-main-assembly-tests
+	export NO_GCE_CHECK=True && cd h2o-assemblies/main/tests/ && ../../../scripts/run.py --wipeall --geterrs --testlist .lookup.txt --numclouds 1 --jvm.xmx 3g --h2ojar ../build/libs/main.jar --username jenkins_user --password jenkins_pwd42 --hash.config "$$PWD/python/realm.properties" --jvm.opts "-Dai.h2o.form_auth"
 
 test-py-smoke-minimal:
 	export NO_GCE_CHECK=True && cd h2o-py/tests/ && ../../scripts/run.py --wipeall --geterrs --testlist ../../tests/pyunitSmokeTestList --numclouds 6 --jvm.xmx 3g --h2ojar ../../h2o-assemblies/minimal/build/libs/minimal.jar 
@@ -259,6 +265,12 @@ test-package-gradle:
 	    -x h2o-web/* \
 	    -x h2o-bindings/* \
 	    -@
+
+test-package-main:
+	zip -q -r test-package-main \
+	    h2o-assemblies/main/build/libs/main.jar \
+	    h2o-assemblies/main/tests/python/ \
+		tests/leakCheckKeywords
 
 test-package-minimal:
 	zip -q -r test-package-minimal \

--- a/scripts/jenkins/groovy/buildConfig.groovy
+++ b/scripts/jenkins/groovy/buildConfig.groovy
@@ -36,9 +36,10 @@ class BuildConfig {
   // always run
   public static final String COMPONENT_ANY = 'any'
   public static final String COMPONENT_HADOOP = 'hadoop'
+  public static final String COMPONENT_MAIN = 'main'
   public static final String COMPONENT_MINIMAL = 'minimal' 
   public static final String COMPONENT_STEAM = 'steam'
-  public static final List<String> TEST_PACKAGES_COMPONENTS = [COMPONENT_PY, COMPONENT_R, COMPONENT_JS, COMPONENT_JAVA, COMPONENT_HADOOP, COMPONENT_MINIMAL, COMPONENT_STEAM]
+  public static final List<String> TEST_PACKAGES_COMPONENTS = [COMPONENT_PY, COMPONENT_R, COMPONENT_JS, COMPONENT_JAVA, COMPONENT_HADOOP, COMPONENT_MINIMAL, COMPONENT_STEAM, COMPONENT_MAIN]
 
   public static final String H2O_JAR_STASH_NAME = 'h2o-3-stash-jar'
   private static final String TEST_PACKAGE_STASH_NAME_PREFIX = 'h2o-3-stash'
@@ -56,7 +57,7 @@ class BuildConfig {
   public static final String MAKEFILE_PATH = 'scripts/jenkins/Makefile.jenkins'
   public static final String BENCHMARK_MAKEFILE_PATH = 'ml-benchmark/jenkins/Makefile.jenkins'
 
-  private static final List<String> STASH_ALWAYS_COMPONENTS = [COMPONENT_R, COMPONENT_MINIMAL, COMPONENT_STEAM]
+  private static final List<String> STASH_ALWAYS_COMPONENTS = [COMPONENT_R, COMPONENT_MINIMAL, COMPONENT_STEAM, COMPONENT_MAIN]
 
   private static final String JACOCO_GRADLE_OPT = 'jacocoCoverage'
 

--- a/scripts/jenkins/groovy/buildH2O3.groovy
+++ b/scripts/jenkins/groovy/buildH2O3.groovy
@@ -68,6 +68,13 @@ def call(final pipelineContext) {
                                 activatePythonEnv = true
                             }
                             makeTarget(pipelineContext) {
+                                target = 'test-package-main'
+                                hasJUnit = false
+                                archiveFiles = false
+                                makefilePath = pipelineContext.getBuildConfig().MAKEFILE_PATH
+                                activatePythonEnv = true
+                            }
+                            makeTarget(pipelineContext) {
                                 target = 'test-package-minimal'
                                 hasJUnit = false
                                 archiveFiles = false

--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -74,6 +74,11 @@ def call(final pipelineContext) {
   // for Python, mainly test with latest supported version
   def PR_STAGES = [
     [
+      stageName: 'Py3.7 Smoke (Main Assembly)', target: 'test-py-smoke-main', pythonVersion: '3.7', timeoutValue: 8,
+      component: pipelineContext.getBuildConfig().COMPONENT_PY,
+      additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_MAIN]
+    ],
+    [
       stageName: 'Py3.7 Smoke (Minimal Assembly)', target: 'test-py-smoke-minimal', pythonVersion: '3.7', timeoutValue: 8,
       component: pipelineContext.getBuildConfig().COMPONENT_PY,
       additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_MINIMAL]


### PR DESCRIPTION
Run the "redirect_relative" test only on the main assembly
    
This is the only assembly that supports relative redirects.
    
Other (specifically Hadoop) assemblies do not have the needed Jetty classes override since the approach was changed in https://github.com/h2oai/h2o-3/pull/6308
