### PR TITLE
PUBDEV-8977: add accessor functions in R and Python to access the GLM neg logll and average objective

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -2167,8 +2167,6 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       }
     }
 
-
-
     private void fitIRLSMML(Solver s) {
       double[] betaCnd = _checkPointFirstIter ? _model._betaCndCheckpoint : _state.beta();
       LineSearchSolver ls = null;

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -2167,6 +2167,8 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       }
     }
 
+
+
     private void fitIRLSMML(Solver s) {
       double[] betaCnd = _checkPointFirstIter ? _model._betaCndCheckpoint : _state.beta();
       LineSearchSolver ls = null;

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -546,7 +546,7 @@ class ModelBase(h2o_meta(Keyed, H2ODisplay)):
         
         :return: the negative likelihood function value
         """
-        return self.extract_scoring_history("negative_log_likelihood")
+        return self._extract_scoring_history("negative_log_likelihood")
 
     def average_objective(self):
         """
@@ -555,10 +555,10 @@ class ModelBase(h2o_meta(Keyed, H2ODisplay)):
         
         :return: the average objective function value
         """
-        return self.extract_scoring_history("objective")
+        return self._extract_scoring_history("objective")
 
         
-    def extract_scoring_history(self, value):
+    def _extract_scoring_history(self, value):
         model = self._model_json["output"]
         if 'glm' == self.algo:
             if self.actual_params['generate_scoring_history'] is True:

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -539,6 +539,46 @@ class ModelBase(h2o_meta(Keyed, H2ODisplay)):
         if "scoring_history" in model and model["scoring_history"] is not None:
             return model["scoring_history"].as_data_frame()
         print("No score history for this model")
+        
+    def negative_log_likelihood(self):
+        """
+        Retrieve model negative likelihood function value from scoring history if exists for GLM model
+        
+        :return: the negative likelihood function value
+        """
+        return self.extract_scoring_history("negative_log_likelihood")
+
+    def avarege_objective(self):
+        """
+        Retrieve model average objective function value from scoring history if exists for GLM model.  If there is no 
+        regularization, the avearge objective value*obj_reg should equal the neg_log_likelihood value.
+        
+        :return: the average objective function value
+        """
+        return self.extract_scoring_history("objective")
+
+        
+    def extract_scoring_history(self, value):
+        model = self._model_json["output"]
+        if 'glm' == self.algo:
+            if self.actual_params['generate_scoring_history'] is True:
+                if "scoring_history" in model and model["scoring_history"] is not None:
+                    sc_history = model["scoring_history"]
+                    col_header = sc_history._col_header
+                    if value in col_header:
+                        index_val = col_header.index(value)
+                        scLen = len(sc_history._cell_values)
+                        return sc_history._cell_values[scLen-1][index_val]
+                    else:
+                        print("{0} not available.".format(value))
+                else:
+                    raise H2OValueError("GLM scoring_history is missing.  Cannot extract {0}.".value)
+            else:
+                raise H2OValueError("For now, need to set generate_scoring_history to True to get {0}".format(value))
+        else:
+            raise H2OValueError("{0} is only for GLM models.".format(value))
+
+
 
     def ntrees_actual(self):
         """

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -548,7 +548,7 @@ class ModelBase(h2o_meta(Keyed, H2ODisplay)):
         """
         return self.extract_scoring_history("negative_log_likelihood")
 
-    def avarege_objective(self):
+    def average_objective(self):
         """
         Retrieve model average objective function value from scoring history if exists for GLM model.  If there is no 
         regularization, the avearge objective value*obj_reg should equal the neg_log_likelihood value.

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8977_negLL_Obj.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8977_negLL_Obj.py
@@ -1,0 +1,29 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+
+def test_glm_negLL_Obj():
+    d = h2o.import_file(pyunit_utils.locate("smalldata/glm_test/gaussian_20cols_10000Rows.csv"))
+    d["C1"] = d["C1"].asfactor()
+    d["C2"] = d["C2"].asfactor()
+    my_y = "C21"
+    my_x = d.names
+    my_x.remove(my_y)
+    glm_model = H2OGeneralizedLinearEstimator(family="gaussian", seed=1234, generate_scoring_history=True)
+    glm_model.train(x=my_x, y=my_y, training_frame=d)
+    glm_model_noReg = H2OGeneralizedLinearEstimator(family="gaussian", seed=1234, generate_scoring_history=True, lambda_=0.0)
+    glm_model_noReg.train(x=my_x, y=my_y, training_frame=d)
+    nll = glm_model.negative_log_likelihood()
+    obj = glm_model.average_objective()
+    nll_noReg = glm_model_noReg.negative_log_likelihood()
+    obj_noReg = glm_model_noReg.average_objective()
+    assert abs(nll_noReg-obj_noReg/glm_model_noReg.actual_params["obj_reg"]) < 1e-6, \
+        "objective ({0}) and negative log likelihood ({1}) should equal but do not.".format(obj_noReg, nll_noReg)
+    assert abs(nll-obj) > 1e-6, "objective ({0}) and negative log likelihood ({1}) should not equal but do" \
+                                            " not.".format(obj, nll)
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(test_glm_negLL_Obj)
+else:
+    test_glm_negLL_Obj()

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -2503,6 +2503,7 @@ h2o.get_regression_influence_diagnostics <- function(model, predictorSize = -1) 
 #'
 #' @param model an \linkS4class{H2OModel} object.
 #' @return The final training negative log likelihood of a GLM model.
+#' 
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -2521,13 +2522,14 @@ h2o.get_regression_influence_diagnostics <- function(model, predictorSize = -1) 
 #' }
 #' @export 
 h2o.negative_log_likelihood <- function(model) {
-    return(h2o.extract_value(model, "negative_log_likelihood"))
+    return(extract_scoring_history(model, "negative_log_likelihood"))
 }
 
 #'
 #' Extracts the final training average objective function of a GLM model.
 #'
 #' @param model an \linkS4class{H2OModel} object.
+#' @return The final training average objective of a GLM model.
 #' 
 #' @examples 
 #' \dontrun{
@@ -2547,10 +2549,10 @@ h2o.negative_log_likelihood <- function(model) {
 #' }
 #' @export 
 h2o.average_objective <- function(model) {
-    return(h2o.extract_value(model, "objective"))
+    return(extract_scoring_history(model, "objective"))
 }
 
-h2o.extract_value <- function(model, value) {
+extract_scoring_history <- function(model, value) {
   if (is(model, "H2OModel") && (model@algorithm=='glm')) {
       if (model@allparameters$generate_scoring_history==TRUE) {
           scHist <- model@model$scoring_history

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -2502,7 +2502,7 @@ h2o.get_regression_influence_diagnostics <- function(model, predictorSize = -1) 
 #' Extracts the final training negative log likelihood of a GLM model.
 #'
 #' @param model an \linkS4class{H2OModel} object.
-#' 
+#' @return The final training negative log likelihood of a GLM model.
 #' @examples 
 #' \dontrun{
 #' library(h2o)

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -2499,6 +2499,71 @@ h2o.get_regression_influence_diagnostics <- function(model, predictorSize = -1) 
 }
 
 #'
+#' Extracts the final training negative log likelihood of a GLM model.
+#'
+#' @param model an \linkS4class{H2OModel} object.
+#' 
+#' @examples 
+#' \dontrun{
+#' library(h2o)
+#' h2o.init()
+#' 
+#' f <- "https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv"
+#' cars <- h2o.importFile(f)
+#' predictors <- c("displacement", "power", "weight", "acceleration", "year")
+#' response <- "acceleration"
+#' cars_model <- h2o.glm((y=response, 
+#'                        x=predictors, 
+#'                        training_frame = cars, 
+#'                        family="gaussian",
+#'                        generate_scoring_history=TRUE)
+#' objValue <- h2o.negative_log_likelihood(cars_model)
+#' }
+#' @export 
+h2o.negative_log_likelihood <- function(model) {
+    return(h2o.extract_value(model, "negative_log_likelihood"))
+}
+
+#'
+#' Extracts the final training average objective function of a GLM model.
+#'
+#' @param model an \linkS4class{H2OModel} object.
+#' 
+#' @examples 
+#' \dontrun{
+#' library(h2o)
+#' h2o.init()
+#' 
+#' f <- "https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv"
+#' cars <- h2o.importFile(f)
+#' predictors <- c("displacement", "power", "weight", "acceleration", "year")
+#' response <- "acceleration"
+#' cars_model <- h2o.glm((y=response, 
+#'                        x=predictors, 
+#'                        training_frame = cars, 
+#'                        family="gaussian",
+#'                        generate_scoring_history=TRUE)
+#' objValue <- h2o.average_objective(cars_model)
+#' }
+#' @export 
+h2o.average_objective <- function(model) {
+    return(h2o.extract_value(model, "objective"))
+}
+
+h2o.extract_value <- function(model, value) {
+  if (is(model, "H2OModel") && (model@algorithm=='glm')) {
+      if (model@allparameters$generate_scoring_history==TRUE) {
+          scHist <- model@model$scoring_history
+          return(scHist[nrow(scHist), value])
+      } else {
+          stop("negative_log_likelihood and average_objection functions can only be extracted when generate_scoring_history=TRUE for now.")
+      }
+  } else {
+      stop("negative_log_likelihood and average_objection functions are only available for GLM models.")
+  }
+}
+
+#'
 #' Return coefficients fitted on the standardized data (requires standardize = True, which is on by default). These coefficients can be used to evaluate variable importance.
 #'
 #' @param object an \linkS4class{H2OModel} object.

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -2518,7 +2518,7 @@ h2o.get_regression_influence_diagnostics <- function(model, predictorSize = -1) 
 #'                        training_frame = cars, 
 #'                        family="gaussian",
 #'                        generate_scoring_history=TRUE)
-#' objValue <- h2o.negative_log_likelihood(cars_model)
+#' nllValue <- h2o.negative_log_likelihood(cars_model)
 #' }
 #' @export 
 h2o.negative_log_likelihood <- function(model) {

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -2513,7 +2513,7 @@ h2o.get_regression_influence_diagnostics <- function(model, predictorSize = -1) 
 #' cars <- h2o.importFile(f)
 #' predictors <- c("displacement", "power", "weight", "acceleration", "year")
 #' response <- "acceleration"
-#' cars_model <- h2o.glm((y=response, 
+#' cars_model <- h2o.glm(y=response, 
 #'                        x=predictors, 
 #'                        training_frame = cars, 
 #'                        family="gaussian",
@@ -2540,7 +2540,7 @@ h2o.negative_log_likelihood <- function(model) {
 #' cars <- h2o.importFile(f)
 #' predictors <- c("displacement", "power", "weight", "acceleration", "year")
 #' response <- "acceleration"
-#' cars_model <- h2o.glm((y=response, 
+#' cars_model <- h2o.glm(y=response, 
 #'                        x=predictors, 
 #'                        training_frame = cars, 
 #'                        family="gaussian",

--- a/h2o-r/h2o-package/pkgdown/_pkgdown.yml
+++ b/h2o-r/h2o-package/pkgdown/_pkgdown.yml
@@ -55,6 +55,7 @@ reference:
       - h2o.auc
       - h2o.automl
       - h2o.auuc
+      - h2o.average_objective
       - h2o.betweenss
       - h2o.biases
       - h2o.bottomN
@@ -233,6 +234,7 @@ reference:
       - h2o.names
       - h2o.nchar
       - h2o.ncol
+      - h2o.negative_log_likelihood
       - h2o.networkTest
       - h2o.nlevels
       - h2o.no_progress

--- a/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_8977_neg_logll_obj.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_8977_neg_logll_obj.R
@@ -1,0 +1,17 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+test_negll_obj <- function() {
+    prostate_h2o <- h2o.importFile(locate("smalldata/prostate/prostate.csv"))
+    x=c("AGE","RACE","DPROS","DCAPS","PSA","GLEASON","CAPSULE")
+    model <- h2o.glm(x = x, y="VOL", training_frame=prostate_h2o, generate_scoring_history=TRUE)
+    modelNoReg <- h2o.glm(x = x, y="VOL", training_frame=prostate_h2o,lambda=0.0, generate_scoring_history=TRUE)
+    nll <- h2o.negative_log_likelihood(model)
+    nllNoReg <- h2o.negative_log_likelihood(modelNoReg)
+    obj <- h2o.average_objective(model)
+    objNoReg <- h2o.average_objective(modelNoReg)
+    expect_true(abs(nll-obj/model@allparameters$obj_reg) > 1e-6)
+    expect_true(abs(nllNoReg-objNoReg/modelNoReg@allparameters$obj_reg) < 1e-6)
+}
+
+doTest("GLM test access to negative log likelihood and average objective function values", test_negll_obj)


### PR DESCRIPTION
This PR complete the task in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8977

I added two accessor functions in R and Python to make sure GLM objective (average) and negative log likelihood are accessible to them when generate_scoring_history = True/TRUE:

negative_log_likelihood
average_objective

This is ugly I agree because I have to get it from scoring_history.  I am putting a JIRA in to add negative_log_likelhood and average_objective to be part of the modelMetrics.  Once that is done, it will get better.