### PR TITLE
[PUBDEV-8708] Fix syntax failures for Python 2.7 tests

### DIFF
--- a/h2o-py/tests/testdir_algos/deeplearning/pyunit_mean_residual_deviance_sklearn.py
+++ b/h2o-py/tests/testdir_algos/deeplearning/pyunit_mean_residual_deviance_sklearn.py
@@ -3,7 +3,7 @@ import sys
 
 from sklearn.metrics import mean_poisson_deviance
 
-from h2o import h2o, H2OFrame
+import h2o
 from h2o.estimators import H2ODeepLearningEstimator
 from tests import pyunit_utils, assert_equals
 
@@ -12,7 +12,7 @@ sys.path.insert(1, os.path.join("..", "..", ".."))
 
 def mean_residual_deviance_sklearn():
     print("poisson")
-    fre: H2OFrame = h2o.import_file(path=pyunit_utils.locate("smalldata/glm_test/freMTPL2freq.csv.zip"))
+    fre = h2o.import_file(path=pyunit_utils.locate("smalldata/glm_test/freMTPL2freq.csv.zip"))
     fre['VehPower'] = fre['VehPower'].asfactor()
     dle = H2ODeepLearningEstimator(training_frame=fre, response_column="ClaimNb", hidden=[5, 5], epochs=1,
                                    train_samples_per_iteration=-1, validation_frame=fre, activation="Tanh",
@@ -30,7 +30,7 @@ def mean_residual_deviance_sklearn():
     print("valid: ", dle_mrd['valid'])
     print("xval: ", dle_mrd['xval'])
 
-    pred: H2OFrame = dle.predict(fre)
+    pred = dle.predict(fre)
     sklearn_nrd = mean_poisson_deviance(fre.as_data_frame()["ClaimNb"], pred.as_data_frame()['predict'])
     print("sklearn: ", sklearn_nrd)
 


### PR DESCRIPTION
A test failure from the last nightly build:
```
/envs/h2o_env_python2.7/lib/python2.7/site-packages/requests/__init__.py:91: RequestsDependencyWarning: urllib3 (1.26.7) or chardet (3.0.4) doesn't match a supported version!
  RequestsDependencyWarning)
versionFromGradle='3.41.0',projectVersion='3.41.0.99999',branch='(HEAD detached at 1e26bda)',lastCommitHash='1e26bda2045ff66bb8025792a57c47fcb0e941dc',gitDescribe='jenkins-3.40.0.1-39-g1e26bda',compiledOn='2023-03-08 06:15:45',compiledBy='jenkins'
('loading the following test utility modules: ', ['/home/jenkins/slave_dir_from_mr-0xc1/workspace/_3-nightly-pipeline_rel-zz_kurka/py2.7-small/h2o-3/h2o-py/tests/_utils.py', '/home/jenkins/slave_dir_from_mr-0xc1/workspace/_3-nightly-pipeline_rel-zz_kurka/py2.7-small/h2o-3/h2o-py/tests/testdir_algos/automl/_automl_utils.py', '/home/jenkins/slave_dir_from_mr-0xc1/workspace/_3-nightly-pipeline_rel-zz_kurka/py2.7-small/h2o-3/h2o-py/tests/testdir_algos/automl/leaderboard/_leaderboard_utils.py'])
[2023-03-08 07:24:24] Connect to h2o on IP: 127.0.0.1 PORT: 40002

Not using any auth
Traceback (most recent call last):
  File "/home/jenkins/slave_dir_from_mr-0xc1/workspace/_3-nightly-pipeline_rel-zz_kurka/py2.7-small/h2o-3/h2o-py/scripts/h2o-py-test-setup.py", line 186, in <module>
    h2o_test_setup(sys.argv)
  File "/home/jenkins/slave_dir_from_mr-0xc1/workspace/_3-nightly-pipeline_rel-zz_kurka/py2.7-small/h2o-3/h2o-py/scripts/h2o-py-test-setup.py", line 181, in h2o_test_setup
    elif _IS_PYUNIT_:    pyunit_utils.pyunit_exec(_TEST_NAME_)
  File "/home/jenkins/slave_dir_from_mr-0xc1/workspace/_3-nightly-pipeline_rel-zz_kurka/py2.7-small/h2o-3/h2o-py/tests/pyunit_utils/utilsPY.py", line 685, in pyunit_exec
    pyunit_c = compile(pyunit, test_path, 'exec')
  File "/home/jenkins/slave_dir_from_mr-0xc1/workspace/_3-nightly-pipeline_rel-zz_kurka/py2.7-small/h2o-3/h2o-py/tests/testdir_algos/deeplearning/pyunit_mean_residual_deviance_sklearn.py", line 15
    fre: H2OFrame = h2o.import_file(path=pyunit_utils.locate("smalldata/glm_test/freMTPL2freq.csv.zip"))
       ^
SyntaxError: invalid syntax
Closing connection _sid_bb59 at exit
```