### PR TITLE
PUBDEV-8948: Speed up negative binomial calculation

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/GLMTask.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMTask.java
@@ -26,8 +26,8 @@ import static hex.glm.GLMModel.GLMParameters.Family.gaussian;
 import static hex.glm.GLMTask.DataAddW2AugXZ.getCorrectChunk;
 import static hex.glm.GLMUtils.updateGradGam;
 import static hex.glm.GLMUtils.updateGradGamMultinomial;
-import static org.apache.commons.math3.special.Gamma.digamma;
-import static org.apache.commons.math3.special.Gamma.trigamma;
+import static org.apache.commons.math3.special.Gamma.*;
+import static org.apache.commons.math3.special.Gamma.logGamma;
 
 /**
  * All GLM related distributed tasks:
@@ -693,10 +693,13 @@ public abstract class GLMTask  {
 
   static double sumOper(double y, double multiplier, int opVal) {
     double summation = 0.0;
-      for (int val = 0; val < y; val++) {
-        double temp = opVal==0?Math.log((val+multiplier)/(val+1)):1.0/(val*multiplier*multiplier+multiplier);
-        summation += opVal==0?temp:(opVal==1?temp:(opVal==2?temp*temp*(2*val*multiplier+1):Math.log(multiplier+val)));
-      }
+    if (opVal == 0){
+      return logGamma(y + multiplier - 1) - logGamma(multiplier - 2) - logGamma(y);
+    }
+    for (int val = 0; val < y; val++) {
+      double temp = 1.0/(val*multiplier*multiplier+multiplier);
+      summation += opVal==1?temp:(opVal==2?temp*temp*(2*val*multiplier+1):Math.log(multiplier+val));
+    }
     return summation;
   }
   

--- a/h2o-algos/src/main/java/hex/glm/GLMTask.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMTask.java
@@ -694,7 +694,7 @@ public abstract class GLMTask  {
   static double sumOper(double y, double multiplier, int opVal) {
     double summation = 0.0;
     if (opVal == 0){
-      return logGamma(y + multiplier - 1) - logGamma(multiplier - 2) - logGamma(y);
+      return logGamma(y + multiplier) - logGamma(multiplier) - logGamma(y + 1);
     }
     for (int val = 0; val < y; val++) {
       double temp = 1.0/(val*multiplier*multiplier+multiplier);


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8948

GLM with NegativeBinomial family can get very slow if we have high values in response this is due to a summation that can be optimized: 

```
Sum_{val= 0}^{y} { log((val+multiplier)/(val+1))} =
Sum log(val+multiplier) - Sum log(val+1) =
log((y+multiplier)!/(multiplier-1)!) - log((y+1)!) =
log((y+multiplier)!) - log((multiplier-1)!) - log((y+1)!) =
logGamma(y + multiplier + 1) - logGamma(multiplier) - logGamma(y+2)
```
**FIXED:**
from `logGamma(y + multiplier - 1) - logGamma(multiplier - 2) - logGamma(y)`
to `logGamma(y + multiplier + 1) - logGamma(multiplier) - logGamma(y+2)`
since `(N-1)! = Gamma(N)`


Improvement can be seen in the following example:
```r
set.seed(42)
n <- 10000
df <- data.frame(a=rnorm(n), b=rnorm(n), c=rnorm(n))
df$d <- MASS::rnegbin(n, exp(df$a + 3*df$b - 4*df$c + 5), 10)

# This is very fast
system.time({
     rglm <- MASS::glm.nb(d ~ ., data = df)
})

hdf <- as.h2o(df)

# This used to be very very slow, now it's computed within 1s
system.time({
    hglm <- h2o.glm(y = "d", training_frame = hdf, family = "negativebinomial")
})
```
(Without this patch I don't recommend waiting for the results it takes more than 10 minutes.)