### PR TITLE
PUBDEV-8912: p-val/z-val work with regularization now

### DIFF
--- a/h2o-docs/src/booklets/v2_2015/source/GLMBooklet.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/GLMBooklet.tex
@@ -994,7 +994,7 @@ hypothesis tests on the values of each coefficient. A high p-value means that a 
 (insiginificant) while a low p-value suggest that the coefficient is statistically significant.
 
 You can request p-values by setting the \\\texttt{compute\_p\_values} option. It can only be used with the
-\texttt{IRLSM} solver. P-values and z-score are compatible with regularization. It is recommended that you also set the \texttt{remove\_collinear\_columns} option. Otherwise, H2O will return an error if it detects collinearity in the dataset and p-values are requested. 
+\texttt{IRLSM} solver. P-values and z-score can be computed with regularization. It is recommended that you also set the \texttt{remove\_collinear\_columns} option. Otherwise, H2O will return an error if it detects collinearity in the dataset and p-values are requested. 
 
 \textbf{Note:} GLM auto-standardizes the data by default (recommended). This changes the p-value of the constant term
 (intercept).

--- a/h2o-docs/src/booklets/v2_2015/source/GLMBooklet.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/GLMBooklet.tex
@@ -994,8 +994,7 @@ hypothesis tests on the values of each coefficient. A high p-value means that a 
 (insiginificant) while a low p-value suggest that the coefficient is statistically significant.
 
 You can request p-values by setting the \\\texttt{compute\_p\_values} option. It can only be used with the
-\texttt{IRLSM} solver and no regularization. It is recommended that you also set the
-\texttt{remove\_collinear\_columns} option. Otherwise, H2O will return an error if it detects collinearity in the dataset and p-values are requested. 
+\texttt{IRLSM} solver. P-values and z-score are compatible with regularization. It is recommended that you also set the \texttt{remove\_collinear\_columns} option. Otherwise, H2O will return an error if it detects collinearity in the dataset and p-values are requested. 
 
 \textbf{Note:} GLM auto-standardizes the data by default (recommended). This changes the p-value of the constant term
 (intercept).

--- a/h2o-docs/src/booklets/v2_2015/source/GLMBooklet.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/GLMBooklet.tex
@@ -994,7 +994,7 @@ hypothesis tests on the values of each coefficient. A high p-value means that a 
 (insiginificant) while a low p-value suggest that the coefficient is statistically significant.
 
 You can request p-values by setting the \\\texttt{compute\_p\_values} option. It can only be used with the
-\texttt{IRLSM} solver. P-values and z-score can be computed with regularization. It is recommended that you also set the \texttt{remove\_collinear\_columns} option. Otherwise, H2O will return an error if it detects collinearity in the dataset and p-values are requested. 
+\texttt{IRLSM} solver. P-values and z-score can be computed with or without regularization. It is recommended that you also set the \texttt{remove\_collinear\_columns} option. Otherwise, H2O will return an error if it detects collinearity in the dataset and p-values are requested. 
 
 \textbf{Note:} GLM auto-standardizes the data by default (recommended). This changes the p-value of the constant term
 (intercept).

--- a/h2o-docs/src/product/data-science/algo-params/compute_p_values.rst
+++ b/h2o-docs/src/product/data-science/algo-params/compute_p_values.rst
@@ -11,7 +11,7 @@ Z-score, standard error, and `p-values <https://en.wikipedia.org/wiki/P-value>`_
 
 **Notes**:
 
-- This option is only applicable when regularization is disabled (``lambda=0``) and when ``solver=IRLSM``. 
+- This option is only applicable when ``solver=IRLSM``. 
 - If collinear columns exist in the data, then you must also specify ``remove_collinear_columns=TRUE``. Otherwise, H2O will return an error. 
 - This option cannot be used with ``family=multinomial`` or with ``beta_constraints``.
 - GLM and GAM auto-standardize the data by default. This changes the p-value of the constant term (intercept).

--- a/h2o-docs/src/product/data-science/algo-params/compute_p_values.rst
+++ b/h2o-docs/src/product/data-science/algo-params/compute_p_values.rst
@@ -11,7 +11,7 @@ Z-score, standard error, and `p-values <https://en.wikipedia.org/wiki/P-value>`_
 
 **Notes**:
 
-- This option is only applicable when ``solver=IRLSM``. 
+- This option is only applicable when ``solver=IRLSM``.
 - If collinear columns exist in the data, then you must also specify ``remove_collinear_columns=TRUE``. Otherwise, H2O will return an error. 
 - This option cannot be used with ``family=multinomial`` or with ``beta_constraints``.
 - GLM and GAM auto-standardize the data by default. This changes the p-value of the constant term (intercept).

--- a/h2o-docs/src/product/data-science/gam.rst
+++ b/h2o-docs/src/product/data-science/gam.rst
@@ -130,7 +130,7 @@ Defining a GAM Model
 
 -  `plug_values <algo-params/plug_values.html>`__: When ``missing_values_handling="PlugValues"``, specify a single row frame containing values that will be used to impute missing values of the training/validation frame.
 
--  `compute_p_values <algo-params/compute_p_values.html>`__: Request computation of p-values. Only applicable with no penalty (lambda = 0 and no beta constraints). Setting remove_collinear_columns is recommended. H2O will return an error if p-values are requested and there are collinear columns and remove_collinear_columns flag is not enabled. Note that this option is not available for ``family="multinomial"`` or ``family="ordinal"``. This option is defaults to false (not enabled).
+-  `compute_p_values <algo-params/compute_p_values.html>`__: Request computation of p-values. P-values can be computed with regularization. Setting ``remove_collinear_columns`` is recommended. H2O will return an error if p-values are requested and there are collinear columns and ``remove_collinear_columns`` flag is not enabled. Note that this option is not available for ``family="multinomial"`` or ``family="ordinal"``; ``IRLSM`` solver requried. This option defaults to ``False`` (disabled).
 
 -  `remove_collinear_columns <algo-params/remove_collinear_columns.html>`__: Specify whether to automatically remove collinear columns during model-building. When enabled, collinear columns will be dropped from the model and will have 0 coefficient in the returned model. This can only be set if there is no regularization (lambda=0). This option is defaults to false (not enabled).
 

--- a/h2o-docs/src/product/data-science/gam.rst
+++ b/h2o-docs/src/product/data-science/gam.rst
@@ -130,7 +130,7 @@ Defining a GAM Model
 
 -  `plug_values <algo-params/plug_values.html>`__: When ``missing_values_handling="PlugValues"``, specify a single row frame containing values that will be used to impute missing values of the training/validation frame.
 
--  `compute_p_values <algo-params/compute_p_values.html>`__: Request computation of p-values. P-values can be computed with regularization. Setting ``remove_collinear_columns`` is recommended. H2O will return an error if p-values are requested and there are collinear columns and ``remove_collinear_columns`` flag is not enabled. Note that this option is not available for ``family="multinomial"`` or ``family="ordinal"``; ``IRLSM`` solver requried. This option defaults to ``False`` (disabled).
+-  `compute_p_values <algo-params/compute_p_values.html>`__: Request computation of p-values. P-values can be computed with or without regularization. Setting ``remove_collinear_columns`` is recommended. H2O will return an error if p-values are requested and there are collinear columns and ``remove_collinear_columns`` flag is not enabled. Note that this option is not available for ``family="multinomial"`` or ``family="ordinal"``; ``IRLSM`` solver requried. This option defaults to ``False`` (disabled).
 
 -  `remove_collinear_columns <algo-params/remove_collinear_columns.html>`__: Specify whether to automatically remove collinear columns during model-building. When enabled, collinear columns will be dropped from the model and will have 0 coefficient in the returned model. This can only be set if there is no regularization (lambda=0). This option is defaults to false (not enabled).
 

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -163,7 +163,7 @@ Defining a GLM Model
 
 -  `plug_values <algo-params/plug_values.html>`__: When ``missing_values_handling="PlugValues"``, specify a single row frame containing values that will be used to impute missing values of the training/validation frame.
 
--  `compute_p_values <algo-params/compute_p_values.html>`__: Request computation of p-values. Only applicable with no penalty (lambda = 0 and no beta constraints). Setting remove_collinear_columns is recommended. H2O will return an error if p-values are requested and there are collinear columns and remove_collinear_columns flag is not enabled. Note that this option is not available for ``family="multinomial"`` or ``family="ordinal"``. This option is disabled by default.
+-  `compute_p_values <algo-params/compute_p_values.html>`__: Request computation of p-values. P-values can be computed with regularization. Setting ``remove_collinear_columns`` is recommended. H2O will return an error if p-values are requested and there are collinear columns and ``remove_collinear_columns`` flag is not enabled. Note that this option is not available for ``family="multinomial"`` or ``family="ordinal"``; ``IRLSM`` solver requried. This option defaults to ``False`` (disabled).
 
 - **dispersion_parameter_method**: Method used to estimate the dispersion factor for Tweedie, Gamma, and Negative Binomial only. Can be one of ``"pearson"`` (default), ``"deviance"``, or ``"ml"``. 
 

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -163,7 +163,7 @@ Defining a GLM Model
 
 -  `plug_values <algo-params/plug_values.html>`__: When ``missing_values_handling="PlugValues"``, specify a single row frame containing values that will be used to impute missing values of the training/validation frame.
 
--  `compute_p_values <algo-params/compute_p_values.html>`__: Request computation of p-values. P-values can be computed with regularization. Setting ``remove_collinear_columns`` is recommended. H2O will return an error if p-values are requested and there are collinear columns and ``remove_collinear_columns`` flag is not enabled. Note that this option is not available for ``family="multinomial"`` or ``family="ordinal"``; ``IRLSM`` solver requried. This option defaults to ``False`` (disabled).
+-  `compute_p_values <algo-params/compute_p_values.html>`__: Request computation of p-values. P-values can be computed with or without regularization. Setting ``remove_collinear_columns`` is recommended. H2O will return an error if p-values are requested and there are collinear columns and ``remove_collinear_columns`` flag is not enabled. Note that this option is not available for ``family="multinomial"`` or ``family="ordinal"``; ``IRLSM`` solver requried. This option defaults to ``False`` (disabled).
 
 - **dispersion_parameter_method**: Method used to estimate the dispersion factor for Tweedie, Gamma, and Negative Binomial only. Can be one of ``"pearson"`` (default), ``"deviance"``, or ``"ml"``. 
 


### PR DESCRIPTION
For: [PUBDEV-8912](https://h2oai.atlassian.net/browse/PUBDEV-8912)

Removed notes that `compute_p_values` doesn't work with regularization; updated booklet to note that p-values/z-values can be computed with regularization turned on.