### PR TITLE
PUBDEV-8972: Added information on `row_to_tree_assignment` function

### DIFF
--- a/h2o-docs/src/product/data-science/gbm-faq/reproducibility.rst
+++ b/h2o-docs/src/product/data-science/gbm-faq/reproducibility.rst
@@ -376,7 +376,7 @@ The **Node Information** subtable stores monitoring information for each node. T
 Can I access the row to tree assignments for my model?
 ######################################################
 
-``row_to_tree_assignment`` provides the row to tree assignments for the model and the provided training data. This feature allows you to debug the model and assists with replicating the model. 
+``row_to_tree_assignment`` provides the row to tree assignments for the model and the provided training data. This feature allows you to debug the model and assists with replicating the model.
 
 **Note**: Multinomial classification models generate a tree for each category, and each tree uses the same sample of data.
 

--- a/h2o-docs/src/product/data-science/gbm-faq/reproducibility.rst
+++ b/h2o-docs/src/product/data-science/gbm-faq/reproducibility.rst
@@ -392,7 +392,7 @@ Can I access the row to tree assignments for my model?
 
       # Build and train the model:
       gbm_model = H2OGradientBoostingEstimator(ntrees=3, sample_rate=0.6, seed=1234)
-      gbm_model.train(y=target, training_frame=fr)
+      gbm_model.train(y=response, training_frame=prostate)
 
       # Access the row to tree assignments:
-      gbm.row_to_tree_assignment(prostate)
+      gbm_model.row_to_tree_assignment(prostate)

--- a/h2o-docs/src/product/data-science/gbm-faq/reproducibility.rst
+++ b/h2o-docs/src/product/data-science/gbm-faq/reproducibility.rst
@@ -376,7 +376,7 @@ The **Node Information** subtable stores monitoring information for each node. T
 Can I access the row to tree assignments for my model?
 ######################################################
 
-``row_to_tree_assignment`` provides the row to tree assignments for the model and the provided training data. This feature allows you to debug the model and assists with replicating the model.
+``row_to_tree_assignment`` provides the row to tree assignments for the model and the provided training data. This feature allows you to debug the model and assists with replicating the model. 
 
 **Note**: Multinomial classification models generate a tree for each category, and each tree uses the same sample of data.
 

--- a/h2o-docs/src/product/data-science/gbm-faq/reproducibility.rst
+++ b/h2o-docs/src/product/data-science/gbm-faq/reproducibility.rst
@@ -372,3 +372,27 @@ The **Node Information** subtable stores monitoring information for each node. T
 - ``os_version``: OS version
 - ``machine_physical_mem``: Machine physical memory
 - ``machine_locale``: Machine locale
+
+Can I access the row to tree assignments for my model?
+######################################################
+
+``row_to_tree_assignment`` provides the row to tree assignments for the model and the provided training data. This feature allows you to debug the model and assists with replicating the model.
+
+**Note**: Multinomial classification models generate a tree for each category, and each tree uses the same sample of data.
+
+.. tabs::
+   .. code-tab:: python
+
+      # Import the prostate dataset:
+      prostate = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate.csv")
+
+      # Set the response:
+      response = "CAPSULE"
+      prostate[response] = prostate[response].asfactor()
+
+      # Build and train the model:
+      gbm_model = H2OGradientBoostingEstimator(ntrees=3, sample_rate=0.6, seed=1234)
+      gbm_model.train(y=target, training_frame=fr)
+
+      # Access the row to tree assignments:
+      gbm.row_to_tree_assignment(prostate)


### PR DESCRIPTION
For: [PUBDEV-8972](https://h2oai.atlassian.net/browse/PUBDEV-8972)

Added to the reproducibility section of the GBM FAQ. Please let me know if it needs to be shifted elsewhere or if any information needs to be changed or updated.

[PUBDEV-8972]: https://h2oai.atlassian.net/browse/PUBDEV-8972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ