### PR TITLE
PUBDEV-8952 Remove duplicate predictors for maxrsweep

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -909,6 +909,10 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
       _invTheta = 1/theta;
     }
 
+    /***
+     * Given the estimated model output x, we want to find the linear part which is transpose(beta)*p+intercept if
+     * beta does not contain the intercept.
+     */
     public final double link(double x) {
       switch(_link) {
         case identity:
@@ -999,7 +1003,10 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
       }
     }
 
-    // function inverse of link function
+    /***
+     * Given the linear combination transpose(beta)*p+intercept (if
+     * beta does not contain the intercept), this method will provide the estimated model output.
+     */
     public final double linkInv(double x) {
       switch(_link) {
         case ologlog:

--- a/h2o-algos/src/main/java/hex/gram/Gram.java
+++ b/h2o-algos/src/main/java/hex/gram/Gram.java
@@ -595,6 +595,44 @@ public final class Gram extends Iced<Gram> {
     return xx;
   }
 
+  /**
+   * This method will copy the xx matrix into a matrix xalloc which is of bigger size than the actual xx by 1 in both
+   * row and column.
+   */
+  public double[][] getXXCPM(double[][] xalloc, boolean lowerDiag, boolean icptFirst) {
+    double[][] xx = xalloc;
+    int off = 0;
+    if(_hasIntercept && icptFirst) {
+      double [] icptRow = _xx[_xx.length-1];
+      xx[0][0] = icptRow[icptRow.length-1];
+      for(int i = 0; i < icptRow.length-1; ++i)
+        xx[i+1][0] = icptRow[i];
+      off = 1;
+    }
+    for( int i = 0; i < _diag.length; ++i ) {
+      xx[i + off][i + off] = _diag[i];
+      if(!lowerDiag) {
+        int col = i+off;
+        double [] xrow = xx[i+off];
+        for (int j = off; j < _xx.length; ++j)
+          xrow[j+_diagN] = _xx[j][col];
+      }
+    }
+    for( int i = 0; i < _xx.length - off; ++i ) {
+      double [] xrow = xx[i+_diag.length + off];
+      double [] xrowOld = _xx[i];
+      System.arraycopy(xrowOld,0,xrow,off,xrowOld.length);
+      if(!lowerDiag) {
+        int col = xrowOld.length-1;
+        int row = i+1;
+        int xrowLen = xrow.length-1;
+        for (int j = col+1; j < xrowLen; ++j)
+          xrow[j] = _xx[row++][col];
+      }
+    }
+    return xx;
+  }
+
   public void add(Gram grm) {
     ArrayUtils.add(_xx,grm._xx);
     ArrayUtils.add(_diag,grm._diag);

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8977_negLL_Obj.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_8977_negLL_Obj.py
@@ -22,7 +22,7 @@ def test_glm_negLL_Obj():
     assert abs(nll_noReg-obj_noReg/glm_model_noReg.actual_params["obj_reg"]) < 1e-6, \
         "objective ({0}) and negative log likelihood ({1}) should equal but do not.".format(obj_noReg, nll_noReg)
     assert abs(nll-obj) > 1e-6, "objective ({0}) and negative log likelihood ({1}) should not equal but do" \
-                                            " not.".format(obj, nll)
+                                            " equal.".format(obj, nll)
 if __name__ == "__main__":
   pyunit_utils.standalone_test(test_glm_negLL_Obj)
 else:

--- a/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8952_maxrsweep_dupCols.py
+++ b/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8952_maxrsweep_dupCols.py
@@ -1,0 +1,34 @@
+import sys
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.model_selection import H2OModelSelectionEstimator
+
+#  This test is used to make sure duplicated columns are removed and if max_predictor_number exceeds the final
+# predictor count, an error message should have been generated.
+def test_maxrsweep_replacement():
+    train = h2o.import_file(pyunit_utils.locate("bigdata/laptop/model_selection/maxrglm200Cols50KRows.csv"))
+    train2 = h2o.import_file(pyunit_utils.locate("bigdata/laptop/model_selection/maxrglm200Cols50KRows.csv"))
+    train2 = train2.drop(200, axis = 1)
+    train = train.cbind(train2)
+    response = "response"
+    predictors = train.names
+    predictors.remove(response)
+
+    try:
+        maxrsweep3_model = H2OModelSelectionEstimator(mode="maxrsweep", max_predictor_number=300, intercept=True,
+                                                      build_glm_model=False)
+        maxrsweep3_model.train(x=predictors, y=response, training_frame=train)
+        assert False, "Should have throw exception of bad max_predictor_number!"
+    except Exception as ex:
+        print(ex)
+        temp = str(ex)
+        assert "max_predictor_number: Your dataset contains duplicated predictors.  After removal, reduce your" \
+               " max_predictor_number to" in temp
+        print("coefficient test passed!")
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_maxrsweep_replacement)
+else:
+    test_maxrsweep_replacement()

--- a/h2o-r/tests/testdir_algos/modelselection/runit_PUBDEV_8952_maxrsweep_dup_predictors_large.R
+++ b/h2o-r/tests/testdir_algos/modelselection/runit_PUBDEV_8952_maxrsweep_dup_predictors_large.R
@@ -1,0 +1,35 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+testMaxrSweepDupPredictors <- function() {
+  train <- h2o.importFile(locate("bigdata/laptop/model_selection/maxrglm200Cols50KRows.csv"))
+  Y <- "response"
+  X <- h2o.colnames(train)
+  X <- X[-201]
+  # model without duplicated columns
+  maxrsweepGLMModel <- h2o.modelSelection(y=Y, x=X, seed=12345, training_frame = train, max_predictor_number=10, 
+                                             mode="maxrsweep", build_glm_model=FALSE)
+  coeffsMaxrsweepGLM <- h2o.coef(maxrsweepGLMModel)
+  
+  train2 <- h2o.importFile(locate("bigdata/laptop/model_selection/maxrglm200Cols50KRows.csv"))
+  train2 <- train2[-c(201)]
+  train <- h2o.cbind(train2, train)
+  Y <- "response"
+  X <- h2o.colnames(train)
+  X <- X[-401]
+  maxrsweepGLMModelDup <- h2o.modelSelection(y=Y, x=X, seed=12345, training_frame = train, max_predictor_number=10, 
+        mode="maxrsweep", build_glm_model=FALSE)
+  coeffsMaxrsweepGLMDup <- h2o.coef(maxrsweepGLMModelDup)
+  
+  # make sure models with and without duplicated predictors yielding the same results
+  numModels <- length(coeffsMaxrsweepGLM)
+  expect_equal(numModels, length(coeffsMaxrsweepGLMDup))
+  
+  for (ind in c(1:numModels)) {
+    oneCoeff <- coeffsMaxrsweepGLM[[ind]]
+    oneCoeffNoDup <- coeffsMaxrsweepGLMDup[[ind]]
+    expect_equal(oneCoeff, oneCoeff, tolerance=1e-6)
+  }
+}
+
+doTest("ModelSelection with maxrsweep: make sure duplicate predictors are removed and no NPE will occur", testMaxrSweepDupPredictors)

--- a/h2o-test-support/src/main/java/water/TestUtil.java
+++ b/h2o-test-support/src/main/java/water/TestUtil.java
@@ -203,6 +203,17 @@ public class TestUtil extends Iced {
       checkArrays(expected[ind], actual[ind], threshold);
     }
   }
+  
+  public static void checkIntArrays(int[][] expected, int[][] actual) {
+    int len1 = expected.length;
+    assertEquals(len1, actual.length);
+
+    for (int ind = 0; ind < len1; ind++) {
+      assertEquals(expected[ind].length, actual[ind].length);
+      Arrays.equals(expected[ind], actual[ind]);
+    }
+  }
+  
 
   /**
    * @deprecated use {@link #generateEnumOnly(int, int, int, double)} instead


### PR DESCRIPTION
This PR completes the task in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8952

I have added backend support code to do the following:
- check for duplicated predictors;
- if found, remove the duplicated predictors;
- generate the CPM, predictor2CPMIndices mapping.

To ensure that my implementation is correct, I have added the following tests:
- Java tests to ensure that when there are duplicated predictors, the CPM, predictor2CPMIndices mappings are generated correctly.
- Python and R tests to make sure maxrsweep models are generated without running into NPE.