### PR TITLE
PUBDEV-9078: 3.40.0.4 Release Notes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,7 +11,7 @@ Download at: <a href='http://h2o-release.s3.amazonaws.com/h2o/rel-zz_kurka/4/ind
 
 #### Docs
 - [[PUBDEV-9049]](https://h2oai.atlassian.net/browse/PUBDEV-9049) - Removed mention of support for Python 2.7 and Python 3.5 from documentation.
-- [[PUBDEV-8049]](https://h2oai.atlassian.net/browse/PUBDEV-8049) - Reorganized parameters by algorithm-specific and common and shared-tree (for tree-based algorithms). Updated parameter descriptions for all supervised and unsupervised algorithms. Shifted all shared GLM family parameters to the GLM algorithm page.
+- [[PUBDEV-8049]](https://h2oai.atlassian.net/browse/PUBDEV-8049) - Reorganized supervised and unsupervised algorithm parameters by algorithm-specific, common, and shared-tree (for tree-based algorithms). Updated parameter descriptions for all supervised and unsupervised algorithms. Shifted all shared GLM family parameters to the GLM algorithm page.
 
 #### Security
 - [[PUBDEV-9072]](https://h2oai.atlassian.net/browse/PUBDEV-9072) - Addressed CVE-2023-1370 by removing the vulnerability from h2o-steam.jar.

--- a/Changes.md
+++ b/Changes.md
@@ -2,7 +2,7 @@
 
 ## H2O
 
-### Kurka (3.40.0.4) - 4/XX/2023
+### Kurka (3.40.0.4) - 4/28/2023
 
 Download at: <a href='http://h2o-release.s3.amazonaws.com/h2o/rel-zz_kurka/4/index.html'>http://h2o-release.s3.amazonaws.com/h2o/rel-zz_kurka/4/index.html</a>
 

--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,9 @@ Download at: <a href='http://h2o-release.s3.amazonaws.com/h2o/rel-zz_kurka/4/ind
 #### Bug
 - [[PUBDEV-9050]](https://h2oai.atlassian.net/browse/PUBDEV-9050) - Fixed the deprecation warning thrown for Python 2.7 and 3.5.
 
+#### Improvement
+- [[PUBDEV-9048]](https://h2oai.atlassian.net/browse/PUBDEV-9048) - Added official support for Python 3.9.
+
 #### Docs
 - [[PUBDEV-9049]](https://h2oai.atlassian.net/browse/PUBDEV-9049) - Removed mention of support for Python 2.7 and Python 3.5 from documentation.
 - [[PUBDEV-8049]](https://h2oai.atlassian.net/browse/PUBDEV-8049) - Reorganized supervised and unsupervised algorithm parameters by algorithm-specific, common, and shared-tree (for tree-based algorithms). Updated parameter descriptions for all supervised and unsupervised algorithms. Shifted all shared GLM family parameters to the GLM algorithm page.

--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Download at: <a href='http://h2o-release.s3.amazonaws.com/h2o/rel-zz_kurka/4/ind
 
 #### Docs
 - [[PUBDEV-9049]](https://h2oai.atlassian.net/browse/PUBDEV-9049) - Removed mention of support for Python 2.7 and Python 3.5 from documentation.
+- [[PUBDEV-8049]](https://h2oai.atlassian.net/browse/PUBDEV-8049) - Reorganized parameters by algorithm-specific and common and shared-tree (for tree-based algorithms). Updated parameter descriptions for all supervised and unsupervised algorithms. Shifted all shared GLM family parameters to the GLM algorithm page.
 
 #### Security
 - [[PUBDEV-9072]](https://h2oai.atlassian.net/browse/PUBDEV-9072) - Addressed CVE-2023-1370 by removing the vulnerability from h2o-steam.jar.

--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,19 @@
 
 ## H2O
 
+### Kurka (3.40.0.4) - 4/XX/2023
+
+Download at: <a href='http://h2o-release.s3.amazonaws.com/h2o/rel-zz_kurka/4/index.html'>http://h2o-release.s3.amazonaws.com/h2o/rel-zz_kurka/4/index.html</a>
+
+#### Bug
+- [[PUBDEV-9050]](https://h2oai.atlassian.net/browse/PUBDEV-9050) - Fixed the deprecation warning thrown for Python 2.7 and 3.5.
+
+#### Docs
+- [[PUBDEV-9049]](https://h2oai.atlassian.net/browse/PUBDEV-9049) - Removed mention of support for Python 2.7 and Python 3.5 from documentation.
+
+#### Security
+- [[PUBDEV-9072]](https://h2oai.atlassian.net/browse/PUBDEV-9072) - Addressed CVE-2023-1370 by removing the vulnerability from h2o-steam.jar.
+
 ### Kurka (3.40.0.3) - 4/4/2023
 
 Download at: <a href='http://h2o-release.s3.amazonaws.com/h2o/rel-zz_kurka/3/index.html'>http://h2o-release.s3.amazonaws.com/h2o/rel-zz_kurka/3/index.html</a>


### PR DESCRIPTION
For: [PUBDEV-9078](https://h2oai.atlassian.net/browse/PUBDEV-9078)
With 28 issues done

Excluding:
- PUBDEV-9075 (jenkins update)
- PUBDEV-9079 (nightly build update)
- All 22 subtasks of PUBDEV-8049 (consolidated all those parameter restructure subtask tickets to just the main ticket to prevent release note bloat)



[PUBDEV-9078]: https://h2oai.atlassian.net/browse/PUBDEV-9078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ