### PR TITLE
[nocheck] White list "checking for future file timestamps" in python

### DIFF
--- a/scripts/validate_r_cmd_check_output.py
+++ b/scripts/validate_r_cmd_check_output.py
@@ -96,7 +96,9 @@ class Check:
             r"^\* checking Rd cross-references ... NOTE",
             r"^Package unavailable to check Rd xrefs*",
             r"^Status: 3 NOTEs",
-            r"^Status: 4 NOTEs"
+            r"^Status: 4 NOTEs",
+            r"^\* checking for future file timestamps ... NOTE",
+            r"^unable to verify current time",
             ]
 
         s = f.readline()


### PR DESCRIPTION
For some reason we have two validation scripts one in R and one in Python. Now the failure is caused by the script in Python (`scripts/validate_r_cmd_check_output.py`). 
This wasn’t a problem until I [removed](https://github.com/h2oai/h2o-3/pull/6300) the `|| true` in the Makefile to stop ignoring the exit code of the python validation script. 