### PR TITLE
[PUBDEV-9086] Send slack alerts for new GitHub issues

### DIFF
--- a/.github/workflows/slack-alerts.yml
+++ b/.github/workflows/slack-alerts.yml
@@ -1,7 +1,7 @@
 name: Send slack alerts for new GitHub issues
 
 on:
-  issues:
+  issues: # workflow.yml should be placed in the default branch to trigger for issues
     types: [opened]
 
 jobs:

--- a/.github/workflows/slack-alerts.yml
+++ b/.github/workflows/slack-alerts.yml
@@ -12,7 +12,7 @@ jobs:
       id: slack
       uses: slackapi/slack-github-action@v1.23.0
       with:
-        channel-id: 'test-slack-alerts'
+        channel-id: 'github-issues'
         payload: |
           {
             "text": ":github: *H2O-3 GitHub Issue Opened*",

--- a/.github/workflows/slack-alerts.yml
+++ b/.github/workflows/slack-alerts.yml
@@ -1,0 +1,28 @@
+name: Send slack alerts for new GitHub issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  send-slack-alert:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Post to a Slack channel
+      id: slack
+      uses: slackapi/slack-github-action@v1.23.0
+      with:
+        channel-id: 'test-slack-alerts'
+        payload: |
+          {
+            "text": ":github: *H2O-3 GitHub Issue Opened*",
+            "attachments": [
+              {
+                "text": "*Title:* ${{ github.event.issue.title }}\n*Link:* ${{ github.event.issue.html_url }}",
+                "color": "good",
+                "fallback": "Build Alert"
+              }
+            ]
+          }
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
### Description 
Send Slack alerts for new GitHub issues. This requirement was raised as a part of JIRA issues migration
Issue: https://github.com/h2oai/h2o-ops/issues/314 https://github.com/h2oai/h2o-infra/issues/304

Note: channel id is to be updated as per the requirement

