### PR TITLE
[PUBDEV-9072] Remove CVE-2023-1370 from h2o-steam.jar

### DIFF
--- a/h2o-assemblies/steam/build.gradle
+++ b/h2o-assemblies/steam/build.gradle
@@ -41,7 +41,6 @@ dependencies {
         exclude group: "org.apache.zookeeper"
         exclude group: "org.eclipse.jetty"
         exclude group: "org.apache.hadoop.thirdparty", module: "hadoop-shaded-protobuf_3_7"
-        exclude group: "org.apache.hadoop", module: "hadoop-auth"
     }
     api("org.apache.hadoop:hadoop-aws:3.3.5") {
         exclude group: "com.amazonaws", module: "aws-java-sdk-bundle"
@@ -63,6 +62,9 @@ dependencies {
     constraints {
         api('com.fasterxml.jackson.core:jackson-databind:2.13.4.2') {
             because 'Fixes CVE-2022-42003'
+        }
+        api('net.minidev:json-smart:2.4.10') {
+            because 'Fixes CVE-2023-1370'
         }
     }
 }

--- a/h2o-assemblies/steam/build.gradle
+++ b/h2o-assemblies/steam/build.gradle
@@ -32,8 +32,8 @@ dependencies {
         exclude group: "org.apache.hadoop"
     }
     // Force latest version Hadoop with unused components excluded - we need Hadoop for Parquet and S3A export 
-    api "org.apache.hadoop:hadoop-hdfs-client:3.3.3"
-    api("org.apache.hadoop:hadoop-common:3.3.3") {
+    api "org.apache.hadoop:hadoop-hdfs-client:3.3.5"
+    api("org.apache.hadoop:hadoop-common:3.3.5") {
         exclude group: "com.sun.jersey"
         exclude group: "javax.servlet"
         exclude group: "org.apache.avro"
@@ -41,8 +41,9 @@ dependencies {
         exclude group: "org.apache.zookeeper"
         exclude group: "org.eclipse.jetty"
         exclude group: "org.apache.hadoop.thirdparty", module: "hadoop-shaded-protobuf_3_7"
+        exclude group: "org.apache.hadoop", module: "hadoop-auth"
     }
-    api("org.apache.hadoop:hadoop-aws:3.3.3") {
+    api("org.apache.hadoop:hadoop-aws:3.3.5") {
         exclude group: "com.amazonaws", module: "aws-java-sdk-bundle"
     }
     // aws-java-sdk-dynamodb is required for S3A support, S3A import throws NoClassDefFoundError (AmazonDynamoDBException)
@@ -53,7 +54,7 @@ dependencies {
     api "org.apache.commons:commons-compress:1.21"
     // Force specific Parquet version to avoid dependency on vulnerable FasterXML jackson-mapper-asl
     api "org.apache.parquet:parquet-hadoop:1.12.2"
-    api("org.apache.hadoop:hadoop-mapreduce-client-core:3.3.3") {
+    api("org.apache.hadoop:hadoop-mapreduce-client-core:3.3.5") {
         transitive = false
     }
     // Google OAuth force version


### PR DESCRIPTION
CVE-2023-1370:  The problem is in the transitive dependency `net.minidev:json-smart:2.4.7` which is brought to the `h2o-steam.jar` via hadoop-auth:
```
net.minidev:json-smart:2.4.7
\--- org.apache.hadoop:hadoop-auth:3.3.3
     \--- org.apache.hadoop:hadoop-common:3.3.3
          \--- runtimeClasspath
```
