### PR TITLE
PUBDEV-8051: Add params slot to R

### DIFF
--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -426,8 +426,8 @@ Once you have retreived the model in R or Python, you can inspect the model para
 .. tabs::
    .. code-tab:: r R
 
-        # View the non-default parameter values for the XGBoost model above
-        xgb@parameters
+        # View the parameter values for the XGBoost model selected above
+        xgb@params$actual
 
    .. code-tab:: python
 

--- a/h2o-docs/src/product/data-science/algo-params/checkpoint.rst
+++ b/h2o-docs/src/product/data-science/algo-params/checkpoint.rst
@@ -122,7 +122,7 @@ Example
         # more trees, so set ntrees = 50
 
         # to see how many trees the original model built you can look at the `ntrees` attribute
-        print(paste("Number of trees built for cars_gbm model:", cars_gbm@allparameters$ntrees))
+        print(paste("Number of trees built for cars_gbm model:", cars_gbm@params$actual$ntrees))
         [1] "Number of trees built for cars_gbm model: 1"
 
         # build and train model with 49 additional trees for a total of 50 trees:

--- a/h2o-docs/src/product/tutorials/datascience/DataScienceH2O-Dev.md
+++ b/h2o-docs/src/product/tutorials/datascience/DataScienceH2O-Dev.md
@@ -1902,7 +1902,7 @@ fit@model$cross_validation_predictions$name
 # Each fold's preds are stored in a N x 1 col, where the row values for non-active folds are set to zero
 # So we will compress this into a single 1-col H2O Frame (easier to digest)
 
-nfolds <- fit@parameters$nfolds
+nfolds <- fit@params$actual$nfolds
 predlist <- sapply(1:nfolds, function(v) h2o.getFrame(fit@model$cross_validation_predictions[[v]]$name)$predict, simplify = FALSE)
 cvpred_sparse <- h2o.cbind(predlist)  # N x V Hdf with rows that are all zeros, except corresponding to the v^th fold if that rows is associated with v
 pred <- apply(cvpred_sparse, 1, sum)  # These are the cross-validated predicted cluster IDs for each of the 1:N observations
@@ -1914,7 +1914,7 @@ This can be extended to other family types as well (multinomial, binomial, regre
 # helper function
 .compress_to_cvpreds <- function(h2omodel, family) {
   # return the frame_id of the resulting 1-col Hdf of cvpreds for learner l
-  V <- h2omodel@allparameters$nfolds
+  V <- h2omodel@params$actual$nfolds
   if (family %in% c("bernoulli", "binomial")) {
     predlist <- sapply(1:V, function(v) h2o.getFrame(h2omodel@model$cross_validation_predictions[[v]]$name)[,3], simplify = FALSE)
   } else {

--- a/h2o-docs/src/product/tutorials/gbm/gbmTuning.Rmd
+++ b/h2o-docs/src/product/tutorials/gbm/gbmTuning.Rmd
@@ -505,7 +505,7 @@ gbm@parameters
 ```
 
 ```
-> gbm@parameters
+> gbm@params$actual
 $model_id
 [1] "final_grid_model_45"
 
@@ -589,7 +589,7 @@ Now we can confirm that these parameters are generally sound, by building a GBM 
 model <- do.call(h2o.gbm,
         ## update parameters in place
         {
-          p <- gbm@parameters
+          p <- gbm@params$actual
           p$model_id = NULL          ## do not overwrite the original grid model
           p$training_frame = df      ## use the full dataset
           p$validation_frame = NULL  ## no validation frame
@@ -634,7 +634,7 @@ for (i in 1:5) {
   cvgbm <- do.call(h2o.gbm,
         ## update parameters in place
         {
-          p <- gbm@parameters
+          p <- gbm@params$actual
           p$model_id = NULL          ## do not overwrite the original grid model
           p$training_frame = df      ## use the full dataset
           p$validation_frame = NULL  ## no validation frame

--- a/h2o-r/h2o-package/R/classes.R
+++ b/h2o-r/h2o-package/R/classes.R
@@ -68,25 +68,34 @@ setRefClass("H2OConnectionMutableState",
 #' @aliases H2OConnection
 #' @export
 setClass("H2OConnection",
-         representation(ip="character", port="numeric", name="character", proxy="character",
-                        https="logical", cacert="character", insecure="logical",
-                        username="character", password="character", use_spnego="logical",
-                        cookies="character",
-                        context_path="character",
-                        mutable="H2OConnectionMutableState"),
-         prototype(ip           = NA_character_,
-                   port         = NA_integer_,
-                   name         = NA_character_,
-                   proxy        = NA_character_,
-                   https        = FALSE,
-                   cacert       = NA_character_,
-                   insecure     = FALSE,
-                   username     = NA_character_,
-                   password     = NA_character_,
-                   use_spnego   = FALSE,
-                   cookies      = NA_character_,
-                   context_path = NA_character_,
-                   mutable      = new("H2OConnectionMutableState")))
+         slots = c(
+           ip = "character",
+           port = "numeric",
+           name = "character",
+           proxy = "character",
+           https = "logical",
+           cacert = "character",
+           insecure = "logical",
+           username = "character",
+           password = "character",
+           use_spnego = "logical",
+           cookies = "character",
+           context_path = "character",
+           mutable = "H2OConnectionMutableState"),
+         prototype = c(
+           ip = NA_character_,
+           port = NA_integer_,
+           name = NA_character_,
+           proxy = NA_character_,
+           https = FALSE,
+           cacert = NA_character_,
+           insecure = FALSE,
+           username = NA_character_,
+           password = NA_character_,
+           use_spnego = FALSE,
+           cookies = NA_character_,
+           context_path = NA_character_,
+           mutable = new("H2OConnectionMutableState")))
 
 setClassUnion("H2OConnectionOrNULL", c("H2OConnection", "NULL"))
 
@@ -389,7 +398,7 @@ setMethod("show", "H2OCoxPHModel", function(object) {
 #' @slot summary A \code{list} containing the a summary compatible with CoxPH summary used in the survival package.
 #' @aliases H2OCoxPHModelSummary
 #' @export
-setClass("H2OCoxPHModelSummary", representation(summary="list"))
+setClass("H2OCoxPHModelSummary", slots = c(summary = "list"))
 
 #' @rdname H2OCoxPHModelSummary-class
 #' @param object An \code{H2OCoxPHModelSummary} object.
@@ -588,9 +597,14 @@ setMethod("getClusterSizes", "H2OClusteringModel", function(object) { object@mod
 #' @aliases H2OModelMetrics
 #' @export
 setClass("H2OModelMetrics",
-         representation(algorithm="character", on_train="logical", on_valid="logical", on_xval="logical", metrics="listOrNull"),
-         prototype(algorithm=NA_character_, on_train=FALSE, on_valid=FALSE, on_xval=FALSE, metrics=NULL),
-         contains="VIRTUAL")
+          slots = c(
+            algorithm = "character",
+            on_train = "logical",
+            on_valid = "logical",
+            on_xval = "logical",
+            metrics = "listOrNull"),
+         prototype = c(algorithm = NA_character_, on_train = FALSE, on_valid = FALSE, on_xval = FALSE, metrics = NULL),
+         contains = "VIRTUAL")
 
 #' @rdname H2OModelMetrics-class
 #' @param object An \code{H2OModelMetrics} object
@@ -831,7 +845,7 @@ setClass("H2OTargetEncoderMetrics", contains="H2OModelMetrics")
 #' @slot model_id the final identifier for the model
 #' @seealso \linkS4class{H2OModel} for the final model types.
 #' @export
-setClass("H2OModelFuture", representation(job_key="character", model_id="character"))
+setClass("H2OModelFuture", slots = c(job_key = "character", model_id = "character"))
 
 #' H2O Future Segment Models
 #'
@@ -840,14 +854,14 @@ setClass("H2OModelFuture", representation(job_key="character", model_id="charact
 #' @slot segment_models_id the final identifier for the segment models collections
 #' @seealso \linkS4class{H2OSegmentModels} for the final segment models types.
 #' @export
-setClass("H2OSegmentModelsFuture", representation(job_key="character", segment_models_id="character"))
+setClass("H2OSegmentModelsFuture", slots = c(job_key = "character", segment_models_id = "character"))
 
 #' H2O Segment Models
 #'
 #' A class to contain the information for segment models.
 #' @slot segment_models_id the  identifier for the segment models collections
 #' @export
-setClass("H2OSegmentModels", representation(segment_models_id="character"))
+setClass("H2OSegmentModels", slots = c(segment_models_id = "character"))
 
 #' H2O Grid
 #'
@@ -865,14 +879,16 @@ setClass("H2OSegmentModels", representation(segment_models_id="character"))
 #' @seealso \linkS4class{H2OModel} for the final model types.
 #' @aliases H2OGrid
 #' @export
-setClass("H2OGrid", representation(grid_id = "character",
-                                   model_ids = "list",
-                                   hyper_names = "list",
-                                   failed_params = "list",
-                                   failure_details = "list",
-                                   failure_stack_traces = "list",
-                                   failed_raw_params = "matrix",
-                                   summary_table = "ANY"))
+setClass("H2OGrid",
+         slots = c(
+           grid_id = "character",
+           model_ids = "list",
+           hyper_names = "list",
+           failed_params = "list",
+           failure_details = "list",
+           failure_stack_traces = "list",
+           failed_raw_params = "matrix",
+           summary_table = "ANY"))
 
 #' @rdname h2o.keyof
 setMethod("h2o.keyof", signature("H2OGrid"), function(object) object@grid_id)

--- a/h2o-r/h2o-package/R/classes.R
+++ b/h2o-r/h2o-package/R/classes.R
@@ -132,15 +132,24 @@ setMethod("h2o.keyof", signature(object = "Keyed"), function(object) {
 #' @slot algorithm A \code{character} string specifying the algorithm that were used to fit the model.
 #' @slot parameters A \code{list} containing the parameter settings that were used to fit the model that differ from the defaults.
 #' @slot allparameters A \code{list} containg all parameters used to fit the model.
+#' @slot params A \code{list} containing default, set, and actual parameters.
 #' @slot have_pojo A \code{logical} indicating whether export to POJO is supported
 #' @slot have_mojo A \code{logical} indicating whether export to MOJO is supported
 #' @slot model A \code{list} containing the characteristics of the model returned by the algorithm.
 #' @aliases H2OModel
 #' @export
 setClass("H2OModel",
-         representation(model_id="character", algorithm="character", parameters="list", allparameters="list", have_pojo="logical", have_mojo="logical", model="list"),
-         prototype(model_id=NA_character_),
-         contains=c("Keyed","VIRTUAL"))
+         slots =  c(
+           model_id = "character",
+           algorithm = "character",
+           parameters = "list",
+           allparameters = "list",
+           params = "list",
+           have_pojo = "logical",
+           have_mojo = "logical",
+           model = "list"),
+         prototype = c(model_id = NA_character_),
+         contains = c("Keyed", "VIRTUAL"))
 
 # TODO: make a more model-specific constructor
 .newH2OModel <- function(Class, model_id, ...) {

--- a/h2o-r/h2o-package/R/classes.R
+++ b/h2o-r/h2o-package/R/classes.R
@@ -82,7 +82,7 @@ setClass("H2OConnection",
            cookies = "character",
            context_path = "character",
            mutable = "H2OConnectionMutableState"),
-         prototype = c(
+         prototype = prototype(
            ip = NA_character_,
            port = NA_integer_,
            name = NA_character_,
@@ -157,7 +157,7 @@ setClass("H2OModel",
            have_pojo = "logical",
            have_mojo = "logical",
            model = "list"),
-         prototype = c(model_id = NA_character_),
+         prototype = prototype(model_id = NA_character_),
          contains = c("Keyed", "VIRTUAL"))
 
 # TODO: make a more model-specific constructor
@@ -603,7 +603,7 @@ setClass("H2OModelMetrics",
             on_valid = "logical",
             on_xval = "logical",
             metrics = "listOrNull"),
-         prototype = c(algorithm = NA_character_, on_train = FALSE, on_valid = FALSE, on_xval = FALSE, metrics = NULL),
+         prototype = prototype(algorithm = NA_character_, on_train = FALSE, on_valid = FALSE, on_xval = FALSE, metrics = NULL),
          contains = "VIRTUAL")
 
 #' @rdname H2OModelMetrics-class

--- a/h2o-r/h2o-package/R/kvstore.R
+++ b/h2o-r/h2o-package/R/kvstore.R
@@ -337,12 +337,34 @@ h2o.getModel <- function(model_id) {
   allparams$response_column <- NULL
   parameters$ignored_columns <- NULL
   parameters$response_column <- NULL
+
+
+  params_to_select <- list(
+    model_id = "name",
+    response_column = "column_name",
+    training_frame = "name",
+    validation_frame = "name"
+  )
+  params <- list(actual=list(), default=list(), input=list())
+  for (p in json$parameters) {
+    if (p$name %in% names(params_to_select)) {
+      params[["actual"]][[p$name]] <- p[["actual_value"]][[params_to_select[[p$name]]]]
+      params[["default"]][[p$name]] <- p[["default_value"]][[params_to_select[[p$name]]]]
+      params[["input"]][[p$name]] <- p[["input_value"]][[params_to_select[[p$name]]]]
+    } else {
+      params[["actual"]][[p$name]] <- p[["actual_value"]]
+      params[["default"]][[p$name]] <- p[["default_value"]]
+      params[["input"]][[p$name]] <- p[["input_value"]]
+    }
+  }
+
   if (identical("glm", json$algo) && allparams$HGLM) {
     .newH2OModel(Class         = Class,
                  model_id      = model_id,
                  algorithm     = json$algo,
                  parameters    = parameters,
                  allparameters = allparams,
+                 params        = params,
                  have_pojo     = FALSE,
                  have_mojo     = FALSE,
                  model         = model)
@@ -352,6 +374,7 @@ h2o.getModel <- function(model_id) {
                algorithm     = json$algo,
                parameters    = parameters,
                allparameters = allparams,
+               params        = params,
                have_pojo     = json$have_pojo,
                have_mojo     = json$have_mojo,
                model         = model)

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -5696,7 +5696,7 @@ h2o.deepfeatures <- function(object, data, layer) {
 #'
 #' #' @aliases H2ONode
 #'
-setClass("H2ONode", representation(
+setClass("H2ONode", slots = c(
   id = "integer"
 ))
 
@@ -5707,7 +5707,7 @@ setClass("H2ONode", representation(
 #'
 #' #' @aliases H2OLeafNode
 #'
-setClass("H2OLeafNode", representation(
+setClass("H2OLeafNode", slots = c(
   prediction = "numeric"
 ),
 contains = "H2ONode")
@@ -5727,7 +5727,7 @@ contains = "H2ONode")
 #' @export
 setClass(
   "H2OSplitNode",
-  representation(
+  slots = c(
     threshold = "numeric",
     left_child = "H2ONode",
     right_child = "H2ONode",
@@ -5798,7 +5798,7 @@ print.H2ONode <- function(node){
 #' @export
 setClass(
   "H2OTree",
-  representation(
+  slots = c(
     root_node = "H2ONode",
     left_children = "integer",
     right_children = "integer",


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8051

This PR consists of 
1) `@params` slot with `actual`, `default`, `input` fields with the same logic as in python
2) update the documentation
3) change `representation(...)` to `slots = c(...)`  in `setClass`; `representation(...)` was deprecated in R 3.0 (https://stat.ethz.ch/R-manual/R-devel/library/methods/html/setClass.html)