### PR TITLE
PUBDEV-8973: Add documentation for not optimized deviance

### DIFF
--- a/h2o-docs/src/product/data-science/gbm-faq/generated_metrics.rst
+++ b/h2o-docs/src/product/data-science/gbm-faq/generated_metrics.rst
@@ -9,8 +9,10 @@ What evaluation metrics are available for GBM?
 - MAE
 - RMSLE
 - Mean Residual Deviance
+- Mean Residual Deviance Not Optimized
 
-**Notes**: MSE = Mean Residual Deviance for Gaussian distributions. Also, look at Mean Residual Deviance when using quantile distributions.
+**Notes**: MSE = Mean Residual Deviance for Gaussian distributions. Also, look at Mean Residual Deviance when using quantile distributions. Mean Residual Deviance Not Optimized is currently only implemented for Poisson distribution. Mean Residual Deviance Not Optimized is calculated from the original deviance formula. Mean Residual Deviance uses an optimized deviance formula for some distributions which provides a different output than the original deviance formula would. 
+
 
 How is variable importance determined?
 ######################################


### PR DESCRIPTION
For: [PUBDEV-8973](https://h2oai.atlassian.net/browse/PUBDEV-8973)

Added information on Mean Residual Deviance Not Optimized. Requires https://github.com/h2oai/h2o-3/pull/6430 to be merged first.

Please let me know if anything needs to be updated.

[PUBDEV-8973]: https://h2oai.atlassian.net/browse/PUBDEV-8973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ