### PR TITLE
XGBoost - small clean-up [nocheck]

### DIFF
--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
@@ -37,8 +37,7 @@ import static hex.tree.xgboost.util.GpuUtils.*;
 import static water.H2O.technote;
 
 /** 
- * Gradient Boosted Trees
- * Based on "Elements of Statistical Learning, Second Edition, page 387"
+ * H2O XGBoost
  */
 public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParameters,XGBoostOutput> 
     implements CalibrationHelper.ModelBuilderWithCalibration<XGBoostModel, XGBoostModel.XGBoostParameters, XGBoostOutput> {
@@ -144,29 +143,6 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
     if (_parms._max_depth < 0) error("_max_depth", "_max_depth must be >= 0.");
     if (_parms._max_depth == 0) _parms._max_depth = Integer.MAX_VALUE;
 
-    // Initialize response based on given distribution family.
-    // Regression: initially predict the response mean
-    // Binomial: just class 0 (class 1 in the exact inverse prediction)
-    // Multinomial: Class distribution which is not a single value.
-
-    // However there is this weird tension on the initial value for
-    // classification: If you guess 0's (no class is favored over another),
-    // then with your first GBM tree you'll typically move towards the correct
-    // answer a little bit (assuming you have decent predictors) - and
-    // immediately the Confusion Matrix shows good results which gradually
-    // improve... BUT the Means Squared Error will suck for unbalanced sets,
-    // even as the CM is good.  That's because we want the predictions for the
-    // common class to be large and positive, and the rare class to be negative
-    // and instead they start around 0.  Guessing initial zero's means the MSE
-    // is so bad, that the R^2 metric is typically negative (usually it's
-    // between 0 and 1).
-
-    // If instead you guess the mean (reversed through the loss function), then
-    // the zero-tree XGBoost model reports an MSE equal to the response variance -
-    // and an initial R^2 of zero.  More trees gradually improves the R^2 as
-    // expected.  However, all the minority classes have large guesses in the
-    // wrong direction, and it takes a long time (lotsa trees) to correct that
-    // - so your CM sucks for a long time.
     if (expensive) {
       if (error_count() > 0)
         throw H2OModelBuilderIllegalArgumentException.makeFromBuilder(XGBoost.this);

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
@@ -324,7 +324,7 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
     return true;
   }
 
-  static DataInfo makeDataInfo(Frame train, Frame valid, XGBoostModel.XGBoostParameters parms, int nClasses) {
+  static DataInfo makeDataInfo(Frame train, Frame valid, XGBoostModel.XGBoostParameters parms) {
     DataInfo dinfo = new DataInfo(
             train,
             valid,

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
@@ -366,10 +366,8 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
       if (original_chunks == 1)
         return original_fr;
       LOG.info("Rebalancing " + name.substring(name.length()-5) + " dataset onto a single node.");
-      Key newKey = Key.make(name + ".1chk");
-      RebalanceDataSet rb = new RebalanceDataSet(original_fr, newKey, 1);
-      H2O.submitTask(rb).join();
-      Frame singleChunkFr = DKV.get(newKey).get();
+      Key<Frame> newKey = Key.make(name + ".1chk");
+      Frame singleChunkFr = RebalanceDataSet.toSingleChunk(original_fr, newKey);
       Scope.track(singleChunkFr);
       return singleChunkFr;
     } else {

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
@@ -240,7 +240,7 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
 
   public XGBoostModel(Key<XGBoostModel> selfKey, XGBoostParameters parms, XGBoostOutput output, Frame train, Frame valid) {
     super(selfKey,parms,output);
-    final DataInfo dinfo = makeDataInfo(train, valid, _parms, output.nclasses());
+    final DataInfo dinfo = makeDataInfo(train, valid, _parms);
     DKV.put(dinfo);
     setDataInfoToOutput(dinfo);
     model_info = new XGBoostModelInfo(parms, dinfo);

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTest.java
@@ -1564,7 +1564,7 @@ public class XGBoostTest extends TestUtil {
       parms._response_column = "year";
       parms._train = f._key;
 
-      DataInfo dinfo = hex.tree.xgboost.XGBoost.makeDataInfo(f, null, parms, 1);
+      DataInfo dinfo = hex.tree.xgboost.XGBoost.makeDataInfo(f, null, parms);
       assertNotNull(dinfo._coefNames);
     } finally {
       Scope.exit();


### PR DESCRIPTION
- Delete comments copied from GBM, we don't build initial predictions
- Use convenience method instead to rebalance to a single chunk
- Remove deep-learning copy&paste from XGBoost code base
