### PR TITLE
PUBDEV-8971: Speed-up XGBoost scoring on wide datasets

### DIFF
--- a/h2o-extensions/xgboost/src/main/java/biz/k11i/xgboost/tree/NodeHelper.java
+++ b/h2o-extensions/xgboost/src/main/java/biz/k11i/xgboost/tree/NodeHelper.java
@@ -1,0 +1,27 @@
+package biz.k11i.xgboost.tree;
+
+import biz.k11i.xgboost.util.ModelReader;
+
+import java.io.IOException;
+
+/**
+ * This class exposes some package-private APIs of RegTreeImpl.Node and provides additional helper methods.
+ * These methods can eventually be folded back into the original class.
+ */
+public class NodeHelper {
+
+    public static RegTreeNode read(ModelReader reader) throws IOException {
+        return new RegTreeImpl.Node(reader);
+    }
+
+    public static boolean isEqual(RegTreeNode left, RegTreeNode right) {
+        return left.getParentIndex() == right.getParentIndex() 
+                && left.getLeftChildIndex() == right.getLeftChildIndex() 
+                && left.getRightChildIndex() == right.getRightChildIndex()
+                && left.getSplitIndex() == right.getSplitIndex()
+                && Float.compare(left.getLeafValue(), right.getLeafValue()) == 0 
+                && Float.compare(left.getSplitCondition(), right.getSplitCondition()) == 0
+                && left.default_left() == right.default_left();
+    }
+
+}

--- a/h2o-extensions/xgboost/src/main/java/biz/k11i/xgboost/tree/NodeHelper.java
+++ b/h2o-extensions/xgboost/src/main/java/biz/k11i/xgboost/tree/NodeHelper.java
@@ -15,13 +15,15 @@ public class NodeHelper {
     }
 
     public static boolean isEqual(RegTreeNode left, RegTreeNode right) {
-        return left.getParentIndex() == right.getParentIndex() 
+        return left == right || (   // also covers null case
+                left.getParentIndex() == right.getParentIndex() 
                 && left.getLeftChildIndex() == right.getLeftChildIndex() 
                 && left.getRightChildIndex() == right.getRightChildIndex()
                 && left.getSplitIndex() == right.getSplitIndex()
                 && Float.compare(left.getLeafValue(), right.getLeafValue()) == 0 
                 && Float.compare(left.getSplitCondition(), right.getSplitCondition()) == 0
-                && left.default_left() == right.default_left();
+                && left.default_left() == right.default_left()
+        );
     }
 
 }

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/predict/PredictorFactory.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/predict/PredictorFactory.java
@@ -34,7 +34,7 @@ public class PredictorFactory {
     }
   }
 
-  private static boolean unsafeTreesSupported() {
+  static boolean unsafeTreesSupported() {
     // XGBoost Predictor uses LE, we can only use our scoring if the system has the same endianness
     return ByteOrder.nativeOrder().equals(ByteOrder.LITTLE_ENDIAN);
   }

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/predict/XGBoostJavaBigScorePredict.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/predict/XGBoostJavaBigScorePredict.java
@@ -1,12 +1,17 @@
 package hex.tree.xgboost.predict;
 
 import biz.k11i.xgboost.Predictor;
+import biz.k11i.xgboost.gbm.GBTree;
+import biz.k11i.xgboost.gbm.GradBooster;
+import biz.k11i.xgboost.tree.RegTree;
+import biz.k11i.xgboost.tree.RegTreeNode;
 import hex.DataInfo;
 import hex.tree.xgboost.XGBoostModel;
 import hex.tree.xgboost.XGBoostOutput;
 import hex.tree.xgboost.XGBoostModelInfo;
 import water.fvec.Chunk;
 import water.fvec.Frame;
+import water.util.ArrayUtils;
 
 public class XGBoostJavaBigScorePredict implements XGBoostBigScorePredict {
 
@@ -15,6 +20,7 @@ public class XGBoostJavaBigScorePredict implements XGBoostBigScorePredict {
   private final XGBoostModel.XGBoostParameters _parms;
   private final double _threshold;
   private final Predictor _predictor;
+  private final boolean[] _usedColumns;
 
   public XGBoostJavaBigScorePredict(
       XGBoostModelInfo model_info,
@@ -27,11 +33,49 @@ public class XGBoostJavaBigScorePredict implements XGBoostBigScorePredict {
     _parms = parms;
     _threshold = threshold;
     _predictor = PredictorFactory.makePredictor(model_info._boosterBytes);
+    _usedColumns = findUsedColumns(_predictor.getBooster(), di, _output.nfeatures());
   }
 
   @Override
   public XGBoostPredict initMap(Frame fr, Chunk[] chks) {
-    return new XGBoostJavaBigScoreChunkPredict(_di, _output, _parms, _threshold, _predictor, fr);
+    return new XGBoostJavaBigScoreChunkPredict(_di, _output, _parms, _threshold, _predictor, _usedColumns, fr);
+  }
+
+  /**
+   * For each input feature decides whether it is used by the model or not.
+   * 
+   * @param booster booster
+   * @param di data info
+   * @param nFeatures number of features provided at training time
+   * @return boolean flag for each input feature indicating whether it is used or not, returns null if the used
+   * features cannot be determined or model uses all of them (null thus effectively means use everything to the caller)
+   */
+  static boolean[] findUsedColumns(GradBooster booster, DataInfo di, final int nFeatures) {
+    if (! (booster instanceof GBTree)) {
+      return null;
+    }
+    int[] splitIndexToColumnIndex = di.coefOriginalColumnIndices();
+    assert ArrayUtils.maxValue(splitIndexToColumnIndex) < nFeatures; // this holds because feature columns go first, before special columns
+    boolean[] usedColumns = new boolean[nFeatures];
+    int usedCount = 0;
+    for (RegTree[] trees : ((GBTree) booster).getGroupedTrees()) {
+      for (RegTree tree : trees) {
+        for (RegTreeNode node : tree.getNodes()) {
+          if (node.isLeaf()) {
+            continue;
+          }
+          int column = splitIndexToColumnIndex[node.getSplitIndex()];
+          if (!usedColumns[column]) {
+            usedCount++;
+            usedColumns[column] = true;
+            if (splitIndexToColumnIndex.length == usedCount) { // all columns already used, abort
+              return null;
+            }
+          }
+        }
+      }
+    }
+    return usedColumns;
   }
 
 }

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/task/XGBoostScoreTask.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/task/XGBoostScoreTask.java
@@ -13,7 +13,7 @@ import water.MemoryManager;
 import water.fvec.Chunk;
 import water.fvec.NewChunk;
 
-public class XGBoostScoreTask extends MRTask<XGBoostScoreTask> {
+public class XGBoostScoreTask extends MRTask<XGBoostScoreTask> { // used to score model metrics
 
     private final XGBoostOutput _output;
     private final int _weightsChunkId;

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostScoringTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostScoringTest.java
@@ -1,0 +1,75 @@
+package hex.tree.xgboost;
+
+import hex.tree.xgboost.util.PredictConfiguration;
+import org.junit.Test;
+import org.junit.Rule;
+
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.runner.RunWith;
+import water.Scope;
+import water.TestUtil;
+import water.fvec.Frame;
+import water.runner.H2ORunner;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.*;
+
+@RunWith(H2ORunner.class)
+public class XGBoostScoringTest extends TestUtil {
+
+    @Rule
+    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+    @Test
+    public void testScoringOnWideDataset() { // compare results of xgboost native and Java predictor scoring
+        Scope.enter();
+        try {
+            String response = "C785";
+            Frame train = parseTestFile("bigdata/laptop/mnist/train.csv.gz")
+                    .toCategoricalCol(response);
+            Scope.track(train);
+            Frame test = parseTestFile("bigdata/laptop/mnist/test.csv.gz")
+                    .toCategoricalCol(response);
+            Scope.track(test);
+            
+            XGBoostModel.XGBoostParameters parms = new XGBoostModel.XGBoostParameters();
+            parms._ntrees = 10;
+            parms._max_depth = 3;
+            parms._train = train._key;
+            parms._response_column = response;
+            parms._seed = 0xCAFE;
+            parms._score_each_iteration = true;
+            parms._backend = XGBoostModel.XGBoostParameters.Backend.cpu;
+
+            System.setProperty(PredictConfiguration.PREDICT_JAVA_PROP, "false");
+            System.setProperty(PredictConfiguration.PREDICT_NATIVE_PROP, "true");
+            assertFalse(PredictConfiguration.useJavaScoring());
+            
+            XGBoostModel modelNative = new XGBoost((XGBoostModel.XGBoostParameters) parms.clone()).trainModel().get();
+            assertNotNull(modelNative);
+            Scope.track_generic(modelNative);
+
+            Frame predsNative = modelNative.score(test);
+            Scope.track(predsNative);
+
+            System.setProperty(PredictConfiguration.PREDICT_JAVA_PROP, "true");
+            System.setProperty(PredictConfiguration.PREDICT_NATIVE_PROP, "false");
+            assertTrue(PredictConfiguration.useJavaScoring());
+            
+            XGBoostModel modelJava = new XGBoost((XGBoostModel.XGBoostParameters) parms.clone()).trainModel().get();
+            assertNotNull(modelJava);
+            Scope.track_generic(modelJava);
+
+            Frame predsJava = modelJava.score(test);
+            Scope.track(predsJava);
+
+            // predictions should match
+            assertFrameEquals(predsNative, predsJava, 1e-7);
+            // scoring history should be the same
+            assertArrayEquals(modelNative._output.scoreKeepers(), modelJava._output.scoreKeepers());
+        } finally {
+            Scope.exit();
+        }
+    }
+
+}

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/predict/PredictorTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/predict/PredictorTest.java
@@ -1,0 +1,79 @@
+package hex.tree.xgboost.predict;
+
+import biz.k11i.xgboost.Predictor;
+import biz.k11i.xgboost.gbm.GBTree;
+import biz.k11i.xgboost.tree.NodeHelper;
+import biz.k11i.xgboost.tree.RegTree;
+import biz.k11i.xgboost.tree.RegTreeImpl;
+import biz.k11i.xgboost.tree.RegTreeNode;
+import hex.tree.xgboost.XGBoostModel;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import water.Scope;
+import water.TestUtil;
+import water.fvec.Frame;
+import water.runner.H2ORunner;
+
+import static org.junit.Assert.*;
+
+@RunWith(H2ORunner.class)
+public class PredictorTest extends TestUtil {
+
+    @Test
+    public void testScoringTreesHaveCorrectNodesInfo() {
+        Assume.assumeTrue(PredictorFactory.unsafeTreesSupported());
+        Scope.enter();
+        try {
+            final String response = "PressureChange";
+            Frame frame = parseTestFile("./smalldata/junit/weather.csv")
+                    .toCategoricalCol(response);
+            Scope.track(frame);
+
+            XGBoostModel.XGBoostParameters parms = new XGBoostModel.XGBoostParameters();
+            parms._ntrees = 10;
+            parms._max_depth = 5;
+            parms._train = frame._key;
+            parms._response_column = response;
+
+            XGBoostModel model = new hex.tree.xgboost.XGBoost(parms).trainModel().get();
+            assertNotNull(model);
+            Scope.track_generic(model);
+
+            byte[] boosterBytes = model.model_info()._boosterBytes;
+
+            Predictor fullPredictor = PredictorFactory.makePredictor(boosterBytes, null, false);
+            assertTrue(fullPredictor.getBooster() instanceof GBTree);
+            GBTree fullBooster = (GBTree) fullPredictor.getBooster();
+
+            Predictor scoringPredictor = PredictorFactory.makePredictor(boosterBytes, null, true);
+            assertTrue(scoringPredictor.getBooster() instanceof GBTree);
+            GBTree scoringBooster = (GBTree) scoringPredictor.getBooster();
+
+            assertEquals(fullBooster.getGroupedTrees().length, scoringBooster.getGroupedTrees().length);
+            for (int i = 0; i < fullBooster.getGroupedTrees().length; i++) {
+                RegTree[] fullTrees = fullBooster.getGroupedTrees()[i];
+                RegTree[] scoringTrees = scoringBooster.getGroupedTrees()[i];
+                assertEquals(fullTrees.length, scoringTrees.length);
+                for (int j = 0; j < fullTrees.length; j++) {
+                    assertTrue(fullTrees[j] instanceof RegTreeImpl);
+                    assertTrue(scoringTrees[j] instanceof XGBoostRegTree);
+                    RegTreeNode[] fullNodes = fullTrees[j].getNodes();
+                    RegTreeNode[] scoringNodes = scoringTrees[j].getNodes();
+                    assertNotSame(fullNodes, scoringNodes);
+                    assertNodesEqual(fullNodes, scoringNodes);
+                }
+            }
+        } finally {
+            Scope.exit();
+        }
+    }
+
+    static void assertNodesEqual(RegTreeNode[] expected, RegTreeNode[] actual) {
+        assertEquals(expected.length, actual.length);
+        for (int i = 0; i < expected.length; i++) {
+            assertTrue(NodeHelper.isEqual(expected[i], actual[i]));
+        }
+    }
+
+}

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/predict/XGBoostJavaBigScorePredictTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/predict/XGBoostJavaBigScorePredictTest.java
@@ -1,0 +1,106 @@
+package hex.tree.xgboost.predict;
+
+import biz.k11i.xgboost.Predictor;
+import hex.genmodel.algos.tree.SharedTreeGraph;
+import hex.genmodel.algos.tree.SharedTreeNode;
+import hex.tree.xgboost.XGBoostModel;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import water.DKV;
+import water.Scope;
+import water.TestUtil;
+import water.fvec.Frame;
+import water.fvec.Vec;
+import water.runner.H2ORunner;
+
+import static org.junit.Assert.*;
+
+@RunWith(H2ORunner.class)
+public class XGBoostJavaBigScorePredictTest extends TestUtil  {
+
+    @Test
+    public void testFindUsedColumns_onlySomeUsed() {
+        XGBoostModel.XGBoostParameters parms = new XGBoostModel.XGBoostParameters();
+        parms._weights_column = "CAPSULE";
+        parms._max_depth = 3;
+        final int nTrees = 5;
+        final int maxUsed = (2 << parms._max_depth) * nTrees; // upper bound for number of used columns
+        
+        boolean[] used = checkFindUsedColumns(parms, nTrees, maxUsed + 100); // add some extra random columns
+        assertTrue(countTrues(used) > 0); // enough trees so that at least one column gets used
+        assertTrue(countTrues(used) < maxUsed); // but not more than the theoretical upper bound
+    }
+
+    @Test
+    public void testFindUsedColumns_noneUsed() {
+        XGBoostModel.XGBoostParameters parms = new XGBoostModel.XGBoostParameters();
+        parms._min_rows = 10_000;
+
+        boolean[] used = checkFindUsedColumns(parms, 1, 0);
+        // min_rows is too high - we cannot make a split => no columns can be used
+        assertEquals(0, countTrues(used));
+    }
+
+    @Test
+    public void testFindUsedColumns_allUsed() {
+        XGBoostModel.XGBoostParameters parms = new XGBoostModel.XGBoostParameters();
+
+        boolean[] used = checkFindUsedColumns(parms, 50, 0);
+        assertNull(used); // null means everything is used
+    }
+
+    private boolean[] checkFindUsedColumns(XGBoostModel.XGBoostParameters parms, final int N, final int nRandCols) {
+        Scope.enter();
+        try {
+            Frame tfr = Scope.track(parseTestFile("./smalldata/prostate/prostate.csv"));
+
+            parms._train = tfr._key;
+            parms._response_column = "AGE";
+            parms._ignored_columns = new String[]{"ID"};
+            parms._seed = 42;
+            parms._ntrees = N;
+            
+            for (int i = 0; i < nRandCols; i++) {
+                Vec randVec = tfr.anyVec().makeRand(42L + i);
+                tfr.add("Rand" + i, randVec);
+            }
+            Scope.track(tfr);
+            DKV.put(tfr);
+
+            XGBoostModel model = Scope.track_generic(new hex.tree.xgboost.XGBoost(parms).trainModel().get());
+            assertNotNull(model);
+
+            boolean[] usedExpected = new boolean[model._output.nfeatures()];
+            for (int i = 0; i < N; i++) {
+                SharedTreeGraph t = model.convert(i, null);
+                for (SharedTreeNode node : t.subgraphArray.get(0).getNodes()) {
+                    if (!node.isLeaf())
+                        usedExpected[node.getSplitIndex()] = true;
+                }
+            }
+
+            Predictor predictor = PredictorFactory.makePredictor(model.model_info()._boosterBytes);
+            boolean[] usedActual = XGBoostJavaBigScorePredict.findUsedColumns(predictor.getBooster(),
+                    model.model_info().dataInfo(), model._output.nfeatures());
+
+            if (countTrues(usedExpected) == usedExpected.length) {
+                assertNull(usedActual);
+            } else {
+                assertArrayEquals(usedExpected, usedActual);
+            }
+            return usedActual;
+        } finally {
+            Scope.exit();
+        }
+    }
+
+    int countTrues(boolean[] bs) {
+        int cnt = 0;
+        for (boolean b : bs) {
+            if (b)
+                cnt++;
+        }
+        return cnt;
+    }
+
+}


### PR DESCRIPTION
The goal of this PR is to speed-up XGBoost scoring, especially on wide datasets and in cases when only a portion of training columns is used to by the model.

Idea: It is expensive to repeatedly (=for each scoring) convert H2O Frame into float[] rows for Predictor scoring. In this change we only convert the columns that are actually actively used by the model.

Measurements (only measures scoring time during training, time to build trees is ignored)

Case MNIST, 60k rows, 785 cols

    Default settings + score_each_iteration = True

    Old: 15.7s
    New: 9.4s


Syntetic, 300k rows, 800 cols

    Extreme settings - max_depth = 1, ntrees = 10 (this forces a small model - only up to 10 different features can be used by the model)

    Old: 89s
    New: 8.1s (10x+ speed-up)

This is an early preview of the implementation demonstrating the direction I would like to evolve the PR in.