### PR TITLE
[PUBDEV-9039] Remove CVE-2014-125087 from h2o-steam.jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,6 @@ ext {
     // Versions of libraries shared cross all projects
     //
     junitVersion  = '4.12'
-    jets3tVersion = '0.7.1'
     awsJavaSdkVersion = '1.12.268'
 
     //

--- a/h2o-persist-hdfs/build.gradle
+++ b/h2o-persist-hdfs/build.gradle
@@ -8,7 +8,6 @@ configurations {
 
 dependencies {
     api project(":h2o-core")
-    api('net.java.dev.jets3t:jets3t:0.9.0')
     api("org.apache.hadoop:$defaultHdfsDependency:$defaultHadoopVersion") {
         // Pull all dependencies to allow run directly from IDE or command line
         transitive = true


### PR DESCRIPTION
`com.jamesmurty.utils:java-xmlbuilder` is brought to h2o-3 via `net.java.dev.jets3t:jets3t` dependecy. This dependency doesn't seem to be used by hadoop libraries `3.3.3` included in h2o-steam.jar.