### PR TITLE
PUBDEV-9022: [DevOps] Snyk Integration 

### DIFF
--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -24,9 +24,9 @@ jobs:
         id: changed-files
         with:
           files: | # This will match all the files with below patterns
-            build.gradle$
-            requirements.txt$
-            package.json$
+            *build.gradle
+            *requirements.txt
+            *package.json
 
       - uses: snyk/actions/setup@master
 
@@ -39,7 +39,7 @@ jobs:
         id: scan1
         continue-on-error: true
         run: |
-          unset CI # By default GH actions will set it to true. Therfore it will affect isCi flag in build.gradle (line #7)
+          unset CI # By default GH actions will set it to true. Therefore it will affect isCi flag in build.gradle (line #7)
           snyk test --all-sub-projects -d --fail-on=all --package-manager=gradle
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -23,14 +23,8 @@ jobs:
         id: changed-files
         with:
           files: | # This will match all the files with below patterns
-            build.gradle
-            */build.gradle
             **/build.gradle
-            ***/build.gradle
-            *requirements.txt
-            */*requirements.txt
-            **/*requirements.txt
-            */package.json
+            **/requirements.txt
             **/package.json
       
       - uses: snyk/actions/setup@master

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -3,7 +3,12 @@ name: Snyk Security Vulnerability Scan
 on:
   workflow_dispatch:
   pull_request:
+  create:
+    tags:
+      - 'jenkins-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
   push:
+    tags:
+      - 'jenkins-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
     branches:
       - 'master'
       - 'rel-*'

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -23,10 +23,16 @@ jobs:
         id: changed-files
         with:
           files: | # This will match all the files with below patterns
-            *build.gradle
+            build.gradle
+            */build.gradle
+            **/build.gradle
+            ***/build.gradle
             *requirements.txt
-            *package.json
-
+            */*requirements.txt
+            **/*requirements.txt
+            */package.json
+            **/package.json
+      
       - uses: snyk/actions/setup@master
 
       - uses: actions/setup-java@v3

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           java-version: "8"
           distribution: 'adopt'
+      
       - name: Snyk scan for Java dependencies 
         if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'build.gradle')
         id: scan1
@@ -49,6 +50,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
+      
       - name: Snyk scan for Python 3.7 dependencies
         if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'requirements.txt')
         id: scan2

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Extract github branch/tag name
         shell: bash
-        run: echo "##[set-output name=ref;]$(echo ${GITHUB_REF##*/})"
+        run: echo "ref=$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
         id: extract_ref
 
       - uses: snyk/actions/setup@master

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -1,6 +1,7 @@
 name: Snyk Security Vulnerability Scan
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0 # To fetch all commits history on branch (Refer: https://github.com/tj-actions/changed-files#usage)
        
       - name: Check changed Deps files
-        uses: tj-actions/changed-files@v10
+        uses: tj-actions/changed-files@v35
         id: changed-files
         with:
           files: | # This will match all the files with below patterns
@@ -30,7 +30,7 @@ jobs:
 
       - uses: snyk/actions/setup@master
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
           java-version: "8"
           distribution: 'adopt'
@@ -44,7 +44,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v3
         with:
           python-version: "3.7"
       - name: Snyk scan for Python 3.7 dependencies
@@ -58,9 +58,9 @@ jobs:
           pip install -r h2o-py/requirements.txt            
           snyk test -d --fail-on=all --file=h2o-py/requirements.txt --package-manager=pip --command=python3 --skip-unresolved   
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
+          node-version: '16.x'
       - name: Snyk scan for Node dependencies
         if: contains(steps.changed-files.outputs.all_changed_and_modified_files, 'package.json')
         id: scan3
@@ -92,12 +92,12 @@ jobs:
         id: extract_ref
 
       - uses: snyk/actions/setup@master
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
           java-version: "8"
           distribution: 'adopt'
           
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v3
         with:
           python-version: "3.7"
       - name: Snyk scan for Python 3.7 dependencies
@@ -108,9 +108,9 @@ jobs:
           pip install -r h2o-py/requirements.txt                  
           snyk monitor -d --fail-on=all --file=h2o-py/requirements.txt --package-manager=pip --command=python3 --skip-unresolved --remote-repo-url=H2O-3 --project-name=H2O-3/${{ steps.extract_ref.outputs.ref }}/h2o-py/requirements.txt      
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
+          node-version: '16.x'
       - name: Snyk scan for Node dependencies
         run: |
           snyk monitor --org=h2oai --remote-repo-url=H2O-3 --file=h2o-web/package.json --project-name=H2O-3/${{ steps.extract_ref.outputs.ref }}/h2o-web/package.json  -d 

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -6,13 +6,12 @@ on:
     branches:
       - 'master'
       - 'rel-*'
-      - 'devops/snyk-integration'
 permissions:
   contents: read
 
 jobs:
   snyk_scan_test:
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -6,13 +6,13 @@ on:
     branches:
       - 'master'
       - 'rel-*'
-
+      - 'devops/snyk-integration'
 permissions:
   contents: read
 
 jobs:
   snyk_scan_test:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -106,14 +106,14 @@ jobs:
         run: |
           sudo apt-get install -y libkrb5-dev
           pip install -r h2o-py/requirements.txt                  
-          snyk monitor -d --fail-on=all --file=h2o-py/requirements.txt --package-manager=pip --command=python3 --skip-unresolved --remote-repo-url=h2o-3/${{ steps.extract_ref.outputs.ref }} --project-name=H2O-3/h2o-3/${{ steps.extract_ref.outputs.ref }}/h2o-py/requirements.txt      
+          snyk monitor -d --fail-on=all --org=h2o-3 --file=h2o-py/requirements.txt --package-manager=pip --command=python3 --skip-unresolved --remote-repo-url=h2o-3/${{ steps.extract_ref.outputs.ref }} --project-name=H2O-3/h2o-3/${{ steps.extract_ref.outputs.ref }}/h2o-py/requirements.txt      
 
       - uses: actions/setup-node@v3
         with:
           node-version: '16.x'
       - name: Snyk scan for Node dependencies
         run: |
-          snyk monitor --org=h2o_3 --remote-repo-url=h2o-3/${{ steps.extract_ref.outputs.ref }} --file=h2o-web/package.json --project-name=H2O-3/h2o-3/${{ steps.extract_ref.outputs.ref }}/h2o-web/package.json  -d 
+          snyk monitor --org=h2o-3 --remote-repo-url=h2o-3/${{ steps.extract_ref.outputs.ref }} --file=h2o-web/package.json --project-name=H2O-3/h2o-3/${{ steps.extract_ref.outputs.ref }}/h2o-web/package.json  -d 
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
@@ -127,7 +127,7 @@ jobs:
             echo ""
             echo "##### SCAN $file START #####"
             echo ""
-            snyk monitor --org=h2o_3 --remote-repo-url=h2o-3/${{ steps.extract_ref.outputs.ref }} --file=$file --project-name=H2O-3/h2o-3/${{ steps.extract_ref.outputs.ref }}/$file -d --skip-unresolved 
+            snyk monitor --org=h2o-3 --remote-repo-url=h2o-3/${{ steps.extract_ref.outputs.ref }} --file=$file --project-name=H2O-3/h2o-3/${{ steps.extract_ref.outputs.ref }}/$file -d --skip-unresolved 
             echo "##### SCAN $file END #####"
           done
         env:

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -44,7 +44,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
       - name: Snyk scan for Python 3.7 dependencies
@@ -97,7 +97,7 @@ jobs:
           java-version: "8"
           distribution: 'adopt'
           
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
       - name: Snyk scan for Python 3.7 dependencies
@@ -106,14 +106,14 @@ jobs:
         run: |
           sudo apt-get install -y libkrb5-dev
           pip install -r h2o-py/requirements.txt                  
-          snyk monitor -d --fail-on=all --file=h2o-py/requirements.txt --package-manager=pip --command=python3 --skip-unresolved --remote-repo-url=H2O-3 --project-name=H2O-3/${{ steps.extract_ref.outputs.ref }}/h2o-py/requirements.txt      
+          snyk monitor -d --fail-on=all --file=h2o-py/requirements.txt --package-manager=pip --command=python3 --skip-unresolved --remote-repo-url=h2o-3/${{ steps.extract_ref.outputs.ref }} --project-name=H2O-3/h2o-3/${{ steps.extract_ref.outputs.ref }}/h2o-py/requirements.txt      
 
       - uses: actions/setup-node@v3
         with:
           node-version: '16.x'
       - name: Snyk scan for Node dependencies
         run: |
-          snyk monitor --org=h2oai --remote-repo-url=H2O-3 --file=h2o-web/package.json --project-name=H2O-3/${{ steps.extract_ref.outputs.ref }}/h2o-web/package.json  -d 
+          snyk monitor --org=h2o_3 --remote-repo-url=h2o-3/${{ steps.extract_ref.outputs.ref }} --file=h2o-web/package.json --project-name=H2O-3/h2o-3/${{ steps.extract_ref.outputs.ref }}/h2o-web/package.json  -d 
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
@@ -127,7 +127,7 @@ jobs:
             echo ""
             echo "##### SCAN $file START #####"
             echo ""
-            snyk monitor --org=h2oai --remote-repo-url=H2O-3 --file=$file --project-name=H2O-3/${{ steps.extract_ref.outputs.ref }}/$file -d --skip-unresolved 
+            snyk monitor --org=h2o_3 --remote-repo-url=h2o-3/${{ steps.extract_ref.outputs.ref }} --file=$file --project-name=H2O-3/h2o-3/${{ steps.extract_ref.outputs.ref }}/$file -d --skip-unresolved 
             echo "##### SCAN $file END #####"
           done
         env:

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -3,9 +3,6 @@ name: Snyk Security Vulnerability Scan
 on:
   workflow_dispatch:
   pull_request:
-  create:
-    tags:
-      - 'jenkins-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
   push:
     tags:
       - 'jenkins-[0-9]+.[0-9]+.[0-9]+.[0-9]+'

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,11 +8,11 @@ systemProp.org.gradle.internal.http.connectionTimeout=300000
 systemProp.org.gradle.internal.http.socketTimeout=300000
 # Increase Xmx to 1G to enable full build (otherwise OOMs when building hadoop jars)
 systemProp.org.gradle.jvmargs=-Xmx1024M
-version=3.40.0
+version=3.41.0
 # Default build profile
 profile=Java
 # Branch codename
-codename=zz_kurka
+codename=bleeding_edge
 # Run findbugs
 doFindbugs=false
 # Run animal sniffer to verify compatibility of API with actual Java version


### PR DESCRIPTION
For: PUBDEV-9022

This PR resolve the issue in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-9022

https://github.com/h2oai/h2o-ops/issues/241 - [PUB-CLOUD-SEC] Integrate Snyk Scans for the given list of Repos

- Fixed deprecation issues with the `set-output` command. - https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- Fixed deprecation issues with the Node.js (Updated to v16) - https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
- Changed the organisation to [H2O-3](https://app.snyk.io/org/h2o-3).
- Created a new service account in Snyk ([H2O_3_SNYK_TOKEN](https://app.snyk.io/org/h2o-3/manage/service-accounts)) & updated the previous SNYK_TOKEN in GItHub.
- Updated GitHub Action versions for Python & Java.
- Updated the [changed-files](https://github.com/marketplace/actions/changed-files) GitHub Action version and migrated to new version for filename pattern matching.
- `remote-repo-url` will follow `repo/branch` format & `project-name` will follow `PRODUCT/repo/branch/file` format.