### PR TITLE
[PUBDEV-8950] Upgrade google-cloud-storage to Avoid CVE-2022-3509

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -73,7 +73,7 @@ jetty9MinimalVersion=9.4.48.v20220622
 servletApiVersion=3.1.0
 
 # Gson
-gsonVersion=2.9.0
+gsonVersion=2.10
 
 # MOJO2 Integration
 mojo2version=2.5.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -73,7 +73,7 @@ jetty9MinimalVersion=9.4.48.v20220622
 servletApiVersion=3.1.0
 
 # Gson
-gsonVersion=2.10
+gsonVersion=2.9.1
 
 # MOJO2 Integration
 mojo2version=2.5.3

--- a/h2o-persist-gcs/build.gradle
+++ b/h2o-persist-gcs/build.gradle
@@ -4,7 +4,7 @@ description = "H2O Persist GCS"
 
 dependencies {
     api project(":h2o-core")
-    api 'com.google.cloud:google-cloud-storage:2.15.1'
+    api 'com.google.cloud:google-cloud-storage:2.13.1'
 
     testImplementation project(":h2o-test-support")
     testRuntimeOnly project(":${defaultWebserverModule}")

--- a/h2o-persist-gcs/build.gradle
+++ b/h2o-persist-gcs/build.gradle
@@ -4,7 +4,7 @@ description = "H2O Persist GCS"
 
 dependencies {
     api project(":h2o-core")
-    api 'com.google.cloud:google-cloud-storage:2.4.2'
+    api 'com.google.cloud:google-cloud-storage:2.15.1'
 
     testImplementation project(":h2o-test-support")
     testRuntimeOnly project(":${defaultWebserverModule}")


### PR DESCRIPTION
This PR removes CVE-2022-3509 from h2o assembly jars.

Before:
```
> Task :h2o-assemblies:steam:dependencyInsight
com.google.protobuf:protobuf-java:3.19.3
   variant "runtime" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-runtime
      org.gradle.libraryelements     = jar
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.environment     = standard-jvm
         org.gradle.jvm.version         = 8
   ]
   Selection reasons:
      - By conflict resolution : between versions 3.19.3 and 2.5.0

com.google.protobuf:protobuf-java:3.19.3
\--- com.google.cloud:google-cloud-storage:2.4.2
     \--- project :h2o-persist-gcs
          \--- runtimeClasspath

com.google.protobuf:protobuf-java:2.5.0 -> 3.19.3
\--- org.apache.hadoop:hadoop-common:3.3.3
     \--- runtimeClasspath

com.google.protobuf:protobuf-java-util:3.19.3
   variant "runtime" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-runtime
      org.gradle.libraryelements     = jar
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.environment     = standard-jvm
         org.gradle.jvm.version         = 8
   ]

com.google.protobuf:protobuf-java-util:3.19.3
\--- com.google.cloud:google-cloud-storage:2.4.2
     \--- project :h2o-persist-gcs
          \--- runtimeClasspath

```

After:
```
> Task :h2o-assemblies:steam:dependencyInsight
com.google.protobuf:protobuf-java:3.21.7
   variant "runtime" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-runtime
      org.gradle.libraryelements     = jar
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.environment     = standard-jvm
         org.gradle.jvm.version         = 8
   ]
   Selection reasons:
      - By conflict resolution : between versions 3.21.7 and 2.5.0

com.google.protobuf:protobuf-java:3.21.7
\--- com.google.cloud:google-cloud-storage:2.13.1
     \--- project :h2o-persist-gcs
          \--- runtimeClasspath

com.google.protobuf:protobuf-java:2.5.0 -> 3.21.7
\--- org.apache.hadoop:hadoop-common:3.3.3
     \--- runtimeClasspath

com.google.protobuf:protobuf-java-util:3.21.7
   variant "runtime" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-runtime
      org.gradle.libraryelements     = jar
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.environment     = standard-jvm
         org.gradle.jvm.version         = 8
   ]

com.google.protobuf:protobuf-java-util:3.21.7
\--- com.google.cloud:google-cloud-storage:2.13.1
     \--- project :h2o-persist-gcs
          \--- runtimeClasspath
```