### PR TITLE
PUBDEV-8870: added missing "introduction" headers

### DIFF
--- a/h2o-docs/src/product/data-science/anova_glm.rst
+++ b/h2o-docs/src/product/data-science/anova_glm.rst
@@ -1,6 +1,9 @@
 ANOVA GLM
 ---------
 
+Introduction
+~~~~~~~~~~~~
+
 H2O ANOVA GLM is used to calculate Type III SS (sum of squares) which is used to investigate the contributions of individual predictors and their interactions to a model. Predictors or interactions with negligible contributions to the model will have high p-values while those with more contributions will have low p-values. We use predictors to express individual predictors or interactions of predictors.
 
 Since ANOVA GLM is mainly used to investigate the contribution of each predictor or interaction, scoring, MOJO, and cross-validation are not supported. 

--- a/h2o-docs/src/product/data-science/coxph.rst
+++ b/h2o-docs/src/product/data-science/coxph.rst
@@ -1,6 +1,9 @@
 Cox Proportional Hazards (CoxPH)
 --------------------------------
 
+Introduction
+~~~~~~~~~~~~
+
 Cox proportional hazards models are the most widely used approach for modeling time to event data. As the name suggests, the *hazard function*, which computes the instantaneous rate of an event occurrence and is expressed mathematically as
 
 :math:`h(t) = \lim_{\Delta t \downarrow 0} \frac{Pr[t \le T < t + \Delta t \mid T \ge t]}{\Delta t},`

--- a/h2o-docs/src/product/data-science/model_selection.rst
+++ b/h2o-docs/src/product/data-science/model_selection.rst
@@ -1,6 +1,9 @@
 ModelSelection
 --------------
 
+Introduction
+~~~~~~~~~~~~
+
 We implemented the ModelSelection toolbox based on GLM at H2O to help users select the best predictor subsets from their dataset for model building. We have currently implemented four modes to select the predictor subsets:
 
 1. ``mode = "allsubsets"`` where all possible combinations of predictor subsets are generated for a given subset size. A model is built for each subset and the one with the highest :math:`R^2` is returned. The best subsets are also returned for subset size :math:`1, 2, ..., n`. This mode guarantees to return the predictor subset with the highest :math:`R^2` value at the cost of computation complexity.


### PR DESCRIPTION
For: [PUBDEV-8870](https://h2oai.atlassian.net/browse/PUBDEV-8870)

I noticed that the header casing was off on CoxPH and ModelSelection due to adding the MOJO support section. This also threw off the side nav. I added an "Introduction" header to the algo pages missing it. Slightly more uniform and fixed the problem.