### PR TITLE
[PUBDEV-8885] Address CVE-2022-42003 and CVE-2022-42889 by Library Upgrades

### DIFF
--- a/h2o-assemblies/main/build.gradle
+++ b/h2o-assemblies/main/build.gradle
@@ -23,6 +23,12 @@ dependencies {
     }
     api project(":h2o-parquet-parser")
     api project(":h2o-k8s-int")
+
+    constraints {
+        api('com.fasterxml.jackson.core:jackson-databind:2.13.4.2') {
+            because 'Fixes CVE-2022-42003'
+        }
+    }
 }
 
 shadowJar {

--- a/h2o-assemblies/steam/build.gradle
+++ b/h2o-assemblies/steam/build.gradle
@@ -58,6 +58,12 @@ dependencies {
     }
     // Google OAuth force version
     api "com.google.oauth-client:google-oauth-client:1.33.3"
+
+    constraints {
+        api('com.fasterxml.jackson.core:jackson-databind:2.13.4.2') {
+            because 'Fixes CVE-2022-42003'
+        }
+    }
 }
 
 shadowJar {

--- a/h2o-genmodel-extensions/jgrapht/build.gradle
+++ b/h2o-genmodel-extensions/jgrapht/build.gradle
@@ -12,5 +12,11 @@ dependencies {
     api "org.jgrapht:jgrapht-ext:1.3.1"
     api "org.jgrapht:jgrapht-io:1.3.1"
     testImplementation group: 'junit', name: 'junit', version: '4.12'
+
+    constraints {
+        api('org.apache.commons:commons-text:1.10.0') {
+            because 'Fixes CVE-2022-42889'
+        }
+    }
 }
 


### PR DESCRIPTION
CVE-2022-42003:

Before this change:
```
> Task :h2o-assemblies:steam:dependencyInsight
com.fasterxml.jackson.core:jackson-databind:2.13.2.2
   variant "runtimeElements" [
      org.gradle.category            = library
      org.gradle.dependency.bundling = external
      org.gradle.libraryelements     = jar
      org.gradle.usage               = java-runtime
      org.gradle.status              = release (not requested)

      Requested attributes not found in the selected variant:
         org.gradle.jvm.environment     = standard-jvm
         org.gradle.jvm.version         = 8
   ]
   Selection reasons:
      - By constraint
      - By conflict resolution : between versions 2.13.2.2, 2.12.7, 2.12.6.1 and 2.13.2

com.fasterxml.jackson.core:jackson-databind:2.13.2.2
\--- org.apache.hadoop:hadoop-common:3.3.3
     \--- runtimeClasspath

com.fasterxml.jackson.core:jackson-databind:2.12.6.1 -> 2.13.2.2
+--- com.amazonaws:aws-java-sdk-core:1.12.268
|    +--- com.amazonaws:aws-java-sdk-s3:1.12.268
|    |    \--- project :h2o-persist-s3
|    |         \--- runtimeClasspath
|    +--- com.amazonaws:aws-java-sdk-sts:1.12.268
|    |    \--- project :h2o-persist-s3 (*)
|    \--- com.amazonaws:aws-java-sdk-kms:1.12.268
|         \--- com.amazonaws:aws-java-sdk-s3:1.12.268 (*)
\--- com.amazonaws:jmespath-java:1.12.268
     +--- com.amazonaws:aws-java-sdk-s3:1.12.268 (*)
     +--- com.amazonaws:aws-java-sdk-sts:1.12.268 (*)
     \--- com.amazonaws:aws-java-sdk-kms:1.12.268 (*)

com.fasterxml.jackson.core:jackson-databind:2.12.7 -> 2.13.2.2
\--- org.apache.hadoop:hadoop-hdfs-client:3.3.4
     \--- runtimeClasspath

com.fasterxml.jackson.core:jackson-databind:2.13.2 -> 2.13.2.2
+--- com.fasterxml.jackson:jackson-bom:2.13.2
|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2
|    |    +--- com.amazonaws:aws-java-sdk-core:1.12.268 (requested com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.6)
|    |    |    +--- com.amazonaws:aws-java-sdk-s3:1.12.268
|    |    |    |    \--- project :h2o-persist-s3
|    |    |    |         \--- runtimeClasspath
|    |    |    +--- com.amazonaws:aws-java-sdk-sts:1.12.268
|    |    |    |    \--- project :h2o-persist-s3 (*)
|    |    |    \--- com.amazonaws:aws-java-sdk-kms:1.12.268
|    |    |         \--- com.amazonaws:aws-java-sdk-s3:1.12.268 (*)
|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.2 (*)
|    +--- com.fasterxml.jackson.core:jackson-core:2.13.2
|    |    +--- com.google.cloud:google-cloud-storage:2.4.2 (requested com.fasterxml.jackson.core:jackson-core:2.13.1)
|    |    |    \--- project :h2o-persist-gcs
|    |    |         \--- runtimeClasspath
|    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2 (*)
|    |    +--- com.fasterxml.jackson:jackson-bom:2.13.2 (*)
|    |    \--- com.fasterxml.jackson.core:jackson-databind:2.13.2.2 (*)
|    +--- com.fasterxml.jackson.core:jackson-databind:2.13.2.2 (*)
|    \--- com.fasterxml.jackson.core:jackson-annotations:2.13.2
|         +--- org.apache.hadoop:hadoop-hdfs-client:3.3.4 (requested com.fasterxml.jackson.core:jackson-annotations:2.12.7)
|         |    \--- runtimeClasspath
|         +--- com.fasterxml.jackson:jackson-bom:2.13.2 (*)
|         \--- com.fasterxml.jackson.core:jackson-databind:2.13.2.2 (*)
\--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2 (*)

(*) - dependencies omitted (listed previously)
```

After this change:
```
> Task :h2o-assemblies:steam:dependencyInsight
com.fasterxml.jackson.core:jackson-databind:2.13.4.2
   variant "runtimeElements" [
      org.gradle.category            = library
      org.gradle.dependency.bundling = external
      org.gradle.libraryelements     = jar
      org.gradle.usage               = java-runtime
      org.gradle.status              = release (not requested)

      Requested attributes not found in the selected variant:
         org.gradle.jvm.environment     = standard-jvm
         org.gradle.jvm.version         = 8
   ]
   Selection reasons:
      - By constraint : Fixes CVE-2022-42003
      - By constraint
      - By conflict resolution : between versions 2.13.4.2, 2.13.2.2, 2.12.6.1 and 2.13.4

com.fasterxml.jackson.core:jackson-databind:2.13.4.2
\--- runtimeClasspath

com.fasterxml.jackson.core:jackson-databind:2.12.6.1 -> 2.13.4.2
+--- com.amazonaws:aws-java-sdk-core:1.12.268
|    +--- com.amazonaws:aws-java-sdk-s3:1.12.268
|    |    \--- project :h2o-persist-s3
|    |         \--- runtimeClasspath
|    +--- com.amazonaws:aws-java-sdk-sts:1.12.268
|    |    \--- project :h2o-persist-s3 (*)
|    \--- com.amazonaws:aws-java-sdk-kms:1.12.268
|         \--- com.amazonaws:aws-java-sdk-s3:1.12.268 (*)
\--- com.amazonaws:jmespath-java:1.12.268
     +--- com.amazonaws:aws-java-sdk-s3:1.12.268 (*)
     +--- com.amazonaws:aws-java-sdk-sts:1.12.268 (*)
     \--- com.amazonaws:aws-java-sdk-kms:1.12.268 (*)

com.fasterxml.jackson.core:jackson-databind:2.13.2.2 -> 2.13.4.2
+--- org.apache.hadoop:hadoop-common:3.3.3
|    \--- runtimeClasspath
\--- org.apache.hadoop:hadoop-hdfs-client:3.3.3
     \--- runtimeClasspath

com.fasterxml.jackson.core:jackson-databind:2.13.4 -> 2.13.4.2
+--- com.fasterxml.jackson:jackson-bom:2.13.4
|    +--- com.fasterxml.jackson.core:jackson-annotations:2.13.4
|    |    +--- org.apache.hadoop:hadoop-hdfs-client:3.3.3 (requested com.fasterxml.jackson.core:jackson-annotations:2.13.2)
|    |    |    \--- runtimeClasspath
|    |    +--- com.fasterxml.jackson:jackson-bom:2.13.4 (*)
|    |    \--- com.fasterxml.jackson.core:jackson-databind:2.13.4.2 (*)
|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.4
|    |    +--- com.amazonaws:aws-java-sdk-core:1.12.268 (requested com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.6)
|    |    |    +--- com.amazonaws:aws-java-sdk-s3:1.12.268
|    |    |    |    \--- project :h2o-persist-s3
|    |    |    |         \--- runtimeClasspath
|    |    |    +--- com.amazonaws:aws-java-sdk-sts:1.12.268
|    |    |    |    \--- project :h2o-persist-s3 (*)
|    |    |    \--- com.amazonaws:aws-java-sdk-kms:1.12.268
|    |    |         \--- com.amazonaws:aws-java-sdk-s3:1.12.268 (*)
|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.4 (*)
|    +--- com.fasterxml.jackson.core:jackson-core:2.13.4
|    |    +--- com.google.cloud:google-cloud-storage:2.4.2 (requested com.fasterxml.jackson.core:jackson-core:2.13.1)
|    |    |    \--- project :h2o-persist-gcs
|    |    |         \--- runtimeClasspath
|    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.4 (*)
|    |    +--- com.fasterxml.jackson:jackson-bom:2.13.4 (*)
|    |    \--- com.fasterxml.jackson.core:jackson-databind:2.13.4.2 (*)
|    \--- com.fasterxml.jackson.core:jackson-databind:2.13.4.2 (*)
\--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.4 (*)
```

CVE-2022-42889:

Before this change:
```
> Task :h2o-assemblies:steam:dependencyInsight
org.apache.commons:commons-text:1.6
   variant "runtime" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-runtime
      org.gradle.libraryelements     = jar
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.environment     = standard-jvm
         org.gradle.jvm.version         = 8
   ]
   Selection reasons:
      - By conflict resolution : between versions 1.6 and 1.4

org.apache.commons:commons-text:1.6
\--- org.jgrapht:jgrapht-io:1.3.1
     \--- project :h2o-genmodel-ext-jgrapht
          \--- runtimeClasspath

org.apache.commons:commons-text:1.4 -> 1.6
\--- org.apache.hadoop:hadoop-common:3.3.3
     \--- runtimeClasspath
```

After this change:
```
org.apache.commons:commons-text:1.10.0
   variant "runtime" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-runtime
      org.gradle.libraryelements     = jar
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.environment     = standard-jvm
         org.gradle.jvm.version         = 8
   ]
   Selection reasons:
      - By constraint : Fixes CVE-2022-42889
      - By conflict resolution : between versions 1.10.0, 1.4 and 1.6

org.apache.commons:commons-text:1.10.0
\--- project :h2o-genmodel-ext-jgrapht
     \--- runtimeClasspath

org.apache.commons:commons-text:1.4 -> 1.10.0
\--- org.apache.hadoop:hadoop-common:3.3.3
     \--- runtimeClasspath

org.apache.commons:commons-text:1.6 -> 1.10.0
\--- org.jgrapht:jgrapht-io:1.3.1
     \--- project :h2o-genmodel-ext-jgrapht
          \--- runtimeClasspath
```