### PR TITLE
PUBDEV-8974: Replace non-functional data paths in code examples in the user guide

### DIFF
--- a/h2o-docs/src/product/data-science/permutation-variable-importance.rst
+++ b/h2o-docs/src/product/data-science/permutation-variable-importance.rst
@@ -55,7 +55,7 @@ Examples
         h2o.init()
 
         # load data
-        prostate_train <- h2o.uploadFile("smalldata/prostate/prostate.csv")
+        prostate_train <- h2o.importFile("http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate.csv")
 
         # train a model
         gbm <- h2o.gbm(y = "CAPSULE", training_frame = prostate_train)
@@ -78,7 +78,7 @@ Examples
         h2o.init()
 
         # load data
-        prostate_train = h2o.import_file(path="smalldata/prostate/prostate.csv")
+        prostate_train = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate.csv")
         prostate_train["CAPSULE"] = prostate_train["CAPSULE"].asfactor()
 
         # train model

--- a/h2o-docs/src/product/data-science/quantiles.rst
+++ b/h2o-docs/src/product/data-science/quantiles.rst
@@ -24,8 +24,7 @@ Examples
 	.. code-tab:: r R
 
 		# Import the prostate dataset:
-		prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
-		prostate <- h2o.uploadFile(path = prostate_path)
+		prostate <- h2o.importFile("http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate.csv")
 
 		# Request quantiles for the parsed dataset
 		quantile(prostate)

--- a/h2o-docs/src/product/faq/python.rst
+++ b/h2o-docs/src/product/faq/python.rst
@@ -146,17 +146,17 @@ Refer to the following example:
     #to categorical. You have 3 options.
 
     #Option 1. Use a dictionary of column names to types. 
-    fr = h2o.import_file("smalldata/logreg/prostate.csv", col_types = {"CAPSULE":"enum"})
+    fr = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/logreg/prostate.csv", col_types = {"CAPSULE":"enum"})
     fr.describe()
 
     #Option 2. Use a list of column types.
     c_types = [None]*9
     c_types[1] = "enum"
-    fr = h2o.import_file("smalldata/logreg/prostate.csv", col_types = c_types)
+    fr = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/logreg/prostate.csv", col_types = c_types)
     fr.describe()
 
     #Option 3. Use parse_setup().
-    fraw = h2o.import_file("smalldata/logreg/prostate.csv", parse = False)
+    fraw = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/logreg/prostate.csv", parse = False)
     fsetup = h2o.parse_setup(fraw) 
     fsetup["column_types"][1] = '"enum"'
     fr = h2o.parse_raw(fsetup) 
@@ -216,7 +216,7 @@ Here is an example of grid search in PySparkling:
     from h2o.grid.grid_search import H2OGridSearch
     from h2o.estimators.gbm import H2OGradientBoostingEstimator
 
-    iris = h2o.import_file("/Users/nidhimehta/h2o-dev/smalldata/iris/iris.csv")
+    iris = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/iris/iris.csv")
 
     ntrees_opt = [5, 10, 15]
     max_depth_opt = [2, 3, 4]


### PR DESCRIPTION
For: [PUBDEV-8974](https://h2oai.atlassian.net/browse/PUBDEV-8974)

I found usages of `uploadFile` in the file you pointed out and in `quantiles.rst`. I noticed some non-functional data paths in the Python FAQ as well when scanning through the user guide. 

[PUBDEV-8974]: https://h2oai.atlassian.net/browse/PUBDEV-8974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ