### PR TITLE
PUBDEV-8708: disable scikit-learn test for python 2.7

### DIFF
--- a/h2o-py/tests/testdir_algos/deeplearning/pyunit_mean_residual_deviance_sklearn.py
+++ b/h2o-py/tests/testdir_algos/deeplearning/pyunit_mean_residual_deviance_sklearn.py
@@ -2,8 +2,6 @@ import os
 import sys
 import unittest
 
-from sklearn.metrics import mean_poisson_deviance
-
 import h2o
 from h2o.estimators import H2ODeepLearningEstimator
 from tests import pyunit_utils, assert_equals
@@ -11,38 +9,40 @@ from tests import pyunit_utils, assert_equals
 sys.path.insert(1, os.path.join("..", "..", ".."))
 
 
-@unittest.skipIf(sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] <= 5),
-                 "Tested only on python >3.5, mean_poisson_deviance is not supported on lower python version")
-def mean_residual_deviance_sklearn():
-    print("poisson")
-    fre = h2o.import_file(path=pyunit_utils.locate("smalldata/glm_test/freMTPL2freq.csv.zip"))
-    fre['VehPower'] = fre['VehPower'].asfactor()
-    dle = H2ODeepLearningEstimator(training_frame=fre, response_column="ClaimNb", hidden=[5, 5], epochs=1,
-                                   train_samples_per_iteration=-1, validation_frame=fre, activation="Tanh",
-                                   distribution="poisson", score_training_samples=0, nfolds=3)
-    dle.train(x=fre.col_names[4:12], y="ClaimNb", training_frame=fre, validation_frame=fre)
+class TestMeanResidualDevianceForPoissonDistributionWithScikitlearn(unittest.TestCase):
+    
+    @unittest.skipIf(sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] <= 5),
+                     "Tested only on python >3.5, mean_poisson_deviance is not supported on lower python version")
+    def mean_residual_deviance_sklearn(self):
+        from sklearn.metrics import mean_poisson_deviance
+        print("poisson")
+        fre = h2o.import_file(path=pyunit_utils.locate("smalldata/glm_test/freMTPL2freq.csv.zip"))
+        fre['VehPower'] = fre['VehPower'].asfactor()
+        dle = H2ODeepLearningEstimator(training_frame=fre, response_column="ClaimNb", hidden=[5, 5], epochs=1,
+                                       train_samples_per_iteration=-1, validation_frame=fre, activation="Tanh",
+                                       distribution="poisson", score_training_samples=0, nfolds=3)
+        dle.train(x=fre.col_names[4:12], y="ClaimNb", training_frame=fre, validation_frame=fre)
+    
+        dle_mrd = dle.mean_residual_deviance(train=True, valid=True, xval=True)
+        assert isinstance(dle_mrd['train'], float), "Expected training mean residual deviance to be a float, but got " \
+                                                    "{0}".format(type(dle_mrd['train']))
+        assert isinstance(dle_mrd['valid'], float), "Expected validation mean residual deviance to be a float, but got " \
+                                                    "{0}".format(type(dle_mrd['valid']))
+        assert isinstance(dle_mrd['xval'], float), "Expected cross-validation mean residual deviance to be a float, " \
+                                                   "but got {0}".format(type(dle_mrd['xval']))
+        print("train: ", dle_mrd['train'])
+        print("valid: ", dle_mrd['valid'])
+        print("xval: ", dle_mrd['xval'])
+    
+        pred = dle.predict(fre)
+        sklearn_nrd = mean_poisson_deviance(fre.as_data_frame()["ClaimNb"], pred.as_data_frame()['predict'])
+        print("sklearn: ", sklearn_nrd)
+    
+        assert_equals(sklearn_nrd, dle_mrd['train'], delta=1e-5)
+        assert_equals(sklearn_nrd, dle_mrd['valid'], delta=1e-5)
+        assert_equals(sklearn_nrd, dle_mrd['xval'], delta=1e0)
 
-    dle_mrd = dle.mean_residual_deviance(train=True, valid=True, xval=True)
-    assert isinstance(dle_mrd['train'], float), "Expected training mean residual deviance to be a float, but got " \
-                                                "{0}".format(type(dle_mrd['train']))
-    assert isinstance(dle_mrd['valid'], float), "Expected validation mean residual deviance to be a float, but got " \
-                                                "{0}".format(type(dle_mrd['valid']))
-    assert isinstance(dle_mrd['xval'], float), "Expected cross-validation mean residual deviance to be a float, " \
-                                               "but got {0}".format(type(dle_mrd['xval']))
-    print("train: ", dle_mrd['train'])
-    print("valid: ", dle_mrd['valid'])
-    print("xval: ", dle_mrd['xval'])
 
-    pred = dle.predict(fre)
-    sklearn_nrd = mean_poisson_deviance(fre.as_data_frame()["ClaimNb"], pred.as_data_frame()['predict'])
-    print("sklearn: ", sklearn_nrd)
+suite = unittest.TestLoader().loadTestsFromTestCase(TestMeanResidualDevianceForPoissonDistributionWithScikitlearn)
+unittest.TextTestRunner().run(suite)
 
-    assert_equals(sklearn_nrd, dle_mrd['train'], delta=1e-5)
-    assert_equals(sklearn_nrd, dle_mrd['valid'], delta=1e-5)
-    assert_equals(sklearn_nrd, dle_mrd['xval'], delta=1e0)
-
-
-if __name__ == "__main__":
-    pyunit_utils.standalone_test(mean_residual_deviance_sklearn)
-else:
-    mean_residual_deviance_sklearn()

--- a/h2o-py/tests/testdir_algos/deeplearning/pyunit_mean_residual_deviance_sklearn.py
+++ b/h2o-py/tests/testdir_algos/deeplearning/pyunit_mean_residual_deviance_sklearn.py
@@ -13,8 +13,9 @@ class TestMeanResidualDevianceForPoissonDistributionWithScikitlearn(unittest.Tes
     
     @unittest.skipIf(sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] <= 5),
                      "Tested only on python >3.5, mean_poisson_deviance is not supported on lower python version")
-    def mean_residual_deviance_sklearn(self):
+    def test_mean_residual_deviance_sklearn(self):
         from sklearn.metrics import mean_poisson_deviance
+        h2o.init(strict_version_check=False)
         print("poisson")
         fre = h2o.import_file(path=pyunit_utils.locate("smalldata/glm_test/freMTPL2freq.csv.zip"))
         fre['VehPower'] = fre['VehPower'].asfactor()

--- a/h2o-py/tests/testdir_algos/deeplearning/pyunit_mean_residual_deviance_sklearn.py
+++ b/h2o-py/tests/testdir_algos/deeplearning/pyunit_mean_residual_deviance_sklearn.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import unittest
 
 from sklearn.metrics import mean_poisson_deviance
 
@@ -10,6 +11,8 @@ from tests import pyunit_utils, assert_equals
 sys.path.insert(1, os.path.join("..", "..", ".."))
 
 
+@unittest.skipIf(sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] <= 5),
+                 "Tested only on python >3.5, mean_poisson_deviance is not supported on lower python version")
 def mean_residual_deviance_sklearn():
     print("poisson")
     fre = h2o.import_file(path=pyunit_utils.locate("smalldata/glm_test/freMTPL2freq.csv.zip"))


### PR DESCRIPTION
JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8708

Fixes failing test that was caused by the scikit-learn functionality requiring python >=3.5