### PR TITLE
[PUBDEV-9045] Release notes for 3.40.0.3

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,23 @@
 
 ## H2O
 
+### Kurka (3.40.0.3) - 4/4/2023
+
+Download at: <a href='http://h2o-release.s3.amazonaws.com/h2o/rel-zz_kurka/3/index.html'>http://h2o-release.s3.amazonaws.com/h2o/rel-zz_kurka/3/index.html</a>
+
+#### Improvement
+- [[PUBDEV-9043]](https://h2oai.atlassian.net/browse/PUBDEV-9043) - Added GAM Knot Locations to Model Output.
+- [[PUBDEV-9039]](https://h2oai.atlassian.net/browse/PUBDEV-9039) - Addressed CVE-2014-125087 in h2o-steam.jar
+
+#### Engineering Story
+- [[PUBDEV-9040]](https://h2oai.atlassian.net/browse/PUBDEV-9040) - Disabled execution of tests in client mode.
+- [[PUBDEV-9035]](https://h2oai.atlassian.net/browse/PUBDEV-9035) - Deprecated support for Python 2.7 and 3.5.
+
+#### Docs
+- [[PUBDEV-9036]](https://h2oai.atlassian.net/browse/PUBDEV-9036) - Introduced a page describing MOJO capabilities.
+- [[PUBDEV-9023]](https://h2oai.atlassian.net/browse/PUBDEV-9023) - Updated the DRF documentation page to reflect what dataset is used to calculate the model metric.
+- [[PUBDEV-9004]](https://h2oai.atlassian.net/browse/PUBDEV-9004) - Updated and rearranged the hyper-parameter list in the Grid Search documentation page.
+
 ### Kurka (3.40.0.2) - 3/9/2023
 
 Download at: <a href='http://h2o-release.s3.amazonaws.com/h2o/rel-zz_kurka/2/index.html'>http://h2o-release.s3.amazonaws.com/h2o/rel-zz_kurka/2/index.html</a>


### PR DESCRIPTION
Excluded jira from the notes: https://h2oai.atlassian.net/browse/PUBDEV-8996 - fix rel-zz_kurka tests failures.