### PR TITLE
[PUBDEV-9081][FOLLOWUP] Fix kerberos tests

### DIFF
--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -647,7 +647,7 @@ def call(final pipelineContext) {
                     spnegoPropertiesPath: 'scripts/jenkins/config/spnego.properties',
                     extraClasspath: '',
                     bundledS3FileSystems: 's3a,s3n'
-            ], pythonVersion: ' 3.6',
+            ], pythonVersion: '3.6',
             customDockerArgs: [ '--privileged' ],
             executionScript: 'h2o-3/scripts/jenkins/groovy/hadoopStage.groovy',
             image: pipelineContext.getBuildConfig().getSmokeHadoopImage(distribution.name, distribution.version, true)


### PR DESCRIPTION
GH issue: https://github.com/h2oai/h2o-3/issues/6828
JiRA ticket: https://h2oai.atlassian.net/browse/PUBDEV-9081

All stages currently fail with the error:
```
[2023-05-18T04:41:43.704Z] + echo Activating Python  3.6

[2023-05-18T04:41:43.704Z] Activating Python  3.6

[2023-05-18T04:41:43.704Z] + . /envs/h2o_env_python 3.6/bin/activate

[2023-05-18T04:41:43.704Z] /home/****/slave_dir_from_mr-0xc1/workspace/3-kerberos-smoke-pipeline_master@tmp/durable-373aac3a/script.sh: 3: .: Can't open /envs/h2o_env_python

script returned exit code 2
```