### PR TITLE
PUBDEV-8983: Add `average_objective` and `negative_log_likelihood` to GLM

### DIFF
--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -244,6 +244,8 @@ Defining a GLM Model
 
 - **generate_variable_inflation_factors**: If ``True``, generates the variable inflation factors for numerical predictors. Defaults to ``False``.
 
+**generate_scoring_history**: Generates scoring history for the GLM model when set to ``True``. This may significantly slow down the algorithm. Defaults to ``False``. When **generate_scoring_history** is enabled, you also will be able to fetch the average objective and the negative log likelihood using their accessor functions: ``average_objective`` and ``negative_log_likelihood``.
+
 
 Interpreting a GLM Model
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1261,7 +1263,8 @@ Below is a simple example showing how to build a Generalized Linear model.
                             y = response, 
                             training_frame = df, 
                             lambda = 0, 
-                            compute_p_values = TRUE)
+                            compute_p_values = TRUE
+                            generate_scoring_history = TRUE)
 
     # Coefficients that can be applied to the non-standardized data
     h2o.coef(prostate_glm)
@@ -1300,6 +1303,10 @@ Below is a simple example showing how to build a Generalized Linear model.
     # Retrieve a graphical plot of the standardized coefficient magnitudes
     h2o.std_coef_plot(prostate_glm)
 
+    # Since you generated the scoring history, you can retrieve the average objective and the negative log likelihood:
+    h2o.average_objective(prostate_glm)
+    h2o.negative_log_likelihood(prostate_glm)
+
    .. code-tab:: python
 
     import h2o
@@ -1317,7 +1324,8 @@ Below is a simple example showing how to build a Generalized Linear model.
 
     prostate_glm = H2OGeneralizedLinearEstimator(family= "binomial", 
                                               lambda_ = 0, 
-                                              compute_p_values = True)
+                                              compute_p_values = True
+                                              generate_scoring_history = True)
     prostate_glm.train(predictors, response_col, training_frame= prostate)
     
     # Coefficients that can be applied to the non-standardized data.
@@ -1354,6 +1362,10 @@ Below is a simple example showing how to build a Generalized Linear model.
 
     # Retrieve a graphical plot of the standardized coefficient magnitudes
     prostate_glm.std_coef_plot()
+
+    # Since you generated the scoring history, you can access the average objective and negative log likelihood:
+    prostate_glm.average_objective()
+    prostate_glm.negative_log_likelihood()
 
 Calling Model Attributes
 ''''''''''''''''''''''''

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -1304,8 +1304,10 @@ Below is a simple example showing how to build a Generalized Linear model.
     h2o.std_coef_plot(prostate_glm)
 
     # Since you generated the scoring history, you can retrieve the average objective and the negative log likelihood:
-    h2o.average_objective(prostate_glm)
-    h2o.negative_log_likelihood(prostate_glm)
+    print(h2o.average_objective(prostate_glm))
+    [1] 0.540688
+    print(h2o.negative_log_likelihood(prostate_glm))
+    [1] 205.4614
 
    .. code-tab:: python
 
@@ -1364,8 +1366,10 @@ Below is a simple example showing how to build a Generalized Linear model.
     prostate_glm.std_coef_plot()
 
     # Since you generated the scoring history, you can access the average objective and negative log likelihood:
-    prostate_glm.average_objective()
-    prostate_glm.negative_log_likelihood()
+    print("average objective: {0}.".format(prostate_glm.average_objective()))
+    average objective: 0.5406879877388551.
+    print("negative log likelihood: {0}.".format(prostate_glm.negative_log_likelihood()))
+    negative log likelihood: 205.46143534076492.
 
 Calling Model Attributes
 ''''''''''''''''''''''''


### PR DESCRIPTION
For: [PUBDEV-8983](https://h2oai.atlassian.net/browse/PUBDEV-8983)

I added the `generate_scoring_history` parameter and included a note on it for both the `average_objective` and the `negative_log_likelihood` accessor functions. Then I added the accessor functions to the main GLM example. Please let me know if anything needs to be updated!

Requires https://github.com/h2oai/h2o-3/pull/6478 to be merged.