### PR TITLE
PUBDEV-8918 - check if response has an attribute before we access the field

### DIFF
--- a/h2o-py/h2o/schemas/schema.py
+++ b/h2o-py/h2o/schemas/schema.py
@@ -9,7 +9,7 @@ from h2o.utils.compatibility import *  # NOQA
 from functools import partial
 
 import h2o
-from h2o.exceptions import H2OConnectionError
+from h2o.exceptions import H2OConnectionError, H2OServerError
 
 
 def define_classes_from_schema(classes, connection):
@@ -27,6 +27,10 @@ class H2OSchema(object):
     @classmethod
     def define_from_schema(cls, connection):
         meta = connection.request("GET %s" % cls._schema_endpoint_)
+
+        if not hasattr(meta, "fields"):
+            raise H2OServerError("Unexpected API output. Please verify server url and port. Response is '%s'" % meta)
+
         cls_vars = vars(cls).keys()
         for attr, dyn in cls._schema_attrs_.items():
             if dyn and attr in cls_vars:  # to not delete attributes that were not dynamically added in the current class

--- a/h2o-py/tests/testdir_misc/pyunit_connection_test.py
+++ b/h2o-py/tests/testdir_misc/pyunit_connection_test.py
@@ -1,0 +1,37 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+
+import h2o
+from tests import pyunit_utils
+import requests
+from h2o.exceptions import H2OConnectionError
+
+
+def test_server_is_responding_with_unexpected_data():
+
+    def empty_metadata_request(method, url, **kwargs):
+        if method == "GET" and url.find("/3/Metadata/schemas") != -1:
+            response = requests.Response()
+            response.status_code = 200
+            # Return empty response with success status code simulate unexpected response body, in this case empty body
+            return response
+
+    try:
+        requests.request_orig = requests.request
+        requests.request = empty_metadata_request
+
+        # try to connect to the cloud with mock response
+        h2o.connect()
+        assert False, "Connection should fail"
+    except H2OConnectionError as e:
+        print(str(e))
+        assert "Unexpected API output. Please verify server url and port." in str(e)
+    finally:
+        requests.request = requests.request_orig
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_server_is_responding_with_unexpected_data)
+else:
+    test_server_is_responding_with_unexpected_data()


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8918

When you connect to the server with:
```
connect_params = {'https': False,
                 'verify_ssl_certificates': False,
                 'context_path': "projects/p1/h2oEngines/e2",
                 'ip': "http://cloud-dev.h2o.ai",
                 'port': 80}

h2o.connect(
    config=connect_params
)
```

you get the

`AttributeError: 'str' object has no attribute 'fields'`

but the problem is that h2o server isn't running there and we access API output without check. Since it is in `_test_connection` method, we should be more paranoid and check the output before we access it.

With this change you get H2OServerError: `Unexpected API output. Please verify server url. Response is '<!doctype html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no"/><meta name="theme-color" content="#000000"/>...'`

Feedback appreciated 🥇 