### PR TITLE
[PUBDEV-8902] Update pyunit_PUBDEV_8849_gam_ispline_increasing Test Suite to Avoid Using Data from S3

### DIFF
--- a/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_8849_gam_ispline_increasing.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_8849_gam_ispline_increasing.py
@@ -7,40 +7,42 @@ import h2o
 from tests import pyunit_utils
 from h2o.estimators.gam import H2OGeneralizedAdditiveEstimator
 
+
 def test_GAM_monotone_splines_sine():
-    file_name = "http://h2o-public-test-data.s3.amazonaws.com/smalldata/gam_test/monotonic_sine.csv"
-    test_data = "http://h2o-public-test-data.s3.amazonaws.com/smalldata/gam_test/notQuite_monotone_sine.csv"
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [3], [2], [1])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [4], [2], [1])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [5], [2], [1])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [3], [2], [3])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [4], [2], [3])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [5], [2], [3])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [3], [2], [4])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [4], [2], [4])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [5], [2], [4])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [3], [2], [5])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [4], [2], [5])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [5], [2], [5])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [3], [2], [6])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [4], [2], [6])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [5], [2], [6])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [3], [2], [7])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [4], [2], [7])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [5], [2], [7])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [3], [2], [8])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [4], [2], [8])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [5], [2], [8])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [3], [2], [9])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [4], [2], [9])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [5], [2], [9])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [3], [2], [10])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [4], [2], [10])
-    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [5], [2], [10])
+    train_file = pyunit_utils.locate("smalldata/gam_test/monotonic_sine.csv")
+    test_file = pyunit_utils.locate("smalldata/gam_test/notQuite_monotone_sine.csv")
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [3], [2], [1])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [4], [2], [1])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [5], [2], [1])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [3], [2], [3])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [4], [2], [3])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [5], [2], [3])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [3], [2], [4])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [4], [2], [4])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [5], [2], [4])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [3], [2], [5])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [4], [2], [5])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [5], [2], [5])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [3], [2], [6])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [4], [2], [6])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [5], [2], [6])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [3], [2], [7])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [4], [2], [7])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [5], [2], [7])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [3], [2], [8])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [4], [2], [8])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [5], [2], [8])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [3], [2], [9])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [4], [2], [9])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [5], [2], [9])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [3], [2], [10])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [4], [2], [10])
+    build_assert_monotone_output(train_file, test_file, [], 'Y', ['X'], [5], [2], [10])
     
-def build_assert_monotone_output(file_name, test_name, x, target, gam_columns, num_knot, bs_choice, spline_order):
-    train_data = h2o.import_file(file_name)
-    test_data = h2o.import_file(test_name)
+    
+def build_assert_monotone_output(train_file, test_file, x, target, gam_columns, num_knot, bs_choice, spline_order):
+    train_data = h2o.import_file(train_file)
+    test_data = h2o.import_file(test_file)
     h2o_model2 = H2OGeneralizedAdditiveEstimator(family='gaussian',
                                                  gam_columns=gam_columns,
                                                  num_knots=num_knot,
@@ -50,6 +52,7 @@ def build_assert_monotone_output(file_name, test_name, x, target, gam_columns, n
     h2o_model2.train(x=x, y=target, training_frame=train_data)
     pred_frame = h2o_model2.predict(test_data)  
     assertMonotonePrediction(pred_frame)
+
 
 def assertMonotonePrediction(pred_frame):
     prediction = pred_frame[0].as_data_frame(use_pandas=True)


### PR DESCRIPTION
This PR should fix the failing test on Python 2.7:
```
/envs/h2o_env_python2.7/lib/python2.7/site-packages/requests/__init__.py:91: RequestsDependencyWarning: urllib3 (1.26.7) or chardet (3.0.4) doesn't match a supported version!
  RequestsDependencyWarning)
versionFromGradle='3.38.0',projectVersion='3.38.0.99999',branch='(HEAD detached at 35e8394)',lastCommitHash='35e8394333787510a4819fa148ba2cd74ac90b17',gitDescribe='jenkins-3.38.0.2-14-g35e8394',compiledOn='2022-11-03 13:47:34',compiledBy='jenkins'
('loading the following test utility modules: ', ['/home/jenkins/slave_dir_from_mr-0xc1/workspace/o-3-nightly-pipeline_rel-zygmund@2/py2.7-small/h2o-3/h2o-py/tests/_utils.py', '/home/jenkins/slave_dir_from_mr-0xc1/workspace/o-3-nightly-pipeline_rel-zygmund@2/py2.7-small/h2o-3/h2o-py/tests/testdir_algos/automl/_automl_utils.py', '/home/jenkins/slave_dir_from_mr-0xc1/workspace/o-3-nightly-pipeline_rel-zygmund@2/py2.7-small/h2o-3/h2o-py/tests/testdir_algos/automl/leaderboard/_leaderboard_utils.py'])
[2022-11-03 14:16:02] Connect to h2o on IP: 127.0.0.1 PORT: 40004

Not using any auth
Traceback (most recent call last):
  File "/home/jenkins/slave_dir_from_mr-0xc1/workspace/o-3-nightly-pipeline_rel-zygmund@2/py2.7-small/h2o-3/h2o-py/scripts/h2o-py-test-setup.py", line 186, in <module>
    h2o_test_setup(sys.argv)
  File "/home/jenkins/slave_dir_from_mr-0xc1/workspace/o-3-nightly-pipeline_rel-zygmund@2/py2.7-small/h2o-3/h2o-py/scripts/h2o-py-test-setup.py", line 181, in h2o_test_setup
    elif _IS_PYUNIT_:    pyunit_utils.pyunit_exec(_TEST_NAME_)
  File "/home/jenkins/slave_dir_from_mr-0xc1/workspace/o-3-nightly-pipeline_rel-zygmund@2/py2.7-small/h2o-3/h2o-py/tests/pyunit_utils/utilsPY.py", line 686, in pyunit_exec
    exec(pyunit_c, dict(__name__='__main__', __file__=test_path))  # forcing module name to ensure that the test behaves the same way as when executed using `python my_test.py`
  File "/home/jenkins/slave_dir_from_mr-0xc1/workspace/o-3-nightly-pipeline_rel-zygmund@2/py2.7-small/h2o-3/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_8849_gam_ispline_increasing.py", line 63, in <module>
    pyunit_utils.standalone_test(test_GAM_monotone_splines_sine)
  File "/home/jenkins/slave_dir_from_mr-0xc1/workspace/o-3-nightly-pipeline_rel-zygmund@2/py2.7-small/h2o-3/h2o-py/tests/pyunit_utils/utilsPY.py", line 701, in standalone_test
    test()
  File "/home/jenkins/slave_dir_from_mr-0xc1/workspace/o-3-nightly-pipeline_rel-zygmund@2/py2.7-small/h2o-3/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_8849_gam_ispline_increasing.py", line 13, in test_GAM_monotone_splines_sine
    build_assert_monotone_output(file_name, test_data, [], 'Y', ['X'], [3], [2], [1])
  File "/home/jenkins/slave_dir_from_mr-0xc1/workspace/o-3-nightly-pipeline_rel-zygmund@2/py2.7-small/h2o-3/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_8849_gam_ispline_increasing.py", line 42, in build_assert_monotone_output
    train_data = h2o.import_file(file_name)
  File "/envs/h2o_env_python2.7/lib/python2.7/site-packages/h2o/h2o.py", line 501, in import_file
    skipped_columns, custom_non_data_line_markers, partition_by, quotechar, escapechar)
  File "/envs/h2o_env_python2.7/lib/python2.7/site-packages/h2o/frame.py", line 451, in _import_parse
    skipped_columns, custom_non_data_line_markers, partition_by, quotechar, escapechar)
  File "/envs/h2o_env_python2.7/lib/python2.7/site-packages/h2o/frame.py", line 467, in _parse
    return self._parse_raw(setup)
  File "/envs/h2o_env_python2.7/lib/python2.7/site-packages/h2o/frame.py", line 495, in _parse_raw
    H2OJob(h2o.api("POST /3/Parse", data=p), "Parse").poll()
  File "/envs/h2o_env_python2.7/lib/python2.7/site-packages/h2o/h2o.py", line 124, in api
    return h2oconn.request(endpoint, data=data, json=json, filename=filename, save_to=save_to)
  File "/envs/h2o_env_python2.7/lib/python2.7/site-packages/h2o/backend/connection.py", line 473, in request
    request_data = self._prepare_data_payload(data) if filename is None else self._prepare_file_payload(filename)
  File "/envs/h2o_env_python2.7/lib/python2.7/site-packages/h2o/backend/connection.py", line 728, in _prepare_data_payload
    value = stringify_list(value)
  File "/envs/h2o_env_python2.7/lib/python2.7/site-packages/h2o/utils/shared_utils.py", line 173, in stringify_list
    for item in arr)
  File "/envs/h2o_env_python2.7/lib/python2.7/site-packages/h2o/utils/shared_utils.py", line 173, in <genexpr>
    for item in arr)
  File "/envs/h2o_env_python2.7/lib/python2.7/site-packages/h2o/utils/shared_utils.py", line 186, in _str
    return _str_tuple(item) if isinstance(item, tuple) else str(item)
UnicodeEncodeError: 'ascii' codec can't encode character u'\ufeff' in position 1: ordinal not in range(128)
Closing connection _sid_987e at exit
```