### PR TITLE
[PUBDEV-9049] Set 3.42.0.1 back as H2O version removing support for Python 2.7

### DIFF
--- a/h2o-py/h2o/__init__.py
+++ b/h2o-py/h2o/__init__.py
@@ -15,7 +15,7 @@ import warnings
 
 if sys.version_info.major < 3 or (sys.version_info.major == 3 and sys.version_info.minor < 6):
     warnings.showwarning(
-        "Your Python version is %s. The support for this version will be removed in H2O 3.44.0.1." % sys.version,
+        "Your Python version is %s. The support for this version will be removed in H2O 3.42.0.1." % sys.version,
         DeprecationWarning,
         "h2o",
         1)


### PR DESCRIPTION
The release 3.40.1.1 contains version `3.42.0.1`.  The message with `3.44.0.1` has not been released yet.