### PR TITLE
PUBDEV-8879: removed SW booklet from download page

### DIFF
--- a/h2o-dist/buildinfo.json
+++ b/h2o-dist/buildinfo.json
@@ -276,11 +276,6 @@
             "name" : "Python",
             "id"   : "booklet-python",
             "path" : "docs-website/h2o-docs/booklets/PythonBooklet.pdf"
-        },
-        {
-            "name" : "Sparkling Water",
-            "id"   : "booklet-sparklingwater",
-            "path" : "docs-website/h2o-docs/booklets/SparklingWaterBooklet.pdf"
         }
     ]
 }


### PR DESCRIPTION
For: [PUBDEV-8879](https://h2oai.atlassian.net/browse/PUBDEV-8879)

I believe this is is the only place I need to remove it from. Please let me know if I'm missing/need to change anything.