### PR TITLE
PUBDEV-9073: parallelize maxrsweep

### DIFF
--- a/h2o-algos/src/main/java/hex/modelselection/ModelSelectionModel.java
+++ b/h2o-algos/src/main/java/hex/modelselection/ModelSelectionModel.java
@@ -84,8 +84,9 @@ public class ModelSelectionModel extends Model<ModelSelectionModel, ModelSelecti
         public double _obj_reg = -1.0;
         public double[] _lambda = new double[]{0.0};
         public boolean _use_all_factor_levels = false;
-        public boolean _build_glm_model = true;
+        public boolean _build_glm_model = false;
         public GLMModel.GLMParameters.Influence _influence;  // if set to dfbetas will calculate the difference of betas obtained from including and excluding a data row
+        public boolean _multinode_mode = false; // for maxrsweep only, if true will run on multiple nodes in cluster
         
         public enum Mode {
             allsubsets, // use combinatorial, exponential runtime
@@ -345,7 +346,10 @@ public class ModelSelectionModel extends Model<ModelSelectionModel, ModelSelecti
                               int actualCPMSize, int[] predsubset, double[][] lastCPM, double r2Scale, 
                               CoeffNormalization coeffN, int[][] pred2CPMIndex, DataInfo dinfo) {
             int lastCPMIndex = actualCPMSize-1;
-            _best_r2_values[index] = 1-r2Scale * lastCPM[lastCPMIndex][lastCPMIndex];
+            if (lastCPM[lastCPMIndex][lastCPMIndex] == Double.MAX_VALUE)
+                _best_r2_values[index] = -1;
+            else
+                _best_r2_values[index] = 1-r2Scale * lastCPM[lastCPMIndex][lastCPMIndex];
             extractCoeffs(predictorNames, allCoefNames, lastCPM, index, hasIntercept, actualCPMSize, predsubset, coeffN,
                     pred2CPMIndex, dinfo);
             updateAddedRemovedPredictors(index);

--- a/h2o-algos/src/main/java/hex/modelselection/ModelSelectionTasks.java
+++ b/h2o-algos/src/main/java/hex/modelselection/ModelSelectionTasks.java
@@ -1,0 +1,51 @@
+package hex.modelselection;
+
+import water.MRTask;
+import water.fvec.Chunk;
+import water.fvec.Frame;
+import water.fvec.Vec;
+
+import java.util.stream.LongStream;
+
+public class ModelSelectionTasks {
+  public static class SweepFrameParallel extends MRTask<SweepFrameParallel> {
+    final double _oneOPivot;
+    final int[] _trackPivotSweeps;
+    final int _sweepIndex;
+    final double[] _ariCol;  // store column of a_ir
+    final int _cpmLen;
+
+    public SweepFrameParallel(int[] trackPSweeps, int sweepInd, Frame cpm) {
+      _trackPivotSweeps = trackPSweeps;
+      _sweepIndex = sweepInd;
+      _cpmLen = cpm.numCols();
+      // extract row corresponding to sweeping row
+      Vec sweepVec = cpm.vec(_sweepIndex);
+      _ariCol = LongStream.range(0, _cpmLen).mapToDouble(x -> sweepVec.at(x)).toArray();
+      _oneOPivot = 1.0 / _ariCol[_sweepIndex];
+    }
+
+    public void map(Chunk[] chks) {
+      int chunkNRows = chks[0]._len;
+      int rowOffset = (int) chks[0].start();
+      int numCols = chks.length;
+      double currEle;
+      for (int rInd = 0; rInd < chunkNRows; rInd++) {
+        int trueRowInd = rInd + rowOffset;
+        for (int cInd = 0; cInd < numCols; cInd++) {
+          currEle = chks[cInd].atd(rInd);
+          if (trueRowInd != _sweepIndex && cInd != _sweepIndex) { // not working on the sweeping row/column
+            currEle = currEle - _ariCol[trueRowInd] * _trackPivotSweeps[cInd] * _trackPivotSweeps[_sweepIndex] * _ariCol[cInd] * _oneOPivot;
+          } else if (trueRowInd == _sweepIndex && cInd == _sweepIndex) { // working on the sweeping element
+            currEle = _oneOPivot;
+          } else if (trueRowInd == _sweepIndex && cInd != _sweepIndex) {  // working on sweeping row
+            currEle = _trackPivotSweeps[cInd] * _trackPivotSweeps[_sweepIndex] * _ariCol[cInd] * _oneOPivot;
+          } else if (trueRowInd != _sweepIndex && cInd == _sweepIndex) {  // working on sweeping column
+            currEle = -_oneOPivot * _ariCol[trueRowInd];
+          }
+          chks[cInd].set(rInd, currEle);
+        }
+      }
+    }
+  }
+}

--- a/h2o-algos/src/main/java/hex/schemas/ModelSelectionV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/ModelSelectionV3.java
@@ -71,7 +71,8 @@ public class ModelSelectionV3 extends ModelBuilderSchema<ModelSelection, ModelSe
                 "mode", // naive, maxr, maxrsweep, backward
                 "build_glm_model",
                 "p_values_threshold",
-                "influence"
+                "influence",
+                "multinode_mode"
         };
 
         @API(help = "Seed for pseudo random number generator (if applicable)", gridable = true)
@@ -113,6 +114,11 @@ public class ModelSelectionV3 extends ModelBuilderSchema<ModelSelection, ModelSe
         @API(help = "Use lambda search starting at lambda max, given lambda is then interpreted as lambda min", 
                 level = API.Level.critical)
         public boolean lambda_search;
+
+        @API(help = "For maxrsweep only.  If enabled, will attempt to perform sweeping action using multiple nodes in " +
+                "the cluster.  Defaults to false.",
+                level = API.Level.critical)
+        public boolean multinode_mode;
 
         @API(help = "For maxrsweep mode only.  If true, will return full blown GLM models with the desired predictor" +
                 "subsets.  If false, only the predictor subsets, predictor coefficients are returned.  This is for" +

--- a/h2o-algos/src/test/java/hex/modelselection/ModelSelectionMaxRSweepTests.java
+++ b/h2o-algos/src/test/java/hex/modelselection/ModelSelectionMaxRSweepTests.java
@@ -7,6 +7,7 @@ import hex.gram.Gram;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import water.DKV;
+import water.Key;
 import water.Scope;
 import water.TestUtil;
 import water.fvec.Frame;
@@ -61,9 +62,10 @@ public class ModelSelectionMaxRSweepTests extends TestUtil {
             List<Integer> correctIgnoredPreds = new ArrayList<>(Arrays.asList(0, 3, 16, 17));
             List<Integer> ignoredCols = new ArrayList<>(Arrays.asList(0, 1, 2, 3, 10, 11, 12, 32, 33));
             List<String> ignoredPredsNames = new ArrayList<>();
+            List<String> ignoredCoefsNames = new ArrayList<>();
             String[] predictornames = dinfo._adaptedFrame.names();
             List<String> correctIgnoredPredNames = correctIgnoredPreds.stream().map(x -> predictornames[x]).collect(Collectors.toList());
-            List<Integer> ignoredFullPreds = findFullDupPred(dinfo, ignoredCols, ignoredPredsNames, predictornames);
+            List<Integer> ignoredFullPreds = findFullDupPred(dinfo, ignoredCols, ignoredPredsNames, ignoredCoefsNames, predictornames);
             // check that ignored predictor columns are generated correctly.
             assert ignoredFullPreds.size() == ignoredCols.size();
             int equalCounts = (int) IntStream.range(0, ignoredCols.size()).filter(x -> ignoredCols.get(x) == ignoredFullPreds.get(x)).count();
@@ -73,6 +75,7 @@ public class ModelSelectionMaxRSweepTests extends TestUtil {
                     "expected and actual removed predictor names list sizes are not equal.";
             equalCounts = (int) IntStream.range(0, ignoredPredsNames.size()).filter(x -> correctIgnoredPredNames.get(x).equals(ignoredPredsNames.get(x))).count();
             assert equalCounts == ignoredPredsNames.size() : "actual and expected removed predictor names are not the same.";
+            assertTrue(ignoredFullPreds.size()==ignoredCoefsNames.size());
         } finally {
             Scope.exit();
         }
@@ -89,22 +92,26 @@ public class ModelSelectionMaxRSweepTests extends TestUtil {
             Frame origF=Scope.track(parseTestFile("smalldata/glm_test/gaussian_20cols_10000Rows.csv"));;
             ModelSelectionModel.ModelSelectionParameters parms=new ModelSelectionModel.ModelSelectionParameters();;
             DataInfo dinfo = setup(origF, parms);
-            List<Integer> correctIgnoredPreds = new ArrayList<>(Arrays.asList(0, 3, 10, 16, 17));
-            List<Integer> correctIgnoredFullPreds = new ArrayList<>(Arrays.asList(0, 1, 2, 3, 10, 11, 12, 26, 32, 33));
+            List<Integer> correctIgnoredPredsInd = new ArrayList<>(Arrays.asList(0, 3, 10, 16, 17));
+            List<Integer> correctIgnoredFullCoefInd = new ArrayList<>(Arrays.asList(0, 1, 2, 3, 10, 11, 12, 26, 32, 33));
             List<Integer> ignoredCols = new ArrayList<>(Arrays.asList(0, 1, 2, 3, 4, 10, 11, 12, 17, 21, 26, 32, 33));
             List<String> ignoredPredsNames = new ArrayList<>();
+            List<String> ignoredCoefNames = new ArrayList<>();
             String[] predictornames = dinfo._adaptedFrame.names();
-            List<String> correctIgnoredPredNames = correctIgnoredPreds.stream().map(x -> predictornames[x]).collect(Collectors.toList());
-            List<Integer> ignoredFullPreds = findFullDupPred(dinfo, ignoredCols, ignoredPredsNames, predictornames);
+            List<String> correctIgnoredPredNames = correctIgnoredPredsInd.stream().map(x -> predictornames[x]).collect(Collectors.toList());
+            List<Integer> ignoredFullCoefInd = findFullDupPred(dinfo, ignoredCols, ignoredPredsNames, ignoredCoefNames, 
+                    predictornames);
+            
             // check that ignored predictor columns are generated correctly.
-            assert ignoredFullPreds.size() == correctIgnoredFullPreds.size();
-            int equalCounts = (int) IntStream.range(0, correctIgnoredFullPreds.size()).filter(x -> correctIgnoredFullPreds.get(x) == ignoredFullPreds.get(x)).count();
-            assert equalCounts == ignoredFullPreds.size() : "expected and actual predictor columns are not equal.";
+            assert ignoredFullCoefInd.size() == correctIgnoredFullCoefInd.size();
+            int equalCounts = (int) IntStream.range(0, correctIgnoredFullCoefInd.size()).filter(x -> correctIgnoredFullCoefInd.get(x) == ignoredFullCoefInd.get(x)).count();
+            assert equalCounts == ignoredFullCoefInd.size() : "expected and actual predictor columns are not equal.";
             // check that the correct duplicated predictor names are removed.
             assert correctIgnoredPredNames.size() == ignoredPredsNames.size() :
                     "expected and actual removed predictor names list sizes are not equal.";
             equalCounts = (int) IntStream.range(0, ignoredPredsNames.size()).filter(x -> correctIgnoredPredNames.get(x).equals(ignoredPredsNames.get(x))).count();
             assert equalCounts == ignoredPredsNames.size() : "actual and expected removed predictor names are not the same.";
+            assertTrue(ignoredFullCoefInd.size()==ignoredCoefNames.size());
         } finally {
             Scope.exit();
         }
@@ -197,7 +204,8 @@ public class ModelSelectionMaxRSweepTests extends TestUtil {
     }
 
     /***
-     * This will test for the correct mapping of predictors to cpm indices with duplicated predictors
+     * This will test for the correct mapping of predictors to cpm indices with duplicated predictors that needs to 
+     * be removed.
      */
     @Test
     public void testPredInd2CPMIndDuplicateCols() {
@@ -208,31 +216,33 @@ public class ModelSelectionMaxRSweepTests extends TestUtil {
             DataInfo dinfo = setup(origF, parms);
 
             // keep only first enum
-            List<Integer> droppedPreds = IntStream.range(1, 20).boxed().collect(Collectors.toList());
+            List<Integer> droppedPreds = IntStream.range(1, 36).boxed().collect(Collectors.toList());
             int[][] correctMap = new int[][]{{0,1,2,3}};
             testCorrectPred2CPMMap(dinfo, 1, droppedPreds, correctMap);
             // keep all enums
-            droppedPreds = IntStream.range(10, 20).boxed().collect(Collectors.toList());
+            droppedPreds = IntStream.range(26, 36).boxed().collect(Collectors.toList());
             correctMap = new int[][]{{0,1,2,3}, {4,5,6}, {7,8,9}, {10,11,12}, {13,14,15}, {16,17}, {18,19}, {20,21}, {22,23}, {24,25}};
             testCorrectPred2CPMMap(dinfo, 10, droppedPreds, correctMap);
             // keep all numerical columns
-            droppedPreds = IntStream.range(0,10).boxed().collect(Collectors.toList());
+            droppedPreds = IntStream.range(0,26).boxed().collect(Collectors.toList());
             correctMap = new int[][]{{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}};
             testCorrectPred2CPMMap(dinfo, 10, droppedPreds, correctMap);
             // keep only even predictors
-            droppedPreds = new ArrayList<>(Arrays.asList(1,3,5,7,9,11,13,15,17,19));
+            droppedPreds = new ArrayList<>(Arrays.asList(4,10,16,20,24,27,29,31,33,35));
             correctMap = new int[][]{{0,1,2,3}, {4,5,6}, {7,8,9}, {10,11},{12,13},{14},{15},{16},{17},{18}};
             testCorrectPred2CPMMap(dinfo, 10, droppedPreds, correctMap);
             // keep only odd predictors
-            droppedPreds = new ArrayList<>(Arrays.asList(0,2,4,6,8,10,12,14,16,18));
+            droppedPreds = new ArrayList<>(Arrays.asList(0,7,13,18,22,26,28,30,32,34));
             correctMap = new int[][]{{0,1,2},{3,4,5},{6,7},{8,9},{10,11},{12}, {13}, {14},{15},{16}};
             testCorrectPred2CPMMap(dinfo, 10, droppedPreds, correctMap);
             // keep first enum and first numerical
-            droppedPreds = new ArrayList<>(Arrays.asList(1,2,3,4,5,6,7,8,9,11,12,13,14,15,16,17,18,19));
+            droppedPreds = IntStream.range(0,36).boxed().collect(Collectors.toList());
+            droppedPreds.removeAll(Arrays.asList(0,1,2,3,26));
             correctMap = new int[][]{{0,1,2,3}, {4}};
             testCorrectPred2CPMMap(dinfo, 2, droppedPreds, correctMap);
             // keep last enum and last numerical
-            droppedPreds = new ArrayList<>(Arrays.asList(0,1,2,3,4,5,6,7,8,10,11,12,13,14,15,16,17,18));
+            droppedPreds = IntStream.range(0,36).boxed().collect(Collectors.toList());
+            droppedPreds.removeAll(Arrays.asList(24,25,35));
             correctMap = new int[][]{{0,1}, {2}};
             testCorrectPred2CPMMap(dinfo, 2, droppedPreds, correctMap);
         } finally {
@@ -444,7 +454,7 @@ public class ModelSelectionMaxRSweepTests extends TestUtil {
         int newPredCPMLength = pred2CPMIndices[newPredInd].length;
         double[][] smallCPM = extractPredSubsetsCPM(allCPM, predIndices, pred2CPMIndices, hasIntercept);
         SweepVector[][] sweepVectors = sweepCPM(smallCPM, sweepIndices, true);
-        double[][] rightSizeCPM = addNewPred2CPM(allCPM, smallCPM, allPreds, pred2CPMIndices, hasIntercept);
+        double[][] rightSizeCPM = addNewPred2CPM(allCPM, null, smallCPM, allPreds, pred2CPMIndices, hasIntercept);
         if (newPredCPMLength == 1) {
             applySweepVectors2NewPred(sweepVectors, rightSizeCPM, newPredCPMLength, null);
         } else {
@@ -465,7 +475,7 @@ public class ModelSelectionMaxRSweepTests extends TestUtil {
         int newPredCPMLength = pred2CPMIndices[newPredInd].length;
         double[][] smallCPM = extractPredSubsetsCPM(allCPM, predIndices, pred2CPMIndices, hasIntercept);
         SweepVector[][] sweepVectors = sweepCPM(smallCPM, sweepIndices, true);
-        double[][] rightSizeCPM = addNewPred2CPM(allCPM, smallCPM, allPreds, pred2CPMIndices, hasIntercept);
+        double[][] rightSizeCPM = addNewPred2CPM(allCPM, null, smallCPM, allPreds, pred2CPMIndices, hasIntercept);
         if (pred2CPMIndices[newPredInd].length > 1) {
             SweepVector[][] newSweepVec = mapBasicVector2Multiple(sweepVectors, newPredCPMLength);
             oneSweepWSweepVector(newSweepVec[0], rightSizeCPM, sweepIndices[0], newPredCPMLength);
@@ -514,42 +524,104 @@ public class ModelSelectionMaxRSweepTests extends TestUtil {
 
     @Test
     public void testPerformAllSweepingNoSweepVector() {
-        final double[][] cpm = new double[][]{{10.000000, -3.925113,  1.192877, -2.675484,  3.657043},
-                {-3.925113,  9.961056,  4.638419,  1.719902, -2.373317},
-                {1.192877,  4.638419,  9.649718, -1.855625,  3.444272},
-                {-2.675484,  1.719902, -1.855625,  6.197150, -3.117239},
-                {3.657043, -2.373317,  3.444272, -3.117239,  3.636824}};
-        final double[][] cpmAfterSweep0N1 = new double[][]{{0.1182966,  0.04661430,  0.3573300, -0.23632874,  0.3219854},
-                {0.0466143,  0.11875914,  0.6064598,  0.07953825, -0.1113826},
-                {-0.3573300, -0.60645976,  6.4104528, -1.94264564 , 3.5768221},
-                {0.2363287, -0.07953825, -1.9426456,  5.42805824, -2.0642052},
-                {-0.3219854,  0.11138257,  3.5768221, -2.06420516, 2.1949635}};
+        final double[][] cpm = new double[][]{{10.000000, -3.925113, 1.192877, -2.675484, 3.657043},
+                {-3.925113, 9.961056, 4.638419, 1.719902, -2.373317},
+                {1.192877, 4.638419, 9.649718, -1.855625, 3.444272},
+                {-2.675484, 1.719902, -1.855625, 6.197150, -3.117239},
+                {3.657043, -2.373317, 3.444272, -3.117239, 3.636824}};
+        final double[][] cpmAfterSweep0N1 = new double[][]{{0.1182966, 0.04661430, 0.3573300, -0.23632874, 0.3219854},
+                {0.0466143, 0.11875914, 0.6064598, 0.07953825, -0.1113826},
+                {-0.3573300, -0.60645976, 6.4104528, -1.94264564, 3.5768221},
+                {0.2363287, -0.07953825, -1.9426456, 5.42805824, -2.0642052},
+                {-0.3219854, 0.11138257, 3.5768221, -2.06420516, 2.1949635}};
         assertCorrectAllSweeping(clone2DArray(cpm), new int[]{0, 1}, cpmAfterSweep0N1);
         assertCorrectAllSweeping(clone2DArray(cpm), new int[]{1, 0}, cpmAfterSweep0N1);
-        final double[][] cpmAfterSweep0N1N2 = new double[][]{{0.13821485,  0.08041945, -0.05574177, -0.1280422,  0.1226070},
-                {0.08041945,  0.17613316, -0.09460483,  0.2633219, -0.4497672},
-                {-0.05574177, -0.09460483,  0.15599522, -0.3030434,  0.5579671},
-                {0.12804222, -0.26332191,  0.30304344,  4.8393522, -0.9802727},
-                {-0.12260698,  0.44976719, -0.55796715, -0.9802727,  0.1992143}};
-        assertCorrectSweeping(clone2DArray(cpm), new int[]{0,1,2}, cpmAfterSweep0N1N2);
-        assertCorrectSweeping(clone2DArray(cpm), new int[]{0,2,1}, cpmAfterSweep0N1N2);
-        assertCorrectSweeping(clone2DArray(cpm), new int[]{2,0,1}, cpmAfterSweep0N1N2);
-        assertCorrectSweeping(clone2DArray(cpm), new int[]{2,1,0}, cpmAfterSweep0N1N2);
-        assertCorrectSweeping(clone2DArray(cpm), new int[]{1,2,0}, cpmAfterSweep0N1N2);
-        assertCorrectSweeping(clone2DArray(cpm), new int[]{1,0,2}, cpmAfterSweep0N1N2);
-        final double[][] cpmAfterSweep0N1N2N3 = new double[][]{{0.14160266,  0.07345233, -0.04772369,  0.02645855,  0.0966703864},
-                {0.07345233,  0.19046119, -0.11109422, -0.05441263, -0.3964279716},
-                {-0.04772369, -0.11109422,  0.17497200,  0.06262066,  0.4965818245},
-                {0.02645855, -0.05441263,  0.06262066,  0.20663923, -0.2025627940},
-                {-0.09667039,  0.39642797, -0.49658182,  0.20256279,  0.0006474807}};
-        assertCorrectSweeping(clone2DArray(cpm), new int[]{0,1,2,3}, cpmAfterSweep0N1N2N3);
-        assertCorrectSweeping(clone2DArray(cpm), new int[]{0,2,1,3}, cpmAfterSweep0N1N2N3);
-        assertCorrectSweeping(clone2DArray(cpm), new int[]{3,2,1,0}, cpmAfterSweep0N1N2N3);
-        assertCorrectSweeping(clone2DArray(cpm), new int[]{3,1,2,0}, cpmAfterSweep0N1N2N3);
-        assertCorrectSweeping(clone2DArray(cpm), new int[]{1,0,2,3}, cpmAfterSweep0N1N2N3);
-        assertCorrectSweeping(clone2DArray(cpm), new int[]{1,3,0,2}, cpmAfterSweep0N1N2N3);
-        assertCorrectSweeping(clone2DArray(cpm), new int[]{2,3,1,0}, cpmAfterSweep0N1N2N3);
-        assertCorrectSweeping(clone2DArray(cpm), new int[]{2,1,0,3}, cpmAfterSweep0N1N2N3);
+        final double[][] cpmAfterSweep0N1N2 = new double[][]{{0.13821485, 0.08041945, -0.05574177, -0.1280422, 0.1226070},
+                {0.08041945, 0.17613316, -0.09460483, 0.2633219, -0.4497672},
+                {-0.05574177, -0.09460483, 0.15599522, -0.3030434, 0.5579671},
+                {0.12804222, -0.26332191, 0.30304344, 4.8393522, -0.9802727},
+                {-0.12260698, 0.44976719, -0.55796715, -0.9802727, 0.1992143}};
+        assertCorrectSweeping(clone2DArray(cpm), new int[]{0, 1, 2}, cpmAfterSweep0N1N2);
+        assertCorrectSweeping(clone2DArray(cpm), new int[]{0, 2, 1}, cpmAfterSweep0N1N2);
+        assertCorrectSweeping(clone2DArray(cpm), new int[]{2, 0, 1}, cpmAfterSweep0N1N2);
+        assertCorrectSweeping(clone2DArray(cpm), new int[]{2, 1, 0}, cpmAfterSweep0N1N2);
+        assertCorrectSweeping(clone2DArray(cpm), new int[]{1, 2, 0}, cpmAfterSweep0N1N2);
+        assertCorrectSweeping(clone2DArray(cpm), new int[]{1, 0, 2}, cpmAfterSweep0N1N2);
+        final double[][] cpmAfterSweep0N1N2N3 = new double[][]{{0.14160266, 0.07345233, -0.04772369, 0.02645855, 0.0966703864},
+                {0.07345233, 0.19046119, -0.11109422, -0.05441263, -0.3964279716},
+                {-0.04772369, -0.11109422, 0.17497200, 0.06262066, 0.4965818245},
+                {0.02645855, -0.05441263, 0.06262066, 0.20663923, -0.2025627940},
+                {-0.09667039, 0.39642797, -0.49658182, 0.20256279, 0.0006474807}};
+        assertCorrectSweeping(clone2DArray(cpm), new int[]{0, 1, 2, 3}, cpmAfterSweep0N1N2N3);
+        assertCorrectSweeping(clone2DArray(cpm), new int[]{0, 2, 1, 3}, cpmAfterSweep0N1N2N3);
+        assertCorrectSweeping(clone2DArray(cpm), new int[]{3, 2, 1, 0}, cpmAfterSweep0N1N2N3);
+        assertCorrectSweeping(clone2DArray(cpm), new int[]{3, 1, 2, 0}, cpmAfterSweep0N1N2N3);
+        assertCorrectSweeping(clone2DArray(cpm), new int[]{1, 0, 2, 3}, cpmAfterSweep0N1N2N3);
+        assertCorrectSweeping(clone2DArray(cpm), new int[]{1, 3, 0, 2}, cpmAfterSweep0N1N2N3);
+        assertCorrectSweeping(clone2DArray(cpm), new int[]{2, 3, 1, 0}, cpmAfterSweep0N1N2N3);
+        assertCorrectSweeping(clone2DArray(cpm), new int[]{2, 1, 0, 3}, cpmAfterSweep0N1N2N3);
+    }
+
+    @Test
+    public void testParallelSweep() {
+        Scope.enter();
+        try {
+            int[] sweepTrack = new int[]{1, 1, 1, 1, 1};
+            String[] predictorNames = new String[]{"1", "2", "3", "intercept", "XTY"};
+            final double[][] cpm = new double[][]{{10.000000, -3.925113, 1.192877, -2.675484, 3.657043},
+                    {-3.925113, 9.961056, 4.638419, 1.719902, -2.373317},
+                    {1.192877, 4.638419, 9.649718, -1.855625, 3.444272},
+                    {-2.675484, 1.719902, -1.855625, 6.197150, -3.117239},
+                    {3.657043, -2.373317, 3.444272, -3.117239, 3.636824}};
+            Frame cpmNoSweep = extractCPM(cpm, predictorNames);
+            Scope.track(cpmNoSweep);
+            final double[][] cpmAfterSweep0N1 = new double[][]{{0.1182966, 0.04661430, 0.3573300, -0.23632874, 0.3219854},
+                    {0.0466143, 0.11875914, 0.6064598, 0.07953825, -0.1113826},
+                    {-0.3573300, -0.60645976, 6.4104528, -1.94264564, 3.5768221},
+                    {0.2363287, -0.07953825, -1.9426456, 5.42805824, -2.0642052},
+                    {-0.3219854, 0.11138257, 3.5768221, -2.06420516, 2.1949635}};
+            Frame cpmAfterSweep0N1F = extractCPM(cpmAfterSweep0N1, predictorNames);
+            Scope.track(cpmAfterSweep0N1F);
+            assertCorrectSweepParallel(extractCPM(cpm, predictorNames), new int[]{0, 1}, cpmAfterSweep0N1F, sweepTrack.clone());
+            assertCorrectSweepParallel(extractCPM(cpm, predictorNames), new int[]{1, 0}, cpmAfterSweep0N1F, sweepTrack.clone());
+            final double[][] cpmAfterSweep0N1N2 = new double[][]{{0.13821485, 0.08041945, -0.05574177, -0.1280422, 0.1226070},
+                    {0.08041945, 0.17613316, -0.09460483, 0.2633219, -0.4497672},
+                    {-0.05574177, -0.09460483, 0.15599522, -0.3030434, 0.5579671},
+                    {0.12804222, -0.26332191, 0.30304344, 4.8393522, -0.9802727},
+                    {-0.12260698, 0.44976719, -0.55796715, -0.9802727, 0.1992143}};
+            Frame cpmAfterSweep0N1N2F = extractCPM(cpmAfterSweep0N1N2, predictorNames);
+            Scope.track(cpmAfterSweep0N1N2F);
+            assertCorrectSweepParallel(extractCPM(cpm, predictorNames), new int[]{0, 1, 2}, cpmAfterSweep0N1N2F, sweepTrack.clone());
+            assertCorrectSweepParallel(extractCPM(cpm, predictorNames), new int[]{0, 2, 1}, cpmAfterSweep0N1N2F, sweepTrack.clone());
+            assertCorrectSweepParallel(extractCPM(cpm, predictorNames), new int[]{2, 0, 1}, cpmAfterSweep0N1N2F, sweepTrack.clone());
+            assertCorrectSweepParallel(extractCPM(cpm, predictorNames), new int[]{2, 1, 0}, cpmAfterSweep0N1N2F, sweepTrack.clone());
+            assertCorrectSweepParallel(extractCPM(cpm, predictorNames), new int[]{1, 2, 0}, cpmAfterSweep0N1N2F, sweepTrack.clone());
+            assertCorrectSweepParallel(extractCPM(cpm, predictorNames), new int[]{1, 0, 2}, cpmAfterSweep0N1N2F, sweepTrack.clone());
+            final double[][] cpmAfterSweep0N1N2N3 = new double[][]{{0.14160266, 0.07345233, -0.04772369, 0.02645855, 0.0966703864},
+                    {0.07345233, 0.19046119, -0.11109422, -0.05441263, -0.3964279716},
+                    {-0.04772369, -0.11109422, 0.17497200, 0.06262066, 0.4965818245},
+                    {0.02645855, -0.05441263, 0.06262066, 0.20663923, -0.2025627940},
+                    {-0.09667039, 0.39642797, -0.49658182, 0.20256279, 0.0006474807}};
+            Frame cpmAfterSweep0N1N2N3F = extractCPM(cpmAfterSweep0N1N2N3, predictorNames);
+            Scope.track(cpmAfterSweep0N1N2N3F);
+            assertCorrectSweepParallel(extractCPM(cpm, predictorNames), new int[]{0, 1, 2, 3}, cpmAfterSweep0N1N2N3F, sweepTrack.clone());
+            assertCorrectSweepParallel(extractCPM(cpm, predictorNames), new int[]{0, 2, 1, 3}, cpmAfterSweep0N1N2N3F, sweepTrack.clone());
+            assertCorrectSweepParallel(extractCPM(cpm, predictorNames), new int[]{3, 2, 1, 0}, cpmAfterSweep0N1N2N3F, sweepTrack.clone());
+            assertCorrectSweepParallel(extractCPM(cpm, predictorNames), new int[]{3, 1, 2, 0}, cpmAfterSweep0N1N2N3F, sweepTrack.clone());
+            assertCorrectSweepParallel(extractCPM(cpm, predictorNames), new int[]{1, 0, 2, 3}, cpmAfterSweep0N1N2N3F, sweepTrack.clone());
+            assertCorrectSweepParallel(extractCPM(cpm, predictorNames), new int[]{1, 3, 0, 2}, cpmAfterSweep0N1N2N3F, sweepTrack.clone());
+            assertCorrectSweepParallel(extractCPM(cpm, predictorNames), new int[]{2, 3, 1, 0}, cpmAfterSweep0N1N2N3F, sweepTrack.clone());
+            assertCorrectSweepParallel(extractCPM(cpm, predictorNames), new int[]{2, 1, 0, 3}, cpmAfterSweep0N1N2N3F, sweepTrack.clone());
+        } finally {
+            Scope.exit();
+        }
+    }
+    
+    public Frame extractCPM(double[][] cpmA, String[] predictorNames) {
+        Frame cpm = new water.util.ArrayUtils().frame(Key.make(), predictorNames, cpmA);
+        Scope.track(cpm);
+        DKV.put(cpm);
+        return cpm;
     }
 
     @Test
@@ -576,6 +648,11 @@ public class ModelSelectionMaxRSweepTests extends TestUtil {
     public static void assertCorrectAllSweeping(double[][] cpm, int[] sweepIndice, double[][] correctCPM) {
         sweepCPM(cpm, sweepIndice, false);
         assert2DArraysEqual(correctCPM, cpm, 1e-6);
+    }
+
+    public static void assertCorrectSweepParallel(Frame cpm, int[] sweepIndice, Frame correctCPM, int[] trackSweep) {
+        sweepCPMParallel(cpm, sweepIndice, trackSweep);
+        TestUtil.assertFrameEquals(correctCPM, cpm, 1e-6);
     }
 
     // test perform one sweep without considering sweeping vectors.  We test with sweeping one index at a time, 
@@ -631,6 +708,84 @@ public class ModelSelectionMaxRSweepTests extends TestUtil {
         assertCorrectSweeping(clone2DArray(cpm), new int[]{2,1,0,3}, cpmAfterSweep0N1N2N3);
     }
 
+    @Test
+    public void testOneSweepParallel() {
+        Scope.enter();
+        try {
+            final double[][] cpm = new double[][]{{10.000000, -3.925113, 1.192877, -2.675484, 3.657043},
+                    {-3.925113, 9.961056, 4.638419, 1.719902, -2.373317},
+                    {1.192877, 4.638419, 9.649718, -1.855625, 3.444272},
+                    {-2.675484, 1.719902, -1.855625, 6.197150, -3.117239},
+                    {3.657043, -2.373317, 3.444272, -3.117239, 3.636824}};
+            final double[][] cpmAfterSweep0 = new double[][]{{0.1000000, -0.3925113, 0.1192877, -0.2675484, 0.3657043},
+                    {0.3925113, 8.4204048, 5.1066367, 0.6697443, -0.9378863},
+                    {-0.1192877, 5.1066367, 9.5074224, -1.5364727, 3.0080318},
+                    {0.2675484, 0.6697443, -1.5364727, 5.4813285, -2.1388030},
+                    {-0.3657043, -0.9378863, 3.0080318, -2.1388030, 2.2994276}};
+            String[] predNames = new String[]{"1", "2", "3", "intercept", "XTT"};
+            int[] trackSweep = new int[]{1,1,1,1,1};
+            assertCorrectSweepParallel(extractCPM(cpm, predNames), new int[]{0}, 
+                    extractCPM(cpmAfterSweep0, predNames), trackSweep);
+            final double[][] cpmAfterSweep0N1 = new double[][]{{0.1182966, 0.04661430, 0.3573300, -0.23632874, 0.3219854},
+                    {0.0466143, 0.11875914, 0.6064598, 0.07953825, -0.1113826},
+                    {-0.3573300, -0.60645976, 6.4104528, -1.94264564, 3.5768221},
+                    {0.2363287, -0.07953825, -1.9426456, 5.42805824, -2.0642052},
+                    {-0.3219854, 0.11138257, 3.5768221, -2.06420516, 2.1949635}};
+            assertCorrectSweepParallel(extractCPM(cpmAfterSweep0, predNames), new int[]{1}, 
+                    extractCPM(cpmAfterSweep0N1, predNames), trackSweep);
+            trackSweep = new int[]{1,1,1,1,1};
+            assertCorrectSweepParallel(extractCPM(cpm, predNames), 
+                    new int[]{0, 1}, extractCPM(cpmAfterSweep0N1, predNames), trackSweep);
+            trackSweep = new int[]{1,1,1,1,1};
+            assertCorrectSweepParallel(extractCPM(cpm, predNames),
+                    new int[]{1,0}, extractCPM(cpmAfterSweep0N1, predNames), trackSweep);
+            final double[][] cpmAfterSweep0N1N2 = new double[][]{{0.13821485, 0.08041945, -0.05574177, -0.1280422, 0.1226070},
+                    {0.08041945, 0.17613316, -0.09460483, 0.2633219, -0.4497672},
+                    {-0.05574177, -0.09460483, 0.15599522, -0.3030434, 0.5579671},
+                    {0.12804222, -0.26332191, 0.30304344, 4.8393522, -0.9802727},
+                    {-0.12260698, 0.44976719, -0.55796715, -0.9802727, 0.1992143}};
+            assertCorrectSweepParallel(extractCPM(cpmAfterSweep0N1, predNames), new int[]{2}, 
+                    extractCPM(cpmAfterSweep0N1N2, predNames), trackSweep);
+            assertCorrectSweepParallel(extractCPM(cpm, predNames), new int[]{0,1,2},
+                    extractCPM(cpmAfterSweep0N1N2, predNames), new int[]{1,1,1,1,1});
+            assertCorrectSweepParallel(extractCPM(cpm, predNames), new int[]{0,2,1},
+                    extractCPM(cpmAfterSweep0N1N2, predNames), new int[]{1,1,1,1,1});
+            assertCorrectSweepParallel(extractCPM(cpm, predNames), new int[]{2,0,1},
+                    extractCPM(cpmAfterSweep0N1N2, predNames), new int[]{1,1,1,1,1});
+            assertCorrectSweepParallel(extractCPM(cpm, predNames), new int[]{2,1,0},
+                    extractCPM(cpmAfterSweep0N1N2, predNames), new int[]{1,1,1,1,1});
+            assertCorrectSweepParallel(extractCPM(cpm, predNames), new int[]{1,2,0},
+                    extractCPM(cpmAfterSweep0N1N2, predNames), new int[]{1,1,1,1,1});
+            assertCorrectSweepParallel(extractCPM(cpm, predNames), new int[]{1,0,2},
+                    extractCPM(cpmAfterSweep0N1N2, predNames), new int[]{1,1,1,1,1});
+            final double[][] cpmAfterSweep0N1N2N3 = new double[][]{{0.14160266, 0.07345233, -0.04772369, 0.02645855, 0.0966703864},
+                    {0.07345233, 0.19046119, -0.11109422, -0.05441263, -0.3964279716},
+                    {-0.04772369, -0.11109422, 0.17497200, 0.06262066, 0.4965818245},
+                    {0.02645855, -0.05441263, 0.06262066, 0.20663923, -0.2025627940},
+                    {-0.09667039, 0.39642797, -0.49658182, 0.20256279, 0.0006474807}};
+            assertCorrectSweepParallel(extractCPM(cpmAfterSweep0N1N2, predNames), new int[]{3},
+                    extractCPM(cpmAfterSweep0N1N2N3, predNames), new int[]{-1,-1,-1,1,1});
+            assertCorrectSweepParallel(extractCPM(cpm, predNames), new int[]{0, 1, 2, 3},
+                    extractCPM(cpmAfterSweep0N1N2N3, predNames), new int[]{1,1,1,1,1});
+            assertCorrectSweepParallel(extractCPM(cpm, predNames), new int[]{0, 2, 1, 3},
+                    extractCPM(cpmAfterSweep0N1N2N3, predNames), new int[]{1,1,1,1,1});
+            assertCorrectSweepParallel(extractCPM(cpm, predNames), new int[]{3, 2, 1, 0},
+                    extractCPM(cpmAfterSweep0N1N2N3, predNames), new int[]{1,1,1,1,1});
+            assertCorrectSweepParallel(extractCPM(cpm, predNames), new int[]{3, 1, 2, 0},
+                    extractCPM(cpmAfterSweep0N1N2N3, predNames), new int[]{1,1,1,1,1});
+            assertCorrectSweepParallel(extractCPM(cpm, predNames), new int[]{1, 0, 2, 3},
+                    extractCPM(cpmAfterSweep0N1N2N3, predNames), new int[]{1,1,1,1,1});
+            assertCorrectSweepParallel(extractCPM(cpm, predNames), new int[]{1, 3, 0, 2},
+                    extractCPM(cpmAfterSweep0N1N2N3, predNames), new int[]{1,1,1,1,1});
+            assertCorrectSweepParallel(extractCPM(cpm, predNames), new int[]{2, 3, 1, 0},
+                    extractCPM(cpmAfterSweep0N1N2N3, predNames), new int[]{1,1,1,1,1});
+            assertCorrectSweepParallel(extractCPM(cpm, predNames), new int[]{2, 1, 0, 3},
+                    extractCPM(cpmAfterSweep0N1N2N3, predNames), new int[]{1,1,1,1,1});
+        } finally {
+            Scope.exit();
+        }
+    }
+
     public static double[][] clone2DArray(double[][] cpm) {
         int cpmDim = cpm.length;
         double[][] cpmClone = new double[cpmDim][cpmDim];
@@ -652,6 +807,50 @@ public class ModelSelectionMaxRSweepTests extends TestUtil {
             performOneSweep(cpm, null, sweepIndice[index], false);
 
         assert2DArraysEqual(correctCPM, cpm, 1e-6);
+    }
+    
+    @Test
+    public void testExtractSubsetCPMFrame() {
+        Scope.enter();
+        try {
+            final double[] vecValues = new double[]{1, 0.1, 0.2, 0.3, 0.4};
+            final double[] vecValues2 = new double[]{0.1, 0.2, 0.3, 0.4, 1};
+            final double[] resp = new double[]{2};
+            final double[][] allCPM = generateCPM(vecValues2, resp);
+            final double[][] allCPMInterceptFirst = generateCPM(vecValues, resp);
+            String[] predNames = new String[]{"1","2","3","4","intercept","XTY"};
+
+            // tests with intercept
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{0}, {}, {}, {}}, allCPMInterceptFirst, new int[]{0}, true);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{0, 1}, {}, {}, {}}, allCPMInterceptFirst, new int[]{0}, true);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{0, 1, 2}, {}, {}, {}}, allCPMInterceptFirst, new int[]{0}, true);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{0, 1, 2, 3}, {}, {}, {}}, allCPMInterceptFirst, new int[]{0}, true);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{}, {1}, {}, {}}, allCPMInterceptFirst, new int[]{1}, true);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{}, {1, 2}, {}, {}}, allCPMInterceptFirst, new int[]{1}, true);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{}, {1, 2, 3}, {}, {}}, allCPMInterceptFirst, new int[]{1}, true);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{}, {}, {2}, {}}, allCPMInterceptFirst, new int[]{2}, true);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{}, {}, {2, 3}, {}}, allCPMInterceptFirst, new int[]{2}, true);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{}, {}, {}, {3}}, allCPMInterceptFirst, new int[]{3}, true);
+
+            // tests with intercept
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{0}, {}, {}, {}, {}}, allCPM, new int[]{0}, false);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{0, 1}, {}, {}, {}, {}}, allCPM, new int[]{0}, false);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{0, 1, 2}, {}, {}, {}, {}}, allCPM, new int[]{0}, false);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{0, 1, 2, 3}, {}, {}, {}, {}}, allCPM, new int[]{0}, false);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{0, 1, 2, 3, 4}, {}, {}, {}, {}}, allCPM, new int[]{0}, false);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{}, {1}, {}, {}, {}}, allCPM, new int[]{1}, false);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{}, {1, 2}, {}, {}, {}}, allCPM, new int[]{1}, false);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{}, {1, 2, 3}, {}, {}, {}}, allCPM, new int[]{1}, false);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{}, {1, 2, 3, 4}, {}, {}, {}}, allCPM, new int[]{1}, false);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{}, {}, {2}, {}, {}}, allCPM, new int[]{2}, false);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{}, {}, {2, 3}, {}, {}}, allCPM, new int[]{2}, false);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{}, {}, {2, 3, 4}, {}, {}}, allCPM, new int[]{2}, false);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{}, {}, {}, {3}, {}}, allCPM, new int[]{3}, false);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{}, {}, {}, {3, 4}, {}}, allCPM, new int[]{3}, false);
+            assertCorrectCPMExtractionFrame(extractCPM(allCPM, predNames), new int[][]{{}, {}, {}, {}, {4}, {}}, allCPM, new int[]{4}, false);
+        } finally {
+            Scope.exit();
+        }
     }
 
     @Test
@@ -712,6 +911,29 @@ public class ModelSelectionMaxRSweepTests extends TestUtil {
         return genCPM;
     }
 
+    public static void assertCorrectCPMExtractionFrame(Frame allCPM, int[][] pred2CMPIndices,
+                                                  double[][] CPMInterceptFirst, int[] predIndices, boolean hasIntercept) {
+        double[][] extractedCpm = extractPredSubsetsCPMFrame(allCPM, predIndices, pred2CMPIndices,
+                hasIntercept);
+        List<Integer> predIndicesList = Arrays.stream(pred2CMPIndices[predIndices[0]]).boxed().collect(Collectors.toList());
+        if (hasIntercept) {
+            predIndicesList = Arrays.stream(pred2CMPIndices[predIndices[0]]).map(x -> x + 1).boxed().collect(Collectors.toList());
+            predIndicesList.add(0,0);
+        }
+        int allCPMSize = allCPM.numCols();
+        predIndicesList.add(allCPMSize-1);
+        int cpmDim = predIndicesList.size();
+        double[][] correctCPM = new double[cpmDim][cpmDim];
+        // generate correct matrix
+        for (int rIndex=0; rIndex<cpmDim; rIndex++) {
+            for (int cIndex=rIndex; cIndex<cpmDim; cIndex++) {
+                correctCPM[rIndex][cIndex] = CPMInterceptFirst[predIndicesList.get(rIndex)][predIndicesList.get(cIndex)];
+                correctCPM[cIndex][rIndex] = CPMInterceptFirst[predIndicesList.get(cIndex)][predIndicesList.get(rIndex)];
+            }
+        }
+        assert2DArraysEqual(correctCPM, extractedCpm, 1e-6);
+    }
+    
     public static void assertCorrectCPMExtraction(double[][] allCPM, int[][] pred2CMPIndices,
                                                   double[][] CPMInterceptFirst, int[] predIndices, boolean hasIntercept) {
         double[][] extractedCpm = extractPredSubsetsCPM(allCPM, predIndices, pred2CMPIndices,
@@ -736,6 +958,46 @@ public class ModelSelectionMaxRSweepTests extends TestUtil {
     }
 
     @Test
+    public void testAddNewPred2CPMFrame() {
+        Scope.enter();
+        try {
+            final double[][] allCPM = new double[][]{{10.0000000, 1.2775780, -2.3233446, 5.5573236, -2.6207931,
+                    -0.8321198, -2.275524}, {1.2775780, 6.9109954, -0.6907638, 1.6104894, -0.2288084, 1.0167696,
+                    -4.049839}, {-2.3233446, -0.6907638, 2.9167538, -0.9018913, -0.8793179, -1.6471318, 2.448738},
+                    {5.5573236, 1.6104894, -0.9018913, 11.4569287, -1.9699385, -2.2898801, -2.018988}, {-2.6207931,
+                    -0.2288084, -0.8793179, -1.9699385, 6.9525541, -0.2876347, 2.896199}, {-0.8321198, 1.0167696,
+                    -1.6471318, -2.2898801, -0.2876347, 11.3756280, -8.946720}, {-2.2755243, -4.0498392, 2.4487380,
+                    -2.0189880, 2.8961986, -8.9467197, 10.464016}};
+            int[][] predInd2CPMIndices = new int[][]{{0, 1, 2}, {3, 4}, {5}};
+            boolean hasIntercept = false;
+            String[] predNames = new String[]{"1", "2", "3", "4", "5", "intercept", "xty"};
+            // pred 0 is chosen and we want to add predictor 1
+            assertCorrectAddNewPred2CPM(allCPM, extractCPM(allCPM, predNames), new int[]{0, 1, 2}, predInd2CPMIndices,
+                    new int[]{0}, 1, hasIntercept);
+            // pred 2, 1 are added, want to add pred 0
+            assertCorrectAddNewPred2CPM(allCPM, extractCPM(allCPM, predNames), new int[]{0, 1, 2}, predInd2CPMIndices,
+                    new int[]{2, 1}, 0, hasIntercept);
+            // pred 0, 2 are added want to add pred 1
+            assertCorrectAddNewPred2CPM(allCPM, extractCPM(allCPM, predNames), new int[]{0, 1, 2, 3}, predInd2CPMIndices,
+                    new int[]{0, 2}, 1, hasIntercept);
+            // with intercept
+            predInd2CPMIndices = new int[][]{{0, 1}, {2}, {3}, {4}};
+            hasIntercept = true;
+            // pred 3,2 are chosen, add 0
+            assertCorrectAddNewPred2CPM(allCPM, extractCPM(allCPM, predNames), new int[]{0, 1, 2}, predInd2CPMIndices,
+                    new int[]{3, 2}, 0, hasIntercept);
+            // pred 2,3,1 are chosen, add 0
+            assertCorrectAddNewPred2CPM(allCPM, extractCPM(allCPM, predNames), new int[]{0, 1, 2, 3}, predInd2CPMIndices,
+                    new int[]{2, 3, 1}, 0, hasIntercept);
+            // pred 0, 1 are chosen, add 2
+            assertCorrectAddNewPred2CPM(allCPM, extractCPM(allCPM, predNames), new int[]{0, 1, 2, 3}, predInd2CPMIndices,
+                    new int[]{0, 1}, 2, hasIntercept);
+        } finally {
+            Scope.exit();
+        }
+    }
+    
+    @Test
     public void testAddNewPred2CPM() {
         final double[][] allCPM = new double[][]{{10.0000000,  1.2775780, -2.3233446,  5.5573236, -2.6207931,
                 -0.8321198, -2.275524}, {1.2775780,  6.9109954, -0.6907638,  1.6104894, -0.2288084,  1.0167696,
@@ -747,24 +1009,25 @@ public class ModelSelectionMaxRSweepTests extends TestUtil {
         int[][] predInd2CPMIndices = new int[][]{{0, 1, 2}, {3, 4}, {5}};
         boolean hasIntercept = false;
         // pred 0 is chosen and we want to add predictor 1
-        assertCorrectAddNewPred2CPM(allCPM, new int[]{0,1,2}, predInd2CPMIndices, new int[]{0}, 1, hasIntercept);
+        assertCorrectAddNewPred2CPM(allCPM,null, new int[]{0,1,2}, predInd2CPMIndices, new int[]{0}, 1, hasIntercept);
         // pred 2, 1 are added, want to add pred 0
-        assertCorrectAddNewPred2CPM(allCPM, new int[]{0,1,2}, predInd2CPMIndices, new int[]{2,1}, 0, hasIntercept);
+        assertCorrectAddNewPred2CPM(allCPM, null,new int[]{0,1,2}, predInd2CPMIndices, new int[]{2,1}, 0, hasIntercept);
         // pred 0, 2 are added want to add pred 1
-        assertCorrectAddNewPred2CPM(allCPM, new int[]{0,1,2,3}, predInd2CPMIndices, new int[]{0,2}, 1, hasIntercept);
+        assertCorrectAddNewPred2CPM(allCPM, null,new int[]{0,1,2,3}, predInd2CPMIndices, new int[]{0,2}, 1, hasIntercept);
         // with intercept
         predInd2CPMIndices = new int[][]{{0,1},{2},{3},{4}};
         hasIntercept = true;
         // pred 3,2 are chosen, add 0
-        assertCorrectAddNewPred2CPM(allCPM, new int[]{0,1,2}, predInd2CPMIndices, new int[]{3,2}, 0, hasIntercept);
+        assertCorrectAddNewPred2CPM(allCPM, null,new int[]{0,1,2}, predInd2CPMIndices, new int[]{3,2}, 0, hasIntercept);
         // pred 2,3,1 are chosen, add 0
-        assertCorrectAddNewPred2CPM(allCPM, new int[]{0,1,2,3}, predInd2CPMIndices, new int[]{2,3,1}, 0, hasIntercept);
+        assertCorrectAddNewPred2CPM(allCPM, null, new int[]{0,1,2,3}, predInd2CPMIndices, new int[]{2,3,1}, 0, hasIntercept);
         // pred 0, 1 are chosen, add 2
-        assertCorrectAddNewPred2CPM(allCPM, new int[]{0,1,2,3}, predInd2CPMIndices, new int[]{0,1}, 2, hasIntercept);
+        assertCorrectAddNewPred2CPM(allCPM, null, new int[]{0,1,2,3}, predInd2CPMIndices, new int[]{0,1}, 2, hasIntercept);
     }
 
-    public static void assertCorrectAddNewPred2CPM(double[][] allCPM, int[] sweepIndices, int[][] predInd2CPMIndices,
-                                                   int[] pred2Include, int pred2Add, boolean hasIntercept) {
+    public static void assertCorrectAddNewPred2CPM(double[][] allCPM, Frame allCPMFrame, int[] sweepIndices,
+                                                   int[][] predInd2CPMIndices, int[] pred2Include, int pred2Add,
+                                                   boolean hasIntercept) {
         // manually generated the cpm after new predictor is included
         int[] allPred = new int[pred2Include.length+1];
         System.arraycopy(pred2Include, 0, allPred, 0, pred2Include.length);
@@ -774,7 +1037,7 @@ public class ModelSelectionMaxRSweepTests extends TestUtil {
         // addNewPred2CPM generated from program
         double[][] smallCPM = extractPredSubsetsCPM(allCPM, pred2Include, predInd2CPMIndices, hasIntercept);
         sweepCPM(smallCPM, sweepIndices, hasIntercept);
-        double[][] subsetCPM = addNewPred2CPM(allCPM, smallCPM, allPred, predInd2CPMIndices, hasIntercept);
+        double[][] subsetCPM = addNewPred2CPM(allCPM, allCPMFrame, smallCPM, allPred, predInd2CPMIndices, hasIntercept);
 
         // program generated subsetCPM is correct if it equals to smallCPM on part of the matrix that is swept.
         int subsetCPMLastInd = subsetCPM.length-1;
@@ -830,11 +1093,20 @@ public class ModelSelectionMaxRSweepTests extends TestUtil {
             parms._train = origF._key;
             parms._mode = maxrsweep;
             parms._build_glm_model = false;
+            parms._multinode_mode = false;
             ModelSelectionModel modelMaxRSweep = new hex.modelselection.ModelSelection(parms).trainModel().get();
             Frame resultFrameSweep = modelMaxRSweep.result();
             Scope.track(resultFrameSweep);
             Scope.track_generic(modelMaxRSweep);
-            
+            parms._multinode_mode = true;
+            ModelSelectionModel modelMaxRSweepMNode = new hex.modelselection.ModelSelection(parms).trainModel().get();
+            Frame resultFrameSweepMNode = modelMaxRSweepMNode.result();
+            Scope.track(resultFrameSweepMNode);
+            Scope.track_generic(modelMaxRSweepMNode);
+            TestUtil.assertIdenticalUpToRelTolerance(new Frame(resultFrameSweep.vec(1)), new Frame(resultFrameSweepMNode.vec(1)), 1e-6);
+            TestUtil.assertIdenticalUpToRelTolerance(new Frame(resultFrameSweep.vec(2)), new Frame(resultFrameSweepMNode.vec(2)), 0);
+
+            parms._multinode_mode = false;
             parms._build_glm_model = true;
             ModelSelectionModel modelMaxRSweepGLM = new hex.modelselection.ModelSelection(parms).trainModel().get();
             Frame resultFrameSweepGLM = modelMaxRSweepGLM.result();
@@ -877,13 +1149,21 @@ public class ModelSelectionMaxRSweepTests extends TestUtil {
             Scope.track(resultFrameSweep);
             Scope.track_generic(modelMaxRSweep);
             
+            parms._multinode_mode = true;
             parms._build_glm_model = true;
+            ModelSelectionModel modelMaxRSweepMN = new hex.modelselection.ModelSelection(parms).trainModel().get();
+            Frame resultFrameSweepMN = modelMaxRSweepMN.result();
+            Scope.track(resultFrameSweepMN);
+            Scope.track_generic(modelMaxRSweepMN);
+
+            parms._multinode_mode = false;
             ModelSelectionModel modelMaxRSweepGLM = new hex.modelselection.ModelSelection(parms).trainModel().get();
             Frame resultFrameSweepGLM = modelMaxRSweepGLM.result();
             Scope.track(resultFrameSweepGLM);
             Scope.track_generic(modelMaxRSweepGLM);
+            TestUtil.assertIdenticalUpToRelTolerance(new Frame(resultFrameSweepGLM.vec(2)), new Frame(resultFrameSweepMN.vec(2)), 1e-6);
+            TestUtil.assertIdenticalUpToRelTolerance(new Frame(resultFrameSweepGLM.vec(3)), new Frame(resultFrameSweepMN.vec(3)), 0);
             
-
             parms._mode = maxr;
             ModelSelectionModel modelMaxR = new hex.modelselection.ModelSelection(parms).trainModel().get();
             Scope.track_generic(modelMaxR);
@@ -930,6 +1210,15 @@ public class ModelSelectionMaxRSweepTests extends TestUtil {
             Frame resultFrameSweepGLM = modelMaxRSweepGLM.result();
             Scope.track(resultFrameSweepGLM);
             
+            parms._multinode_mode = true;
+            ModelSelectionModel modelMaxRSweepGLMMN = new hex.modelselection.ModelSelection(parms).trainModel().get();
+            Scope.track_generic(modelMaxRSweepGLMMN);
+            Frame resultFrameSweepGLMMN = modelMaxRSweepGLMMN.result();
+            Scope.track(resultFrameSweepGLMMN);
+            TestUtil.assertIdenticalUpToRelTolerance(new Frame(resultFrameSweepGLM.vec(2)), new Frame(resultFrameSweepGLMMN.vec(2)), 1e-6);
+            TestUtil.assertIdenticalUpToRelTolerance(new Frame(resultFrameSweepGLM.vec(3)), new Frame(resultFrameSweepGLMMN.vec(3)), 0);
+            
+            parms._multinode_mode = false;
             parms._mode = maxr;
             ModelSelectionModel modelMaxR = new hex.modelselection.ModelSelection(parms).trainModel().get();
             Scope.track_generic(modelMaxR);

--- a/h2o-py/h2o/estimators/model_selection.py
+++ b/h2o-py/h2o/estimators/model_selection.py
@@ -87,9 +87,10 @@ class H2OModelSelectionEstimator(H2OEstimator):
                  max_predictor_number=1,  # type: int
                  min_predictor_number=1,  # type: int
                  mode="maxr",  # type: Literal["allsubsets", "maxr", "maxrsweep", "backward"]
-                 build_glm_model=True,  # type: bool
+                 build_glm_model=False,  # type: bool
                  p_values_threshold=0.0,  # type: float
                  influence=None,  # type: Optional[Literal["dfbetas"]]
+                 multinode_mode=False,  # type: bool
                  ):
         """
         :param model_id: Destination id for this model; auto-generated if not specified.
@@ -315,7 +316,7 @@ class H2OModelSelectionEstimator(H2OEstimator):
                predictorsubsets.  If false, only the predictor subsets, predictor coefficients are returned.  This is
                forspeeding up the model selection process.  The users can choose to build the GLM models themselvesby
                using the predictor subsets themselves.  Defaults to false.
-               Defaults to ``True``.
+               Defaults to ``False``.
         :type build_glm_model: bool
         :param p_values_threshold: For mode='backward' only.  If specified, will stop the model building process when
                all coefficientsp-values drop below this threshold
@@ -325,6 +326,10 @@ class H2OModelSelectionEstimator(H2OEstimator):
                excluded in the dataset.
                Defaults to ``None``.
         :type influence: Literal["dfbetas"], optional
+        :param multinode_mode: For maxrsweep only.  If enabled, will attempt to perform sweeping action using multiple
+               nodes in the cluster.  Defaults to false.
+               Defaults to ``False``.
+        :type multinode_mode: bool
         """
         super(H2OModelSelectionEstimator, self).__init__()
         self._parms = {}
@@ -387,6 +392,7 @@ class H2OModelSelectionEstimator(H2OEstimator):
         self.build_glm_model = build_glm_model
         self.p_values_threshold = p_values_threshold
         self.influence = influence
+        self.multinode_mode = multinode_mode
 
     @property
     def training_frame(self):
@@ -1201,7 +1207,7 @@ class H2OModelSelectionEstimator(H2OEstimator):
         selection process.  The users can choose to build the GLM models themselvesby using the predictor subsets
         themselves.  Defaults to false.
 
-        Type: ``bool``, defaults to ``True``.
+        Type: ``bool``, defaults to ``False``.
         """
         return self._parms.get("build_glm_model")
 
@@ -1238,6 +1244,21 @@ class H2OModelSelectionEstimator(H2OEstimator):
     def influence(self, influence):
         assert_is_type(influence, None, Enum("dfbetas"))
         self._parms["influence"] = influence
+
+    @property
+    def multinode_mode(self):
+        """
+        For maxrsweep only.  If enabled, will attempt to perform sweeping action using multiple nodes in the cluster.
+        Defaults to false.
+
+        Type: ``bool``, defaults to ``False``.
+        """
+        return self._parms.get("multinode_mode")
+
+    @multinode_mode.setter
+    def multinode_mode(self, multinode_mode):
+        assert_is_type(multinode_mode, None, bool)
+        self._parms["multinode_mode"] = multinode_mode
 
 
     def get_regression_influence_diagnostics(self, predictor_size=None):

--- a/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8763_maxrSweep_NPE_large.py
+++ b/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8763_maxrSweep_NPE_large.py
@@ -11,26 +11,39 @@ def test_maxrsweep_NPE():
     predictors = train.names
     predictors.remove(response)
     npred = 100
-    maxrsweep_model = H2OModelSelectionEstimator(mode="maxrsweep", max_predictor_number=npred, intercept=True)
+    maxrsweep_model = H2OModelSelectionEstimator(mode="maxrsweep", max_predictor_number=npred, intercept=True, 
+                                                 build_glm_model=True)
     maxrsweep_model.train(x=predictors, y=response, training_frame=train)
     maxrsweep_coeffs = maxrsweep_model.coef()
     maxrsweep_coeffs_norm = maxrsweep_model.coef_norm()
     maxrsweep_best_model_predictors = maxrsweep_model.get_best_model_predictors()
-    maxrsweep_model_glm = H2OModelSelectionEstimator(mode="maxrsweep", max_predictor_number=npred, intercept=True, 
-                                                    build_glm_model=False)
+    maxrsweep_model_glm = H2OModelSelectionEstimator(mode="maxrsweep", max_predictor_number=npred, intercept=True)
     maxrsweep_model_glm.train(x=predictors, y=response, training_frame=train)
     maxrsweepGLM_coeffs = maxrsweep_model_glm.coef()
     maxrsweepGLM_coeffs_norm = maxrsweep_model_glm.coef_norm()
     maxrsweepGLM_best_model_predictors = maxrsweep_model_glm.get_best_model_predictors()
 
+    maxrsweep_model_MM = H2OModelSelectionEstimator(mode="maxrsweep", max_predictor_number=npred, intercept=True,
+                                                     multinode_mode=True)
+    maxrsweep_model_MM.train(x=predictors, y=response, training_frame=train)
+    maxrsweep_coeffs_MM = maxrsweep_model_MM.coef()
+    maxrsweep_coeffs_norm_MM = maxrsweep_model_MM.coef_norm()
+    maxrsweep_best_model_predictors_MM = maxrsweep_model_MM.get_best_model_predictors()
+
     for ind in range(0, len(maxrsweep_coeffs)):
         pyunit_utils.assertCoefDictEqual(maxrsweep_coeffs[ind], maxrsweepGLM_coeffs[ind], 1e-6)
+        pyunit_utils.assertCoefDictEqual(maxrsweep_coeffs[ind], maxrsweep_coeffs_MM[ind], 1e-6)
         pyunit_utils.assertCoefDictEqual(maxrsweep_coeffs_norm[ind], maxrsweepGLM_coeffs_norm[ind], 1e-6)
+        pyunit_utils.assertCoefDictEqual(maxrsweep_coeffs_norm[ind], maxrsweep_coeffs_norm_MM[ind], 1e-6)
         maxrsweep_best_model_predictors[ind].sort()
         maxrsweepGLM_best_model_predictors[ind].sort()
+        maxrsweep_best_model_predictors_MM[ind].sort()
         assert maxrsweep_best_model_predictors[ind] == maxrsweepGLM_best_model_predictors[ind], \
             "Expected predictor subset: {0}, actual predictor subset: {1}".format(maxrsweep_best_model_predictors[ind],
                                                                                   maxrsweepGLM_best_model_predictors[ind])
+        assert maxrsweep_best_model_predictors[ind] == maxrsweep_best_model_predictors_MM[ind], \
+            "Expected predictor subset: {0}, actual predictor subset: {1}".format(maxrsweep_best_model_predictors[ind],
+                                                                                  maxrsweep_best_model_predictors_MM[ind])
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(test_maxrsweep_NPE)

--- a/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8785_8235_8703_modelselection_gaussian.py
+++ b/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8785_8235_8703_modelselection_gaussian.py
@@ -13,14 +13,18 @@ def test_modelselection_gaussian():
     d = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
     my_y = "GLEASON"
     my_x = ["AGE","RACE","CAPSULE","DCAPS","PSA","VOL","DPROS"]
-    model_maxrsweep = modelSelection(seed=12345, max_predictor_number=3, mode="maxrsweep")
+    model_maxrsweep = modelSelection(seed=12345, max_predictor_number=3, mode="maxrsweep", build_glm_model=True)
     model_maxrsweep.train(training_frame=d, x=my_x, y=my_y)
-    model_maxrsweep_glm = modelSelection(seed=12345, max_predictor_number=3, mode="maxrsweep", build_glm_model=False)
+    model_maxrsweep_MM = modelSelection(seed=12345, max_predictor_number=3, mode="maxrsweep", build_glm_model=True, 
+                                        multinode_mode=True)
+    model_maxrsweep_MM.train(training_frame=d, x=my_x, y=my_y)
+    model_maxrsweep_glm = modelSelection(seed=12345, max_predictor_number=3, mode="maxrsweep")
     model_maxrsweep_glm.train(training_frame=d, x=my_x, y=my_y)
     model_maxr = modelSelection(seed=12345, max_predictor_number=3, mode="maxr")
     model_maxr.train(training_frame=d, x=my_x, y=my_y)
 
     # make sure results returned by maxr and maxrsweep are the same
+    pyunit_utils.compare_frames_local(model_maxrsweep_MM.result()[2:4], model_maxrsweep.result()[2:4], prob=1.0, tol=1e-6)
     pyunit_utils.compare_frames_local(model_maxr.result()[2:4], model_maxrsweep.result()[2:4], prob=1.0, tol=1e-6)
     pyunit_utils.compare_frames_local(model_maxr.result()[2:4], model_maxrsweep_glm.result()[1:3], prob=1.0, tol=1e-6)
     model_allsubsets = modelSelection(seed=12345, max_predictor_number=3, mode="allsubsets")

--- a/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8785_8346_8703_modelselection_result_frame.py
+++ b/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8785_8346_8703_modelselection_result_frame.py
@@ -15,12 +15,15 @@ def test_gaussian_result_frame_model_id():
     
     maxr_model = modelSelection(seed=12345, max_predictor_number=7, mode="maxr")
     maxr_model.train(training_frame=d, x=my_x, y=my_y)
-    maxrsweep_model = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep")
+    maxrsweep_model = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep", build_glm_model=True)
     maxrsweep_model.train(training_frame=d, x=my_x, y=my_y)
-    maxrsweep_model_glm = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep", build_glm_model=False)
+    maxrsweep_model_glm = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep")
     maxrsweep_model_glm.train(training_frame=d, x=my_x, y=my_y)
+    maxrsweep_model_MM = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep", multinode_mode=True)
+    maxrsweep_model_MM.train(training_frame=d, x=my_x, y=my_y)
 
     # make sure results returned by maxr and maxrsweep are the same
+    pyunit_utils.compare_frames_local(maxrsweep_model_MM.result()[2:4], maxrsweep_model_glm.result()[2:4], prob=1.0, tol=1e-6)
     pyunit_utils.compare_frames_local(maxr_model.result()[2:4], maxrsweep_model.result()[2:4], prob=1.0, tol=1e-6)
     pyunit_utils.compare_frames_local(maxr_model.result()[2:4], maxrsweep_model_glm.result()[1:3], prob=1.0, tol=1e-6)
     

--- a/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8785_8346_8703_modelselection_result_frame_model_id.py
+++ b/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8785_8346_8703_modelselection_result_frame_model_id.py
@@ -21,13 +21,16 @@ def test_modelselection_gaussian_model_id():
     maxr_model = modelSelection(seed=12345, max_predictor_number=7, mode="maxr")
     maxr_model.train(training_frame=d, x=my_x, y=my_y)
     result_frame_maxr = maxr_model.result()
-    maxrsweep_model = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep")
+    maxrsweep_model = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep", build_glm_model=True)
     maxrsweep_model.train(training_frame=d, x=my_x, y=my_y)
-    maxrsweep_model_glm = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep", build_glm_model=False)
+    maxrsweep_model_glm = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep")
     maxrsweep_model_glm.train(training_frame=d, x=my_x, y=my_y)
+    maxrsweep_model_MM = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep", multinode_mode=True)
+    maxrsweep_model_MM.train(training_frame=d, x=my_x, y=my_y)
     
     # make sure results returned by maxr and maxrsweep are the same
     pyunit_utils.compare_frames_local(maxr_model.result()[2:4], maxrsweep_model.result()[2:4], prob=1.0, tol=1e-6)
+    pyunit_utils.compare_frames_local(maxrsweep_model_MM.result()[2:4], maxrsweep_model_glm.result()[2:4], prob=1.0, tol=1e-6)
     pyunit_utils.compare_frames_local(maxr_model.result()[2:4], maxrsweep_model_glm.result()[1:3], prob=1.0, tol=1e-6)
     
     for ind in list(range(numRows)):

--- a/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8785_8346_modelselection_result_frame_model_id_serialization.py
+++ b/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8785_8346_modelselection_result_frame_model_id_serialization.py
@@ -20,13 +20,17 @@ def test_modelselection_serialization():
     maxr_model.train(training_frame=d, x=my_x, y=my_y)
     model_path_maxr = maxr_model.download_model(tmpdir)
 
-    maxrsweep_model = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep")
+    maxrsweep_model = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep", build_glm_model=True)
     maxrsweep_model.train(training_frame=d, x=my_x, y=my_y)
     model_path_maxrsweep = maxrsweep_model.download_model(tmpdir)
 
-    maxrsweep_model_glm = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep", build_glm_model=False)
+    maxrsweep_model_glm = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep")
     maxrsweep_model_glm.train(training_frame=d, x=my_x, y=my_y)
     model_path_maxrsweep_glm = maxrsweep_model_glm.download_model(tmpdir)
+
+    maxrsweep_model_MM = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep")
+    maxrsweep_model_MM.train(training_frame=d, x=my_x, y=my_y)
+    model_path_maxrsweep_MM = maxrsweep_model_MM.download_model(tmpdir)
 
     # make sure results returned by maxr and maxrsweep are the same
     pyunit_utils.compare_frames_local(maxr_model.result()[2:4], maxrsweep_model.result()[2:4], prob=1.0, tol=1e-5)
@@ -54,7 +58,7 @@ def test_modelselection_serialization():
         pyunit_utils.compare_frames_local(pred_frame_allsubsets, pred_id_maxr, prob=1)
         model_from_id_maxrsweep = h2o.get_model(modelIDs_maxrsweep[ind]['name'])
         pred_id_maxrsweep = model_from_id_maxrsweep.predict(d)
-        pyunit_utils.compare_frames_local(pred_id_maxr, pred_id_maxrsweep, prob=1, tol=1e-6)
+        pyunit_utils.compare_frames_local(pred_id_maxr, pred_id_maxrsweep, prob=1, tol=1e-6)   
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(test_modelselection_serialization)

--- a/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8785_8427_8703_modelselection_coefs.py
+++ b/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8785_8427_8703_modelselection_coefs.py
@@ -15,21 +15,26 @@ def test_modelselection_gaussian_coefs():
     allsubsets_model.train(training_frame=d, x=my_x, y=my_y)
     coefs_allsubsets = allsubsets_model.coef()
     coefs_norm_allsubsets = allsubsets_model.coef_norm()
-    maxrsweep_model = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep")
+    maxrsweep_model = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep", build_glm_model=True)
     maxrsweep_model.train(training_frame=d, x=my_x, y=my_y)
-    maxrsweep_model_glm = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep", build_glm_model=False)
+    maxrsweep_model_glm = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep")
     maxrsweep_model_glm.train(training_frame=d, x=my_x, y=my_y)
+    maxrsweep_model_MM = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep", multinode_mode=True)
+    maxrsweep_model_MM.train(training_frame=d, x=my_x, y=my_y)
     maxr_model = modelSelection(seed=12345, max_predictor_number=7, mode="maxr")
     maxr_model.train(training_frame=d, x=my_x, y=my_y)
     # make sure results returned by maxr and maxrsweep are the same
     pyunit_utils.compare_frames_local(maxr_model.result()[2:4], maxrsweep_model.result()[2:4], prob=1.0, tol=1e-6)
     pyunit_utils.compare_frames_local(maxr_model.result()[2:4], maxrsweep_model_glm.result()[1:3], prob=1.0, tol=1e-6)
+    pyunit_utils.compare_frames_local(maxrsweep_model_MM.result()[2:4], maxrsweep_model_glm.result()[2:4], prob=1.0, tol=1e-6)
     coefs_maxr = maxr_model.coef()
     coefs_norm_maxr = maxr_model.coef_norm()
     coefs_maxrsweep = maxrsweep_model.coef()
     coefs_norm_maxrsweep = maxrsweep_model.coef_norm()
     coefs_maxrsweep_glm = maxrsweep_model_glm.coef()
     coefs_norm_maxrsweep_glm = maxrsweep_model_glm.coef_norm()  
+    coefs_marxsweep_MM = maxrsweep_model_MM.coef()
+    coefs_norm_maxrsweep_MM = maxrsweep_model_MM.coef_norm()
     
     for ind in list(range(len(coefs_allsubsets))):
         one_coef_allsubsets = coefs_allsubsets[ind]
@@ -40,6 +45,8 @@ def test_modelselection_gaussian_coefs():
         one_coef_norm_maxrsweep = coefs_norm_maxrsweep[ind]
         one_coef_maxrsweep_glm = coefs_maxrsweep_glm[ind]
         one_coef_norm_maxrsweep_glm = coefs_norm_maxrsweep_glm[ind]
+        one_coef_maxrsweep_MM = coefs_marxsweep_MM[ind]
+        one_coef_norm_maxrsweep_MM = coefs_norm_maxrsweep_MM[ind]
         # coefficients obtained from accessing model_id, generate model and access the model coeffs
         one_model = h2o.get_model(allsubsets_model._model_json["output"]["best_model_ids"][ind]['name'])
         model_coef = one_model.coef()
@@ -56,10 +63,14 @@ def test_modelselection_gaussian_coefs():
         pyunit_utils.assertCoefDictEqual(one_model_coef_norm, model_coef_norm, 1e-6)
         pyunit_utils.assertCoefDictEqual(one_model_coef, one_coef_maxr, 1e-6)
         pyunit_utils.assertCoefDictEqual(one_model_coef, one_coef_maxrsweep, 1e-6)
+        pyunit_utils.assertCoefDictEqual(one_model_coef, one_coef_maxrsweep_glm, 1e-6)
+        pyunit_utils.assertCoefDictEqual(one_model_coef, one_coef_maxrsweep_MM, 1e-6)        
         pyunit_utils.assertCoefDictEqual(one_model_coef_norm, one_coef_norm_maxr, 1e-6)
         pyunit_utils.assertCoefDictEqual(one_model_coef_norm, one_coef_norm_maxrsweep, 1e-6)
         pyunit_utils.assertCoefDictEqual(one_model_coef_norm, one_coef_norm_maxrsweep_glm, 1e-6)
         pyunit_utils.assertCoefDictEqual(one_model_coef_norm, one_coef_norm_maxrsweep_glm, 1e-6)
+        pyunit_utils.assertCoefDictEqual(one_model_coef_norm, one_coef_norm_maxrsweep_MM, 1e-6)        
+        
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(test_modelselection_gaussian_coefs)

--- a/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8785_8758_maxrSweep_fix_replacement_large.py
+++ b/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8785_8758_maxrSweep_fix_replacement_large.py
@@ -17,9 +17,13 @@ def test_maxrsweep_replacement():
     predictors = train.names
     predictors.remove(response)
     npred = 10
-    maxrsweep_model = H2OModelSelectionEstimator(mode="maxrsweep", max_predictor_number=npred, intercept=True, build_glm_model=False, standardize=True)
+    maxrsweep_model = H2OModelSelectionEstimator(mode="maxrsweep", max_predictor_number=npred, intercept=True, standardize=True)
     maxrsweep_model.train(x=predictors, y=response, training_frame=train)
     maxrsweep_best_predictors = maxrsweep_model.coef()
+    maxrsweep_model_MM = H2OModelSelectionEstimator(mode="maxrsweep", max_predictor_number=npred, intercept=True, 
+                                                    standardize=True, multinode_mode=True)
+    maxrsweep_model_MM.train(x=predictors, y=response, training_frame=train)
+    maxrsweep_best_predictors_MM = maxrsweep_model_MM.coef()
     maxr_model = H2OModelSelectionEstimator(mode="maxr", max_predictor_number=npred, intercept=True)
     maxr_model.train(x=predictors, y=response, training_frame=train)
     maxr_best_predictors = maxr_model.coef()
@@ -30,10 +34,15 @@ def test_maxrsweep_replacement():
         maxr_one_coef.sort()
         maxrsweep_one_coef = list(maxrsweep_best_predictors[index].keys())
         maxrsweep_one_coef.sort()
+        maxrsweep_one_coef_MM = list(maxrsweep_best_predictors_MM[index].keys())
+        maxrsweep_one_coef_MM.sort()
         assert correct_pred_subsets[index]==maxr_one_coef, "Expected predictor subset: {0}, actual predictor subset from" \
                                                     " maxr: {1}.  They are different".format(correct_pred_subsets[index], maxr_one_coef)
         assert correct_pred_subsets[index]==maxrsweep_one_coef, "Expected predictor subset: {0}, actual predictor subset from" \
                                                     " maxrsweep: {1}.  They are different".format(correct_pred_subsets[index], maxrsweep_one_coef)
+        assert correct_pred_subsets[index]==maxrsweep_one_coef_MM, "Expected predictor subset: {0}, actual predictor subset from" \
+                                                                " maxrsweep with multinode_mode: {1}.  They are " \
+                                                                   "different".format(correct_pred_subsets[index], maxrsweep_one_coef_MM)
 if __name__ == "__main__":
     pyunit_utils.standalone_test(test_maxrsweep_replacement)
 else:

--- a/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8786_modelselection_result_frame_added_removed_preds.py
+++ b/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8786_modelselection_result_frame_added_removed_preds.py
@@ -17,13 +17,17 @@ def test_gaussian_result_frame_model_id():
     maxr_model.train(training_frame=d, x=my_x, y=my_y)
     verifyCorrectAddedRemovedPreds(maxr_model, 'maxr')
         
-    maxrsweep_model = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep")
+    maxrsweep_model = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep", build_glm_model=True)
     maxrsweep_model.train(training_frame=d, x=my_x, y=my_y)
     verifyCorrectAddedRemovedPreds(maxrsweep_model, 'maxrsweep')
 
-    maxrsweep_model_glm = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep", build_glm_model=False)
+    maxrsweep_model_glm = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep")
     maxrsweep_model_glm.train(training_frame=d, x=my_x, y=my_y)
     verifyCorrectAddedRemovedPreds(maxrsweep_model_glm, 'maxrsweep')
+
+    maxrsweep_model_MM = modelSelection(seed=12345, max_predictor_number=7, mode="maxrsweep", multinode_mode=True)
+    maxrsweep_model_MM.train(training_frame=d, x=my_x, y=my_y)
+    verifyCorrectAddedRemovedPreds(maxrsweep_model_MM, 'maxrsweep')
 
     allsubsets_model = modelSelection(seed=12345, max_predictor_number=7, mode="allsubsets")
     allsubsets_model.train(training_frame=d, x=my_x, y=my_y)

--- a/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8916_maxrSweep_fix_replacement_large.py
+++ b/h2o-py/tests/testdir_algos/modelselection/pyunit_PUBDEV_8916_maxrSweep_fix_replacement_large.py
@@ -47,8 +47,12 @@ def test_maxrsweep_replacement():
     predictors.remove(response)
     npred = 63
     maxrsweep_model = H2OModelSelectionEstimator(mode="maxrsweep", max_predictor_number=npred, intercept=True, 
-                                                 build_glm_model=False, standardize=True)
+                                                 multinode_mode=False, standardize=True)
     maxrsweep_model.train(x=predictors, y=response, training_frame=train)
+
+    maxrsweep_model_MM = H2OModelSelectionEstimator(mode="maxrsweep", max_predictor_number=npred, intercept=True,
+                                                    standardize=True, multinode_mode=True)
+    maxrsweep_model_MM.train(x=predictors, y=response, training_frame=train)
 
     predSubsets = correct_pred_dict.keys()
     for oneKey in predSubsets:
@@ -57,10 +61,15 @@ def test_maxrsweep_replacement():
         correct_pred_subset.sort()
         maxrsweep_one_coef = list(maxrsweep_model.coef(oneKey).keys())
         maxrsweep_one_coef.sort()
+        maxrsweep_one_coef_MM = list(maxrsweep_model_MM.coef(oneKey).keys())
+        maxrsweep_one_coef_MM.sort()
         print("subset size: {0}".format(oneKey))
         assert correct_pred_subset==maxrsweep_one_coef, \
             "Expected coeffs: {0}, Actual from maxrsweep: {1}.  They are different.".format(correct_pred_subset, 
                                                                                             maxrsweep_one_coef)
+        assert correct_pred_subset==maxrsweep_one_coef_MM, \
+            "Expected coeffs: {0}, Actual from maxrsweep with multinode_mode: {1}.  They are different." \
+            "".format(correct_pred_subset, maxrsweep_one_coef_MM)
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(test_maxrsweep_replacement)

--- a/h2o-py/tests/testdir_algos/modelselection/pyunit_hexdev_784_dupcols.py
+++ b/h2o-py/tests/testdir_algos/modelselection/pyunit_hexdev_784_dupcols.py
@@ -1,0 +1,68 @@
+import sys
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.model_selection import H2OModelSelectionEstimator
+
+# In this test, the training data contains duplicated columns that will need to be removed.  Just want to check
+# and make sure that the multinod_mode=True and False will return the same results.
+def test_maxrsweep_dup_cols():
+    train = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/model_selection/wideDupCols.csv")
+    response="response"
+    predictors = train.names
+    predictors.remove(response)
+    npred = 20
+    maxrsweep_model_glm = H2OModelSelectionEstimator(mode="maxrsweep", max_predictor_number=npred, intercept=True, 
+                                                 build_glm_model=True)
+    maxrsweep_model_glm.train(x=predictors, y=response, training_frame=train)
+    maxrsweep_model_glm_MM = H2OModelSelectionEstimator(mode="maxrsweep", max_predictor_number=npred, intercept=True,
+                                                     build_glm_model=True, multinode_mode=True)
+    maxrsweep_model_glm_MM.train(x=predictors, y=response, training_frame=train)
+    maxrsweep_model = H2OModelSelectionEstimator(mode="maxrsweep", max_predictor_number=npred, intercept=True)
+    maxrsweep_model.train(x=predictors, y=response, training_frame=train)
+    maxrsweep_model_MM = H2OModelSelectionEstimator(mode="maxrsweep", max_predictor_number=npred, intercept=True, 
+                                                        multinode_mode=True)
+    maxrsweep_model_MM.train(x=predictors, y=response, training_frame=train)
+    
+    maxrsweep_glm_coeffs = maxrsweep_model_glm.coef()
+    maxrsweep_glm_coeffs_MM = maxrsweep_model_glm_MM.coef()
+    maxrsweep_coeffs = maxrsweep_model.coef()
+    maxrsweep_coeffs_MM = maxrsweep_model_MM.coef()
+
+    maxrsweep_glm_coeffs_norm = maxrsweep_model_glm.coef_norm()
+    maxrsweep_glm_coeffs_MM_norm = maxrsweep_model_glm_MM.coef_norm()
+    maxrsweep_coeffs_norm = maxrsweep_model.coef_norm()
+    maxrsweep_coeffs_MM_norm = maxrsweep_model_MM.coef_norm()
+
+    maxrsweep_best_model_predictors = maxrsweep_model.get_best_model_predictors()
+    maxrsweep_best_model_predictors_MM = maxrsweep_model_MM.get_best_model_predictors()
+    maxrsweep_best_model_predictors_glm = maxrsweep_model_glm.get_best_model_predictors()
+    maxrsweep_best_model_predictors_glm_MM = maxrsweep_model_glm_MM.get_best_model_predictors()
+
+# make sure all models produce the same set of coefficients since they are building the same predictor subsets
+    for ind in range(0, len(maxrsweep_coeffs)):
+        pyunit_utils.assertCoefDictEqual(maxrsweep_coeffs[ind], maxrsweep_coeffs_MM[ind], 1e-6)
+        pyunit_utils.assertCoefDictEqual(maxrsweep_coeffs[ind], maxrsweep_glm_coeffs_MM[ind], 1e-6)
+        pyunit_utils.assertCoefDictEqual(maxrsweep_coeffs[ind], maxrsweep_glm_coeffs[ind], 1e-6)
+        pyunit_utils.assertCoefDictEqual(maxrsweep_coeffs_norm[ind], maxrsweep_coeffs_MM_norm[ind], 1e-6)
+        pyunit_utils.assertCoefDictEqual(maxrsweep_coeffs_norm[ind], maxrsweep_glm_coeffs_MM_norm[ind], 1e-6)
+        pyunit_utils.assertCoefDictEqual(maxrsweep_coeffs_norm[ind], maxrsweep_glm_coeffs_norm[ind], 1e-6)
+        maxrsweep_best_model_predictors[ind].sort()
+        maxrsweep_best_model_predictors_MM[ind].sort()
+        maxrsweep_best_model_predictors_glm[ind].sort()
+        maxrsweep_best_model_predictors_glm_MM[ind].sort()
+        assert maxrsweep_best_model_predictors[ind] == maxrsweep_best_model_predictors_MM[ind], \
+            "normal vs multinode mode: Expected predictor subset: {0}, actual predictor subset: {1}".format(maxrsweep_best_model_predictors[ind],
+                                                                                  maxrsweep_best_model_predictors_MM[ind])
+        assert maxrsweep_best_model_predictors[ind] == maxrsweep_best_model_predictors_glm[ind], \
+            "normal vs build glm: Expected predictor subset: {0}, actual predictor subset: {1}".format(maxrsweep_best_model_predictors_glm[ind],
+                                                                                  maxrsweep_best_model_predictors_MM[ind])
+        assert maxrsweep_best_model_predictors[ind] == maxrsweep_best_model_predictors_glm_MM[ind], \
+            "normal vs build glm multinode mode: Expected predictor subset: {0}, actual predictor subset: {1}".format(maxrsweep_best_model_predictors_glm_MM[ind],
+                                                                                  maxrsweep_best_model_predictors_MM[ind])
+        print("comparing results for predictor subset size {0}".format(ind+1))
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_maxrsweep_dup_cols)
+else:
+    test_maxrsweep_dup_cols()

--- a/h2o-r/h2o-package/R/modelselection.R
+++ b/h2o-r/h2o-package/R/modelselection.R
@@ -122,11 +122,13 @@
 #' @param build_glm_model \code{Logical}. For maxrsweep mode only.  If true, will return full blown GLM models with the desired
 #'        predictorsubsets.  If false, only the predictor subsets, predictor coefficients are returned.  This is
 #'        forspeeding up the model selection process.  The users can choose to build the GLM models themselvesby using
-#'        the predictor subsets themselves.  Defaults to false. Defaults to TRUE.
+#'        the predictor subsets themselves.  Defaults to false. Defaults to FALSE.
 #' @param p_values_threshold For mode='backward' only.  If specified, will stop the model building process when all coefficientsp-values
 #'        drop below this threshold  Defaults to 0.
 #' @param influence If set to dfbetas will calculate the difference in beta when a datarow is included and excluded in the
 #'        dataset. Must be one of: "dfbetas".
+#' @param multinode_mode \code{Logical}. For maxrsweep only.  If enabled, will attempt to perform sweeping action using multiple nodes
+#'        in the cluster.  Defaults to false. Defaults to FALSE.
 #' @examples
 #' \dontrun{
 #' library(h2o)
@@ -193,9 +195,10 @@ h2o.modelSelection <- function(x,
                                max_predictor_number = 1,
                                min_predictor_number = 1,
                                mode = c("allsubsets", "maxr", "maxrsweep", "backward"),
-                               build_glm_model = TRUE,
+                               build_glm_model = FALSE,
                                p_values_threshold = 0,
-                               influence = c("dfbetas"))
+                               influence = c("dfbetas"),
+                               multinode_mode = FALSE)
 {
   # Validate required training_frame first and other frame args: should be a valid key or an H2OFrame object
   training_frame <- .validate.H2OFrame(training_frame, required=TRUE)
@@ -328,6 +331,8 @@ h2o.modelSelection <- function(x,
     parms$p_values_threshold <- p_values_threshold
   if (!missing(influence))
     parms$influence <- influence
+  if (!missing(multinode_mode))
+    parms$multinode_mode <- multinode_mode
 
   # Error check and build model
   model <- .h2o.modelJob('modelselection', parms, h2oRestApiVersion=3, verbose=FALSE)
@@ -387,9 +392,10 @@ h2o.modelSelection <- function(x,
                                                max_predictor_number = 1,
                                                min_predictor_number = 1,
                                                mode = c("allsubsets", "maxr", "maxrsweep", "backward"),
-                                               build_glm_model = TRUE,
+                                               build_glm_model = FALSE,
                                                p_values_threshold = 0,
                                                influence = c("dfbetas"),
+                                               multinode_mode = FALSE,
                                                segment_columns = NULL,
                                                segment_models_id = NULL,
                                                parallelism = 1)
@@ -527,6 +533,8 @@ h2o.modelSelection <- function(x,
     parms$p_values_threshold <- p_values_threshold
   if (!missing(influence))
     parms$influence <- influence
+  if (!missing(multinode_mode))
+    parms$multinode_mode <- multinode_mode
 
   # Build segment-models specific parameters
   segment_parms <- list()

--- a/h2o-r/tests/testdir_algos/modelselection/runit_PUBDEV_8235_8703_modelselection_gaussian.R
+++ b/h2o-r/tests/testdir_algos/modelselection/runit_PUBDEV_8235_8703_modelselection_gaussian.R
@@ -13,27 +13,22 @@ testModelSelection <- function() {
   bestPredictorNamesAllsubsets <- h2o.get_best_model_predictors(allsubsetsModel)
   maxrModel <- h2o.modelSelection(y=Y, x=X, seed=12345, training_frame = bhexFV, max_predictor_number=2, mode="maxr")
   bestR2ValueMaxr <- h2o.get_best_r2_values(maxrModel)
-  maxrsweepModel <- h2o.modelSelection(y=Y, x=X, seed=12345, training_frame = bhexFV, max_predictor_number=2, mode="maxrsweep")
-  bestR2ValueMaxrsweep <- h2o.get_best_r2_values(maxrModel)
-  maxrsweepModelGLM <- h2o.modelSelection(y=Y, x=X, seed=12345, training_frame = bhexFV, max_predictor_number=2, mode="maxrsweep", build_glm_model=FALSE)
+  maxrsweepModel <- h2o.modelSelection(y=Y, x=X, seed=12345, training_frame = bhexFV, max_predictor_number=2, 
+                                       mode="maxrsweep", build_glm_model=TRUE)
+  bestR2ValueMaxrsweep <- h2o.get_best_r2_values(maxrsweepModel)
+  maxrsweepModelGLM <- h2o.modelSelection(y=Y, x=X, seed=12345, training_frame = bhexFV, max_predictor_number=2, mode="maxrsweep")
   bestR2ValueMaxrsweepGLM <- h2o.get_best_r2_values(maxrsweepModelGLM)
+  maxrsweepModelMM <- h2o.modelSelection(y=Y, x=X, seed=12345, training_frame = bhexFV, max_predictor_number=2, 
+                                         mode="maxrsweep", multinode_mode=TRUE)
+  bestR2ValueMaxrsweepMM <- h2o.get_best_r2_values(maxrsweepModelMM)
   # check and make sure two predictor model found has the highest R2 value
-  pred2List <- list(c("AGE","RACE"), c("AGE","CAPSULE"), c("AGE","DCAPS"), c("AGE", "PSA"), c("AGE","VOL"),c("AGE", "DPROS"),
-                    c("RACE","CAPSULE"),c("RACE","DCAPS"),c("RACE","PSA"),c("RACE","VOL"),c("RACE","DPROS"), c("CAPSULE","DCAPS"),
-                    c("CAPSULE","PSA"),c("CAPSULE","VOL"),c("CAPSULE","DPROS"), c("DCAPS","PSA"),c("DCAPS","VOL"),c("DCAPS","DPROS"),
-                    c("PSA","VOL"),c("PSA","DPROS"), c("VOL","DPROS"))
   pred2List <- list(c("AGE","RACE"),c("AGE","CAPSULE"),c("AGE","DCAPS"),c("AGE","PSA"),c("AGE","VOL"),c("AGE","DPROS"),
   c("RACE","CAPSULE"),c("RACE","DCAPS"),c("RACE","PSA"),c("RACE","VOL"),c("RACE","DPROS"),
   c("CAPSULE","DCAPS"),c("CAPSULE","PSA"),c("CAPSULE","VOL"),c("CAPSULE","DPROS"),
   c("DCAPS","PSA"),c("DCAPS","VOL"),c("DCAPS","DPROS"),
   c("PSA","VOL"),c("PSA","DPROS"),
   c("VOL","DPROS"))
-  pred2list <- list(c("CAPSULE", "AGE"), c("CAPSULE", "RACE"), c("CAPSULE", "DPROS"), c("CAPSULE", "DCAPS"), c("CAPSULE", "PSA"), c("CAPSULE", "VOL"),
-                    c("AGE", "RACE"), c("AGE", "DPROS"), c("AGE", "DCAPS"), c("AGE", "PSA"), c("AGE", "VOL"),
-                    c("RACE", "DPROS"), c("RACE", "DCAPS"), c("RACE", "PSA"), c("RACE", "VOL"),
-                    c("DPROS", "DCAPS"), c("DPROS", "PSA"), c("DPROS", "VOL"),
-                    c("DCAPS", "PSA"), c("DCAPS", "VOL"),
-                    c("PSA", "VOL"))
+
   bestR2 <- c()
   for (pred in pred2List) {
     m <- h2o.glm(y=Y, x=pred, seed=12345, training_frame = bhexFV, family="gaussian", link="identity")
@@ -43,7 +38,7 @@ testModelSelection <- function() {
   expect_true(abs(max(bestR2)-bestR2ValueMaxr[2]) < 1e-6)
   expect_true(abs(bestR2ValueMaxr[2] - bestR2ValueMaxrsweep[2]) < 1e-5)
   expect_true(abs(bestR2ValueMaxr[2] - bestR2ValueMaxrsweepGLM[2]) < 1e-5)
- 
+  expect_true(abs(bestR2ValueMaxr[2] - bestR2ValueMaxrsweepMM[2]) < 1e-5)
   print("Model wth best R2 value have predictors:")
   print(bestPredictorNamesAllsubsets[[2]])
 }

--- a/h2o-r/tests/testdir_algos/modelselection/runit_PUBDEV_8346_8703_modelselection_result_frame.R
+++ b/h2o-r/tests/testdir_algos/modelselection/runit_PUBDEV_8346_8703_modelselection_result_frame.R
@@ -18,16 +18,21 @@ testModelSelectionResultFrame <- function() {
   resultFrameMaxr <- h2o.result(maxrModel)
  
    maxrsweepModel <- h2o.modelSelection(y=Y, x=X, seed=12345, training_frame = bhexFV, max_predictor_number=numModel,
-   mode="maxrsweep")
+   mode="maxrsweep", build_glm_model=TRUE)
    bestR2Maxrsweep <- h2o.get_best_r2_values(maxrsweepModel)
    resultFrameMaxrsweep <- h2o.result(maxrsweepModel) 
    
    maxrsweepModelGLM <- h2o.modelSelection(y=Y, x=X, seed=12345, training_frame = bhexFV, max_predictor_number=numModel,
-   mode="maxrsweep", build_glm_model=FALSE)
+   mode="maxrsweep")
    bestR2MaxrsweepGLM <- h2o.get_best_r2_values(maxrsweepModelGLM)
-   resultFrameMaxrsweepGLM <- h2o.result(maxrsweepModelGLM) 
-  
-  for (ind in c(1:numModel)) {
+   resultFrameMaxrsweepGLM <- h2o.result(maxrsweepModelGLM)
+
+   maxrsweepModelMM <- h2o.modelSelection(y=Y, x=X, seed=12345, training_frame = bhexFV, max_predictor_number=numModel,
+                                            mode="maxrsweep", multinode_mode=TRUE)
+   bestR2MaxrsweepMM <- h2o.get_best_r2_values(maxrsweepModelMM)
+   resultFrameMaxrsweepMM <- h2o.result(maxrsweepModelMM)
+
+    for (ind in c(1:numModel)) {
     r2Allsubsets <- bestR2Allsubsets[ind]
     r2FrameAllsubsets <- resultFrameAllsubsets[ind, 3] # get r2
     glmModelAllsubsets <- h2o.getModel(resultFrameAllsubsets[ind, 2])
@@ -43,6 +48,7 @@ testModelSelectionResultFrame <- function() {
     r2FrameMaxr <- resultFrameMaxr[ind, 3]  # get r2
     r2FrameMaxrsweep <- resultFrameMaxrsweep[ind, 3]
     r2FrameMaxrsweepGLM <- resultFrameMaxrsweepGLM[ind, 2]
+    r2FrameMaxrsweepMM <- resultFrameMaxrsweepMM[ind, 2]
     glmModelMaxr <- h2o.getModel(resultFrameMaxr[ind, 2])
     predFrameMaxr <- h2o.predict(glmModelMaxr, bhexFV)
     print(predFrameMaxr[1,1])
@@ -54,6 +60,7 @@ testModelSelectionResultFrame <- function() {
     expect_equal(r2FrameMaxr, r2ModelMaxr, tolerance=1e-06)
     expect_equal(r2FrameMaxr, r2ModelAllsubsets, tolerance=1e-06)
     expect_equal(r2FrameMaxrsweepGLM, r2ModelAllsubsets, tolerance=1e-06)
+    expect_equal(r2FrameMaxrsweepMM, r2ModelAllsubsets, tolerance=1e-06)        
   }
 }
 

--- a/h2o-r/tests/testdir_algos/modelselection/runit_PUBDEV_8346_modelselection_result_frame_model_id.R
+++ b/h2o-r/tests/testdir_algos/modelselection/runit_PUBDEV_8346_modelselection_result_frame_model_id.R
@@ -16,9 +16,13 @@ testModelSelectionResultFrameModelID <- function() {
   resultFrameMaxr <- h2o.result(maxrModel)
   bestModelIDsMaxr <- maxrModel@model$best_model_ids
   maxrsweepModel <- h2o.modelSelection(y=Y, x=X, seed=12345, training_frame = bhexFV, max_predictor_number=numModel,
-  mode="maxrsweep")
+  mode="maxrsweep", build_glm_model=TRUE)
   resultFrameMaxrsweep <- h2o.result(maxrsweepModel)
   bestModelIDsMaxrsweep <- maxrsweepModel@model$best_model_ids
+  maxrsweepModelMM <- h2o.modelSelection(y=Y, x=X, seed=12345, training_frame = bhexFV, max_predictor_number=numModel,
+                                         mode="maxrsweep", build_glm_model=TRUE, multinode_mode=TRUE)
+  resultFrameMaxrsweepMM <- h2o.result(maxrsweepModelMM)
+  bestModelIDsMaxrsweepMM <- maxrsweepModelMM@model$best_model_ids
 
   for (ind in c(1:numModel)) {
     glmModelAllsubsets <- h2o.getModel(resultFrameAllsubsets[ind, 2])
@@ -31,13 +35,22 @@ testModelSelectionResultFrameModelID <- function() {
     predFrameMaxr <- h2o.predict(glmModelMaxr, bhexFV)
     glmModel2Maxr <- h2o.getModel(bestModelIDsMaxr[[ind]]$name)
     predFrame2Maxr <- h2o.predict(glmModel2Maxr, bhexFV)
+    compareFrames(predFrameMaxr, predFrame2Maxr, prob=1, tolerance = 1e-6)
     compareFrames(predFrameAllsubsets, predFrame2Maxr, prob=1, tolerance = 1e-6)
     
     glmModelMaxrsweep <- h2o.getModel(resultFrameMaxrsweep[ind, 2])
     predFrameMaxrsweep <- h2o.predict(glmModelMaxrsweep, bhexFV)
     glmModel2Maxrsweep <- h2o.getModel(bestModelIDsMaxrsweep[[ind]]$name)
     predFrame2Maxrsweep <- h2o.predict(glmModel2Maxrsweep, bhexFV)
+    compareFrames(predFrameMaxrsweep, predFrame2Maxrsweep, prob=1, tolerance = 1e-6)
     compareFrames(predFrameAllsubsets, predFrame2Maxrsweep, prob=1, tolerance = 1e-6)
+
+    glmModelMaxrsweepMM <- h2o.getModel(resultFrameMaxrsweepMM[ind, 2])
+    predFrameMaxrsweepMM <- h2o.predict(glmModelMaxrsweepMM, bhexFV)
+    glmModel2MaxrsweepMM <- h2o.getModel(bestModelIDsMaxrsweepMM[[ind]]$name)
+    predFrame2MaxrsweepMM <- h2o.predict(glmModel2MaxrsweepMM, bhexFV)
+    compareFrames(predFrameMaxrsweepMM, predFrame2MaxrsweepMM, prob=1, tolerance = 1e-6)
+    compareFrames(predFrameAllsubsets, predFrame2MaxrsweepMM, prob=1, tolerance = 1e-6)
   }
 }
 

--- a/h2o-r/tests/testdir_algos/modelselection/runit_PUBDEV_8427_modelselection_coeffs.R
+++ b/h2o-r/tests/testdir_algos/modelselection/runit_PUBDEV_8427_modelselection_coeffs.R
@@ -18,11 +18,11 @@ testModelSelectionCoeffs <- function() {
   coeffsMaxr <- h2o.coef(maxrModel)
   coeffsNormMaxr <- h2o.coef_norm(maxrModel)
   maxrsweepModel <- h2o.modelSelection(y=Y, x=X, seed=12345, training_frame = bhexFV, max_predictor_number=numModel, 
-      mode="maxrsweep")
+      mode="maxrsweep", build_glm_model=TRUE)
   coeffsMaxrsweep <- h2o.coef(maxrsweepModel)
   coeffsNormMaxrsweep <- h2o.coef_norm(maxrsweepModel)
   maxrsweepGLMModel <- h2o.modelSelection(y=Y, x=X, seed=12345, training_frame = bhexFV, max_predictor_number=numModel, 
-        mode="maxrsweep", build_glm_model=FALSE)
+        mode="maxrsweep")
 
   coeffsMaxrsweepGLM <- h2o.coef(maxrsweepGLMModel)
   coeffsNormMaxrsweepGLM <- h2o.coef_norm(maxrsweepGLMModel)

--- a/h2o-r/tests/testdir_algos/modelselection/runit_PUBDEV_8427_modelselection_coeffs_demo.R
+++ b/h2o-r/tests/testdir_algos/modelselection/runit_PUBDEV_8427_modelselection_coeffs_demo.R
@@ -34,6 +34,14 @@ testModelSelectionCoeffs <- function() {
    coeffsNormMaxrsweep <- h2o.coef_norm(maxrsweepModel) # list of standardized coefficients from model built from each predictor size
    print(coeffsNormMaxrsweep)
 
+   maxrsweepModelMM <- h2o.modelSelection(y=Y, x=X, seed=12345, training_frame = bhexFV, max_predictor_number=numModel,
+                                         mode="maxrsweep", multinode_mode=TRUE)
+   resultMaxrsweepMM <- h2o.result(maxrsweepModelMM) # H2OFrame containing best model_ids, best_r2_value, predictor subsets
+   print(resultMaxrsweepMM)
+   coeffsMaxrsweepMM <- h2o.coef(maxrsweepModelMM) # list of coefficients from model built from each predictor size
+   print(coeffsMaxrsweepMM)
+   coeffsNormMaxrsweepMM <- h2o.coef_norm(maxrsweepModelMM) # list of standardized coefficients from model built from each predictor size
+   print(coeffsNormMaxrsweepMM)
     
   for (index in seq(numModel)) {
     oneModelCoeffAllsubsets <- h2o.coef(allsubsetsModel, index)
@@ -56,6 +64,13 @@ testModelSelectionCoeffs <- function() {
     coefsMaxrsweep <- coeffsNormMaxrsweep[[index]]
     coefsAllsubsets <- coeffsNormAllsubsets[[index]]
     expect_equal(coefsMaxrsweep[order(coefsMaxrsweep)], coefsAllsubsets[order(coefsAllsubsets)], tolerance=1e-6)
+
+    oneModelCoeffMaxrsweepMM <- h2o.coef(maxrsweepModelMM, index)
+    oneModelCoeffNormMaxrsweepMM <- h2o.coef_norm(maxrsweepModelMM, index)
+    expect_equal(coeffsMaxrsweep[[index]], oneModelCoeffMaxrsweepMM, tolerance=1e-6)
+    expect_equal(coeffsNormMaxrsweep[[index]], oneModelCoeffNormMaxrsweepMM, tolerance=1e-6)
+    coefsMaxrsweepMM <- coeffsNormMaxrsweepMM[[index]]
+    expect_equal(coefsMaxrsweepMM[order(coefsMaxrsweep)], coefsAllsubsets[order(coefsAllsubsets)], tolerance=1e-6)
   }
 }
 


### PR DESCRIPTION
This PR completes the work in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-9073

In general, the CPM is swept each time we add a predictor to the predictor subset.  The CPM is stored normally as a double[][] array.  Hence, during each sweeping action, only one node is involved.  To parallelize this operation, I have chosen to make CPM into a frame and conduct the sweeping per chunk.  This is described in the doc attached to the JIRA.

Java/Python/R tests have been added to make sure that the multinode_mode is working correctly.

I need to add a timing tests to make sure the the multinode mode does not slow down the operation.