### PR TITLE
PUBDEV-8981: Add information on GLM dispersion estimation using maximum likelihood method for the negative binomial family

### DIFF
--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -579,6 +579,8 @@ The corresponding deviance is:
 
 **Note**: Future versions of this model will optimize the coefficients as well as the dispersion parameter. Please stay tuned.
 
+
+
 Links
 '''''
 
@@ -624,6 +626,9 @@ For **AUTO**:
 
 Dispersion Parameter Estimation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tweedie
+'''''''
 
 The density for the maximum likelihood function for Tweedie can be written as:
 
@@ -717,7 +722,7 @@ As :math:`p` closes in on 1, the Tweedie density function becomes multimodal. Th
 As a conservative condition, to ensure that the density is unimodal for most values of :math:`y,\phi`, we should have :math:`p>1.2`.
 
 Tweedie Dispersion Example
-''''''''''''''''''''''''''
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. tabs::
    .. code-tab:: r R
@@ -768,6 +773,28 @@ Tweedie Dispersion Example
       # Retrieve the estimated dispersion:
       model._model_json["output"]["dispersion"]
       8.966819788535565
+
+Negative Binomial
+'''''''''''''''''
+
+GLM dispersion estimation using the maximum likelihood method for the negative binomial family is available when you set ``dispersion_parameter_method=“ml”``.
+
+**Note**: Regularization is not supported when using dispersion parameter estimation using maximum likelihood.
+
+The coefficients (betas) are estimated using IRLSM. The dispersion parameter theta is estimated after each IRLSM iteration. After the first beta update, the initial theta estimate is made using the method of moments as a starting point. Then, theta is updated using the maximum likelihood in each iteration.
+
+When not converged:
+
+- Estimate coefficients (betas)
+- Estimate dispersion (thetas)
+
+   - If first iteration:
+
+      - Theta <- Method of Moments estimate
+
+   - Else:
+   
+      - Theta <- Maximum Likelihood estimate using Newton’s method with learning rate estimated using Golden section search
 
 Hierarchical GLM
 ~~~~~~~~~~~~~~~~

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -779,22 +779,22 @@ Negative Binomial
 
 GLM dispersion estimation using the maximum likelihood method for the negative binomial family is available when you set ``dispersion_parameter_method=“ml”``.
 
-**Note**: Regularization is not supported when using dispersion parameter estimation using maximum likelihood.
+**Note**: Regularization is not supported when you use dispersion parameter estimation with maximum likelihood.
 
-The coefficients (betas) are estimated using IRLSM. The dispersion parameter theta is estimated after each IRLSM iteration. After the first beta update, the initial theta estimate is made using the method of moments as a starting point. Then, theta is updated using the maximum likelihood in each iteration.
+The coefficients, or betas, are estimated using IRLSM. The dispersion parameter theta is estimated after each IRLSM iteration. After the first beta update, the initial theta estimate is made using the method of moments as a starting point. Then, theta is updated using the maximum likelihood in each iteration.
 
-When not converged:
+While not converged:
 
-- Estimate coefficients (betas)
-- Estimate dispersion (thetas)
+1. Estimate coefficients (betas)
+2. Estimate dispersion (thetas)
 
-   - If first iteration:
+   a. If it is the first iteration:
 
-      - Theta <- Method of Moments estimate
+      i. Theta :math:`\gets` Method of Moments estimate
 
-   - Else:
+   b. Otherwise:
    
-      - Theta <- Maximum Likelihood estimate using Newton’s method with learning rate estimated using Golden section search
+      i. Theta :math:`\gets` Maximum Likelihood estimate using Newton’s method with learning rate estimated using Golden section search
 
 Hierarchical GLM
 ~~~~~~~~~~~~~~~~

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -741,7 +741,7 @@ Tweedie Dispersion Example
                        y = response, 
                        training_frame = training_data, 
                        family = 'tweedie',
-                       tweedie_variance_power = 3 
+                       tweedie_variance_power = 3, 
                        lambda = 0, 
                        compute_p_values = TRUE, 
                        dispersion_parameter_method = "pearson", 

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -627,7 +627,7 @@ For **AUTO**:
 Dispersion Parameter Estimation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Regularization is not supported when you use dispersion parameter estimation with maximum likelihood.
+Regularization is not supported when you use dispersion parameter estimation with maximum likelihood. 
 
 Tweedie
 '''''''

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -627,6 +627,8 @@ For **AUTO**:
 Dispersion Parameter Estimation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Regularization is not supported when you use dispersion parameter estimation with maximum likelihood.
+
 Tweedie
 '''''''
 
@@ -728,65 +730,65 @@ Tweedie Dispersion Example
    .. code-tab:: r R
 
       # Import the training data:
-      training_data <- h2o.importFile("http://h2o-public-test-data.s3.amazonaws.com/smalldata/glm_test/gamma_dispersion_factor_9_10kRows.csv")
+      training_data <- h2o.importFile("http://h2o-public-test-data.s3.amazonaws.com/smalldata/glm_test/tweedie_p3_phi1_10KRows.csv")
 
       # Set the predictors and response:
       predictors <- c('abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.')
-      response <- 'resp'
+      response <- 'x'
 
       # Build and train the model:
       model <- h2o.glm(x = predictors, 
                        y = response, 
                        training_frame = training_data, 
-                       family = 'gamma', 
+                       family = 'tweedie',
+                       tweedie_variance_power = 3 
                        lambda = 0, 
                        compute_p_values = TRUE, 
-                       dispersion_parameter_method = "ml", 
-                       init_dispersion_parameter = 1.1, 
+                       dispersion_parameter_method = "pearson", 
+                       init_dispersion_parameter = 0.5, 
                        dispersion_epsilon = 1e-4, 
                        max_iterations_dispersion = 100)
 
       # Retrieve the estimated dispersion:
       model@model$dispersion
-      [1] 8.96682
+      [1] 0.7599965
 
 
    .. code-tab:: python
 
       # Import the training data:
-      training_data = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/glm_test/gamma_dispersion_factor_9_10kRows.csv")
+      training_data = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/glm_test/tweedie_p3_phi1_10KRows.csv")
 
       # Set the predictors and response:
       predictors = ["abs.C1.", "abs.C2.", "abs.C3.", "abs.C4.", "abs.C5.""]
-      response = "resp"
+      response = "x"
 
       # Build and train the model:
-      model = H2OGeneralizedLinearEstimator(family="gamma", 
+      model = H2OGeneralizedLinearEstimator(family="tweedie", 
                                             lambda_=0, 
                                             compute_p_values=True, 
-                                            dispersion_parameter_method="ml", 
-                                            init_dispersion_parameter=1.1, 
-                                            dispersion_epsilon=1e-4, 
+                                            dispersion_parameter_method="pearson", 
+                                            init_dispersion_parameter=0.5, 
+                                            dispersion_epsilon=1e-4,
+                                            tweedie_variance_power=3, 
                                             max_iterations_dispersion=100)
       model.train(x=predictors, y=response, training_frame=training_data)
 
       # Retrieve the estimated dispersion:
       model._model_json["output"]["dispersion"]
-      8.966819788535565
+      0.7599964835351135
 
 Negative Binomial
 '''''''''''''''''
 
 GLM dispersion estimation using the maximum likelihood method for the negative binomial family is available when you set ``dispersion_parameter_method=“ml”``.
 
-**Note**: Regularization is not supported when you use dispersion parameter estimation with maximum likelihood.
-
 The coefficients, or betas, are estimated using IRLSM. The dispersion parameter theta is estimated after each IRLSM iteration. After the first beta update, the initial theta estimate is made using the method of moments as a starting point. Then, theta is updated using the maximum likelihood in each iteration.
 
 While not converged:
 
 1. Estimate coefficients (betas)
-2. Estimate dispersion (thetas)
+2. Estimate dispersion (theta)
 
    a. If it is the first iteration:
 


### PR DESCRIPTION
For: [PUBDEV-8981](https://h2oai.atlassian.net/browse/PUBDEV-8981)

I added the section to the [Dispersion Parameter Estimation section](https://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/glm.html#dispersion-parameter-estimation) (turned the current information into subsection "Tweedie"). I followed the provided write-up, but please let me know if something needs to be updated.

[PUBDEV-8981]: https://h2oai.atlassian.net/browse/PUBDEV-8981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ