### PR TITLE
[PUBDEV-9035] Deprecate Support for Python 2.7, 3.5

### DIFF
--- a/h2o-py/h2o/__init__.py
+++ b/h2o-py/h2o/__init__.py
@@ -11,6 +11,16 @@ from codecs import open
 import os
 import sys
 import zipfile
+import platform
+import warnings
+
+_python_version = platform.python_version()
+if _python_version < "3.6":
+    warnings.showwarning(
+        "Your Python version is %s. The support for this version will be removed in H2O 3.42.0.1." % _python_version,
+        DeprecationWarning,
+        "h2o",
+        1)
 
 __no_export = set(dir())  # variables defined above this are not exported
 
@@ -67,7 +77,6 @@ except:
 
 if __version__.endswith("99999"):
     print(__buildinfo__)
-
 
 try:
     # Export explain functions that are useful for lists of models


### PR DESCRIPTION
It throws warning during `import h2o`. The warning cannot be supressed.
<img width="1018" alt="Screenshot 2023-03-30 at 15 36 06" src="https://user-images.githubusercontent.com/3674621/228853730-b294975a-a5ee-4491-a4b7-70f023e2e662.png">
