### PR TITLE
PUBDEV-9088: updated name list in booklet

### DIFF
--- a/h2o-docs/src/booklets/v2_2015/source/GLMBooklet.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/GLMBooklet.tex
@@ -33,9 +33,11 @@
 \bigskip
 \line(1,0){250}  %inserts  horizontal line 
 
-\textsc{\small{Tomas Nykodym \hspace{10pt} Tom Kraljevic \hspace{10pt} Amy Wang \hspace{10pt} Wendy Wong}}
+\textsc{\small{Tomas Fryda \hspace{10pt} Tomas Nykodym \hspace{10pt} Tom Kraljevic}}
 
-\textsc{\small{Edited by: Angela Bartz}}
+\textsc{\small{Amy Wang \hspace{10pt} Wendy Wong}}
+
+\textsc{\small{Edited by: Angela Bartz \hspace{10pt} Hannah Tillman}}
 \\
 \bigskip
 \line(1,0){250}  %inserts  horizontal line
@@ -69,9 +71,10 @@
 
 Generalized Linear Modeling with H2O\\
 
-by Tomas Nykodym, Tom Kraljevic, Amy Wang \&\ Wendy Wong \\ 
+by Tomas Fryda, Tomas Nykodym, Tom Kraljevic, \\ 
+Amy Wang \&\ Wendy Wong \\
 with assistance from Nadine Hussami \&\ Ariel Rao \\
-Edited by: Angela Bartz
+Edited by: Angela Bartz \&\ Hannah Tillman
 
 \bigskip
   Published by H2O.ai, Inc. \\


### PR DESCRIPTION
For: [PUBDEV-9088](https://h2oai.atlassian.net/browse/PUBDEV-9088)

Currently, I shifted names down so that they weren't too long on either the title or secondary page.

<img width="678" alt="Screen Shot 2023-05-18 at 8 14 32 AM" src="https://github.com/h2oai/h2o-3/assets/52463461/a9c5bb6a-0858-4eab-aa13-e47e3c4460d2">
<img width="902" alt="Screen Shot 2023-05-18 at 8 17 37 AM" src="https://github.com/h2oai/h2o-3/assets/52463461/d9ba0456-604f-4918-9f59-88ee524c4ae7">

