### PR TITLE
PUBDEV-8900: Estimate tweedie dispersion parameter, variance power using maximum likelihood.

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/DispersionUtils.java
+++ b/h2o-algos/src/main/java/hex/glm/DispersionUtils.java
@@ -110,6 +110,14 @@ public class DispersionUtils {
                     return dispersionList.get(loglikelihoodList.indexOf(Collections.max(loglikelihoodList)));
                 }
             }
+            if (loglikelihoodList.size() > 10) {
+                if (loglikelihoodList.stream().skip(loglikelihoodList.size() - 3).noneMatch((x) -> x != null && Double.isFinite(x))) {
+                    Log.warn("tweedie dispersion parameter estimation got stuck in numerically unstable region.");
+                    tDispersion.cleanUp();
+                    // If there's NaN Collections.max picks it
+                    return Double.NaN;
+                }
+            }
             // get new update to dispersion
             update = computeTask._dLogLL / computeTask._d2LogLL;
             if (Math.abs(update) < 1e-3) { // line search for speedup and increase magnitude of change

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -2964,7 +2964,11 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
         }
       }
 
-      if (_parms._compute_p_values) { // compute p-values, standard error, estimate dispersion parameters... 
+      // Make sure if we set dispersion for Tweedie p and phi estimation even without calculating p values
+      if (tweedie.equals(_parms._family) && !_parms._fix_dispersion_parameter && !_parms._fix_tweedie_variance_power) {
+        _model.setDispersion(_parms._init_dispersion_parameter, true);
+      }
+      if (_parms._compute_p_values) { // compute p-values, standard error, estimate dispersion parameters...
         double se = _parms._init_dispersion_parameter;
         boolean seEst = false;
         double[] beta = _state.beta();  // standardized if _parms._standardize=true, original otherwise

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -922,8 +922,6 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
         case tweedie:
           if (_nclass != 1) error("_family", H2O.technote(2, "Tweedie requires the response to be numeric."));
           if (ml.equals(_parms._dispersion_parameter_method)) {
-            if (!_parms._fix_dispersion_parameter && !_parms._fix_tweedie_variance_power)
-              throw H2O.unimpl("Estimation of both Tweedie dispersion parameter and Tweedie variance power has not been implemented yet. Please set fix_dispersion_parameter=True.");
             // Check if response contains zeros if so limit variance power to (1,2)
             if (_response.min() <= 0)
               warn("_tweedie_var_power", "Response contains zeros and/or values lower than zero. "+
@@ -1091,6 +1089,10 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
                     "equivalent to the Gamma family.  Please use Gamma family instead.");
           if (_parms._tweedie_epsilon <= 0)
             error("tweedie_epsilon", " must exceed 0.");
+          if (_parms._tweedie_variance_power == 0)
+            // Later Null GLM model can fail if dispersion estimation is on (assert in TweedieEstimator)
+            // This way we make sure it will yield nice error from the model builder (i.e. not an assert error)
+            _parms._tweedie_variance_power = 1.5; 
         }
       }
       
@@ -2266,9 +2268,14 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
             converged = updateNegativeBinomialDispersion(iterCnt, _state.beta(), previousLLH, weights, response) && converged;
             Log.info("GLM negative binomial dispersion estimation: iteration = "+iterCnt+"; theta = " + _parms._theta);
           } else if (tweedie.equals(_parms._family)){
-            if (_parms._fix_dispersion_parameter && ! _parms._fix_tweedie_variance_power) {
-              converged = updateTweedieVariancePower(iterCnt, _state.expandBeta(betaCnd), weights, response) && converged;
-              Log.info("GLM Tweedie variance power estimation: iteration = "+iterCnt+"; p = " + _parms._tweedie_variance_power);
+            if (!_parms._fix_tweedie_variance_power) {
+              if (!_parms._fix_dispersion_parameter) {
+                converged = updateTweediePandPhi(iterCnt, _state.expandBeta(betaCnd), weights, response) && converged;
+                Log.info("GLM Tweedie p and phi estimation: iteration = " + iterCnt + "; p = " + _parms._tweedie_variance_power + "; phi = " + _parms._init_dispersion_parameter);
+              } else {
+                converged = updateTweedieVariancePower(iterCnt, _state.expandBeta(betaCnd), weights, response) && converged;
+                Log.info("GLM Tweedie variance power estimation: iteration = " + iterCnt + "; p = " + _parms._tweedie_variance_power);
+              }
             }
           }
 
@@ -2307,11 +2314,11 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       // Let's assume the var power will be close to the one in last iteration and hopefully save some time 
       if (iterCnt > 1) {
         boolean forceInversion = (originalP > 1.95 && originalP < 2.1);
-        TweedieVariancePowerMLEstimator lo = new TweedieVariancePowerMLEstimator(
+        TweedieEstimator lo = new TweedieEstimator(
                 Math.max(lowerBound, p - 0.01),
                 phi, forceInversion).compute(mu, response, weights);
-        TweedieVariancePowerMLEstimator mid = new TweedieVariancePowerMLEstimator(p, phi, forceInversion).compute(mu, response, weights);
-        TweedieVariancePowerMLEstimator hi = new TweedieVariancePowerMLEstimator(
+        TweedieEstimator mid = new TweedieEstimator(p, phi, forceInversion).compute(mu, response, weights);
+        TweedieEstimator hi = new TweedieEstimator(
                 Math.min(upperBound, p + 0.01), phi, forceInversion).compute(mu, response, weights);
         if (mid._loglikelihood > lo._loglikelihood && !Double.isNaN(lo._loglikelihood) && !Double.isNaN(mid._loglikelihood))
           lowerBound = lo._p;
@@ -2336,8 +2343,8 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
 
       if (upperBound == Double.POSITIVE_INFINITY) {
         // look at p=2 and p=3 (cheap to compute)
-        TweedieVariancePowerMLEstimator tvp2 = new TweedieVariancePowerMLEstimator(2, phi).compute(mu, response, weights);
-        TweedieVariancePowerMLEstimator tvp3 = new TweedieVariancePowerMLEstimator(3, phi).compute(mu, response, weights);
+        TweedieEstimator tvp2 = new TweedieEstimator(2, phi).compute(mu, response, weights);
+        TweedieEstimator tvp3 = new TweedieEstimator(3, phi).compute(mu, response, weights);
         double llhI = tvp3._loglikelihood, llhIm1 = tvp2._loglikelihood;
         // pI == p_i, pIm1 == p_{i-1}, ...
         double pI = 3, pIm1 = 2, pIm2 = lowerBound;
@@ -2359,7 +2366,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
           pIm1 = pI;
           llhIm1 = llhI;
           pI *= 2;
-          TweedieVariancePowerMLEstimator tvp = new TweedieVariancePowerMLEstimator(pI, phi).compute(mu, response, weights);
+          TweedieEstimator tvp = new TweedieEstimator(pI, phi).compute(mu, response, weights);
           llhI = tvp._loglikelihood;
 
           if (bestLLH < llhI && llhI != 0) {
@@ -2377,9 +2384,9 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       for (int i = 0; i < _parms._max_iterations_dispersion; i++) {
         // likelihood, grad, and hess get unstable for the series method near 2, so I'm not using Newton's method for 
         // this region and instead use "hybrid" (series+inversion) likelihood calculation
-        if (d < newtonThreshold && p >= lowerBound && p <= upperBound && newtonFailures < 3 && !(p >= 1.95 && p <= 2.1) && p != 3) {
+        if (d < newtonThreshold && p >= lowerBound && p <= upperBound && newtonFailures < 3 && !(p >= 1.95 && p <= 2.1) && p < 2) {
           // Use Newton's method in bracketed space
-          TweedieVariancePowerMLEstimator tvp = new TweedieVariancePowerMLEstimator(
+          TweedieEstimator tvp = new TweedieEstimator(
                   p,
                   phi,
                   false, true, true, false).compute(mu, response, weights);
@@ -2405,9 +2412,9 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
           d *= 0.618;  // division by golden ratio
           final double lowerBoundProposal = upperBound - d;
           final double upperBoundProposal = lowerBound + d;
-          TweedieVariancePowerMLEstimator lowerEst = new TweedieVariancePowerMLEstimator(
+          TweedieEstimator lowerEst = new TweedieEstimator(
                   lowerBoundProposal, phi, forceInversion).compute(mu, response, weights);
-          TweedieVariancePowerMLEstimator upperEst = new TweedieVariancePowerMLEstimator(
+          TweedieEstimator upperEst = new TweedieEstimator(
                   upperBoundProposal, phi, forceInversion).compute(mu, response, weights);
 
           if (forceInversion)
@@ -2432,7 +2439,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
             converged = true;
             break;
           }
-          if (!Double.isFinite(upperEst._loglikelihood) && !Double.isFinite(lowerEst._loglikelihood) && lowerEst._p < 5) {
+          if (!Double.isFinite(upperEst._loglikelihood) && !Double.isFinite(lowerEst._loglikelihood)) {
             break;
           }
           if (upperEst._loglikelihood == 0 && lowerEst._loglikelihood == 0) {
@@ -2443,6 +2450,162 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       updateTweedieParms(bestP, phi);
       Scope.exit();
       return Math.abs(originalP - bestP) < _parms._dispersion_epsilon && converged;
+    }
+
+    private boolean updateTweediePandPhi(int iterCnt, double[] betaCnd, Vec weights, Vec response) {
+      final double originalP = _parms._tweedie_variance_power;
+      final double originalPhi = _parms._init_dispersion_parameter;
+      final double contractRatio = 0.5;
+      double bestLLH = Double.NEGATIVE_INFINITY, bestP = 1.5, bestPhi = 1, p, phi, centroidP, centroidPhi, diffP, diffPhi, diffInParams, diffInLLH;
+      boolean converged = false;
+      Scope.enter();
+      DispersionTask.GenPrediction gPred = new DispersionTask.GenPrediction(betaCnd, _model, _dinfo).doAll(
+              1, Vec.T_NUM, _dinfo._adaptedFrame);
+      Vec mu = Scope.track(gPred.outputFrame(Key.make(), new String[]{"prediction"}, null)).vec(0);
+      try {
+        // Nelder-Mead
+        TweedieEstimator teTmp, teReflected, teExtended, teContractedIn, teContractedOut;
+        // high likelihood (to be sorted later)
+        TweedieEstimator teHigh = new TweedieEstimator(1.5, 1)
+                .compute(mu, response, weights);
+        // middle likelihood
+        TweedieEstimator teMiddle = new TweedieEstimator(response.min() > 0 ? 3 : 1.75, 0.5)
+                .compute(mu, response, weights);
+        // low likelihood
+        TweedieEstimator teLow = new TweedieEstimator(response.min() > 0 ? 2 : 1.2, 2)
+                .compute(mu, response, weights);
+
+        // 1. Sort
+        if (teLow._loglikelihood > teHigh._loglikelihood) {
+          teTmp = teLow;
+          teLow = teHigh;
+          teHigh = teTmp;
+        }
+        if (teMiddle._loglikelihood > teHigh._loglikelihood) {
+          teTmp = teMiddle;
+          teMiddle = teHigh;
+          teHigh = teTmp;
+        }
+        if (teLow._loglikelihood > teMiddle._loglikelihood) {
+          teTmp = teLow;
+          teLow = teMiddle;
+          teMiddle = teTmp;
+        }
+        for (int i = 0; i < _parms._max_iterations_dispersion; i++) {
+          if (!(Double.isFinite(teLow._loglikelihood) && Double.isFinite(teHigh._loglikelihood)))
+            return false;
+          // 2. Reflect
+          centroidP = (teMiddle._p + teHigh._p) / 2.0;
+          centroidPhi = (teMiddle._phi + teHigh._phi) / 2.0;
+          diffP = centroidP - teLow._p;
+          diffPhi = centroidPhi - teLow._phi;
+          // reflected p and phi
+          p = teLow._p + 2 * diffP;
+          phi = teLow._phi + 2 * diffPhi;
+          p = Math.max(p, 1 + 1e-10);
+          if (response.min() <= 0) p = Math.min(p, 2 - 1e-10);
+          phi = Math.max(phi, 1e-10);
+          teReflected = new TweedieEstimator(p, phi).compute(mu, response, weights);
+
+          if (teReflected._loglikelihood > teMiddle._loglikelihood && teReflected._loglikelihood < teHigh._loglikelihood) {
+            teLow = teReflected;
+          } else if (teReflected._loglikelihood > teHigh._loglikelihood) {
+            // 3. Extend
+            p += diffP;
+            phi += diffPhi;
+            p = Math.max(p, 1 + 1e-10);
+            if (response.min() <= 0) p = Math.min(p, 2 - 1e-10);
+            phi = Math.max(phi, 1e-10);
+
+            if (p == teReflected._p && phi == teReflected._phi)
+              teExtended = teReflected; // if it gets out of bounds don't let it go further
+            else
+              teExtended = new TweedieEstimator(p, phi).compute(mu, response, weights);
+
+            if (teExtended._loglikelihood > teReflected._loglikelihood)
+              teLow = teExtended;
+            else
+              teLow = teReflected;
+          } else {
+            // 4. Contract
+            if (teReflected._loglikelihood < teMiddle._loglikelihood) {
+              // Contract out
+              p = Math.max(teLow._p + (1 + contractRatio) * diffP, 1 + 1e-10);
+              phi = Math.max(teLow._phi + (1 + contractRatio) * diffPhi, 1e-10);
+              teContractedOut = new TweedieEstimator(p, phi).compute(mu, response, weights);
+
+              // Contract in 
+              p = Math.max(teLow._p + (1 - contractRatio) * diffP, 1 + 1e-10);
+              phi = Math.max(teLow._phi + (1 - contractRatio) * diffPhi, 1e-10);
+              teContractedIn = new TweedieEstimator(p, phi).compute(mu, response, weights);
+
+              if (teContractedOut._loglikelihood > teContractedIn._loglikelihood)
+                teTmp = teContractedOut;
+              else
+                teTmp = teContractedIn;
+            } else
+              teTmp = teMiddle;
+
+            if (teTmp._loglikelihood > teMiddle._loglikelihood) {
+              teLow = teTmp;
+            } else {
+              // shrink
+              p = (teLow._p + teHigh._p) / 2;
+              phi = (teLow._phi + teHigh._phi) / 2;
+              teLow = new TweedieEstimator(p, phi).compute(mu, response, weights);
+
+              p = (teMiddle._p + teHigh._p) / 2;
+              phi = (teMiddle._phi + teHigh._phi) / 2;
+              teMiddle = new TweedieEstimator(p, phi).compute(mu, response, weights);
+            }
+          }
+
+          // 1. Sort
+          if (teLow._loglikelihood > teHigh._loglikelihood) {
+            teTmp = teLow;
+            teLow = teHigh;
+            teHigh = teTmp;
+          }
+          if (teMiddle._loglikelihood > teHigh._loglikelihood) {
+            teTmp = teMiddle;
+            teMiddle = teHigh;
+            teHigh = teTmp;
+          }
+          if (teLow._loglikelihood > teMiddle._loglikelihood) {
+            teTmp = teLow;
+            teLow = teMiddle;
+            teMiddle = teTmp;
+          }
+
+          if (bestLLH < teHigh._loglikelihood) {
+            bestLLH = teHigh._loglikelihood;
+            bestP = teHigh._p;
+            bestPhi = teHigh._phi;
+          }
+
+          diffInParams = Math.max(
+                  Math.abs((Math.abs(teHigh._p - teMiddle._p) - Math.abs(teMiddle._p - teLow._p)) / (Math.abs(teHigh._p - teMiddle._p) + Math.abs(teMiddle._p - teLow._p) + _parms._dispersion_epsilon)),
+                  Math.abs((Math.abs(teHigh._phi - teMiddle._phi) - Math.abs(teMiddle._phi - teLow._phi)) / (Math.abs(teHigh._phi - teMiddle._phi) + Math.abs(teMiddle._phi - teLow._phi) + _parms._dispersion_epsilon))
+          );
+          diffInLLH = Math.abs((teMiddle._loglikelihood - teLow._loglikelihood) / (teHigh._loglikelihood + _parms._dispersion_epsilon));
+
+          Log.info("Nelder-Mead dispersion (phi) and variance power (p) estimation: beta iter: " + iterCnt +
+                  "; Nelder-Mead iter: "+i+
+                  "; estimated p: " + bestP + "; estimated phi: " + bestPhi + 
+                  "; log(Likelihood): " + bestLLH + "; diff in params: " + diffInParams + "; diff in LLH: " + diffInLLH +
+                  "; dispersion_epsilon: " + _parms._dispersion_epsilon);
+
+          converged = diffInParams < _parms._dispersion_epsilon && diffInLLH < _parms._dispersion_epsilon;
+          if (converged)
+            break;
+      }
+
+        updateTweedieParms(bestP, bestPhi);
+        
+        return Math.abs(originalP - bestP) < _parms._dispersion_epsilon && Math.abs(originalPhi - bestPhi) < _parms._dispersion_epsilon && converged;
+      } finally {
+        Scope.exit();
+      }
     }
 
     private void updateTweedieParms(double p, double dispersion) {

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -698,7 +698,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
           return -2 * (Math.log(yr / ym) - (yr - ym) / ym);
         case tweedie:
           if (DispersionMethod.ml.equals(_dispersion_parameter_method)) {
-            return TweedieVariancePowerMLEstimator.deviance(yr, ym, _tweedie_variance_power);
+            return TweedieEstimator.deviance(yr, ym, _tweedie_variance_power);
           }
           double theta = _tweedie_variance_power == 1
             ?Math.log(y1/ym)
@@ -723,7 +723,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
                         yr*Math.log(_theta)+yr*Math.log(1+_theta*ym)):
                 ((yr==0 && ym>0)?(_invTheta*Math.log(1+_theta*ym)):0)); // with everything
       }  else if (Family.tweedie.equals(_family) && DispersionMethod.ml.equals(_dispersion_parameter_method) && !_fix_tweedie_variance_power) {
-        return -TweedieVariancePowerMLEstimator.logLikelihood(yr, ym, _tweedie_variance_power, _init_dispersion_parameter);
+        return -TweedieEstimator.logLikelihood(yr, ym, _tweedie_variance_power, _init_dispersion_parameter);
       }  else
         return .5 * deviance(yr,ym);
     }
@@ -963,8 +963,11 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
 
     final NormalDistribution _dprobit = new NormalDistribution(0,1);  // get the normal distribution
     
-    public GLMWeightsFun(GLMParameters parms) {this(parms._family,parms._link, parms._tweedie_variance_power, 
-            parms._tweedie_link_power, parms._theta, parms._init_dispersion_parameter, GLMParameters.DispersionMethod.ml.equals(parms._dispersion_parameter_method) && !parms._fix_tweedie_variance_power);}
+    public GLMWeightsFun(GLMParameters parms) {
+      this(parms._family,parms._link, parms._tweedie_variance_power,
+              parms._tweedie_link_power, parms._theta, parms._init_dispersion_parameter,
+              GLMParameters.DispersionMethod.ml.equals(parms._dispersion_parameter_method) && !parms._fix_tweedie_variance_power);
+    }
 
     public GLMWeightsFun(Family fam, Link link, double var_power, double link_power, double theta, double dispersion, boolean varPowerEstimation) {
       _family = fam;
@@ -1150,7 +1153,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
           return -2 * (Math.log(yr / ym) - (yr - ym) / ym);
         case tweedie:
           if (_varPowerEstimation)
-            return TweedieVariancePowerMLEstimator.deviance(yr, ym, _var_power);
+            return TweedieEstimator.deviance(yr, ym, _var_power);
           double val;
           if (_var_power==1) {
             val = yr*Math.log(y1/ym)-(yr-ym);
@@ -1230,7 +1233,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
           return -2 * (Math.log(yr / ym) - (yr - ym) / ym);
         case tweedie:
           if (_varPowerEstimation)
-            return -TweedieVariancePowerMLEstimator.logLikelihood(yr, ym, _var_power, _dispersion);
+            return -TweedieEstimator.logLikelihood(yr, ym, _var_power, _dispersion);
          //  we ignore the a(y,phi,p) term in the likelihood calculation here since we are not optimizing over them
           double temp = 0;
           if (_var_power==1) {

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -1417,9 +1417,14 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
 
   public void setZValues(double [] zValues, double dispersion, boolean dispersionEstimated) {
     _output._zvalues = zValues;
-    _output._dispersion = dispersion;
-    _output._dispersionEstimated = dispersionEstimated;
+    setDispersion(dispersion, dispersionEstimated);
   }
+  
+  public void setDispersion(double dispersion, boolean dispersionEstimated) {
+    _output._dispersion = dispersion;
+    _output._dispersionEstimated = dispersionEstimated; 
+  }
+  
   public static class GLMOutput extends Model.Output {
     Submodel[] _submodels = new Submodel[0];
     DataInfo _dinfo;

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -767,7 +767,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
           return w * invPhiEst * log(w * yr * invPhiEst / prediction) - w * yr * invPhiEst / prediction 
                   - log(yr) - Gamma.logGamma(w * invPhiEst);
         case tweedie:
-          return -TweedieVariancePowerMLEstimator.logLikelihood(yr, ym[0], _tweedie_variance_power, _init_dispersion_parameter);
+          return -TweedieEstimator.logLikelihood(yr, ym[0], _tweedie_variance_power, _init_dispersion_parameter);
         case multinomial:
           // if probability is not given, then it is 1.0 if prediction equals to the real y and 0 othervice
           double predictedProbabilityOfActualClass = ym.length > 1 ? ym[(int) yr + 1] : (prediction == yr ? 1.0 : 0.0);

--- a/h2o-algos/src/test/java/hex/glm/GLMTweediePowerEstimationTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMTweediePowerEstimationTest.java
@@ -2003,11 +2003,11 @@ public class GLMTweediePowerEstimationTest extends TestUtil {
                 -264.904735165081, -41.9320737200906, -12.5092249292647
         };
 
-        TweedieVariancePowerMLEstimator tvp = null, tvpDp = null;
+        TweedieEstimator tvp = null, tvpDp = null;
         for (double p : ps) {
             for (double phi : phis) {
-                tvp = new TweedieVariancePowerMLEstimator(p, phi, false, false, false, false);
-                tvpDp = new TweedieVariancePowerMLEstimator(p, phi, false, true, true, false); // should have higher precision
+                tvp = new TweedieEstimator(p, phi, false, false, false, false);
+                tvpDp = new TweedieEstimator(p, phi, false, true, true, false); // should have higher precision
                 for (double y : ys) {
                     for (double mu : mus) {
                         final double actual = tvp.logLikelihood(y, mu);
@@ -3173,12 +3173,12 @@ public class GLMTweediePowerEstimationTest extends TestUtil {
                 Double.NEGATIVE_INFINITY, -20.1078694130054, -20.0714568560393, -20.0662737156024,
                 -20.0662637814756};
 
-        TweedieVariancePowerMLEstimator tvp = null, tvpDp = null;
+        TweedieEstimator tvp = null, tvpDp = null;
         for (double p : ps) {
             for (double phi : phis) {
                 boolean forceInversion = p > 1.95 && p < 2.1;
-                tvp = new TweedieVariancePowerMLEstimator(p, phi, false, false, false, forceInversion);
-                tvpDp = new TweedieVariancePowerMLEstimator(p, phi, false, true, true, false); // should have higher precision
+                tvp = new TweedieEstimator(p, phi, false, false, false, forceInversion);
+                tvpDp = new TweedieEstimator(p, phi, false, true, true, false); // should have higher precision
                 for (double y : ys) {
                     for (double mu : mus) {
                         final double actual = tvp.logLikelihood(y, mu);

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -1054,7 +1054,7 @@ class ModelBase(h2o_meta(Keyed, H2ODisplay)):
         """
         tm = ModelBase._get_metrics(self, train, valid, xval)
         m = {}
-        for k, v in viewitems(tm): m[k] = None if v is None else v.loglikelihood()
+        for k, v in tm.items(): m[k] = None if v is None else v.loglikelihood()
         return list(m.values())[0] if len(m) == 1 else m
 
     def gini(self, train=False, valid=False, xval=False):

--- a/h2o-py/tests/testdir_algos/glm/pyunit_tweedie_p_and_phi_ml_estimation.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_tweedie_p_and_phi_ml_estimation.py
@@ -22,7 +22,8 @@ def test_tweedie_p_and_phi_estimation_1p2_phi_2_no_link_power_est():
     # Estimate from R tweedie.profile (using p with step 0.001; but different link power (R didn't converge with the same as in h2o)): p= 1.195102 ;  phi= 2.032903 
     assert abs(model_ml.actual_params["tweedie_variance_power"] - 1.19325) < 0.001
     assert abs(model_ml.actual_params["init_dispersion_parameter"] - 2.01912) < 0.001
-    assert abs(model_ml.actual_params["init_dispersion_parameter"] - model_ml._model_json["output"]["dispersion"]) <1e-16
+    assert abs(
+        model_ml.actual_params["init_dispersion_parameter"] - model_ml._model_json["output"]["dispersion"]) < 1e-16
 
 
 def test_tweedie_p_and_phi_estimation_1_8_no_link_power_est():
@@ -32,7 +33,7 @@ def test_tweedie_p_and_phi_estimation_1_8_no_link_power_est():
     x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
     model_ml = H2OGeneralizedLinearEstimator(family='tweedie', fix_dispersion_parameter=False,
                                              fix_tweedie_variance_power=False,
-                                             tweedie_variance_power=1.8, dispersion_learning_rate=1,
+                                             tweedie_variance_power=1.8,
                                              lambda_=0, compute_p_values=False,
                                              dispersion_parameter_method="ml", init_dispersion_parameter=2,
                                              max_iterations_dispersion=1000)
@@ -43,7 +44,8 @@ def test_tweedie_p_and_phi_estimation_1_8_no_link_power_est():
     # Estimate from R tweedie.profile (using p with step 0.001; but different link power (R didn't converge with the same as in h2o)): p= 1.798571 ;  phi= 1.994105 
     assert abs(model_ml.actual_params["tweedie_variance_power"] - 1.7981745663886501) < 0.001
     assert abs(model_ml.actual_params["init_dispersion_parameter"] - 1.9890117211840974) < 0.001
-    assert abs(model_ml.actual_params["init_dispersion_parameter"] - model_ml._model_json["output"]["dispersion"]) <1e-16
+    assert abs(
+        model_ml.actual_params["init_dispersion_parameter"] - model_ml._model_json["output"]["dispersion"]) < 1e-16
 
 
 def test_tweedie_p_and_phi_estimation_2p1_disp2_est():
@@ -62,7 +64,8 @@ def test_tweedie_p_and_phi_estimation_2p1_disp2_est():
     # Estimate from R tweedie.profile: p= 2.163265 ;  phi= 2.62834 
     assert abs(model_ml.actual_params["tweedie_variance_power"] - 2.1632) < 2e-4
     assert abs(model_ml.actual_params["init_dispersion_parameter"] - 2.62834) < 2e-4
-    assert abs(model_ml.actual_params["init_dispersion_parameter"] - model_ml._model_json["output"]["dispersion"]) <1e-16
+    assert abs(
+        model_ml.actual_params["init_dispersion_parameter"] - model_ml._model_json["output"]["dispersion"]) < 1e-16
 
 
 def measure_time(t):
@@ -77,7 +80,7 @@ def measure_time(t):
 
 
 pyunit_utils.run_tests([
-    test_tweedie_p_and_phi_estimation_1p2_phi_2_no_link_power_est,  # 8.461037509999999s
-    test_tweedie_p_and_phi_estimation_1_8_no_link_power_est,  # 452.663033281s
-    test_tweedie_p_and_phi_estimation_2p1_disp2_est,  # 127.51284229400001s 
+    test_tweedie_p_and_phi_estimation_1p2_phi_2_no_link_power_est,  # 8.461037509999999s -> 7.163699680999999s
+    test_tweedie_p_and_phi_estimation_1_8_no_link_power_est,  # 452.663033281s ->  10.295818489000002s
+    test_tweedie_p_and_phi_estimation_2p1_disp2_est,  # 127.51284229400001s -> 113.20302847699999s
 ])

--- a/h2o-py/tests/testdir_algos/glm/pyunit_tweedie_p_and_phi_ml_estimation.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_tweedie_p_and_phi_ml_estimation.py
@@ -1,0 +1,80 @@
+import sys
+
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+
+
+def test_tweedie_p_and_phi_estimation_1p2_phi_2_no_link_power_est():
+    training_data = h2o.import_file(pyunit_utils.locate("smalldata/glm_test/tweedie_p1p2_phi2_5Cols_10KRows.csv"))
+    Y = 'resp'
+    x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
+    model_ml = H2OGeneralizedLinearEstimator(family='tweedie', fix_dispersion_parameter=False,
+                                             fix_tweedie_variance_power=False,
+                                             tweedie_variance_power=1.5,
+                                             lambda_=0, compute_p_values=False,
+                                             dispersion_parameter_method="ml", seed=12345)
+    model_ml.train(training_frame=training_data, x=x, y=Y)
+    print("p = 1.2, phi = 2 converged to p =", model_ml.actual_params["tweedie_variance_power"], "; phi =",
+          model_ml.actual_params["init_dispersion_parameter"])
+    # p = 1.2, phi = 2 converged to p = 1.1932493756749825 ; phi = 2.0191183402978257
+    # Estimate from R tweedie.profile (using p with step 0.001; but different link power (R didn't converge with the same as in h2o)): p= 1.195102 ;  phi= 2.032903 
+    assert abs(model_ml.actual_params["tweedie_variance_power"] - 1.19325) < 0.001
+    assert abs(model_ml.actual_params["init_dispersion_parameter"] - 2.01912) < 0.001
+
+
+def test_tweedie_p_and_phi_estimation_1_8_no_link_power_est():
+    training_data = h2o.import_file(
+        pyunit_utils.locate("smalldata/glm_test/tweedie_1p8Power_2Dispersion_5Col_10KRows.csv"))
+    Y = 'resp'
+    x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
+    model_ml = H2OGeneralizedLinearEstimator(family='tweedie', fix_dispersion_parameter=False,
+                                             fix_tweedie_variance_power=False,
+                                             tweedie_variance_power=1.8, dispersion_learning_rate=1,
+                                             lambda_=0, compute_p_values=False,
+                                             dispersion_parameter_method="ml", init_dispersion_parameter=2,
+                                             max_iterations_dispersion=1000)
+    model_ml.train(training_frame=training_data, x=x, y=Y)
+    print("p = 1.8, phi = 2 converged to p =", model_ml.actual_params["tweedie_variance_power"], "; phi =",
+          model_ml.actual_params["init_dispersion_parameter"])
+    # p = 1.8, phi = 2 converged to p = 1.7981745663886501 ; phi = 1.9890117211840974
+    # Estimate from R tweedie.profile (using p with step 0.001; but different link power (R didn't converge with the same as in h2o)): p= 1.798571 ;  phi= 1.994105 
+    assert abs(model_ml.actual_params["tweedie_variance_power"] - 1.7981745663886501) < 0.001
+    assert abs(model_ml.actual_params["init_dispersion_parameter"] - 1.9890117211840974) < 0.001
+
+
+def test_tweedie_p_and_phi_estimation_2p1_disp2_est():
+    training_data = h2o.import_file(
+        pyunit_utils.locate("smalldata/glm_test/tweedie_p2p1_disp3_5Cols_10kRows_est1p89.csv"))
+    Y = 'resp'
+    x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
+    training_data = training_data[training_data[Y] > 0, :]
+    model_ml = H2OGeneralizedLinearEstimator(family='tweedie', fix_dispersion_parameter=False,
+                                             fix_tweedie_variance_power=False,
+                                             lambda_=0, compute_p_values=False, tweedie_variance_power=1.5,
+                                             dispersion_parameter_method="ml", seed=12345)
+    model_ml.train(training_frame=training_data, x=x, y=Y)
+    print("p = 2.1, phi = 2 converged to p =", model_ml.actual_params["tweedie_variance_power"], "; phi =",
+          model_ml.actual_params["init_dispersion_parameter"])
+    # Estimate from R tweedie.profile: p= 2.163265 ;  phi= 2.62834 
+    assert abs(model_ml.actual_params["tweedie_variance_power"] - 2.1632) < 2e-4
+    assert abs(model_ml.actual_params["init_dispersion_parameter"] - 2.62834) < 2e-4
+
+
+def measure_time(t):
+    def _():
+        import time
+        start = time.monotonic()
+        t()
+        print(f"The {t.__name__} took {time.monotonic() - start}s")
+
+    _.__name__ = t.__name__
+    return _
+
+
+pyunit_utils.run_tests([
+    test_tweedie_p_and_phi_estimation_1p2_phi_2_no_link_power_est,  # 8.461037509999999s
+    test_tweedie_p_and_phi_estimation_1_8_no_link_power_est,  # 452.663033281s
+    test_tweedie_p_and_phi_estimation_2p1_disp2_est,  # 127.51284229400001s 
+])

--- a/h2o-py/tests/testdir_algos/glm/pyunit_tweedie_p_and_phi_ml_estimation.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_tweedie_p_and_phi_ml_estimation.py
@@ -22,6 +22,7 @@ def test_tweedie_p_and_phi_estimation_1p2_phi_2_no_link_power_est():
     # Estimate from R tweedie.profile (using p with step 0.001; but different link power (R didn't converge with the same as in h2o)): p= 1.195102 ;  phi= 2.032903 
     assert abs(model_ml.actual_params["tweedie_variance_power"] - 1.19325) < 0.001
     assert abs(model_ml.actual_params["init_dispersion_parameter"] - 2.01912) < 0.001
+    assert abs(model_ml.actual_params["init_dispersion_parameter"] - model_ml._model_json["output"]["dispersion"]) <1e-16
 
 
 def test_tweedie_p_and_phi_estimation_1_8_no_link_power_est():
@@ -42,6 +43,7 @@ def test_tweedie_p_and_phi_estimation_1_8_no_link_power_est():
     # Estimate from R tweedie.profile (using p with step 0.001; but different link power (R didn't converge with the same as in h2o)): p= 1.798571 ;  phi= 1.994105 
     assert abs(model_ml.actual_params["tweedie_variance_power"] - 1.7981745663886501) < 0.001
     assert abs(model_ml.actual_params["init_dispersion_parameter"] - 1.9890117211840974) < 0.001
+    assert abs(model_ml.actual_params["init_dispersion_parameter"] - model_ml._model_json["output"]["dispersion"]) <1e-16
 
 
 def test_tweedie_p_and_phi_estimation_2p1_disp2_est():
@@ -60,6 +62,7 @@ def test_tweedie_p_and_phi_estimation_2p1_disp2_est():
     # Estimate from R tweedie.profile: p= 2.163265 ;  phi= 2.62834 
     assert abs(model_ml.actual_params["tweedie_variance_power"] - 2.1632) < 2e-4
     assert abs(model_ml.actual_params["init_dispersion_parameter"] - 2.62834) < 2e-4
+    assert abs(model_ml.actual_params["init_dispersion_parameter"] - model_ml._model_json["output"]["dispersion"]) <1e-16
 
 
 def measure_time(t):

--- a/h2o-py/tests/testdir_algos/glm/pyunit_tweedie_p_and_phi_ml_estimation_large.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_tweedie_p_and_phi_ml_estimation_large.py
@@ -160,15 +160,15 @@ def measure_time(t):
 def run_random_test():
     import random
     tests = [
-        test_tweedie_p_and_phi_estimation_2p6_disp2_est,  # 1547.11469818s
-        test_tweedie_p_and_phi_estimation_2p5_phi_2p5_no_link_power_est,  # 1700.5806319029998s
-        test_tweedie_p_and_phi_estimation_3_phi_0p5_no_link_power_est,  # 2992.1222389420004s
-        test_tweedie_p_and_phi_estimation_3_no_link_power_est,  # 2969.200690304s
-        test_tweedie_p_and_phi_estimation_3_phi_1p5_no_link_power_est,  # 1295.719605385002s
-        test_tweedie_p_and_phi_estimation_5_no_link_power_est,  # 2117.0419905989984s
-        test_tweedie_p_and_phi_estimation_5_phi_0p5_no_link_power_est,  # 2783.940797473999s
+        test_tweedie_p_and_phi_estimation_2p6_disp2_est,  # 1547.11469818s -> 1418.9195188410001s -> 613.7193842849999s
+        test_tweedie_p_and_phi_estimation_2p5_phi_2p5_no_link_power_est,  # 1700.5806319029998s -> 1537.708712792s -> 752.2378191370001s
+        test_tweedie_p_and_phi_estimation_3_phi_0p5_no_link_power_est,  # 2992.1222389420004s ->  2801.2481954240006s -> 1314.5836838070002s
+        test_tweedie_p_and_phi_estimation_3_no_link_power_est,  # 2969.200690304s ->  3250.5404198899987s ->  1438.913372169s
+        test_tweedie_p_and_phi_estimation_3_phi_1p5_no_link_power_est,  # 1295.719605385002s -> 1491.1029589709997s -> 789.1963182149993s
+        test_tweedie_p_and_phi_estimation_5_no_link_power_est,  # 2117.0419905989984s -> 2520.0094414819996s -> 1221.1567296999992s
+        test_tweedie_p_and_phi_estimation_5_phi_0p5_no_link_power_est,  # 2783.940797473999s -> 2976.205751714s -> 1513.149319389s
     ]
-    return random.choices(tests, weights=[1295.0 / w for w in [1547, 1700, 2992, 2969, 1295, 2117, 2783]])
+    return [random.choice(tests)]
 
 
 pyunit_utils.run_tests(run_random_test())

--- a/h2o-py/tests/testdir_algos/glm/pyunit_tweedie_p_and_phi_ml_estimation_large.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_tweedie_p_and_phi_ml_estimation_large.py
@@ -1,0 +1,174 @@
+import sys
+
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+
+
+def test_tweedie_p_and_phi_estimation_2p6_disp2_est():
+    training_data = h2o.import_file(
+        pyunit_utils.locate("bigdata/laptop/glm_test/tweedie_p2p6_disp2_5Cols_10krows_est1p94.csv"))
+    Y = 'resp'
+    x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
+    training_data = training_data[training_data[Y] > 0, :]
+    trueDisp = 2.6
+    model_ml = H2OGeneralizedLinearEstimator(family='tweedie', fix_dispersion_parameter=False,
+                                             fix_tweedie_variance_power=False,
+                                             tweedie_variance_power=trueDisp,
+                                             lambda_=0, compute_p_values=False,
+                                             init_dispersion_parameter=2.0,
+                                             dispersion_parameter_method="ml", seed=12345)
+    model_ml.train(training_frame=training_data, x=x, y=Y)
+    print("p = 2.6, phi = 2 converged to p =", model_ml.actual_params["tweedie_variance_power"], "; phi =",
+          model_ml.actual_params["init_dispersion_parameter"])
+    # p = 2.6, phi = 2 converged to p = 2.6724208506680243 ; phi = 1.9585751651721317
+    # Estimate from R tweedie.profile (using p with step 0.001): p= 2.671429 ;  phi= 1.958288 
+    assert abs(model_ml.actual_params["tweedie_variance_power"] - 2.6724) < 2e-4
+    assert abs(model_ml.actual_params["init_dispersion_parameter"] - 1.9585) < 2e-4
+
+
+def test_tweedie_p_and_phi_estimation_3_no_link_power_est():
+    training_data = h2o.import_file(pyunit_utils.locate("bigdata/laptop/glm_test/tweedie_p3_phi1_10KRows.csv"))
+    Y = 'x'
+    x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
+    training_data = training_data[training_data[Y] > 0, :]
+    model_ml = H2OGeneralizedLinearEstimator(family='tweedie', fix_dispersion_parameter=False,
+                                             fix_tweedie_variance_power=False,
+                                             tweedie_variance_power=2.5,
+                                             lambda_=0, compute_p_values=False,
+                                             dispersion_parameter_method="ml", seed=12345)
+    model_ml.train(training_frame=training_data, x=x, y=Y)
+    print("p = 3, phi = 1 converged to p =", model_ml.actual_params["tweedie_variance_power"], "; phi =",
+          model_ml.actual_params["init_dispersion_parameter"])
+    # p = 3, phi = 1 converged to p = 2.9892180905617645 ; phi = 0.9918345933463155
+    # Estimate from R tweedie.profile (using p with step 0.001): p= 2.988776 ;  phi= 0.991949
+    assert abs(model_ml.actual_params["tweedie_variance_power"] - 2.98921) < 2e-4
+    assert abs(model_ml.actual_params["init_dispersion_parameter"] - 0.9918) < 2e-4
+
+
+def test_tweedie_p_and_phi_estimation_5_no_link_power_est():
+    training_data = h2o.import_file(pyunit_utils.locate("bigdata/laptop/glm_test/tweedie_p5_phi1_10KRows.csv"))
+    Y = 'x'
+    x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
+    training_data = training_data[training_data[Y] > 0, :]
+
+    model_ml = H2OGeneralizedLinearEstimator(family='tweedie', fix_dispersion_parameter=False,
+                                             fix_tweedie_variance_power=False,
+                                             tweedie_variance_power=1.5,
+                                             lambda_=0, compute_p_values=False,
+                                             dispersion_parameter_method="ml", seed=12345)
+    model_ml.train(training_frame=training_data, x=x, y=Y)
+    print("p = 5, phi = 1 converged to p =", model_ml.actual_params["tweedie_variance_power"], "; phi =",
+          model_ml.actual_params["init_dispersion_parameter"])
+    # p = 5, phi = 1 converged to p = 5.027117009572835 ; phi = 1.0103477213453012
+    # Estimate from R tweedie.profile (using p with step 0.001): p= 5.027143 ;  phi= 1.010372 
+    assert abs(model_ml.actual_params["tweedie_variance_power"] - 5.02711) < 2e-4
+    assert abs(model_ml.actual_params["init_dispersion_parameter"] - 1.01034) < 2e-4
+
+
+def test_tweedie_p_and_phi_estimation_5_phi_0p5_no_link_power_est():
+    training_data = h2o.import_file(pyunit_utils.locate("bigdata/laptop/glm_test/tweedie_p5_phi0p5_10KRows.csv"))
+    Y = 'x'
+    x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
+    training_data = training_data[training_data[Y] > 0, :]
+
+    model_ml = H2OGeneralizedLinearEstimator(family='tweedie', fix_dispersion_parameter=False,
+                                             fix_tweedie_variance_power=False,
+                                             tweedie_variance_power=1.5, init_dispersion_parameter=0.5,
+                                             lambda_=0, compute_p_values=False,
+                                             dispersion_parameter_method="ml", seed=12345)
+    model_ml.train(training_frame=training_data, x=x, y=Y)
+    print("p = 5, phi = 0.5 converged to p =", model_ml.actual_params["tweedie_variance_power"], "; phi =",
+          model_ml.actual_params["init_dispersion_parameter"])
+    # p = 5, phi = 0.5 converged to p = 4.9431171179656594 ; phi = 0.4880765893343399
+    # Estimate from R tweedie.profile (using p with step 0.001): p= 4.943061 ;  phi= 0.4880817 
+    assert abs(model_ml.actual_params["tweedie_variance_power"] - 4.94311) < 2e-4
+    assert abs(model_ml.actual_params["init_dispersion_parameter"] - 0.488076) < 2e-4
+
+
+def test_tweedie_p_and_phi_estimation_3_phi_1p5_no_link_power_est():
+    training_data = h2o.import_file(pyunit_utils.locate("bigdata/laptop/glm_test/tweedie_p3_phi1p5_10KRows.csv"))
+    Y = 'x'
+    x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
+    training_data = training_data[training_data[Y] > 0, :]
+    model_ml = H2OGeneralizedLinearEstimator(family='tweedie', fix_dispersion_parameter=False,
+                                             fix_tweedie_variance_power=False,
+                                             tweedie_variance_power=1.5, init_dispersion_parameter=1.5,
+                                             lambda_=0, compute_p_values=False,
+                                             dispersion_parameter_method="ml", seed=12345)
+    model_ml.train(training_frame=training_data, x=x, y=Y)
+    print("p = 3, phi = 1.5 converged to p =", model_ml.actual_params["tweedie_variance_power"], "; phi =",
+          model_ml.actual_params["init_dispersion_parameter"])
+    # p = 3, phi = 1.5 converged to p = 2.9970294935158193 ; phi = 1.481355462371787
+    # Estimate from R tweedie.profile (using p with step 0.001): p= 2.996939 ;  phi= 1.481323 
+    assert abs(model_ml.actual_params["tweedie_variance_power"] - 2.9970) < 2e-4
+    assert abs(model_ml.actual_params["init_dispersion_parameter"] - 1.481355) < 2e-4
+
+
+def test_tweedie_p_and_phi_estimation_3_phi_0p5_no_link_power_est():
+    training_data = h2o.import_file(pyunit_utils.locate("bigdata/laptop/glm_test/tweedie_p3_phi0p5_10KRows.csv"))
+    Y = 'x'
+    x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
+    training_data = training_data[training_data[Y] > 0, :]
+    model_ml = H2OGeneralizedLinearEstimator(family='tweedie', fix_dispersion_parameter=False,
+                                             fix_tweedie_variance_power=False,
+                                             tweedie_variance_power=1.5, init_dispersion_parameter=0.5,
+                                             lambda_=0, compute_p_values=False,
+                                             dispersion_parameter_method="ml", seed=12345)
+    model_ml.train(training_frame=training_data, x=x, y=Y)
+    print("p = 3, phi = 0.5 converged to p =", model_ml.actual_params["tweedie_variance_power"], "; phi =",
+          model_ml.actual_params["init_dispersion_parameter"])
+    # p = 3, phi = 0.5 converged to p = 3.003833130003513 ; phi = 0.5021598824912168
+    # Estimate from R tweedie.profile (using p with step 0.001): p= 3.003061 ;  phi= 0.502445 
+    assert abs(model_ml.actual_params["tweedie_variance_power"] - 3.0038) < 2e-4
+    assert abs(model_ml.actual_params["init_dispersion_parameter"] - 0.50215) < 2e-4
+
+
+def test_tweedie_p_and_phi_estimation_2p5_phi_2p5_no_link_power_est():
+    training_data = h2o.import_file(
+        pyunit_utils.locate("bigdata/laptop/glm_test/tweedie_p2p5_phi2p5_5Cols_10KRows.csv"))
+    Y = 'resp'
+    x = ['abs.C1.', 'abs.C2.', 'abs.C3.', 'abs.C4.', 'abs.C5.']
+    training_data = training_data[training_data[Y] > 0, :]
+
+    model_ml = H2OGeneralizedLinearEstimator(family='tweedie', fix_dispersion_parameter=False,
+                                             fix_tweedie_variance_power=False,
+                                             tweedie_variance_power=1.5, init_dispersion_parameter=2.5,
+                                             lambda_=0, compute_p_values=False,
+                                             dispersion_parameter_method="ml", seed=12345)
+    model_ml.train(training_frame=training_data, x=x, y=Y)
+    print("p = 2.5, phi = 2.5 converged to p =", model_ml.actual_params["tweedie_variance_power"], "; phi =",
+          model_ml.actual_params["init_dispersion_parameter"])
+    # p = 2.5, phi = 2.5 converged to p = 2.5928359533723895 ; phi = 2.6301240916926067
+    # Estimate from R tweedie.profile (using p with step 0.001): p= 2.589796 ;  phi= 2.618605 
+    assert abs(model_ml.actual_params["tweedie_variance_power"] - 2.592835) < 2e-4
+    assert abs(model_ml.actual_params["init_dispersion_parameter"] - 2.63012) < 2e-4
+
+
+def measure_time(t):
+    def _():
+        import time
+        start = time.monotonic()
+        t()
+        print(f"The {t.__name__} took {time.monotonic() - start}s")
+
+    _.__name__ = t.__name__
+    return _
+
+
+def run_random_test():
+    import random
+    tests = [
+        test_tweedie_p_and_phi_estimation_2p6_disp2_est,  # 1547.11469818s
+        test_tweedie_p_and_phi_estimation_2p5_phi_2p5_no_link_power_est,  # 1700.5806319029998s
+        test_tweedie_p_and_phi_estimation_3_phi_0p5_no_link_power_est,  # 2992.1222389420004s
+        test_tweedie_p_and_phi_estimation_3_no_link_power_est,  # 2969.200690304s
+        test_tweedie_p_and_phi_estimation_3_phi_1p5_no_link_power_est,  # 1295.719605385002s
+        test_tweedie_p_and_phi_estimation_5_no_link_power_est,  # 2117.0419905989984s
+        test_tweedie_p_and_phi_estimation_5_phi_0p5_no_link_power_est,  # 2783.940797473999s
+    ]
+    return random.choices(tests, weights=[1295.0 / w for w in [1547, 1700, 2992, 2969, 1295, 2117, 2783]])
+
+
+pyunit_utils.run_tests(run_random_test())

--- a/h2o-py/tests/testdir_algos/glm/pyunit_tweedie_variance_power_ml_estimation_large.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_tweedie_variance_power_ml_estimation_large.py
@@ -164,7 +164,7 @@ def test_tweedie_var_power_estimation_2p1_disp2_est():
                                              dispersion_parameter_method="ml", seed=12345)
     model_ml.train(training_frame=training_data, x=x, y=Y)
     print("estimated variance power: {0}, true variance power: {1}".format(model_ml.actual_params["tweedie_variance_power"], trueDisp))
-    assert abs(model_ml.actual_params["tweedie_variance_power"] - 2.144064040064248) < 1e-6
+    assert abs(model_ml.actual_params["tweedie_variance_power"] - 2.144064040064248) < 2e-4
 
 
 def test_tweedie_var_power_estimation_2p6_disp2_est():
@@ -180,22 +180,32 @@ def test_tweedie_var_power_estimation_2p6_disp2_est():
                                              dispersion_parameter_method="ml", seed=12345)
     model_ml.train(training_frame=training_data, x=x, y=Y)
     print("estimated variance power: {0}, true variance power: {1}".format(model_ml.actual_params["tweedie_variance_power"], trueDisp))
-    assert abs(model_ml.actual_params["tweedie_variance_power"] - 2.67437207518084) < 1e-6
+    assert abs(model_ml.actual_params["tweedie_variance_power"] - 2.67437207518084) < 2e-4
 
+
+def measure_time(t):
+    def _():
+        import time
+        start = time.monotonic()
+        t()
+        print(f"The test {t.__name__} took {time.monotonic()-start}s")
+    _.__name__ = t.__name__
+    return _
 
 def run_random_test():
     import random
     tests = [
-        test_tweedie_var_power_estimation_2p1_disp2_est,  # takes 531s
-        test_tweedie_var_power_estimation_2p6_disp2_est,  # takes 1034s
-        test_tweedie_var_power_estimation_2p5_phi_2p5_no_link_power_est,  # takes 1968s
-        test_tweedie_var_power_estimation_3_phi_0p5_no_link_power_est,  # takes 1185s
-        test_tweedie_var_power_estimation_3_no_link_power_est,  # takes 2654s
-        test_tweedie_var_power_estimation_3_phi_1p5_no_link_power_est,  # takes 2309s
-        test_tweedie_var_power_estimation_5_no_link_power_est,  # takes 830s
-        test_tweedie_var_power_estimation_5_phi_0p5_no_link_power_est,  # takes 1151s
+        test_tweedie_var_power_estimation_2p1_disp2_est,  # takes 531s -> 49s (without Newton's method) 
+        test_tweedie_var_power_estimation_2p6_disp2_est,  # takes 1034s -> 434s
+        test_tweedie_var_power_estimation_2p5_phi_2p5_no_link_power_est,  # takes 1968s -> 1064s
+        test_tweedie_var_power_estimation_3_phi_0p5_no_link_power_est,  # takes 1185s -> 685s
+        test_tweedie_var_power_estimation_3_no_link_power_est,  # takes 2654s -> 1444s
+        test_tweedie_var_power_estimation_3_phi_1p5_no_link_power_est,  # takes 2309s -> 1314s
+        test_tweedie_var_power_estimation_5_no_link_power_est,  # takes 830s -> 964s
+        test_tweedie_var_power_estimation_5_phi_0p5_no_link_power_est,  # takes 1151s -> 1221s
     ]
-    return random.choices(tests, weights=[531.0/w for w in [531, 1034, 1968, 1185, 2654, 2309, 830, 1151]])
+    return random.choices(tests, weights=[49.0/w for w in [49, 434, 1064, 685, 1444, 1314, 964, 1221]])
+    # weights=[531.0/w for w in [531, 1034, 1968, 1185, 2654, 2309, 830, 1151]])
 
 
 pyunit_utils.run_tests(run_random_test())

--- a/h2o-py/tests/testdir_algos/glm/pyunit_tweedie_variance_power_ml_estimation_large.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_tweedie_variance_power_ml_estimation_large.py
@@ -204,8 +204,7 @@ def run_random_test():
         test_tweedie_var_power_estimation_5_no_link_power_est,  # takes 830s -> 964s
         test_tweedie_var_power_estimation_5_phi_0p5_no_link_power_est,  # takes 1151s -> 1221s
     ]
-    return random.choices(tests, weights=[49.0/w for w in [49, 434, 1064, 685, 1444, 1314, 964, 1221]])
-    # weights=[531.0/w for w in [531, 1034, 1968, 1185, 2654, 2309, 830, 1151]])
+    return [random.choice(tests)]
 
 
 pyunit_utils.run_tests(run_random_test())

--- a/scripts/jenkins/groovy/buildConfig.groovy
+++ b/scripts/jenkins/groovy/buildConfig.groovy
@@ -316,7 +316,7 @@ class BuildConfig {
       changeType != "D" && // was not deleted
               change.startsWith('h2o-py/') && change.contains("pyunit_") &&
               change.lastIndexOf("pyunit_") > change.lastIndexOf("/") && // Allow to run "pyunit_*" files inside of "pyunit_*" directory but do not allow e.g. utilsPY.py to run
-              !change.contains("pyunit_explain") // takes too much time to run
+              !change.contains("pyunit_explain") && !change.endsWith("_large.py") // takes too much time to run
     }.collect {
       it.key.replaceFirst(".*pyunit_", "pyunit_") // Extract only filename from path
     }


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8900


This PR contains some improvements to the original `TweedieEstimator` that make it more likely that the Fourier inversion method will terminate - there are some rare cases caused by rounding that cause increment in finding zeros to be so small so that is rounded to zero. This should be fixed and it shouldn't be concern for the variance power estimation (these cases occur with p very close to 1 (e.g. 1+1e-16) and at the same time phi very close to 0 (e.g., 1e-16)) or the estimation of both `phi` and `p` (as both optimization procedures limit the ranges of those parameters). However, it could cause issue when calculating AIC with user specified variance power and dispersion.

Another improvement is to make sure that `init()` is allowed to complete in order to show the model builder errors - now in master when used doesn't specify `tweedie_variance_power` and has dispersion method equal to `ml` the `init` method will try to build null model and it will fail since there is an `assert` in the `TweedieEstimator` that makes sure that `p>1`.

This PR contains implementation of Nelder-Mead optimization method[1,2] with one modification it is constrained so that $p \geq 1+10^{-10}$  and $\phi \geq 10^{-10}$.


[1] https://en.wikipedia.org/wiki/Nelder%E2%80%93Mead_method
[2] https://people.duke.edu/~hpgavin/cee201/Nelder-Mead-2D.pdf