### PR TITLE
PUBDEV-8904: Updated booklet links and locations GBM/GLM/DL

### DIFF
--- a/h2o-docs/src/product/data-science/deep-learning.rst
+++ b/h2o-docs/src/product/data-science/deep-learning.rst
@@ -15,7 +15,7 @@ Deep Learning supports importing and exporting `MOJOs <../save-and-load-model.ht
 
 Quick Start and Additional Resources
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-* `Deep Learning Booklet <http://h2o.ai/resources>`__
+* `Deep Learning Booklet <https://docs.h2o.ai/h2o/latest-stable/h2o-docs/booklets/DeepLearningBooklet.pdf>`__
 * Deep Learning in H2O Tutorial (R): `[GitHub] <https://htmlpreview.github.io/?https://github.com/ledell/sldm4-h2o/blob/master/sldm4-deeplearning-h2o.html>`__
 * H2O + TensorFlow on AWS GPU Tutorial (Python Notebook) `[Blog] <https://www.h2o.ai/blog/h2o-tensorflow-on-aws-gpu/>`__ `[Github] <https://github.com/h2oai/sparkling-water/blob/master/py/examples/notebooks/TensorFlowDeepLearning.ipynb>`__
 * Deep learning in H2O with Arno Candel (Overview) `[Youtube] <https://www.youtube.com/watch?v=zGdXaRug7LI/>`__

--- a/h2o-docs/src/product/data-science/gbm.rst
+++ b/h2o-docs/src/product/data-science/gbm.rst
@@ -28,13 +28,15 @@ MOJO Support
 
 GBM supports importing and exporting `MOJOs <../save-and-load-model.html#supported-mojos>`__.
 
-Quick Start
-~~~~~~~~~~~~
+Quick Start and Additional Resources
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 * Quick GBM using H2O Flow (Lending Club Dataset) `[Youtube] <https://www.youtube.com/watch?v=1R9iBBCxhE8>`__
 * Simplest getting started R script `[Github] <https://github.com/h2oai/h2o-tutorials/blob/master/tutorials/gbm-randomforest/GBM_RandomForest_Example.R>`__
 * GBM & Random Forest Video Overview `[Youtube] <https://www.youtube.com/watch?v=9wn1f-30_ZY>`__
 * GBM and other algos in R (Citi Bike Dataset) `[Youtube] <https://www.youtube.com/watch?v=_ig6ZmBfhH8/>`__ `[Github] <https://github.com/h2oai/h2o-3/blob/master/h2o-r/demos/rdemo.citi.bike.small.R/>`__ 
 * Prof. Trevor Hastie - Gradient Boosting Machine Learning `[Youtube] <https://www.youtube.com/watch?v=wPqtzj5VZus/>`__
+* `GBM Booklet <https://docs.h2o.ai/h2o/latest-stable/h2o-docs/booklets/GBMBooklet.pdf>`__
 
 Defining a GBM Model
 ~~~~~~~~~~~~~~~~~~~~
@@ -340,9 +342,6 @@ zero-weighted rows are sliced away first, the integer weight is used.
 The resulting histogram is either kept at full ``nbins`` resolution or
 potentially shrunk to the discrete integer range, which affects the
 split points.
-
-For more information about the GBM algorithm, refer to the `Gradient
-Boosting Machine booklet <http://h2o.ai/resources>`__.
 
 Parallel Performance in GBM
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -1570,9 +1570,6 @@ than (N/CPUs), O is dominated by p.
 
   :math:`Complexity = O(p^3 + N*p^2)`
 
-For more information about how GLM works, refer to the `Generalized
-Linear Modeling booklet <http://h2o.ai/resources>`__.
-
 References
 ~~~~~~~~~~
 

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -26,6 +26,11 @@ MOJO Support
 
 GLM supports importing and exporting `MOJOs <../save-and-load-model.html#supported-mojos>`__.
 
+Additional Resources
+~~~~~~~~~~~~~~~~~~~~
+
+* `GLM Booklet <https://docs.h2o.ai/h2o/latest-stable/h2o-docs/booklets/GLMBooklet.pdf>`__
+
 Defining a GLM Model
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
For: [PUBDEV-8904](https://h2oai.atlassian.net/browse/PUBDEV-8904)

I updated the booklet links to point to the actual booklets and not to the resources page. I also made it so that each booklet link was at the top of the algo page under the "additional resources" section.