### PR TITLE
[PUBDEV-8985] Upgrade Default Parquet Library to 1.8.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -52,7 +52,7 @@ publicNexusLocation="http://nexus.h2o.ai:8081/repository"
 httpClientVersion=4.5.2
 
 # Version of Apache Parquet dependency (should be kept in sync with the version used in current Spark releases)
-defaultParquetVersion=1.8.1
+defaultParquetVersion=1.8.3
 
 # Default Hadoop client version
 defaultHadoopVersion=2.8.4


### PR DESCRIPTION
The parquet common library utilises java logging and version 1.8.2+ can respect logging setttings set via log4j.

In current version: https://github.com/apache/parquet-mr/blob/apache-parquet-1.8.1/parquet-common/src/main/java/org/apache/parquet/Log.java#L62

In new version: https://github.com/apache/parquet-mr/blob/apache-parquet-1.8.3/parquet-common/src/main/java/org/apache/parquet/Log.java#L62