### PR TITLE
PUBDEV-9008: Added that `max_runtime_secs` cannot always produce a reproducible model

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/max_runtime_secs.rst
+++ b/h2o-docs/src/product/data-science/algo-params/max_runtime_secs.rst
@@ -19,6 +19,10 @@ When performing a grid search, this option specifies the maximum runtime in seco
 
 Specifying ``max_runtime_secs=0`` disables this option, thus allowing for an unlimited amount of runtime.
 
+.. warning::
+	``max_runtime_secs`` cannot always produce a reproducible model for GBM, DRF, XGBoost, Isolation Forest, or Uplift DRF.
+
+
 Related Parameters
 ~~~~~~~~~~~~~~~~~~
 

--- a/h2o-docs/src/product/data-science/drf.rst
+++ b/h2o-docs/src/product/data-science/drf.rst
@@ -168,7 +168,7 @@ Defining a DRF Model
    than this value. This option defaults to 0.001.
 
 -  `max_runtime_secs <algo-params/max_runtime_secs.html>`__: Maximum allowed runtime in seconds for model
-   training. Use 0 (default) to disable.
+   training. This value is set to ``0`` (disabled) by default. **Note**: ``max_runtime_secs`` cannot always produce a reproducible model for DRF.
 
 -  `seed <algo-params/seed.html>`__: Specify the random number generator (RNG) seed for
    algorithm components dependent on randomization. The seed is

--- a/h2o-docs/src/product/data-science/gbm.rst
+++ b/h2o-docs/src/product/data-science/gbm.rst
@@ -218,7 +218,7 @@ Defining a GBM Model
    than this value. This value defaults to 0.001.
 
 -  `max_runtime_secs <algo-params/max_runtime_secs.html>`__: Maximum allowed runtime in seconds for model
-   training.  This defaults to 0 (unlimited).
+   training. This value is set to ``0`` (disabled) by default. **Note**: ``max_runtime_secs`` cannot always produce a reproducible model for GBM.
 
 -  `build_tree_one_node <algo-params/build_tree_one_node.html>`__: Specify whether to run on a single node. This is suitable for small datasets as there is no network overhead but fewer CPUs are used. This option is defaults to false (not enabled).
 

--- a/h2o-docs/src/product/data-science/if.rst
+++ b/h2o-docs/src/product/data-science/if.rst
@@ -48,7 +48,7 @@ Defining an Isolation Forest Model
 
 -  `min_rows <algo-params/min_rows.html>`__: Specify the minimum number of observations for a leaf (``nodesize`` in R). This value defaults to 1.
 
--  `max_runtime_secs <algo-params/max_runtime_secs.html>`__: Maximum allowed runtime in seconds for model training. This value is set to 0 (disabeld) by default.
+-  `max_runtime_secs <algo-params/max_runtime_secs.html>`__: Maximum allowed runtime in seconds for model training. This value is set to ``0`` (disabled) by default. **Note**: ``max_runtime_secs`` cannot always produce a reproducible model for Isolation Forest.
 
 -  `seed <algo-params/seed.html>`__: Specify the random number generator (RNG) seed for algorithm components dependent on randomization. The seed is consistent for each H2O instance so that you can create models with the same starting conditions in alternative configurations. This value defaults to -1 (time-based random number).
 

--- a/h2o-docs/src/product/data-science/upliftdrf.rst
+++ b/h2o-docs/src/product/data-science/upliftdrf.rst
@@ -165,7 +165,7 @@ Defining a Uplift DRF Model
    optimal value for your configuration. This option defaults to 1024.
 
 -  `max_runtime_secs <algo-params/max_runtime_secs.html>`__: Maximum allowed runtime in seconds for model
-   training. Use 0 (default) to disable.
+   training. This value is set to ``0`` (disabled) by default. **Note**: ``max_runtime_secs`` cannot always produce a reproducible model for Uplift DRF.
 
 -  `seed <algo-params/seed.html>`__: Specify the random number generator (RNG) seed for
    algorithm components dependent on randomization. The seed is

--- a/h2o-docs/src/product/data-science/xgboost.rst
+++ b/h2o-docs/src/product/data-science/xgboost.rst
@@ -89,7 +89,7 @@ Defining an XGBoost Model
 
 -  `stopping_tolerance <algo-params/stopping_tolerance.html>`__: Specify the relative tolerance for the metric-based stopping to stop training if the improvement is less than this value. This value defaults to 0.001.
 
--  `max_runtime_secs <algo-params/max_runtime_secs.html>`__: Maximum allowed runtime in seconds for model training. This option defaults to 0 (disabled) by default.
+-  `max_runtime_secs <algo-params/max_runtime_secs.html>`__: Maximum allowed runtime in seconds for model training. This value is set to ``0`` (disabled) by default. **Note**: ``max_runtime_secs`` cannot always produce a reproducible model for XGBoost.
 
 -  `build_tree_one_node <algo-params/build_tree_one_node.html>`__: Specify whether to run on a single node. This is suitable for small datasets as there is no network overhead but fewer CPUs are used. Also useful when you want to use ``exact`` tree method. This value is disabled by default.
 


### PR DESCRIPTION
For: PUBDEV-9008

I added the reproducibility warning to the `max_runtime_secs` algo page and a note in the parameter list of each algorithm.