### PR TITLE
[PUBDEV-8895] Address CVE-2022-40153, CVE-2022-40154, CVE-2022-40155, CVE-2022-40156 by upgrading woodstox-core

### DIFF
--- a/h2o-assemblies/steam/build.gradle
+++ b/h2o-assemblies/steam/build.gradle
@@ -63,6 +63,9 @@ dependencies {
         api('com.fasterxml.jackson.core:jackson-databind:2.13.4.2') {
             because 'Fixes CVE-2022-42003'
         }
+        api('com.fasterxml.woodstox:woodstox-core:5.4.0') {
+            because 'Fixes CVE-2022-40153, CVE-2022-40154, CVE-2022-40155, CVE-2022-40156'
+        }
     }
 }
 


### PR DESCRIPTION
Dependency description: https://mvnrepository.com/artifact/com.fasterxml.woodstox/woodstox-core/5.3.0

Before:
```
> Task :h2o-assemblies:steam:dependencyInsight
com.fasterxml.woodstox:woodstox-core:5.3.0
   variant "runtime" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-runtime
      org.gradle.libraryelements     = jar
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.environment     = standard-jvm
         org.gradle.jvm.version         = 8
   ]

com.fasterxml.woodstox:woodstox-core:5.3.0
\--- org.apache.hadoop:hadoop-common:3.3.3
     \--- runtimeClasspath
```

After:
```
> Task :h2o-assemblies:steam:dependencyInsight
com.fasterxml.woodstox:woodstox-core:5.4.0
   variant "runtime" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-runtime
      org.gradle.libraryelements     = jar
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.environment     = standard-jvm
         org.gradle.jvm.version         = 8
   ]
   Selection reasons:
      - By constraint : Fixes CVE-2022-40153, CVE-2022-40154, CVE-2022-40155, CVE-2022-40156
      - By conflict resolution : between versions 5.4.0 and 5.3.0

com.fasterxml.woodstox:woodstox-core:5.4.0
\--- runtimeClasspath

com.fasterxml.woodstox:woodstox-core:5.3.0 -> 5.4.0
\--- org.apache.hadoop:hadoop-common:3.3.3
     \--- runtimeClasspath

```

Main and Minimal jar is not affected. 