### PR TITLE
PUBDEV-9043 add gam knot locations to model output if enabled

### DIFF
--- a/h2o-algos/src/main/java/hex/gam/GAM.java
+++ b/h2o-algos/src/main/java/hex/gam/GAM.java
@@ -123,7 +123,7 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
     int isInd = _cubicSplineNum;
     int msInd = _cubicSplineNum+_iSplineNum;
     int tpInd = _cubicSplineNum+_iSplineNum+_mSplineNum;
-    int gamIndex=0; // index into the sorted arrays with CS/I-splines/M front, TP back.
+    int gamIndex; // index into the sorted arrays with CS/I-splines/M front, TP back.
     for (int outIndex = 0; outIndex < _parms._gam_columns.length; outIndex++) { // go through each gam_column group
       String tempKey = allNull ? null : _parms._knot_ids[outIndex]; // one knot_id for each smoother
       if (_parms._bs[outIndex] == TP_SPLINE_TYPE) { // thin plate regression
@@ -1095,6 +1095,8 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
           model._output._starT = _starT;
         }
       }
+      if (_parms._store_knot_locations)
+        model._output.copyKnots(_knots, _parms._gam_columns_sorted);
       copyGLMCoeffs(glm, model, _parms, nclasses());  // copy over coefficient names and generate coefficients as beta = z*GLM_beta
       copyGLMtoGAMModel(model, glm, _parms, valid()!=null);  // copy over fields from glm model to gam model
       if (_cvOn) {

--- a/h2o-algos/src/main/java/hex/gam/GAMModel.java
+++ b/h2o-algos/src/main/java/hex/gam/GAMModel.java
@@ -255,6 +255,7 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
     boolean _glmCvOn = false;
     public boolean[] _splines_non_negative;
     public boolean[] _splines_non_negative_sorted;
+    public boolean _store_knot_locations = false;
 
     @Override
     public long progressUnits() {
@@ -395,6 +396,35 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
     public String[] _responseDomains;
     public String _gam_transformed_center_key;
     final Family _family;
+    public String[] _gam_knot_column_names;
+    public double[][] _knot_locations;
+
+    /***
+     * The function will copy over the knot locations into _knot_locations and the gam column names corresponding to
+     * the knot locations into _gam_knot_column_names.
+     */
+    public void copyKnots(double[][][] knots, String[][] gam_columns_sorted) {
+      int numGam = gam_columns_sorted.length;
+      int trueGamNum = 0;
+      for (int index=0; index<numGam; index++) {
+        trueGamNum += gam_columns_sorted[index].length;
+      }
+      _gam_knot_column_names = new String[trueGamNum];
+      _knot_locations = new double[trueGamNum][];
+      int knotIndex=0;
+      for (int index=0; index<numGam; index++) {
+        if (knots[index].length==1) {
+          _gam_knot_column_names[knotIndex] = gam_columns_sorted[index][0];
+          _knot_locations[knotIndex++] = knots[index][0].clone();
+        } else {
+          int dupKnots = knots[index].length;
+          for (int index2=0; index2<dupKnots; index2++) {
+            _gam_knot_column_names[knotIndex] = gam_columns_sorted[index][index2];
+            _knot_locations[knotIndex++] = knots[index][index2].clone();
+          }
+        }
+      }
+    }
     
     @Override
     public int nclasses() {

--- a/h2o-algos/src/main/java/hex/schemas/GAMModelV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GAMModelV3.java
@@ -38,6 +38,12 @@ public class GAMModelV3 extends ModelSchemaV3<GAMModel, GAMModelV3, GAMModel.GAM
 
     @API(help="GLM standard error values.  For debugging purposes only")
     double[] glm_std_err;
+    
+    @API(help = "knot locations for all gam columns.")
+    double[][] knot_locations;
+
+    @API(help = "Gam column names for knots stored in knot_locations")
+    String[] gam_knot_column_names;
   }
 
   public GAMV3.GAMParametersV3 createParametersSchema() { return new GAMV3.GAMParametersV3();}

--- a/h2o-algos/src/main/java/hex/schemas/GAMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GAMV3.java
@@ -82,6 +82,7 @@ public class GAMV3 extends ModelBuilderSchema<GAM, GAMV3, GAMV3.GAMParametersV3>
             "bs", // array, name of basis functions used
             "scale", // array, smoothing parameter for GAM,
             "keep_gam_cols",
+            "store_knot_locations",
             "auc_type"
     };
 
@@ -228,6 +229,10 @@ public class GAMV3 extends ModelBuilderSchema<GAM, GAMV3, GAMV3.GAMParametersV3>
 
     @API(help="In case of linearly dependent columns, remove some of the dependent columns", level = Level.secondary, direction = Direction.INPUT)
     public boolean remove_collinear_columns; // _remove_collinear_columns
+
+    @API(help="If set to true, will return knot locations as double[][] array for gam column names found knots_for_gam." +
+            "  Default to false.", level = Level.secondary, direction = Direction.INPUT)    
+    public boolean store_knot_locations;
 
     @API(help = "Number of knots for gam predictors.  If specified, must specify one for each gam predictor.  For " +
             "monotone I-splines, mininum = 2, for cs spline, minimum = 3.  For thin plate, minimum is size of " +

--- a/h2o-bindings/bin/custom/python/gen_gam.py
+++ b/h2o-bindings/bin/custom/python/gen_gam.py
@@ -37,12 +37,45 @@ def class_extensions():
         if "glm_scoring_history" in model and model["glm_scoring_history"] is not None:
             return model["glm_scoring_history"].as_data_frame()
         print("No score history for this model")
+        
+    def get_knot_locations(self, gam_column=None):
+        """
+        Retrieve gam columns knot locations if store_knot_location parameter is enabled.  If a gam column name is 
+        specified, the know loations corresponding to that gam column is returned.  Otherwise, all knot locations are
+        returned for all gam columns.  The order of the gam columns are specified in gam_knot_column_names of the 
+        model output.
+        
+        :return: knot locations of gam columns.
+        """
+        if not(self.actual_params["store_knot_locations"]):
+            raise H2OValueError("Knot locations are not available.  Please re-run with store_knot_locations=True")
+        knot_locations = self._model_json['output']['knot_locations']
+        gam_names = self._model_json['output']['gam_knot_column_names']
+        if gam_column is None:
+            return knot_locations
+        else:
+            if gam_column in gam_names:
+                return knot_locations[gam_names.index(gam_column)]
+            else:
+                raise H2OValueError("{0} is not a valid gam column name.".format(gam_column))
 
+    def get_gam_knot_column_names(self):
+        """
+        Retrieve gam column names corresponding to the knot locations that will be returned if store_knot_location
+        parameter is enabled.  
+     
+        :return: gam column names whose knot locations are stored in the knot_locations.
+        """
+        if not(self.actual_params["store_knot_locations"]):
+            raise H2OValueError("Knot locations are not available.  Please re-run with store_knot_locations=True")
+
+        return self._model_json['output']['gam_knot_column_names']
 
 extensions = dict(
     __imports__="""
 import h2o
 from h2o.utils.typechecks import U
+from h2o.exceptions import H2OValueError
 """,
     __class__=class_extensions,
 )

--- a/h2o-py/h2o/estimators/gam.py
+++ b/h2o-py/h2o/estimators/gam.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from h2o.utils.metaclass import deprecated_params, deprecated_property
 import h2o
 from h2o.utils.typechecks import U
+from h2o.exceptions import H2OValueError
 from h2o.estimators.estimator_base import H2OEstimator
 from h2o.exceptions import H2OValueError
 from h2o.frame import H2OFrame
@@ -104,6 +105,7 @@ class H2OGeneralizedAdditiveEstimator(H2OEstimator):
                  bs=None,  # type: Optional[List[int]]
                  scale=None,  # type: Optional[List[float]]
                  keep_gam_cols=False,  # type: bool
+                 store_knot_locations=False,  # type: bool
                  auc_type="auto",  # type: Literal["auto", "none", "macro_ovr", "weighted_ovr", "macro_ovo", "weighted_ovo"]
                  ):
         """
@@ -365,6 +367,10 @@ class H2OGeneralizedAdditiveEstimator(H2OEstimator):
         :param keep_gam_cols: Save keys of model matrix
                Defaults to ``False``.
         :type keep_gam_cols: bool
+        :param store_knot_locations: If set to true, will return knot locations as double[][] array for gam column names
+               found knots_for_gam.  Default to false.
+               Defaults to ``False``.
+        :type store_knot_locations: bool
         :param auc_type: Set default multinomial AUC type.
                Defaults to ``"auto"``.
         :type auc_type: Literal["auto", "none", "macro_ovr", "weighted_ovr", "macro_ovo", "weighted_ovo"]
@@ -438,6 +444,7 @@ class H2OGeneralizedAdditiveEstimator(H2OEstimator):
         self.bs = bs
         self.scale = scale
         self.keep_gam_cols = keep_gam_cols
+        self.store_knot_locations = store_knot_locations
         self.auc_type = auc_type
 
     @property
@@ -1409,6 +1416,21 @@ class H2OGeneralizedAdditiveEstimator(H2OEstimator):
         self._parms["keep_gam_cols"] = keep_gam_cols
 
     @property
+    def store_knot_locations(self):
+        """
+        If set to true, will return knot locations as double[][] array for gam column names found knots_for_gam.
+        Default to false.
+
+        Type: ``bool``, defaults to ``False``.
+        """
+        return self._parms.get("store_knot_locations")
+
+    @store_knot_locations.setter
+    def store_knot_locations(self, store_knot_locations):
+        assert_is_type(store_knot_locations, None, bool)
+        self._parms["store_knot_locations"] = store_knot_locations
+
+    @property
     def auc_type(self):
         """
         Set default multinomial AUC type.
@@ -1447,3 +1469,36 @@ class H2OGeneralizedAdditiveEstimator(H2OEstimator):
         if "glm_scoring_history" in model and model["glm_scoring_history"] is not None:
             return model["glm_scoring_history"].as_data_frame()
         print("No score history for this model")
+
+    def get_knot_locations(self, gam_column=None):
+        """
+        Retrieve gam columns knot locations if store_knot_location parameter is enabled.  If a gam column name is 
+        specified, the know loations corresponding to that gam column is returned.  Otherwise, all knot locations are
+        returned for all gam columns.  The order of the gam columns are specified in gam_knot_column_names of the 
+        model output.
+
+        :return: knot locations of gam columns.
+        """
+        if not(self.actual_params["store_knot_locations"]):
+            raise H2OValueError("Knot locations are not available.  Please re-run with store_knot_locations=True")
+        knot_locations = self._model_json['output']['knot_locations']
+        gam_names = self._model_json['output']['gam_knot_column_names']
+        if gam_column is None:
+            return knot_locations
+        else:
+            if gam_column in gam_names:
+                return knot_locations[gam_names.index(gam_column)]
+            else:
+                raise H2OValueError("{0} is not a valid gam column name.".format(gam_column))
+
+    def get_gam_knot_column_names(self):
+        """
+        Retrieve gam column names corresponding to the knot locations that will be returned if store_knot_location
+        parameter is enabled.  
+
+        :return: gam column names whose knot locations are stored in the knot_locations.
+        """
+        if not(self.actual_params["store_knot_locations"]):
+            raise H2OValueError("Knot locations are not available.  Please re-run with store_knot_locations=True")
+
+        return self._model_json['output']['gam_knot_column_names']

--- a/h2o-py/tests/testdir_algos/gam/pyunit_pubdev_9043_knot_locations.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_pubdev_9043_knot_locations.py
@@ -1,0 +1,58 @@
+from __future__ import print_function
+from __future__ import division
+import sys
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gam import H2OGeneralizedAdditiveEstimator
+
+# in this test, want to check that knot locations are returned correct.
+def test_gam_knot_locations():
+    h2o_data = h2o.import_file(pyunit_utils.locate("smalldata/glm_test/binomial_20_cols_10KRows.csv"))
+    h2o_data["C1"] = h2o_data["C1"].asfactor()
+    h2o_data["C2"] = h2o_data["C2"].asfactor()
+    h2o_data["C21"] = h2o_data["C21"].asfactor()
+
+    knotsC11 = [-1.999662934845682, -0.008421144219463272, 1.999459888242264]
+    frameKnotC11 = h2o.H2OFrame(python_obj=knotsC11)
+    knotsC12 = [-1.9997515661932348, -0.6738945321313676, 0.6508273358344479, 1.9992225172858493]
+    frameKnotC12 = h2o.H2OFrame(python_obj=knotsC12)
+    knotsC13 = [-1.999891109720008, -0.9927241013095163, 0.02801505726801068, 1.033088395720594, 1.9999726397528468]
+    frameKnotC13 = h2o.H2OFrame(python_obj=knotsC13)
+    knotsC145 = [[-1.9995687220225768, -1.3179329594362712, -0.6660494855259786, 0.018720676310811868, 
+                  0.6698634783003867, 1.3416090970090029], [0.59241038898347, -0.5351329568631273, -0.5172803270321329,
+                                                            0.3428670679538648, -1.6541548995899171, -1.8415195601489895]]
+    temp = [list(x) for x in zip(*knotsC145)]
+    frameKnotC145 = h2o.H2OFrame(python_obj=temp)
+    usedGam = ["C11", "C12", "C13", "C14", "C15"]
+    gam = H2OGeneralizedAdditiveEstimator(family='binomial', gam_columns=["C11", "C12", "C13", ["C14", "C15"]],  
+                                          knot_ids = [frameKnotC11.key, frameKnotC12.key, frameKnotC13.key, frameKnotC145.key],
+                                          bs=[0,2,3,1], standardize=True, lambda_=[0], alpha=[0], max_iterations=1, 
+                                          store_knot_locations=True)
+    gam.train(x=["C1","C2"], y="C21", training_frame=h2o_data)
+    # check and make sure the returned knot locations and knot gam names are correct
+    allKnots = gam.get_knot_locations()
+    c11Knots = gam.get_knot_locations("C11")
+    assert pyunit_utils.equal_two_arrays(allKnots[0], c11Knots)
+    assert pyunit_utils.equal_two_arrays(knotsC11, c11Knots)
+    c12Knots = gam.get_knot_locations("C12")
+    assert pyunit_utils.equal_two_arrays(allKnots[1], c12Knots)
+    assert pyunit_utils.equal_two_arrays(knotsC12, c12Knots)
+    c13Knots = gam.get_knot_locations("C13")
+    assert pyunit_utils.equal_two_arrays(allKnots[2], c13Knots)
+    assert pyunit_utils.equal_two_arrays(knotsC13, c13Knots)
+    c14Knots = gam.get_knot_locations("C14")
+    assert pyunit_utils.equal_two_arrays(allKnots[3], c14Knots)
+    assert pyunit_utils.equal_two_arrays(knotsC145[0], c14Knots)
+    c15Knots = gam.get_knot_locations("C15")
+    assert pyunit_utils.equal_two_arrays(allKnots[4], c15Knots)
+    assert pyunit_utils.equal_two_arrays(knotsC145[1], c15Knots)
+    gam_knot_columns = gam.get_gam_knot_column_names()
+    gam_knot_columns.sort()
+    usedGam.sort()
+    assert gam_knot_columns == usedGam, "Expected array: {0}, actual: {1}".format(usedGam, gam_knot_columns)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_gam_knot_locations)
+else:
+    test_gam_knot_locations()

--- a/h2o-r/h2o-package/pkgdown/_pkgdown.yml
+++ b/h2o-r/h2o-package/pkgdown/_pkgdown.yml
@@ -130,6 +130,7 @@ reference:
       - h2o.generic
       - h2o.genericModel
       - h2o.get_automl
+      - h2o.get_knot_locations
       - h2o.get_leaderboard
       - h2o.get_ntrees_actual
       - h2o.get_segment_models
@@ -149,6 +150,8 @@ reference:
       - h2o.anovaglm
       - h2o.get_best_r2_values
       - h2o.get_best_model_predictors
+      - h2o.get_knot_locations
+      - h2o.get_gam_knot_column_names
       - h2o.get_predictor_added_per_step
       - h2o.get_predictor_removed_per_step
       - h2o.get_regression_influence_diagnostics

--- a/h2o-r/tests/testdir_algos/gam/runit_pubdev_9043_knot_location.R
+++ b/h2o-r/tests/testdir_algos/gam/runit_pubdev_9043_knot_location.R
@@ -1,0 +1,32 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+test.model.gam.knot.locations <- function() {
+    data <- h2o.importFile(locate("smalldata/glm_test/binomial_20_cols_10KRows.csv"))
+    data$C21 <- as.factor(data$C21)
+    
+    # Set the predictor and response columns
+    predictors <- c("C11","C12","C13")
+    response <- 'C21'
+    gam_model <- h2o.gam(x = predictors,
+                         y = response,
+                         training_frame = data,
+                         family = 'binomial',
+                         gam_columns = predictors,
+                         scale = c(1,0.01,0.1),
+                         bs = c(2,0,1),
+                         num_knots = c(10, 12, 13), store_knot_locations=TRUE)
+    all_gam_knots <- h2o.get_knot_locations(gam_model)
+    gam_knot_names <- gam_model@model$gam_knot_column_names
+    knotC11 <- h2o.get_knot_locations(gam_model, gam_knot_names[1])
+    compare_arrays(knotC11[[1]], all_gam_knots[[1]])
+    knotC12 <- h2o.get_knot_locations(gam_model, gam_knot_names[2])
+    compare_arrays(knotC12[[1]], all_gam_knots[[2]])
+    knotC13 <- h2o.get_knot_locations(gam_model, gam_knot_names[3])
+    compare_arrays(knotC13[[1]], all_gam_knots[[3]])
+    gam_knots <- h2o.get_gam_knot_column_names(gam_model)
+    expect_true(length(predictors) == length(gam_knot_names))
+}
+
+doTest("General Additive Model test to check knot outputs in model", test.model.gam.knot.locations)
+


### PR DESCRIPTION
This PR resolves the issue here: https://h2oai.atlassian.net/browse/PUBDEV-9043.

I added a parameter to enable knot location output and then output the know locations in Java backend.
Added accessor functions in R and python to get knot locations.
Added Java, R, python unit tests to make sure the knot locations are returned when enabled.