### PR TITLE
PUBDEV-8865: GAM failed with numknots=2 for I-spline

### DIFF
--- a/h2o-algos/src/main/java/hex/gam/GAM.java
+++ b/h2o-algos/src/main/java/hex/gam/GAM.java
@@ -466,6 +466,7 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
     Frame adaptTrain() {
       int numGamFrame = _parms._gam_columns.length;
       _zTranspose = GamUtils.allocate3DArray(numGamFrame, _parms, firstOneLess);  // for centering for all smoothers 
+      zeroOutIStranspose(_parms._bs_sorted, _zTranspose);
       _penaltyMat = _parms._savePenaltyMat?GamUtils.allocate3DArray(numGamFrame, _parms, sameOrig):null;
       _penaltyMatCenter = GamUtils.allocate3DArray(numGamFrame, _parms, bothOneLess);
       removeCenteringIS(_penaltyMatCenter, _parms);
@@ -628,7 +629,6 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
         Frame oneGamifiedColumn = oneGAMCol.outputFrame(Key.make(), _newGAMColNames, null);
         for (int index=0; index<numBasis; index++)
           _gamColMeans[_gamColIndex][index] = oneGamifiedColumn.vec(index).mean();
-        copy2DArray(generateZTransp(oneGamifiedColumn, numBasis), _zTranspose[_gamColIndex]); // copy transpose(Z)
         DKV.put(oneGamifiedColumn);
         _gamFrameKeysCenter[_gamColIndex] = oneGamifiedColumn._key;
         System.arraycopy(oneGamifiedColumn.names(), 0, _gamColNamesCenter[_gamColIndex], 0,
@@ -676,7 +676,7 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
         for (int index = 0; index < _numKnots; index++)
           _gamColMeans[_gamColIndex][index] = oneAugmentedColumnCenter.vec(index).mean();
         oneAugmentedColumnCenter = genOneGamCol.centralizeFrame(oneAugmentedColumnCenter,
-                _predictVec.name(0) + "_" + _splineType + "_center", _parms);
+                _predictVec.name(0) + "_" + _splineType + "_center_cs_", _parms);
         copy2DArray(genOneGamCol._ZTransp, _zTranspose[_gamColIndex]); // copy transpose(Z)
         double[][] transformedPenalty = ArrayUtils.multArrArr(ArrayUtils.multArrArr(genOneGamCol._ZTransp,
                 genOneGamCol._penaltyMat), ArrayUtils.transpose(genOneGamCol._ZTransp));  // transform penalty as zt*S*z

--- a/h2o-algos/src/main/java/hex/gam/GamSplines/ThinPlateDistanceWithKnots.java
+++ b/h2o-algos/src/main/java/hex/gam/GamSplines/ThinPlateDistanceWithKnots.java
@@ -92,7 +92,7 @@ public class ThinPlateDistanceWithKnots extends MRTask<ThinPlateDistanceWithKnot
             false, false, false, false, null);
     // expand the frame with k-M columns which will contain the product of Xnmd*ZCS
     for (int colInd = 0; colInd < newColNum; colInd++) {
-      fr.add(colNameStart+"_cs_"+colInd, fr.anyVec().makeZero());
+      fr.add(colNameStart+"_tp_"+colInd, fr.anyVec().makeZero());
     }
     new BMulInPlaceTask(frInfo, zCST, numCols, false).doAll(fr);
     for (int index=0; index < numCols; index++) { // remove the original gam columns

--- a/h2o-algos/src/main/java/hex/gam/MatrixFrameUtils/GAMModelUtils.java
+++ b/h2o-algos/src/main/java/hex/gam/MatrixFrameUtils/GAMModelUtils.java
@@ -21,7 +21,7 @@ public class GAMModelUtils {
             +gamNoCenterCoeffLength(parms);
     model._output._coefficient_names_no_centering = new String[totCoefNumsNoCenter]; // copy coefficient names from GLM to GAM
     int gamNumStart = copyGLMCoeffNames2GAMCoeffNames(model, glm);
-    copyGLMCoeffs2GAMCoeffs(model, glm, parms._family, gamNumStart, nclass); // obtain beta without centering
+    copyGLMCoeffs2GAMCoeffs(model, glm, parms._family, gamNumStart, nclass, parms._intercept); // obtain beta without centering
     // copy over GLM coefficients
     int glmCoeffLen = glm._output._coefficient_names.length;
     model._output._coefficient_names = new String[glmCoeffLen];
@@ -59,9 +59,9 @@ public class GAMModelUtils {
     int numGam = parms._gam_columns.length;
     int gamifiedColCount = 0;
     for (int index = 0; index < numGam; index++) {
-      if (parms._bs_sorted[index]==0 || parms._bs_sorted[index]==2) { // cubic spline
+      if (parms._bs_sorted[index]==0) { // cubic spline, I-spline coeff length stays the same because no centering
         gamifiedColCount++;
-      } else {
+      } else if (parms._bs_sorted[index] == 1){ // for thin-plate
         gamifiedColCount += (1+parms._M[tpCount++]);
       }
     }
@@ -204,7 +204,7 @@ public class GAMModelUtils {
   }
 
   public static void copyGLMCoeffs2GAMCoeffs(GAMModel model, GLMModel glm, GLMParameters.Family family,
-                                             int gamNumStart, int nclass) {
+                                             int gamNumStart, int nclass, boolean hasIntercept) {
     int numCoeffPerClass = model._output._coefficient_names_no_centering.length;
     if (family.equals(GLMParameters.Family.multinomial) || family.equals(GLMParameters.Family.ordinal)) {
       double[][] model_beta_multinomial = glm._output.get_global_beta_multinomial();
@@ -213,39 +213,56 @@ public class GAMModelUtils {
       model._output._standardized_model_beta_multinomial_no_centering = new double[nclass][];
       for (int classInd = 0; classInd < nclass; classInd++) {
         model._output._model_beta_multinomial_no_centering[classInd] = convertCenterBeta2Beta(model._output._zTranspose,
-                gamNumStart, model_beta_multinomial[classInd], numCoeffPerClass);
+                gamNumStart, model_beta_multinomial[classInd], numCoeffPerClass, model._output._gamColNames, hasIntercept);
         model._output._standardized_model_beta_multinomial_no_centering[classInd] = convertCenterBeta2Beta(model._output._zTranspose,
-                gamNumStart, standardized_model_beta_multinomial[classInd], numCoeffPerClass);
+                gamNumStart, standardized_model_beta_multinomial[classInd], numCoeffPerClass, model._output._gamColNames, hasIntercept);
       }
     } else {  // other families
       model._output._model_beta_no_centering = convertCenterBeta2Beta(model._output._zTranspose, gamNumStart,
-              glm.beta(), numCoeffPerClass);
+              glm.beta(), numCoeffPerClass, model._output._gamColNames, hasIntercept);
       model._output._standardized_model_beta_no_centering = convertCenterBeta2Beta(model._output._zTranspose, gamNumStart,
-              glm._output.getNormBeta(), numCoeffPerClass);
+              glm._output.getNormBeta(), numCoeffPerClass, model._output._gamColNames, hasIntercept);
     }
   }
 
   // This method carries out the evaluation of beta = Z betaCenter as explained in documentation 7.2
   public static double[] convertCenterBeta2Beta(double[][][] ztranspose, int gamNumStart, double[] centerBeta,
-                                                int betaSize) {
+                                                int betaSize, String[][] gamColNames, boolean hasIntercept) {
     double[] originalBeta = new double[betaSize];
     if (ztranspose!=null) { // centering is performed
       int numGamCols = ztranspose.length;
       int gamColStart = gamNumStart;
       int origGamColStart = gamNumStart;
       System.arraycopy(centerBeta,0, originalBeta, 0, gamColStart);   // copy everything before gamCols
+      int numGamCoef;
       for (int colInd=0; colInd < numGamCols; colInd++) {
+        numGamCoef = gamColNames[colInd].length;
         double[] tempCbeta = new double[ztranspose[colInd].length];
-        System.arraycopy(centerBeta, gamColStart, tempCbeta, 0, tempCbeta.length);
-        double[] tempBeta = ArrayUtils.multVecArr(tempCbeta, ztranspose[colInd]);
-        System.arraycopy(tempBeta, 0, originalBeta, origGamColStart, tempBeta.length);
-        gamColStart += tempCbeta.length;
-        origGamColStart += tempBeta.length;
+        if (tempCbeta.length > 0) {
+          System.arraycopy(centerBeta, gamColStart, tempCbeta, 0, tempCbeta.length);
+          double[] tempBeta = ArrayUtils.multVecArr(tempCbeta, ztranspose[colInd]);
+          System.arraycopy(tempBeta, 0, originalBeta, origGamColStart, tempBeta.length);
+          gamColStart += tempCbeta.length;
+          origGamColStart += tempBeta.length;
+        } else { // no centering needed for these GAM coefficients
+          System.arraycopy(centerBeta, gamColStart, originalBeta, origGamColStart, numGamCoef);
+          origGamColStart += numGamCoef;
+          gamColStart += numGamCoef;
+        }
       }
-      originalBeta[betaSize-1]=centerBeta[centerBeta.length-1];
-    } else
+      if (hasIntercept)
+        originalBeta[betaSize-1]=centerBeta[centerBeta.length-1];
+    } else {  // no centering for all gam columns
       System.arraycopy(centerBeta, 0, originalBeta, 0, betaSize); // no change needed, just copy over
+    }
 
     return originalBeta;
+  }
+
+  public static void zeroOutIStranspose(int[] bs_sorted, double[][][] zTranspose) {
+    int numGam = bs_sorted.length;
+    for (int index=0; index<numGam; index++)
+      if (bs_sorted[index] == 2)
+        zTranspose[index] = new double[0][0];
   }
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamMojoReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamMojoReader.java
@@ -92,11 +92,17 @@ public class GamMojoReader extends ModelMojoReader<GamMojoModelBase> {
     int[] numKnotsM1 = subtract(_model._num_knots_sorted, 1);
     int numKnotsLen = numKnotsM1.length;
     int isCounter=0;
-    for (int index=0; index<numKnotsLen; index++)
-      if (_model._bs_sorted[index] == 2)
+    int[] zSecondDim = new int[numKnotsLen];
+    for (int index=0; index<numKnotsLen; index++) {
+      if (_model._bs_sorted[index] == 2) {
         numKnotsM1[index] = _model._numBasisSize[isCounter++];
+        zSecondDim[index] = 0;
+      } else {
+        zSecondDim[index] = numKnotsM1[index];
+      }
+    }
     _model._gamColNamesCenter = read2DStringArrays(numKnotsM1, "gamColNamesCenter");
-    _model._zTranspose = read3DArray("zTranspose", _model._num_gam_columns, numKnotsM1, _model._num_knots_sorted);
+    _model._zTranspose = read3DArray("zTranspose", _model._num_gam_columns, zSecondDim, _model._num_knots_sorted);
     _model._knots = read3DArray("knots", _model._num_gam_columns, _model._gamPredSize, _model._num_knots_sorted);
     if (_model._numCSCol > 0) {
       int[] numKnotsM2 = subtract(_model._num_knots_sorted, 2);

--- a/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_8865_spline_coeffs.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_8865_spline_coeffs.py
@@ -1,0 +1,46 @@
+from __future__ import division
+from __future__ import print_function
+import sys, os
+
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gam import H2OGeneralizedAdditiveEstimator
+
+def test_GAM_coeffs_check():
+    h2o_data = h2o.import_file(path=pyunit_utils.locate("smalldata/glm_test/binomial_20_cols_10KRows.csv"))
+    h2o_data["C1"] = h2o_data["C1"].asfactor()
+    h2o_data["C2"] = h2o_data["C2"].asfactor()
+    h2o_data["C3"] = h2o_data["C3"].asfactor()
+    h2o_data["C4"] = h2o_data["C4"].asfactor()
+    h2o_data["C5"] = h2o_data["C5"].asfactor()
+    h2o_data["C6"] = h2o_data["C6"].asfactor()
+    h2o_data["C7"] = h2o_data["C7"].asfactor()
+    h2o_data["C8"] = h2o_data["C8"].asfactor()
+    h2o_data["C9"] = h2o_data["C9"].asfactor()
+    h2o_data["C10"] = h2o_data["C10"].asfactor()
+    myY = "C21"
+    h2o_data["C21"] = h2o_data["C21"].asfactor()
+    names = h2o_data.names
+    myX = names.remove(myY)
+    # build the GAM model
+    h2o_model = H2OGeneralizedAdditiveEstimator(family='binomial', bs=[0, 1, 2, 2, 2], seed=9, spline_orders = [1,1,3,1,2], 
+                                                gam_columns=["C11", "C12", "C13", "C14", "C15"], )
+    h2o_model.train(x=myX, y=myY, training_frame=h2o_data)
+    # check and make sure coefficients regarding I-spline parameters are the same from coefficients that are centered
+    # and non-centered.
+    gam_is_coef_names = ["C13_is_0", "C13_is_1", "C13_is_2", "C14_is_0", "C15_is_0", "C15_is_1"]
+    model_coef = h2o_model.coef()
+    gam_coef_table = h2o_model._model_json["output"]["coefficients_table_no_centering"]._cell_values
+    table_len = len(gam_coef_table);
+    for cName in gam_is_coef_names:
+        for index in range(0, table_len):
+            if gam_coef_table[index][0] == cName:
+                coef_val = gam_coef_table[index][1]
+                assert abs(coef_val-model_coef[cName]) < 1e-6, "Expected coeff: {0}, actual: " \
+                                                               "{1}".format(model_coef[cName], coef_val)
+   
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_GAM_coeffs_check)
+else:
+    test_GAM_coeffs_check()

--- a/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_8865_two_knots_fail.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_8865_two_knots_fail.py
@@ -6,8 +6,9 @@ import h2o
 from tests import pyunit_utils
 from h2o.estimators.gam import H2OGeneralizedAdditiveEstimator
 
+# test taken from Narasimha Durgam
 def test_2_knots():
-    train = h2o.import_file(pyunit_utils.locate("smalldata/gam_test/dataset-37830.csv"))
+    train = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/gam_test/dataset-37830.csv")
     y = "wage"
     x = ["year","age"]
 

--- a/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_8865_two_knots_fail.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_8865_two_knots_fail.py
@@ -1,0 +1,29 @@
+from __future__ import division
+from __future__ import print_function
+import sys, os
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gam import H2OGeneralizedAdditiveEstimator
+
+def test_2_knots():
+    train = h2o.import_file(pyunit_utils.locate("smalldata/gam_test/dataset-37830.csv"))
+    y = "wage"
+    x = ["year","age"]
+
+    # build the GAM model
+    h2o_model = H2OGeneralizedAdditiveEstimator(family='gaussian', bs=[2], gam_columns=["age"], seed=9, 
+                                                spline_orders = [1], num_knots = [2])
+    h2o_model.train(x=x, y=y, training_frame=train)
+    # get the model coefficients
+    h2oCoeffs = h2o_model.coef()
+    age_is_0_val = h2oCoeffs["age_is_0"]
+    age_is_0_val_table = h2o_model._model_json["output"]["coefficients_table_no_centering"]._cell_values[2][1]
+    assert abs(age_is_0_val-age_is_0_val_table) < 1e-6, "expected gam spline coefficient: {0}, actual: " \
+                                                        "{1}".format(age_is_0_val_table, age_is_0_val)
+    h2oCoeffs
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_2_knots)
+else:
+    test_2_knots()


### PR DESCRIPTION
This PR resolves the issue in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8865

Basically, there is a bug when transforming coefficients that have been centered to coefficients without centering.  For I-spline, no transformation is needed.  We only need to make sure the coefficients are copied correctly from centered coefficients to normal coefficients.