### PR TITLE
PUBDEV-8637 - row to tree assignments python API

### DIFF
--- a/h2o-bindings/bin/custom/python/gen_gbm.py
+++ b/h2o-bindings/bin/custom/python/gen_gbm.py
@@ -8,6 +8,7 @@ options = dict(
         'h2o.model.extensions.SupervisedTrees',
         'h2o.model.extensions.HStatistic',
         'h2o.model.extensions.Contributions',
+        'h2o.model.extensions.RowToTreeAssignment',
     ],
 )
 

--- a/h2o-bindings/src/main/java/water/bindings/examples/Example.java
+++ b/h2o-bindings/src/main/java/water/bindings/examples/Example.java
@@ -181,7 +181,7 @@ public class Example {
                                                                               null,
                                                                               false, false, -1, null,
                                                                               false, false, false, false, null,
-                                                                              false, false, null, -1, -1, false, false, -1, false, null, null, null, -1, null).execute().body();
+                                                                              false, false, false, null, -1, -1, false, false, -1, false, null, null, null, -1, null).execute().body();
             System.out.println("predictions: " + predictions);
 
         }

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -30,7 +30,8 @@ class H2OGradientBoostingEstimator(H2OEstimator):
                                       'h2o.model.extensions.Trees',
                                       'h2o.model.extensions.SupervisedTrees',
                                       'h2o.model.extensions.HStatistic',
-                                      'h2o.model.extensions.Contributions'],
+                                      'h2o.model.extensions.Contributions',
+                                      'h2o.model.extensions.RowToTreeAssignment'],
                  'verbose': True}
 
     def __init__(self,

--- a/h2o-py/h2o/model/extensions/__init__.py
+++ b/h2o-py/h2o/model/extensions/__init__.py
@@ -13,6 +13,7 @@ from .trees import Trees
 from .supervised_trees import SupervisedTrees
 from .varimp import VariableImportance
 from .contributions import Contributions
+from .row_to_tree_assignment import RowToTreeAssignment
 
 module = sys.modules[__name__]
 
@@ -51,5 +52,6 @@ __all__ = [  # mainly useful here for the generated documentation
     'Trees',
     'SupervisedTrees', 
     'VariableImportance',
-    'Contributions'
+    'Contributions',
+    'RowToTreeAssignment'
 ]

--- a/h2o-py/h2o/model/extensions/row_to_tree_assignment.py
+++ b/h2o-py/h2o/model/extensions/row_to_tree_assignment.py
@@ -1,0 +1,13 @@
+import h2o
+from h2o.exceptions import H2OValueError
+from h2o.job import H2OJob
+
+
+class RowToTreeAssignment:
+
+    def _row_to_tree_assignment(self, test_data):
+        if not isinstance(test_data, h2o.H2OFrame): raise H2OValueError("test_data must be an instance of H2OFrame")
+        j = H2OJob(h2o.api("POST /4/Predictions/models/%s/frames/%s" % (self.model_id, test_data.frame_id),
+                           data={"row_to_tree_assignment": True}), "Row to tree assignment")
+        j.poll()
+        return h2o.get_frame(j.dest_key)

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -237,6 +237,44 @@ class ModelBase(h2o_meta(Keyed, H2ODisplay)):
             err_msg += " You can plot standardized coefficient magnitudes by calling std_coef_plot() on the model."
         raise H2OTypeError(message=err_msg)
 
+    def row_to_tree_assignment(self, original_training_data):
+        """
+        Output row to tree assignment for the model and provided training data.
+
+        Output is frame of size nrow = nrow(original_training_data) and ncol = number_of_trees_in_model+1 in format:
+         row_id    tree_1    tree_2    tree_3
+              0         0         1         1
+              1         1         1         1
+              2         1         0         0
+              3         1         1         0
+              4         0         1         1
+              5         1         1         1
+              6         1         0         0
+              7         0         1         0
+              8         0         1         1
+              9         1         0         0
+
+        :param H2OFrame original_training_data: Data that was used for model training. Currently there is no validation
+            of the input.
+        :returns: A new H2OFrame made of row to tree assignment output.
+
+        **Note**: Multinomial classification generate tree for each category, each tree use the same sample of the data.
+
+        :examples:
+
+        >>> prostate = "http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate.csv"
+        >>> fr = h2o.import_file(prostate)
+        >>> predictors = list(range(2, fr.ncol))
+        >>> m = H2OGradientBoostingEstimator(ntrees=10, seed=1234, sample_rate=0.6)
+        >>> m.train(x=predictors, y=1, training_frame=fr)
+        >>> # Output row to tree assignment
+        >>> m.row_to_tree_assignment(fr)
+        """
+        if has_extension(self, 'RowToTreeAssignment'):
+            return self._row_to_tree_assignment(original_training_data)
+        err_msg = "This model doesn't support calculation of row to tree assignment."
+        raise H2OTypeError(message=err_msg)
+
     def feature_frequencies(self, test_data):
         """
         Retrieve the number of occurrences of each feature for given observations 

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_row_to_tree_assignment_api.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_row_to_tree_assignment_api.py
@@ -1,0 +1,36 @@
+from __future__ import print_function
+import os
+import sys
+
+sys.path.insert(1, os.path.join("..","..",".."))
+import h2o
+from tests import pyunit_utils, assert_equals
+from h2o.estimators import H2OGradientBoostingEstimator
+
+
+def test_row_to_tree_assignment_output():
+    fr = h2o.import_file(path=pyunit_utils.locate("smalldata/prostate/prostate.csv"))
+    target = "CAPSULE"
+    fr[target] = fr[target].asfactor()
+
+    gbm = H2OGradientBoostingEstimator(ntrees=3,
+                                       sample_rate=0.6,
+                                       seed=95)
+    gbm.train(y=target, training_frame=fr)
+
+    row_to_tree_assignment = gbm.row_to_tree_assignment(fr)
+
+    print(h2o.ls())
+    print()
+    print("Frame id", row_to_tree_assignment.frame_id)
+
+    print(row_to_tree_assignment)
+
+    assert_equals(["row_id", "tree_1", "tree_2", "tree_3"], row_to_tree_assignment.names)
+    assert_equals(fr.nrows, row_to_tree_assignment.nrows)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_row_to_tree_assignment_output)
+else:
+    test_row_to_tree_assignment_output()

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_row_to_tree_assignment_large.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_row_to_tree_assignment_large.py
@@ -1,0 +1,32 @@
+from __future__ import print_function
+import os
+import sys
+
+sys.path.insert(1, os.path.join("..","..",".."))
+import h2o
+from tests import pyunit_utils, assert_equals
+from h2o.estimators import H2OGradientBoostingEstimator
+
+
+def test_row_to_tree_assignment_output_on_large_dataset():
+    fr = h2o.import_file(path=pyunit_utils.locate("bigdata/laptop/creditcardfraud/creditcardfraud.csv"))
+    target = "Class"
+    fr[target] = fr[target].asfactor()
+
+    gbm = H2OGradientBoostingEstimator(ntrees=1000,
+                                       sample_rate=0.6)
+    gbm.train(y=target, training_frame=fr)
+
+    row_to_tree_assignment = gbm.row_to_tree_assignment(fr)
+
+    names_expected = ["row_id"]
+    names_expected.extend([("tree_" + str(item)) for item in range(1, 1001)])
+
+    assert_equals(names_expected, row_to_tree_assignment.names)
+    assert_equals(fr.nrows, row_to_tree_assignment.nrows)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_row_to_tree_assignment_output_on_large_dataset)
+else:
+    test_row_to_tree_assignment_output_on_large_dataset()


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8637

Hello, here is the implementation for rowToTreeAssignment python API.

```
fr = h2o.import_file(path=pyunit_utils.locate("smalldata/prostate/prostate.csv"))
target = "CAPSULE"
fr[target] = fr[target].asfactor()

gbm = H2OGradientBoostingEstimator(ntrees=3,
                                   sample_rate=0.6,
                                   seed=95)
gbm.train(y=target, training_frame=fr)

row_to_tree_assignment = gbm.row_to_tree_assignment(fr)

  row_id    tree_1    tree_2    tree_3
       0         0         1         1
       1         1         1         1
       2         1         0         0
       3         1         1         0
       4         0         1         1
       5         1         1         1
       6         1         0         0
       7         0         1         0
       8         0         1         1
       9         1         0         0
```