### PR TITLE
PUBDEV-9081 - remove future also from dependency check

### DIFF
--- a/h2o-py/conda/h2o-client/meta.yaml
+++ b/h2o-py/conda/h2o-client/meta.yaml
@@ -12,13 +12,11 @@ requirements:
     - python
     - pip >=9.0.1
     - setuptools
-    - future >=0.15.2
     - tabulate >=0.7.5
     - requests >=2.10
 
   run:
     - python
-    - future >=0.15.2
     - tabulate >=0.7.5
     - requests >=2.10
 

--- a/h2o-py/conda/h2o-main/meta.yaml
+++ b/h2o-py/conda/h2o-main/meta.yaml
@@ -12,13 +12,11 @@ requirements:
     - python
     - pip >=9.0.1
     - setuptools
-    - future >=0.15.2
     - tabulate >=0.7.5
     - requests >=2.10
 
   run:
     - python
-    - future >=0.15.2
     - tabulate >=0.7.5
     - requests >=2.10
 


### PR DESCRIPTION
GH issue: https://github.com/h2oai/h2o-3/issues/6828
JiRA ticket: https://h2oai.atlassian.net/browse/PUBDEV-9081

I tried to build without future in my env and found bug:

```
> Task :h2o-py:verifyDependencies FAILED

    ERRORS:

    Python module `future` is missing: install it with `pip install 'future>=0.15.2'`
```