### PR TITLE
PUBDEV-9057: GAM algorithm parameter reorganization

### DIFF
--- a/h2o-docs/src/product/data-science/gam.rst
+++ b/h2o-docs/src/product/data-science/gam.rst
@@ -25,7 +25,7 @@ Algorithm-specific parameters
 
 -  **num_knots**: An array that specifies the number of knots for each predictor specified in ``gam_columns``.
 
--  **spline_orders**: Order of I-splines/monotone splines used for GAM predictors. For example, ``spline_orders=3`` means a polynomial of order 3 will be used in the splines. If specified, this option must be the same size as ``gam_columns``. Values for ``bs=0`` or ``bs=1`` will be ignored.
+-  **spline_orders**: Order of I-splines (also known as monotone splines) and NBSplineTypeI M-splines used for GAM predictors. For example, ``spline_orders=3`` means a polynomial of order 3 will be used in the splines. If specified, this option must be the same size as ``gam_columns``. Values for ``bs=0`` or ``bs=1`` will be ignored.
 
 -  **knot_ids**: A string array storing frame keys/IDs that contain knot locations. Specify one value for each GAM column specified in ``gam_columns``.
 
@@ -33,18 +33,18 @@ Algorithm-specific parameters
 
 -  **scale_tp_penalty_mat**: Scale penalty matrix for thin plate smoothers. This option defaults to ``False``.
 
--  **bs**: An array specifying the B-Splines for each GAM predictor. You must include one value for each GAM predictor. One of:
+-  **bs**: An array specifying the spline types for each GAM predictor. You must include one value for each GAM predictor. One of:
 
     - ``0`` (default) specifies cubic regression spline. 
     - ``1`` specifies thin plate regression with knots.
-    - ``2`` specifies monotone splines.
-    - ``3`` specifies splines of any polynomial order.
+    - ``2`` specifies monotone splines (or I-splines).
+    - ``3`` specifies NBSplineTypeI M-splines (which can support any polynomial order).
    
 -  **scale**: An array specifying the smoothing parameter for GAM. If specified, must be the same length as ``gam_columns``.
 
 -  **keep_gam_cols**: Specify whether to save keys storing GAM columns. This option defaults to ``False`` (disabled).
 
--  **splines_non_negative**: (Applicable for I-spline/``bs=2`` only) Set this option to ``True`` if the I-splines are monotonically increasing (and monotonically non-decreasing). Set this option to ``False`` if the I-splines are monotonically decreasing (and monotonically non-increasing). If specified, this option must be the same size as ``gam_columns``. Values for other spline types will be ignored. This option defaults to ``True`` (enabled).
+-  **splines_non_negative**: (Applicable for I-spline or ``bs=2`` only) Set this option to ``True`` if the I-splines are monotonically increasing (and monotonically non-decreasing). Set this option to ``False`` if the I-splines are monotonically decreasing (and monotonically non-increasing). If specified, this option must be the same size as ``gam_columns``. Values for other spline types will be ignored. This option defaults to ``True`` (enabled).
 
 Common parameters
 '''''''''''''''''

--- a/h2o-docs/src/product/data-science/gam.rst
+++ b/h2o-docs/src/product/data-science/gam.rst
@@ -21,58 +21,46 @@ Parameters are optional unless specified as *required*. GAM shares many `GLM par
 Algorithm-specific parameters
 '''''''''''''''''''''''''''''
 
--  **gam_columns**: *Required* An array of column names representing the smoothing terms used for prediction. GAM will build a smoother for each specified column. 
-
--  **num_knots**: An array that specifies the number of knots for each predictor specified in ``gam_columns``.
-
--  **spline_orders**: Order of I-splines (also known as monotone splines) and NBSplineTypeI M-splines used for GAM predictors. For example, ``spline_orders=3`` means a polynomial of order 3 will be used in the splines. If specified, this option must be the same size as ``gam_columns``. Values for ``bs=0`` or ``bs=1`` will be ignored.
-
--  **knot_ids**: A string array storing frame keys/IDs that contain knot locations. Specify one value for each GAM column specified in ``gam_columns``.
-
--  **standardize_tp_gam_cols**: Standardize thin plate predictor columns. This option defaults to ``False``.
-
--  **scale_tp_penalty_mat**: Scale penalty matrix for thin plate smoothers. This option defaults to ``False``.
-
 -  **bs**: An array specifying the spline types for each GAM predictor. You must include one value for each GAM predictor. One of:
 
     - ``0`` (default) specifies cubic regression spline. 
     - ``1`` specifies thin plate regression with knots.
     - ``2`` specifies monotone splines (or I-splines).
     - ``3`` specifies NBSplineTypeI M-splines (which can support any polynomial order).
-   
--  **scale**: An array specifying the smoothing parameter for GAM. If specified, must be the same length as ``gam_columns``.
 
+-  **gam_columns**: *Required* An array of column names representing the smoothing terms used for prediction. GAM will build a smoother for each specified column. 
+  
 -  **keep_gam_cols**: Specify whether to save keys storing GAM columns. This option defaults to ``False`` (disabled).
 
--  **splines_non_negative**: (Applicable for I-spline or ``bs=2`` only) Set this option to ``True`` if the I-splines are monotonically increasing (and monotonically non-decreasing). Set this option to ``False`` if the I-splines are monotonically decreasing (and monotonically non-increasing). If specified, this option must be the same size as ``gam_columns``. Values for other spline types will be ignored. This option defaults to ``True`` (enabled).
+-  **knot_ids**: A string array storing frame keys/IDs that contain knot locations. Specify one value for each GAM column specified in ``gam_columns``.
+
+-  **num_knots**: An array that specifies the number of knots for each predictor specified in ``gam_columns``.
+
+-  **scale**: An array specifying the smoothing parameter for GAM. If specified, must be the same length as ``gam_columns``.
+
+-  **scale_tp_penalty_mat**: Scale penalty matrix for thin plate smoothers. This option defaults to ``False``.
+ 
+-  **splines_non_negative**: (Applicable for I-spline or ``bs=2`` only) Set this option to ``True`` if the I-splines are monotonically increasing (or monotonically non-decreasing). Set this option to ``False`` if the I-splines are monotonically decreasing (or monotonically non-increasing). If specified, this option must be the same size as ``gam_columns``. Values for other spline types will be ignored. This option defaults to ``True`` (enabled).
+
+-  **spline_orders**: Order of I-splines (also known as monotone splines) and NBSplineTypeI M-splines used for GAM predictors. For I-splines, the ``spline_orders`` will be the same as the polynomials used to generate the splines. For M-splines, the polynomials will be ``spline_orders`` :math:`-1`. For example, ``spline_orders=3`` for I-splines means a polynomial of order 3 will be used in the splines while for M-splines it means a polynomial of order 2 will be used. If specified, this option must be the same size as ``gam_columns``. Values for ``bs=0`` or ``bs=1`` will be ignored.
+
+-  **standardize_tp_gam_cols**: Standardize thin plate predictor columns. This option defaults to ``False``.
 
 Common parameters
 '''''''''''''''''
 
--  `training_frame <algo-params/training_frame.html>`__: *Required* Specify the dataset used to build the model. 
-    
-     **NOTE**: In Flow, if you click the **Build a model** button from the ``Parse`` cell, the training frame is entered automatically.
+- `auc_type <algo-params/auc_type.html>`__: Set the default multinomial AUC type. Must be one of:
 
--  `y <algo-params/y.html>`__: *Required* Specify the column to use as the dependent variable.
+    - ``"AUTO"`` (default)
+    - ``"NONE"``
+    - ``"MACRO_OVR"``
+    - ``"WEIGHTED_OVR"``
+    - ``"MACRO_OVO"``
+    - ``"WEIGHTED_OVO"``
 
-    -  For a regression model, this column must be numeric (**Real** or **Int**).
-    -  For a classification model, this column must be categorical (**Enum** or **String**). If the family is ``Binomial``, the dataset must contain two levels.
+-  `early_stopping <algo-params/early_stopping.html>`__: Specify whether to stop early when there is no more relative improvement on the training or validation set. This option defaults to ``True`` (enabled).
 
--  `x <algo-params/x.html>`__: Specify a vector containing the names or indices of the predictor variables to use when building the model. If ``x`` is missing, then no predictors will be used.
-
--  `validation_frame <algo-params/validation_frame.html>`__: Specify the dataset used to evaluate the accuracy of the model.
-
--  `model_id <algo-params/model_id.html>`__: Specify a custom name for the model to use as a reference. By default, H2O automatically generates a destination key.
-
--  `nfolds <algo-params/nfolds.html>`__: Specify the number of folds for cross-validation. The value can be ``0`` (default) to disable or :math:`\geq` ``2``. 
-
--  `seed <algo-params/seed.html>`__: Specify the random number generator (RNG) seed for algorithm components dependent on randomization. The seed is consistent for each H2O instance so that you can create models with the same starting conditions in alternative configurations. This option defaults to ``-1`` (time-based random number).
-
--  `keep_cross_validation_models <algo-params/keep_cross_validation_models.html>`__: Specify whether to keep the cross-validated models. Keeping cross-validation models may consume significantly more memory in the H2O cluster. This option defaults to ``True`` (enabled).
-
--  `keep_cross_validation_predictions <algo-params/keep_cross_validation_predictions.html>`__: Specify whether to keep the cross-validation predictions. This option defaults to ``False`` (disabled).
-
--  `keep_cross_validation_fold_assignment <algo-params/keep_cross_validation_fold_assignment.html>`__: Enable this option to preserve the cross-validation fold assignment. This option defaults to ``False`` (disabled).
+-  `export_checkpoints_dir <algo-params/export_checkpoints_dir.html>`__: Specify a directory to which generated models will automatically be exported.
 
 -  `fold_assignment <algo-params/fold_assignment.html>`__: (Applicable only if a value for ``nfolds`` is specified and ``fold_column`` is not specified) Specify the cross-validation fold assignment scheme. One of:
 
@@ -87,37 +75,33 @@ Common parameters
 
 -  `ignored_columns <algo-params/ignored_columns.html>`__: (Python and Flow only) Specify the column or columns to be excluded from the model. In Flow, click the checkbox next to a column name to add it to the list of columns excluded from the model. To add all columns, click the **All** button. To remove a column from the list of ignored columns, click the X next to the column name. To remove all columns from the list of ignored columns, click the **None** button. To search for a specific column, type the column name in the **Search** field above the column list. To only show columns with a specific percentage of missing values, specify the percentage in the **Only show columns with more than 0% missing values** field. To change the selections for the hidden columns, use the **Select Visible** or **Deselect Visible** buttons.
 
--  `score_each_iteration <algo-params/score_each_iteration.html>`__: Enable this option to score during each iteration of the model training. This option defaults to ``False`` (disabled).
+-  `keep_cross_validation_fold_assignment <algo-params/keep_cross_validation_fold_assignment.html>`__: Enable this option to preserve the cross-validation fold assignment. This option defaults to ``False`` (disabled).
+
+-  `keep_cross_validation_models <algo-params/keep_cross_validation_models.html>`__: Specify whether to keep the cross-validated models. Keeping cross-validation models may consume significantly more memory in the H2O cluster. This option defaults to ``True`` (enabled).
+
+-  `keep_cross_validation_predictions <algo-params/keep_cross_validation_predictions.html>`__: Specify whether to keep the cross-validation predictions. This option defaults to ``False`` (disabled).
+
+-  `max_active_predictors <algo-params/max_active_predictors.html>`__: Specify the maximum number of active predictors during computation. This value is used as a stopping criterium to prevent expensive model building with many predictors. This value defaults to ``-1`` (unlimited). This default indicates that if the ``IRLSM`` solver is used, the value of ``max_active_predictors`` is set to ``5000``, otherwise it is set to ``100000000``.
+
+-  `max_iterations <algo-params/max_iterations.html>`__: Specify the number of training iterations. This option defaults to ``-1`` (unlimited).
+
+- `max_runtime_secs <algo-params/max_runtime_secs.html>`__: Maximum allowed runtime in seconds for model training. Use ``0`` (default) to disable.
+
+-  `missing_values_handling <algo-params/missing_values_handling.html>`__: Specify how to handle missing values (one of: ``Skip``, ``MeanImputation`` (default), or ``PlugValues``). 
+
+-  `model_id <algo-params/model_id.html>`__: Specify a custom name for the model to use as a reference. By default, H2O automatically generates a destination key.
+
+-  `nfolds <algo-params/nfolds.html>`__: Specify the number of folds for cross-validation. The value can be ``0`` (default) to disable or :math:`\geq` ``2``. 
 
 -  `offset_column <algo-params/offset_column.html>`__: Specify a column to use as the offset; the value cannot be the same as the value for the ``weights_column``.
    
      **Note**: Offsets are per-row "bias values" that are used during model training. For Gaussian distributions, they can be seen as simple corrections to the response (``y``) column. Instead of learning to predict the response (y-row), the model learns to predict the (row) offset of the response column. For other distributions, the offset corrections are applied in the linearized space before applying the inverse link function to get the actual response values. 
 
--  `weights_column <algo-params/weights_column.html>`__: Specify a column to use for the observation weights, which are used for bias correction. The specified ``weights_column`` must be included in the specified ``training_frame``. 
-    
-    *Python only*: To use a weights column when passing an H2OFrame to ``x`` instead of a list of column names, the specified ``training_frame`` must contain the specified ``weights_column``. 
-   
-    **Note**: Weights are per-row observation weights and do not increase the size of the data frame. This is typically the number of times a row is repeated, but non-integer values are supported as well. During training, rows with higher weights matter more due to the larger loss function pre-factor.
+-  `score_each_iteration <algo-params/score_each_iteration.html>`__: Enable this option to score during each iteration of the model training. This option defaults to ``False`` (disabled).
+
+-  `seed <algo-params/seed.html>`__: Specify the random number generator (RNG) seed for algorithm components dependent on randomization. The seed is consistent for each H2O instance so that you can create models with the same starting conditions in alternative configurations. This option defaults to ``-1`` (time-based random number).
 
 -  `standardize <algo-params/standardize.html>`__: Specify whether to standardize the numeric columns to have a mean of zero and unit variance. Standardization is highly recommended; if you do not use standardization, the results can include components that are dominated by variables that appear to have larger variances relative to other attributes as a matter of scale, rather than true contribution. This option defaults to ``False`` (disabled).
-
--  `missing_values_handling <algo-params/missing_values_handling.html>`__: Specify how to handle missing values (one of: ``Skip``, ``MeanImputation`` (default), or ``PlugValues``). 
-
--  `max_iterations <algo-params/max_iterations.html>`__: Specify the number of training iterations. This option defaults to ``-1`` (unlimited).
-
--  `max_active_predictors <algo-params/max_active_predictors.html>`__: Specify the maximum number of active predictors during computation. This value is used as a stopping criterium to prevent expensive model building with many predictors. This value defaults to ``-1`` (unlimited). This default indicates that if the ``IRLSM`` solver is used, the value of ``max_active_predictors`` is set to ``5000``, otherwise it is set to ``100000000``.
-
--  `export_checkpoints_dir <algo-params/export_checkpoints_dir.html>`__: Specify a directory to which generated models will automatically be exported.
-
--  `early_stopping <algo-params/early_stopping.html>`__: Specify whether to stop early when there is no more relative improvement on the training or validation set. This option defaults to ``True`` (enabled).
-
-- `stopping_rounds <algo-params/stopping_rounds.html>`__: Stops training when the option selected for ``stopping_metric`` doesn't improve for the specified number of training rounds, based on a simple moving average. To disable this feature, specify ``0`` (default). 
-
-    **Note:** If cross-validation is enabled:
-  
-    - All cross-validation models stop training when the validation metric doesn't improve.
-    - The main model runs for the mean number of epochs.
-    - N+1 models may be off by the number specified for ``stopping_rounds`` from the best model, but the cross-validation metric estimates the performance of the main model for the resulting number of epochs (which may be fewer than the specified number of epochs).
 
 - `stopping_metric <algo-params/stopping_metric.html>`__: Specify the metric to use for early stopping. The available options are:
 
@@ -134,18 +118,34 @@ Common parameters
     - ``misclassification``
     - ``mean_per_class_error``
 
+- `stopping_rounds <algo-params/stopping_rounds.html>`__: Stops training when the option selected for ``stopping_metric`` doesn't improve for the specified number of training rounds, based on a simple moving average. To disable this feature, specify ``0`` (default). 
+
+    **Note:** If cross-validation is enabled:
+  
+    - All cross-validation models stop training when the validation metric doesn't improve.
+    - The main model runs for the mean number of epochs.
+    - N+1 models may be off by the number specified for ``stopping_rounds`` from the best model, but the cross-validation metric estimates the performance of the main model for the resulting number of epochs (which may be fewer than the specified number of epochs).
+
 - `stopping_tolerance <algo-params/stopping_tolerance.html>`__: Specify the relative tolerance for the metric-based stopping to stop training if the improvement is less than this value. This option defaults to ``0.001``.
 
-- `max_runtime_secs <algo-params/max_runtime_secs.html>`__: Maximum allowed runtime in seconds for model training. Use ``0`` (default) to disable.
+-  `training_frame <algo-params/training_frame.html>`__: *Required* Specify the dataset used to build the model. 
+    
+     **NOTE**: In Flow, if you click the **Build a model** button from the ``Parse`` cell, the training frame is entered automatically.
 
-- `auc_type <algo-params/auc_type.html>`__: Set the default multinomial AUC type. Must be one of:
+-  `validation_frame <algo-params/validation_frame.html>`__: Specify the dataset used to evaluate the accuracy of the model.
 
-    - ``"AUTO"`` (default)
-    - ``"NONE"``
-    - ``"MACRO_OVR"``
-    - ``"WEIGHTED_OVR"``
-    - ``"MACRO_OVO"``
-    - ``"WEIGHTED_OVO"``
+-  `weights_column <algo-params/weights_column.html>`__: Specify a column to use for the observation weights, which are used for bias correction. The specified ``weights_column`` must be included in the specified ``training_frame``. 
+    
+    *Python only*: To use a weights column when passing an H2OFrame to ``x`` instead of a list of column names, the specified ``training_frame`` must contain the specified ``weights_column``. 
+   
+    **Note**: Weights are per-row observation weights and do not increase the size of the data frame. This is typically the number of times a row is repeated, but non-integer values are supported as well. During training, rows with higher weights matter more due to the larger loss function pre-factor.
+
+-  `x <algo-params/x.html>`__: Specify a vector containing the names or indices of the predictor variables to use when building the model. If ``x`` is missing, then no predictors will be used.
+
+-  `y <algo-params/y.html>`__: *Required* Specify the column to use as the dependent variable.
+
+    -  For a regression model, this column must be numeric (**Real** or **Int**).
+    -  For a classification model, this column must be categorical (**Enum** or **String**). If the family is ``Binomial``, the dataset must contain two levels.
 
 .. _scenario1:
 

--- a/h2o-docs/src/product/data-science/gam.rst
+++ b/h2o-docs/src/product/data-science/gam.rst
@@ -16,213 +16,136 @@ GAM supports importing and exporting `MOJOs <../save-and-load-model.html#support
 Defining a GAM Model
 ~~~~~~~~~~~~~~~~~~~~
 
--  `model_id <algo-params/model_id.html>`__: (Optional) Specify a custom name for the model to use as a reference. By default, H2O automatically generates a destination key.
+Parameters are optional unless specified as *required*. GAM shares many `GLM parameters <glm.html#shared-glm-family-parameters>`__.
 
--  `training_frame <algo-params/training_frame.html>`__: (Required) Specify the dataset used to build the model. **NOTE**: In Flow, if you click the **Build a model** button from the ``Parse`` cell, the training frame is entered automatically.
+Algorithm-specific parameters
+'''''''''''''''''''''''''''''
 
--  `validation_frame <algo-params/validation_frame.html>`__: (Optional) Specify the dataset used to evaluate the accuracy of the model.
+-  **gam_columns**: *Required* An array of column names representing the smoothing terms used for prediction. GAM will build a smoother for each specified column. 
 
--  `nfolds <algo-params/nfolds.html>`__: Specify the number of folds for cross-validation. This value defaults to 0 (no cross-validation).
+-  **num_knots**: An array that specifies the number of knots for each predictor specified in ``gam_columns``.
 
--  `seed <algo-params/seed.html>`__: Specify the random number generator (RNG) seed for algorithm components dependent on randomization. The seed is consistent for each H2O instance so that you can create models with the same starting conditions in alternative configurations. This option defaults to -1 (time-based random number).
+-  **spline_orders**: Order of I-splines/monotone splines used for GAM predictors. For example, ``spline_orders=3`` means a polynomial of order 3 will be used in the splines. If specified, this option must be the same size as ``gam_columns``. Values for ``bs=0`` or ``bs=1`` will be ignored.
 
--  `y <algo-params/y.html>`__: (Required) Specify the column to use as the dependent variable.
+-  **knot_ids**: A string array storing frame keys/IDs that contain knot locations. Specify one value for each GAM column specified in ``gam_columns``.
 
-   -  For a regression model, this column must be numeric (**Real** or **Int**).
-   -  For a classification model, this column must be categorical (**Enum** or **String**). If the family is **Binomial**, the dataset cannot contain more than two levels.
+-  **standardize_tp_gam_cols**: Standardize thin plate predictor columns. This option defaults to ``False``.
 
--  `x <algo-params/x.html>`__: Specify a vector containing the names or indices of the predictor variables to use when building the model. If ``x`` is missing, then all columns except ``y`` are used.
+-  **scale_tp_penalty_mat**: Scale penalty matrix for thin plate smoothers. This option defaults to ``False``.
 
--  `keep_cross_validation_models <algo-params/keep_cross_validation_models.html>`__: Specify whether to keep the cross-validated models. Keeping cross-validation models may consume significantly more memory in the H2O cluster. This option is defaults to true (enabled).
+-  **bs**: An array specifying the B-Splines for each GAM predictor. You must include one value for each GAM predictor. One of:
 
--  `keep_cross_validation_predictions <algo-params/keep_cross_validation_predictions.html>`__: Specify whether to keep the cross-validation predictions. This option is defaults to false (not enabled).
+    - ``0`` (default) specifies cubic regression spline. 
+    - ``1`` specifies thin plate regression with knots.
+    - ``2`` specifies monotone splines.
+    - ``3`` specifies splines of any polynomial order.
+   
+-  **scale**: An array specifying the smoothing parameter for GAM. If specified, must be the same length as ``gam_columns``.
 
--  `keep_cross_validation_fold_assignment <algo-params/keep_cross_validation_fold_assignment.html>`__: Enable this option to preserve the cross-validation fold assignment. This option is defaults to false (not enabled).
+-  **keep_gam_cols**: Specify whether to save keys storing GAM columns. This option defaults to ``False`` (disabled).
 
--  `fold_assignment <algo-params/fold_assignment.html>`__: (Applicable only if a value for **nfolds** is specified and **fold_column** is not specified) Specify the cross-validation fold assignment scheme. The available options are AUTO (which is Random), Random, `Modulo <https://en.wikipedia.org/wiki/Modulo_operation>`__, or Stratified (which will stratify the folds based on the response variable for classification problems). This option defaults to AUTO.
+-  **splines_non_negative**: (Applicable for I-spline/``bs=2`` only) Set this option to ``True`` if the I-splines are monotonically increasing (and monotonically non-decreasing). Set this option to ``False`` if the I-splines are monotonically decreasing (and monotonically non-increasing). If specified, this option must be the same size as ``gam_columns``. Values for other spline types will be ignored. This option defaults to ``True`` (enabled).
+
+Common parameters
+'''''''''''''''''
+
+-  `training_frame <algo-params/training_frame.html>`__: *Required* Specify the dataset used to build the model. 
+    
+     **NOTE**: In Flow, if you click the **Build a model** button from the ``Parse`` cell, the training frame is entered automatically.
+
+-  `y <algo-params/y.html>`__: *Required* Specify the column to use as the dependent variable.
+
+    -  For a regression model, this column must be numeric (**Real** or **Int**).
+    -  For a classification model, this column must be categorical (**Enum** or **String**). If the family is ``Binomial``, the dataset must contain two levels.
+
+-  `x <algo-params/x.html>`__: Specify a vector containing the names or indices of the predictor variables to use when building the model. If ``x`` is missing, then no predictors will be used.
+
+-  `validation_frame <algo-params/validation_frame.html>`__: Specify the dataset used to evaluate the accuracy of the model.
+
+-  `model_id <algo-params/model_id.html>`__: Specify a custom name for the model to use as a reference. By default, H2O automatically generates a destination key.
+
+-  `nfolds <algo-params/nfolds.html>`__: Specify the number of folds for cross-validation. The value can be ``0`` (default) to disable or :math:`\geq` ``2``. 
+
+-  `seed <algo-params/seed.html>`__: Specify the random number generator (RNG) seed for algorithm components dependent on randomization. The seed is consistent for each H2O instance so that you can create models with the same starting conditions in alternative configurations. This option defaults to ``-1`` (time-based random number).
+
+-  `keep_cross_validation_models <algo-params/keep_cross_validation_models.html>`__: Specify whether to keep the cross-validated models. Keeping cross-validation models may consume significantly more memory in the H2O cluster. This option defaults to ``True`` (enabled).
+
+-  `keep_cross_validation_predictions <algo-params/keep_cross_validation_predictions.html>`__: Specify whether to keep the cross-validation predictions. This option defaults to ``False`` (disabled).
+
+-  `keep_cross_validation_fold_assignment <algo-params/keep_cross_validation_fold_assignment.html>`__: Enable this option to preserve the cross-validation fold assignment. This option defaults to ``False`` (disabled).
+
+-  `fold_assignment <algo-params/fold_assignment.html>`__: (Applicable only if a value for ``nfolds`` is specified and ``fold_column`` is not specified) Specify the cross-validation fold assignment scheme. One of:
+
+     - ``AUTO`` (default; uses ``Random``)
+     - ``Random``
+     - ``Modulo`` (`read more about Modulo <https://en.wikipedia.org/wiki/Modulo_operation>`__)
+     - ``Stratified`` (which will stratify the folds based on the response variable for classification problems)
 
 -  `fold_column <algo-params/fold_column.html>`__: Specify the column that contains the cross-validation fold index assignment per observation.
 
--  `ignored_columns <algo-params/ignored_columns.html>`__: (Optional, Python and Flow only) Specify the column or columns to be excluded from the model. In Flow, click the checkbox next to a column name to add it to the list of columns excluded from the model. To add all columns, click the **All** button. To remove a column from the list of ignored columns, click the X next to the column name. To remove all columns from the list of ignored columns, click the **None** button. To search for a specific column, type the column name in the **Search** field above the column list. To only show columns with a specific percentage of missing values, specify the percentage in the **Only show columns with more than 0% missing values** field. To change the selections for the hidden columns, use the **Select Visible** or **Deselect Visible** buttons.
+-  `ignore_const_cols <algo-params/ignore_const_cols.html>`__: Enable this option to ignore constant training columns since no information can be gained from them. This option defaults to ``True`` (enabled).
 
--  `ignore_const_cols <algo-params/ignore_const_cols.html>`__: Enable this option to ignore constant
-   training columns, since no information can be gained from them. This option is defaults to true (enabled).
+-  `ignored_columns <algo-params/ignored_columns.html>`__: (Python and Flow only) Specify the column or columns to be excluded from the model. In Flow, click the checkbox next to a column name to add it to the list of columns excluded from the model. To add all columns, click the **All** button. To remove a column from the list of ignored columns, click the X next to the column name. To remove all columns from the list of ignored columns, click the **None** button. To search for a specific column, type the column name in the **Search** field above the column list. To only show columns with a specific percentage of missing values, specify the percentage in the **Only show columns with more than 0% missing values** field. To change the selections for the hidden columns, use the **Select Visible** or **Deselect Visible** buttons.
 
--  `score_each_iteration <algo-params/score_each_iteration.html>`__: (Optional) Enable this option to score during each iteration of the model training. This option is defaults to false (not enabled).
+-  `score_each_iteration <algo-params/score_each_iteration.html>`__: Enable this option to score during each iteration of the model training. This option defaults to ``False`` (disabled).
 
 -  `offset_column <algo-params/offset_column.html>`__: Specify a column to use as the offset; the value cannot be the same as the value for the ``weights_column``.
    
-     **Note**: Offsets are per-row "bias values" that are used during model training. For Gaussian distributions, they can be seen as simple corrections to the response (y) column. Instead of learning to predict the response (y-row), the model learns to predict the (row) offset of the response column. For other distributions, the offset corrections are applied in the linearized space before applying the inverse link function to get the actual response values. 
+     **Note**: Offsets are per-row "bias values" that are used during model training. For Gaussian distributions, they can be seen as simple corrections to the response (``y``) column. Instead of learning to predict the response (y-row), the model learns to predict the (row) offset of the response column. For other distributions, the offset corrections are applied in the linearized space before applying the inverse link function to get the actual response values. 
 
--  `weights_column <algo-params/weights_column.html>`__: Specify a column to use for the observation weights, which are used for bias correction. The specified ``weights_column`` must be included in the specified ``training_frame``. *Python only*: To use a weights column when passing an H2OFrame to ``x`` instead of a list of column names, the specified ``training_frame`` must contain the specified``weights_column``. 
+-  `weights_column <algo-params/weights_column.html>`__: Specify a column to use for the observation weights, which are used for bias correction. The specified ``weights_column`` must be included in the specified ``training_frame``. 
+    
+    *Python only*: To use a weights column when passing an H2OFrame to ``x`` instead of a list of column names, the specified ``training_frame`` must contain the specified ``weights_column``. 
    
-    **Note**: Weights are per-row observation weights and do not increase the size of the data frame. This is typically the number of times a row is repeated, but non-integer values are supported as well. During training, rows with higher weights matter more, due to the larger loss function pre-factor.
+    **Note**: Weights are per-row observation weights and do not increase the size of the data frame. This is typically the number of times a row is repeated, but non-integer values are supported as well. During training, rows with higher weights matter more due to the larger loss function pre-factor.
 
--  `family <algo-params/family.html>`__: Specify the model type.
+-  `standardize <algo-params/standardize.html>`__: Specify whether to standardize the numeric columns to have a mean of zero and unit variance. Standardization is highly recommended; if you do not use standardization, the results can include components that are dominated by variables that appear to have larger variances relative to other attributes as a matter of scale, rather than true contribution. This option defaults to ``False`` (disabled).
 
-   -  If the family is **gaussian**, the response must be numeric (**Real** or **Int**). 
-   -  If the family is **binomial**, the response must be categorical 2 levels/classes or binary (**Enum** or **Int**).
-   -  If the family is **fractionalbinomial**, the response must be a numeric between 0 and 1.
-   -  If the family is **multinomial**, the response can be categorical with more than two levels/classes (**Enum**).
-   -  If the family is **ordinal**, the response must be categorical with at least 3 levels.
-   -  If the family is **quasibinomial**, the response must be numeric.
-   -  If the family is **poisson**, the response must be numeric and non-negative (**Int**).
-   -  If the family is **negativebinomial**, the response must be numeric and non-negative (**Int**).
-   -  If the family is **gamma**, the response must be numeric and continuous and positive (**Real** or **Int**).
-   -  If the family is **tweedie**, the response must be numeric and continuous (**Real**) and non-negative.
-   - If the family is **AUTO** (default),
+-  `missing_values_handling <algo-params/missing_values_handling.html>`__: Specify how to handle missing values (one of: ``Skip``, ``MeanImputation`` (default), or ``PlugValues``). 
 
-      - and the response is **Enum** with cardinality = 2, then the family is automatically determined as **binomial**.
-      - and the response is **Enum** with cardinality > 2, then the family is automatically determined as **multinomial**.
-      - and the response is numeric (**Real** or **Int**), then the family is automatically determined as **gaussian**.
+-  `max_iterations <algo-params/max_iterations.html>`__: Specify the number of training iterations. This option defaults to ``-1`` (unlimited).
 
--  `tweedie_variance_power <algo-params/tweedie_variance_power.html>`__: (Only applicable if *Tweedie* is
-   specified for **Family**) Specify the Tweedie variance power (defaults to 0).
+-  `max_active_predictors <algo-params/max_active_predictors.html>`__: Specify the maximum number of active predictors during computation. This value is used as a stopping criterium to prevent expensive model building with many predictors. This value defaults to ``-1`` (unlimited). This default indicates that if the ``IRLSM`` solver is used, the value of ``max_active_predictors`` is set to ``5000``, otherwise it is set to ``100000000``.
 
--  `tweedie_link_power <algo-params/tweedie_link_power.html>`__: (Only applicable if *Tweedie* is specified
-   for **Family**) Specify the Tweedie link power (defaults to 0).
+-  `export_checkpoints_dir <algo-params/export_checkpoints_dir.html>`__: Specify a directory to which generated models will automatically be exported.
 
--  `theta <algo-params/theta.html>`__: Theta value (equal to 1/r) for use with the negative binomial family. This value must be > 0 and defaults to 0.  
+-  `early_stopping <algo-params/early_stopping.html>`__: Specify whether to stop early when there is no more relative improvement on the training or validation set. This option defaults to ``True`` (enabled).
 
--  `solver <algo-params/solver.html>`__: Specify the solver to use (AUTO, IRLSM, L_BFGS, COORDINATE_DESCENT_NAIVE, COORDINATE_DESCENT, GRADIENT_DESCENT_LH, or GRADIENT_DESCENT_SQERR). IRLSM is fast on problems with a small number of predictors and for lambda search with L1 penalty, while `L_BFGS <http://cran.r-project.org/web/packages/lbfgs/vignettes/Vignette.pdf>`__ scales better for datasets with many columns. COORDINATE_DESCENT is IRLSM with the covariance updates version of cyclical coordinate descent in the innermost loop. COORDINATE_DESCENT_NAIVE is IRLSM with the naive updates version of cyclical coordinate descent in the innermost loop. GRADIENT_DESCENT_LH and GRADIENT_DESCENT_SQERR can only be used with the Ordinal family. AUTO (default) will set the solver based on the given data and other parameters.
-
--  `alpha <algo-params/alpha.html>`__: Specify the regularization distribution between L1 and L2. The default value of alpha is 0 when ``solver = 'L-BFGS'``, otherwise it is 0.5.
-
--  `lambda <algo-params/lambda.html>`__: Specify the regularization strength.
-
--  `lambda_search <algo-params/lambda_search.html>`__: Specify whether to enable lambda search, starting with lambda max (the smallest :math:`\lambda` that drives all coefficients to zero). If you also specify a value for ``lambda_min_ratio``, then this value is interpreted as lambda min. If you do not specify a value for ``lambda_min_ratio``, then GAM will calculate the minimum lambda. This option is defaults to false (not enabled).
-
--  `early_stopping <algo-params/early_stopping.html>`__: Specify whether to stop early when there is no more relative improvement on the training or validation set. This option is defaults to true (enabled).
-
-- `stopping_rounds <algo-params/stopping_rounds.html>`__: Stops training when the option selected for **stopping_metric** doesn't improve for the specified number of training rounds, based on a simple moving average. To disable this feature, specify ``0`` (default). 
+- `stopping_rounds <algo-params/stopping_rounds.html>`__: Stops training when the option selected for ``stopping_metric`` doesn't improve for the specified number of training rounds, based on a simple moving average. To disable this feature, specify ``0`` (default). 
 
     **Note:** If cross-validation is enabled:
   
     - All cross-validation models stop training when the validation metric doesn't improve.
     - The main model runs for the mean number of epochs.
-    - N+1 models may be off by the number specified for **stopping_rounds** from the best model, but the cross-validation metric estimates the performance of the main model for the resulting number of epochs (which may be fewer than the specified number of epochs).
+    - N+1 models may be off by the number specified for ``stopping_rounds`` from the best model, but the cross-validation metric estimates the performance of the main model for the resulting number of epochs (which may be fewer than the specified number of epochs).
 
 - `stopping_metric <algo-params/stopping_metric.html>`__: Specify the metric to use for early stopping. The available options are:
 
-  - ``AUTO``: This defaults to ``logloss`` for classification, ``deviance`` for regression, and ``anomaly_score`` for Isolation Forest. Note that ``custom`` and ``custom_increasing`` can only be used in GBM and DRF with the Python Client. Must be one of: ``AUTO``, ``anomaly_score``. Defaults to ``AUTO``.
-  - ``anomaly_score`` (Isolation Forest only)
-  - ``deviance``
-  - ``logloss``
-  - ``MSE``
-  - ``RMSE``
-  - ``MAE``
-  - ``RMSLE``
-  - ``AUC`` (area under the ROC curve)
-  - ``AUCPR`` (area under the Precision-Recall curve)
-  - ``lift_top_group``
-  - ``misclassification``
-  - ``mean_per_class_error``
-  - ``custom`` (GBM/DRF Python client only)
-  - ``custom_increasing`` (GBM/DRF Python client only)
+    - ``AUTO`` (default): (This defaults to ``logloss`` for classification and ``deviance`` for regression)
+    - ``deviance``
+    - ``logloss``
+    - ``MSE``
+    - ``RMSE``
+    - ``MAE``
+    - ``RMSLE``
+    - ``AUC`` (area under the ROC curve)
+    - ``AUCPR`` (area under the Precision-Recall curve)
+    - ``lift_top_group``
+    - ``misclassification``
+    - ``mean_per_class_error``
 
-- `stopping_tolerance <algo-params/stopping_tolerance.html>`__: Specify the relative tolerance for the metric-based stopping to stop training if the improvement is less than this value. Defaults to ``0.001``.
-   
--  `nlambdas <algo-params/nlambdas.html>`__: (Applicable only if **lambda_search** is enabled) Specify the number of lambdas to use in the search. When ``alpha`` > 0, the default value for ``lambda_min_ratio`` is :math:`1e^{-4}`, then the default value for ``nlambdas`` is 100. This gives a ratio of 0.912. (For best results when using strong rules, keep the ratio close to this default.) When ``alpha=0``, the default value for ``nlamdas`` is set to 30 because fewer lambdas are needed for ridge regression. This value defaults to -1 (disabled).
+- `stopping_tolerance <algo-params/stopping_tolerance.html>`__: Specify the relative tolerance for the metric-based stopping to stop training if the improvement is less than this value. This option defaults to ``0.001``.
 
--  `standardize <algo-params/standardize.html>`__: Specify whether to standardize the numeric columns to have a mean of zero and unit variance. Standardization is highly recommended; if you do not use standardization, the results can include components that are dominated by variables that appear to have larger variances relative to other attributes as a matter of scale, rather than true contribution. This option is defaults to false (not enabled).
+- `max_runtime_secs <algo-params/max_runtime_secs.html>`__: Maximum allowed runtime in seconds for model training. Use ``0`` (default) to disable.
 
--  `missing_values_handling <algo-params/missing_values_handling.html>`__: Specify how to handle missing values (Skip, MeanImputation, or PlugValues). This value defaults to MeanImputation.
+- `auc_type <algo-params/auc_type.html>`__: Set the default multinomial AUC type. Must be one of:
 
--  `plug_values <algo-params/plug_values.html>`__: When ``missing_values_handling="PlugValues"``, specify a single row frame containing values that will be used to impute missing values of the training/validation frame.
-
--  `compute_p_values <algo-params/compute_p_values.html>`__: Request computation of p-values. P-values can be computed with or without regularization. Setting ``remove_collinear_columns`` is recommended. H2O will return an error if p-values are requested and there are collinear columns and ``remove_collinear_columns`` flag is not enabled. Note that this option is not available for ``family="multinomial"`` or ``family="ordinal"``; ``IRLSM`` solver requried. This option defaults to ``False`` (disabled).
-
--  `remove_collinear_columns <algo-params/remove_collinear_columns.html>`__: Specify whether to automatically remove collinear columns during model-building. When enabled, collinear columns will be dropped from the model and will have 0 coefficient in the returned model. This can only be set if there is no regularization (lambda=0). This option is defaults to false (not enabled).
-
--  `intercept <algo-params/intercept.html>`__: Specify whether to include a constant term in the model. This option is defaults to true (enabled).
-
--  `non_negative <algo-params/non_negative.html>`__: Specify whether to force coefficients to have non-negative values. This option is defaults to false (not enabled).
-
--  `max_iterations <algo-params/max_iterations.html>`__: Specify the number of training iterations (defaults to -1, which means unlimited).
-
--  `objective_epsilon <algo-params/objective_epsilon.html>`__: If the objective value is less than this threshold, then the model is converged. By default, this is set to -1 (automatic), which means the following: if ``lambda_search=True``, then this value defaults to .0001. If ``lambda_search=False`` and lambda is equal to zero, then this value defaults to .000001. For any other value of lambda, the default value of objective_epsilon is set to .0001.
-
--  `beta_epsilon <algo-params/beta_epsilon.html>`__: Converge if beta changes less than this value (using L-infinity norm). This only applies to IRLSM solver, and the default value is 0.0001.
-
--  `gradient_epsilon <algo-params/gradient_epsilon.html>`__: (For L-BFGS only) Specify a threshold for convergence. If the objective value (using the L-infinity norm) is less than this threshold, the model is converged. By default this is set ti -1, which means the following: if ``lambda_search=True``, then this value defaults to .0001. If ``lambda_search=False`` and lambda is equal to zero, then this value defaults to .000001. For any other value of lambda, this value defaults to .0001.
-
--  `link <algo-params/link.html>`__: Specify a link function (Identity, Family_Default, Logit, Log, Inverse, Tweedie, or Ologit). The default value is Family_Default.
-
-   -  If the family is **Gaussian**, then **Identity**, **Log**, and **Inverse** are supported.
-   -  If the family is **Binomial**, then **Logit** is supported.
-   -  If the family is **Fractionalbinomial**, then Logit is supported.
-   -  If the family is **Poisson**, then **Log** and **Identity** are supported.
-   -  If the family is **Gamma**, then **Inverse**, **Log**, and **Identity** are supported.
-   -  If the family is **Tweedie**, then only **Tweedie** is supported.
-   -  If the family is **Multinomial**, then only **Family_Default** is supported. (This defaults to ``multinomial``.)
-   -  If the family is **Quasibinomial**, then only **Logit** is supported.
-   -  If the family is **Ordinal**, then only **Ologit** is supported
-   -  If the family is **Negative Binomial**, then only **Log** and **Identity** are supported.
-   - If the family is **AUTO**,
-
-      - and a link is not specified, then the link is determined as **Family_Default** (defaults to the family to which AUTO is determined).
-      - and a link is specified, the link is used so long as the specified link is compatible with the family to which AUTO is determined. Otherwise, an error message is thrown stating that AUTO for underlying data requires a different link and gives a list of possible compatible links.
-      - The list of supported links for ``family = AUTO`` is:
-
-          1. If the response is **Enum** with cardinality = 2, then **Logit** is supported.
-          2. If the response is **Enum** with cardinality > 2, then only **Family_Default** is supported (this defaults to **multinomial**).
-          3. If the response is numeric (**Real** or **Int**), then **Identity**, **Log**, and **Inverse** are suported.
-
--  `prior <algo-params/prior.html>`__: Specify prior probability for p(y==1). Use this parameter for logistic regression if the data has been sampled and the mean of response does not reflect reality. This value must be a value in the range (0,1) or set to -1 (disabled).  This option is set to -1 (disabled) by default.  
-   
-     **Note**: This is a simple method affecting only the intercept. You may want to use weights and offset for a better fit.
-
--  `lambda_min_ratio <algo-params/lambda_min_ratio.html>`__: Specify the minimum lambda to use for lambda search. This is specified as a ratio of **lambda_max**, which is the smallest :math:`\lambda` for which the solution is all zeros. This value defaults to 0.
-
--  `beta_constraints <algo-params/beta_constraints.html>`__: Specify a dataset to use beta constraints. The selected frame is used to constrain the coefficient vector to provide upper and lower bounds. The dataset must contain a names column with valid coefficient names.
-
--  `max_active_predictors <algo-params/max_active_predictors.html>`__: Specify the maximum number of active predictors during computation. This value is used as a stopping criterium to prevent expensive model building with many predictors. This value defaults to -1 (unlimited).
-
--  `interactions <algo-params/interactions.html>`__: Specify a list of predictor column indices to interact. All pairwise combinations will be computed for this list. 
-
--  `interaction_pairs <algo-params/interaction_pairs.html>`__: When defining interactions, use this option to specify a list of pairwise column interactions (interactions between two variables). Note that this is different than ``interactions``, which will compute all pairwise combinations of specified columns.
-
--  **obj_reg**: Specifies the likelihood divider in objective value computation. This defaults to ``1/n`` where ``n`` is the number of observations (rows) in the training set.
-
--  `export_checkpoints_dir <algo-params/export_checkpoints_dir.html>`__: Specify a directory to which generated models will automatically be exported.
-
-- **subspaces**: A list of model parameters that, when in the same subspace list, can vary freely amongst each other. This allows the user to group model parameters that can vary with restrictions. If specified, the following parameters must have the same array dimension:
-  
-  - ``gam_columns``
-  - ``scale``
-  - ``num_knots``
-  - ``bs``
-
-These parameters can be specified as follows:
-
-  .. code-block:: bash
-    
-    hyper_parameters = {
-        'alpha':[0.9, 0.1],
-        ‘subspaces’: [{
-            ‘scale’:[[1,1,1],[0.1, 0.1, 0.1]], 
-            ‘num_knots’:[[4,4,4],[5,5,5]], 
-            ‘gam_columns’:[[“C1”,“C2",“C3”]]
-        }, {
-            ‘scale’:[[1,1],[0.1, 0.1,]], 
-            ‘num_knots’:[[4,4],[5,5]], 
-            ‘gam_columns’:[[“C2",“C3”]]
-        }]
-   }
-
-With this hyperparameter specification, there will be 16 GAM models built.
-
--  **num_knots**: An array that specifies the number of knots for each predictor specified in ``gam_columns``.
-            
--  **knot_ids**: A string array storing frame keys/IDs that contain knot locations. Specify one value for each GAM column specified in ``gam_columns``.
-
--  **gam_columns**: Required. An array of column names representing the smoothing terms used for prediction. GAM will build a smoother for each specified column. 
-
--  **bs**: An array specifying the B-Splines for each GAM predictor. You must include one value for each GAM predictor. This defaults to `0`, which specifies cubic regression spline.
-
--  **scale**: An array specifying the smoothing parameter for GAM. 
-
--  **keep_gam_cols**: Specify whether to save keys storing GAM columns. This option is defaults to false (not enabled).
+    - ``"AUTO"`` (default)
+    - ``"NONE"``
+    - ``"MACRO_OVR"``
+    - ``"WEIGHTED_OVR"``
+    - ``"MACRO_OVO"``
+    - ``"WEIGHTED_OVO"``
 
 .. _scenario1:
 


### PR DESCRIPTION
For: [PUBDEV-9057](https://h2oai.atlassian.net/browse/PUBDEV-9057) (Sub-task of [PUBDEV-8049](https://h2oai.atlassian.net/browse/PUBDEV-8049))
NOTE: This PR cannot be merged until https://github.com/h2oai/h2o-3/pull/6686 is merged.

This PR reorganizes GAM parameters by algorithm-specific and common. It has the removal of shared GLM family parameters which will be localized to the GLM parameter list and linked to from the top of the GAM parameter section.

It also updates the parameter descriptions to help standardize the structure amongst each parameter.

[PUBDEV-9057]: https://h2oai.atlassian.net/browse/PUBDEV-9057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PUBDEV-8049]: https://h2oai.atlassian.net/browse/PUBDEV-8049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ