### PR TITLE
[PUBDEV-9080] Upgrade org.codehaus.jettison:jettison in h2o-steam.jar to get rid of vulnerabilities

### DIFF
--- a/h2o-assemblies/steam/build.gradle
+++ b/h2o-assemblies/steam/build.gradle
@@ -66,6 +66,12 @@ dependencies {
         api('net.minidev:json-smart:2.4.10') {
             because 'Fixes CVE-2023-1370'
         }
+        api('org.codehaus.jettison:jettison:1.5.4') {
+            because 'Fixes CVE-2023-1436'
+            because 'Fixes CVE-2022-45693'
+            because 'Fixes CVE-2022-45685'
+            because 'Fixes CVE-2022-40150'
+        }
     }
 }
 


### PR DESCRIPTION
GH issue: https://github.com/h2oai/h2o-3/issues/6827

Affected vulnerabitlities:
- [CVE-2023-1436](https://nvd.nist.gov/vuln/detail/CVE-2023-1436)
- [CVE-2022-45693](https://nvd.nist.gov/vuln/detail/CVE-2022-45693)
- [CVE-2022-45685](https://nvd.nist.gov/vuln/detail/CVE-2022-45685)
- [CVE-2022-40150](https://nvd.nist.gov/vuln/detail/CVE-2022-40150)

State brought by this PR:
```
> Task :h2o-assemblies:steam:dependencyInsight
org.codehaus.jettison:jettison:1.5.4
   variant "runtime" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-runtime
      org.gradle.libraryelements     = jar
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.environment     = standard-jvm
         org.gradle.jvm.version         = 8
   ]
   Selection reasons:
      - By constraint : Fixes CVE-2022-40150
      - By conflict resolution : between versions 1.5.4 and 1.1

org.codehaus.jettison:jettison:1.5.4
\--- runtimeClasspath

org.codehaus.jettison:jettison:1.1 -> 1.5.4
\--- com.github.pjfanning:jersey-json:1.20
     \--- org.apache.hadoop:hadoop-common:3.3.5
          \--- runtimeClasspath
```