### PR TITLE
PUBDEV-8958: fixed buggy code

### DIFF
--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -4435,7 +4435,7 @@ def assertEqualRegPaths(keys, pathList, index, onePath, tol=1e-6):
 
 def assertEqualCoeffDicts(coef1Dict, coef2Dict, tol = 1e-6):
     assert len(coef1Dict) == len(coef2Dict), "Length of first coefficient dict: {0}, length of second coefficient " \
-                                             "dict: {1} and they are different.".format(len(coef1Dict, len(coef2Dict)))
+                                             "dict: {1} and they are different.".format(len(coef1Dict), len(coef2Dict))
     for key in coef1Dict:
         val1 = coef1Dict[key]
         val2 = coef2Dict[key]


### PR DESCRIPTION
This PR fixes the problem in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8958

fixed bug: .format(len(coef1Dict, len(coef2Dict))) with .format(len(coef1Dict), len(coef2Dict))