### PR TITLE
[PUBDEV-9047] Make H2OFrame in strdistance lazily evaluated

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -3249,7 +3249,7 @@ class H2OFrame(Keyed, H2ODisplay):
         assert_is_type(y, H2OFrame)
         assert_is_type(measure, Enum('lv', 'lcs', 'qgram', 'jaccard', 'jw', 'soundex'))
         assert_is_type(compare_empty, bool)
-        return H2OFrame._expr(expr=ExprNode("strDistance", self, y, measure, compare_empty))._frame()
+        return H2OFrame._expr(expr=ExprNode("strDistance", self, y, measure, compare_empty))
 
     def asfactor(self):
         """


### PR DESCRIPTION
This change is needed to be able to exacetue the operation in `H2OAssembly`.