### PR TITLE
PUBDEV-9090: Add GLM loglikelihood and AIC documentation [nocheck]

### DIFF
--- a/h2o-docs/src/booklets/v2_2015/source/GLMBooklet.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/GLMBooklet.tex
@@ -658,6 +658,7 @@ V_k = \frac{\Gamma(1+\alpha k)\phi^{k(\alpha -1)}(p-1)^{\alpha k}}{\Gamma(1+k)w^
 \lstinputlisting[style=python]{GLM_Vignette_code_examples/glm_tweedie_dispersion_example.py}
 
 \paragraph{Tweedie Variance Power Estimation} 
+\label{par:tweevar}
 
 Depending on $p$, $y$, and $\phi$, different methods are used for this log likelihood estimation. To start, let:
 
@@ -1397,6 +1398,128 @@ Retrieve these statistics using the following accessor functions:
 
 \waterExampleInPython
 \lstinputlisting[style=python]{GLM_Vignette_code_examples/glm_accessors.py}
+
+\subsubsection{GLM Likelihood and AIC}
+
+During model training, simplified formulas of likelihood and AIC are used. After the model is built, the full formula is used to calculate the output of the full log likelihood and full AIC values.
+
+\textbf{Note:} The log likelihood value is not available in the cross-validation metrics. The AIC value is available and is calculated using the original simplified formula independent of the log likelihood.
+
+The following are the supported GLM families and formulae (the log likelihood is calculated for the  \emph{i}th observation).
+
+\textbf{Gaussian:}
+
+$$l(\mu_i (\beta); y_i, w_i) = - \frac{1}{2} \Big[ \frac{w_i (y_i - \mu_i)^2}{\phi} + \log \big(\frac{\phi}{w_i} \big) + \log (2 \pi) \Big]$$
+
+where
+
+\begin{itemize}
+\item $\phi$ is the dispersion parameter estimation
+\item $\mu_i$ is the prediction
+\item $y_i$ is the real value of the target variable
+\end{itemize}
+
+\emph{Note:} You must estimate the dispersion parameter. During initialization, \texttt{compute\_p\_values} and \texttt{remove\_collinear\_columns)} must be set to \texttt{True} to facilitate this estimation process. Also, \texttt{dispersion\_parameter\_method} must be set to \texttt{"pearson"}.
+
+\textbf{Binomial:}
+
+$$l \big(\mu_i (\beta); y_i, w_i \big) = w_i \big(y_i \log \{ \mu_i \} + (1-y_i) \log \{ 1-\mu_i \} \big)$$
+
+where
+\begin{itemize}
+\item $\mu_i$ is the probability of 1
+\item $y_i$ is the real value of the target variable
+\end{itemize} 
+
+
+\textbf{Quasibinomial:}
+
+\begin{itemize}
+\item If the predicted value equals $y_i$, log likelihood is 0
+\item If $\mu_i >1$ then $l(\mu_i (\beta); y_i) = y_i \log \{ \mu_i \}$
+\item Otherwise, $l(\mu_i (\beta); y_i) = y_i \log \{ \mu_i \} + (1-y_i) \log \{ 1- \mu_i \}$ where
+\begin{itemize}
+\item $\mu_i$ is the probability of 1
+\item $y_i$ is the real value of the target variable
+\end{itemize}
+\end{itemize}
+
+\textbf{Fractional Binomial:}
+
+$$l(\mu_i (\beta); y_i) = w_i \Big(y_i \times \log \big(\frac{y_i}{\mu_i} \big) + (1-y_i) \times \log \big(\frac{1-y_i}{1-\mu_i} \big) \Big)$$
+
+where
+
+\begin{itemize}
+\item $\mu_i$ is the probability of 1
+\item $y_i$ is the real value of the target variable
+\end{itemize}
+
+\textbf{Poisson:}
+
+$$l(\mu_i (\beta); y_i) = w_i \big(y_i \times \log (\mu_i) - \mu_i - \log (\Gamma (y_i +1)) \big)$$
+
+where
+
+\begin{itemize}
+\item $\mu_i$ is the prediction
+\item $y_i$ is the real value of the target variable
+\end{itemize}
+
+\textbf{Negative Binomial:}
+
+$$l(\mu_i (\beta); y_i, w_i) = y_i \log \big(\frac{k \mu}{w_i} \big) - \big(y_i + \frac{w_i}{k} \big) \log \big(1 + \frac{k \mu}{w_i} \big) + \log \Big(\frac{\Gamma \big( y_i = \frac{w_i}{k} \big)} {\Gamma (y_i +1) \Gamma \big(\frac{w_i}{k}\big)} \Big)$$
+
+where
+
+\begin{itemize}
+\item $\mu_i$ is the prediction
+\item $y_i$ is the real value of the target variable
+\item $k = \frac{1}{\phi}$ is the dispersion parameter estimation
+\end{itemize}
+
+\emph{Note:} You must estimate the dispersion parameter. During initialization, \texttt{compute\_p\_values} and \texttt{remove\_collinear\_columns)} must be set to \texttt{True} to facilitate this estimation process. Also, \texttt{dispersion\_parameter\_method} must be set to \texttt{"ml"}. Since texttt{dispersion\_parameter\_method} only works without regularization, you disable regularization by setting \texttt{lambda} equal to an array of \texttt{0.0}.
+
+\textbf{Gamma:}
+
+$$l(\mu_i (\beta); y_i, w_i) = \frac{w_i}{\phi} \log \big( \frac{w_i y_i}{\phi \mu_i} \big) - \frac{w_i y_i}{\phi \mu_i} - \log (y_i) - \log \big(\Gamma \big(\frac{w)i}{\phi} \big) \big)$$
+
+where
+
+\begin{itemize}
+\item $\mu_i$ is the prediction
+\item $y_i$ is the real value of the target variable
+\item $\phi$ is the dispersion parameter estimation
+\end{itemize}
+
+\emph{Note:} You must estimate the dispersion parameter. During initialization, \texttt{compute\_p\_values} and \texttt{remove\_collinear\_columns)} must be set to \texttt{True} to facilitate this estimation process. Also, \texttt{dispersion\_parameter\_method} must be set to \texttt{"ml"}. Since texttt{dispersion\_parameter\_method} only works without regularization, you disable regularization by setting \texttt{lambda} equal to an array of \texttt{0.0}.
+
+\textbf{Multinomial:}
+
+$$l(\mu_i(\beta); y_i) = w_i \log (\mu_i)$$
+
+where $\mu_i$ is the predicted probability of the actual class $y_i$
+
+\textbf{Tweedie:}
+
+The Tweedie calculation is located in the section \ref{par:tweevar}.
+
+\emph{Note:} You must estimate the dispersion parameter. During initialization, \texttt{compute\_p\_values} and \texttt{remove\_collinear\_columns)} must be set to \texttt{True} to facilitate this estimation process. Also, \texttt{dispersion\_parameter\_method} must be set to \texttt{"ml"}. Since texttt{dispersion\_parameter\_method} only works without regularization, you disable regularization by setting \texttt{lambda} equal to an array of \texttt{0.0}.
+
+\paragraph{Final AIC Calculation}
+
+The final AIC in the output metric is calculated using the standard formula, utilizing the previously computed log likelihood.
+
+$$\text{AIC} = -2LL + 2p$$
+
+where
+
+\begin{itemize}
+\item $p$ is the number of parameters estimated in the model
+\item $LL$ is the log likelihood
+\end{itemize}
+
+To manage computational intensity, \texttt{calc\_like} is used. This parameter was previously only used for HGLM models, but its utilization has been expanded. By default, \texttt{calc\_like=False}, but you can set it to \texttt{True} to enable the calculation of the full log likelihood and full AIC. This computation is performed during the final scoring phase after the model finishes building.
 
 \subsection{Confusion Matrix}
 

--- a/h2o-docs/src/booklets/v2_2015/source/GLMBooklet.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/GLMBooklet.tex
@@ -1401,7 +1401,7 @@ Retrieve these statistics using the following accessor functions:
 
 \subsubsection{GLM Likelihood and AIC}
 
-During model training, simplified formulas of likelihood and AIC are used. After the model is built, the full formula is used to calculate the output of the full log likelihood and full AIC values.
+During model training, simplified formulas of likelihood and AIC are used. After the model is built, the full formula is used to calculate the output of the full log likelihood and full AIC values. The full formula is used to calculate the output of the full log likelihood and full AIC values if the parameter \texttt{calc\_like} is set to \texttt{True}.
 
 \textbf{Note:} The log likelihood value is not available in the cross-validation metrics. The AIC value is available and is calculated using the original simplified formula independent of the log likelihood.
 
@@ -1419,7 +1419,7 @@ where
 \item $y_i$ is the real value of the target variable
 \end{itemize}
 
-\emph{Note:} You must estimate the dispersion parameter. During initialization, \texttt{compute\_p\_values} and \texttt{remove\_collinear\_columns)} must be set to \texttt{True} to facilitate this estimation process. Also, \texttt{dispersion\_parameter\_method} must be set to \texttt{"pearson"}.
+\emph{Note:} For Gaussian family, you need the dispersion parameter estimate in order to calculate the full log likelihood and AIC. Hence, when \texttt{calc\_like} is set to \texttt{True}, the parameters \texttt{compute\_p\_values} and \texttt{remove\_collinear\_columns} must be set to \texttt{True}. The parameter  \texttt{dispersion\_parameter\_method} is set to \texttt{"pearson"} by default. However, you can also set \\ \texttt{dispersion\_parameter\_method} to \texttt{"deviance"} if you like.
 
 \textbf{Binomial:}
 
@@ -1468,7 +1468,7 @@ where
 
 \textbf{Negative Binomial:}
 
-$$l(\mu_i (\beta); y_i, w_i) = y_i \log \big(\frac{k \mu}{w_i} \big) - \big(y_i + \frac{w_i}{k} \big) \log \big(1 + \frac{k \mu}{w_i} \big) + \log \Big(\frac{\Gamma \big( y_i = \frac{w_i}{k} \big)} {\Gamma (y_i +1) \Gamma \big(\frac{w_i}{k}\big)} \Big)$$
+$$l(\mu_i (\beta); y_i, w_i) = y_i \log \big(\frac{k \mu}{w_i} \big) - \big(y_i + \frac{w_i}{k} \big) \log \big(1 + \frac{k \mu}{w_i} \big) + \log \Big(\frac{\Gamma \big( y_i + \frac{w_i}{k} \big)} {\Gamma (y_i +1) \Gamma \big(\frac{w_i}{k}\big)} \Big)$$
 
 where
 
@@ -1478,11 +1478,11 @@ where
 \item $k = \frac{1}{\phi}$ is the dispersion parameter estimation
 \end{itemize}
 
-\emph{Note:} You must estimate the dispersion parameter. During initialization, \texttt{compute\_p\_values} and \texttt{remove\_collinear\_columns)} must be set to \texttt{True} to facilitate this estimation process. Also, \texttt{dispersion\_parameter\_method} must be set to \texttt{"ml"}. Since texttt{dispersion\_parameter\_method} only works without regularization, you disable regularization by setting \texttt{lambda} equal to an array of \texttt{0.0}.
+\emph{Note:} For Negative Binomial family, you need the dispersion parameter estimate. When the parameter \texttt{calc\_like} is set to \texttt{True}, the parameters \texttt{compute\_p\_values} and \texttt{remove\_collinear\_columns} are set to \texttt{True} for you. By default, the parameter \texttt{dispersion\_parameter\_method} is set to \texttt{"pearson"}. However, you can set \texttt{dispersion\_parameter\_method} to \texttt{"deviance"} or \texttt{"ml"} if you prefer.
 
 \textbf{Gamma:}
 
-$$l(\mu_i (\beta); y_i, w_i) = \frac{w_i}{\phi} \log \big( \frac{w_i y_i}{\phi \mu_i} \big) - \frac{w_i y_i}{\phi \mu_i} - \log (y_i) - \log \big(\Gamma \big(\frac{w)i}{\phi} \big) \big)$$
+$$l(\mu_i (\beta); y_i, w_i) = \frac{w_i}{\phi} \log \big( \frac{w_i y_i}{\phi \mu_i} \big) - \frac{w_i y_i}{\phi \mu_i} - \log (y_i) - \log \big(\Gamma \big(\frac{w_i}{\phi} \big) \big)$$
 
 where
 
@@ -1492,7 +1492,7 @@ where
 \item $\phi$ is the dispersion parameter estimation
 \end{itemize}
 
-\emph{Note:} You must estimate the dispersion parameter. During initialization, \texttt{compute\_p\_values} and \texttt{remove\_collinear\_columns)} must be set to \texttt{True} to facilitate this estimation process. Also, \texttt{dispersion\_parameter\_method} must be set to \texttt{"ml"}. Since texttt{dispersion\_parameter\_method} only works without regularization, you disable regularization by setting \texttt{lambda} equal to an array of \texttt{0.0}.
+\emph{Note:} For Gamma family, you need the dispersion parameter estimate. When the parameter \texttt{calc\_like} is set to \texttt{True}, the parameters \texttt{compute\_p\_values} and \texttt{remove\_collinear\_columns} are set to \texttt{True} for you. By default, the parameter \texttt{dispersion\_parameter\_deviance} is set to \texttt{"pearson"}. However, you can set \texttt{dispersion\_parameter\_deviance} to \texttt{"deviance"} or \texttt{"ml"} if you prefer.
 
 \textbf{Multinomial:}
 
@@ -1504,7 +1504,7 @@ where $\mu_i$ is the predicted probability of the actual class $y_i$
 
 The Tweedie calculation is located in the section \ref{par:tweevar}.
 
-\emph{Note:} You must estimate the dispersion parameter. During initialization, \texttt{compute\_p\_values} and \texttt{remove\_collinear\_columns)} must be set to \texttt{True} to facilitate this estimation process. Also, \texttt{dispersion\_parameter\_method} must be set to \texttt{"ml"}. Since texttt{dispersion\_parameter\_method} only works without regularization, you disable regularization by setting \texttt{lambda} equal to an array of \texttt{0.0}.
+\emph{Note:} For Tweedie family, you need the dispersion parameter estimate. When parameter \texttt{calc\_like} is set to \texttt{True}, the parameter \\ \texttt{dispersion\_parameter\_method} is set to \texttt{"ml"} which provides you with the best log likelihood estimation.
 
 \paragraph{Final AIC Calculation}
 
@@ -1515,11 +1515,11 @@ $$\text{AIC} = -2LL + 2p$$
 where
 
 \begin{itemize}
-\item $p$ is the number of parameters estimated in the model
+\item $p$ is the number of non-zero coefficients estimated in the model
 \item $LL$ is the log likelihood
 \end{itemize}
 
-To manage computational intensity, \texttt{calc\_like} is used. This parameter was previously only used for HGLM models, but its utilization has been expanded. By default, \texttt{calc\_like=False}, but you can set it to \texttt{True} to enable the calculation of the full log likelihood and full AIC. This computation is performed during the final scoring phase after the model finishes building.
+To manage computational intensity, \texttt{calc\_like} is used. This parameter was previously only used for HGLM models, but its utilization has been expanded. By default, \texttt{calc\_like=False}, but you can set it to \texttt{True} and \texttt{HGLM} to \texttt{False} to enable the calculation of the full log likelihood and full AIC. This computation is performed during the final scoring phase after the model finishes building.
 
 \subsection{Confusion Matrix}
 

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -41,7 +41,7 @@ Algorithm-specific parameters
 
 - **build_null_model**: If set, will build a model with only the intercept.  This option defaults to ``False``.
 
--  **calc_like**: Specify whether to return likelihood function value for HGLM or normal GLM. Setting this option to ``True`` while disabling ``HGLM`` will enable the calculation of the full log likelihood and full AIC. This option defaults to ``False`` (disabled). 
+-  **calc_like**: Specify whether to return likelihood function value for HGLM or normal GLM. Setting this option to ``True`` while disabling ``HGLM`` will enable the calculation of the full log likelihood and full AIC. This option defaults to ``False`` (disabled).
 
 - **dispersion_epsilon**: If changes in dispersion parameter estimation or loglikelihood value is smaller than ``dispersion_epsilon``, this will break out of the dispersion parameter estimation loop using maximum likelihood. This option defaults to ``0.0001``.
 

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -41,7 +41,7 @@ Algorithm-specific parameters
 
 - **build_null_model**: If set, will build a model with only the intercept.  This option defaults to ``False``.
 
--  **calc_like**: Specify whether to return likelihood function value for HGLM or normal GLM. Setting this option to ``True`` enables the calculation of the full log likelihood and full AIC. This option defaults to ``False`` (disabled).
+-  **calc_like**: Specify whether to return likelihood function value for HGLM or normal GLM. Setting this option to ``True`` while disabling ``HGLM`` will enable the calculation of the full log likelihood and full AIC. This option defaults to ``False`` (disabled).
 
 - **dispersion_epsilon**: If changes in dispersion parameter estimation or loglikelihood value is smaller than ``dispersion_epsilon``, this will break out of the dispersion parameter estimation loop using maximum likelihood. This option defaults to ``0.0001``.
 
@@ -1370,7 +1370,7 @@ This process is repeated until the estimates :math:`\hat{\beta}` change by less 
 Likelihood and AIC
 ''''''''''''''''''
 
-During model training, simplified formulas of likelihood and AIC are used. After the model is built, the full formula is used to calculate the output of the full log likelihood and full AIC values.
+During model training, simplified formulas of likelihood and AIC are used. After the model is built, the full formula is used to calculate the output of the full log likelihood and full AIC values. The full formula is used to calculate the output of the full log likelihood and full AIC values if the parameter ``calc_like`` is set to ``True``.
 
 .. note::
    
@@ -1392,7 +1392,7 @@ where
 
 .. note::
    
-   You must estimate the dispersion parameter. During initialization, ``compute_p_values`` and ``remove_collinear_columns`` must be set to ``True`` to facilitate this estimation process. Also, ``dispersion_parameter_method`` must be set to ``"pearson"``.
+   For Gaussian family, you need the dispersion parameter estimate in order to calculate the full log likelihood and AIC. Hence, when ``calc_like`` is set to ``True``, the parameters ``compute_p_values`` and ``remove_collinear_columns`` are set to ``True``. The parameter ``dispersion_parameter_method`` is set to ``"pearson"`` by default. However, you can set the ``dispersion_parameter_method`` to ``deviance`` if you prefer.
 
 **Binomial**:
 
@@ -1411,7 +1411,7 @@ where
 - If :math:`\mu_i >1` then :math:`l(\mu_i (\beta); y_i) = y_i \log \{ \mu_i \}`
 - Otherwise, :math:`l(\mu_i (\beta); y_i) = y_i \log \{ \mu_i \} + (1-y_i) \log \{ 1- \mu_i \}` where
    
-   - :math:`mu_i` is the probability of 1
+   - :math:`\mu_i` is the probability of 1
    - :math:`y_i` is the real value of the target variable
 
 **Fractional Binomial**:
@@ -1440,7 +1440,7 @@ where
 
 .. math::
    
-   l(\mu_i (\beta); y_i, w_i) = y_i \log \big(\frac{k \mu}{w_i} \big) - \big(y_i + \frac{w_i}{k} \big) \log \big(1 + \frac{k \mu}{w_i} \big) + \log \Big(\frac{\Gamma \big( y_i = \frac{w_i}{k} \big)} {\Gamma (y_i +1) \Gamma \big(\frac{w_i}{k}\big)} \Big)
+   l(\mu_i (\beta); y_i, w_i) = y_i \log \big(\frac{k \mu}{w_i} \big) - \big(y_i + \frac{w_i}{k} \big) \log \big(1 + \frac{k \mu}{w_i} \big) + \log \Big(\frac{\Gamma \big( y_i + \frac{w_i}{k} \big)} {\Gamma (y_i +1) \Gamma \big(\frac{w_i}{k}\big)} \Big)
 
 where
 
@@ -1450,15 +1450,13 @@ where
 
 .. note::
    
-   You must estimate the dispersion parameter. During initialization, ``compute_p_values`` and ``remove_collinear_columns`` must be set to ``True`` to facilitate this estimation process. Also, ``dispersion_parameter_method`` must be set to ``"ml"``.
-
-   Since ``dispersion_parameter_method="ml"`` only works without regularization, you disable regularization by setting ``lambda`` equal to an array of ``0.0``.
+   For Negative Binomial family, you need the dispersion parameter estimate. When the parameter ``calc_like`` is set to ``True``, the parameters ``compute_p_values`` and ``remove_collinear_columns`` are set to ``True`` for you. By default, the parameter ``dispersion_parameter_method`` is set to ``"pearson"``. However, you can set ``dispersion_parameter_method`` to ``"deviance"`` or ``"ml"`` if you prefer.
 
 **Gamma**:
 
 .. math::
    
-   l(\mu_i (\beta); y_i, w_i) = \frac{w_i}{\phi} \log \big( \frac{w_i y_i}{\phi \mu_i} \big) - \frac{w_i y_i}{\phi \mu_i} - \log (y_i) - \log \big(\Gamma \big(\frac{w)i}{\phi} \big) \big)
+   l(\mu_i (\beta); y_i, w_i) = \frac{w_i}{\phi} \log \big( \frac{w_i y_i}{\phi \mu_i} \big) - \frac{w_i y_i}{\phi \mu_i} - \log (y_i) - \log \big(\Gamma \big(\frac{w_i}{\phi} \big) \big)
 
 where
 
@@ -1468,9 +1466,7 @@ where
 
 .. note::
    
-   You must estimate the dispersion parameter. During initialization, ``compute_p_values`` and ``remove_collinear_columns`` must be set to ``True`` to facilitate this estimation process. Also, ``dispersion_parameter_method`` must be set to ``"ml"``.
-
-   Since ``dispersion_parameter_method="ml"`` only works without regularization, you disable regularization by setting ``lambda`` equal to an array of ``0.0``.
+   For Gamma family, you need the dispersion parameter estimate. When the parameter ``calc_like`` is set to ``True``, the parameters ``compute_p_values`` and ``remove_collinear_columns`` are set to ``True`` for you. By default, the parameter ``dispersion_parameter_method`` is set to ``"pearson"``. However, you can set ``dispersion_parameter_method`` to ``"deviance"`` or ``"ml"`` if you prefer.
 
 **Multinomial**:
 
@@ -1486,9 +1482,7 @@ The Tweedie calculation is located in the section `Tweedie Likelihood Calculatio
 
 .. note::
    
-   You must estimate the dispersion parameter. During initialization, ``compute_p_values`` and ``remove_collinear_columns`` must be set to ``True`` to facilitate this estimation process. Also, ``dispersion_parameter_method`` must be set to ``"ml"``.
-
-   Since ``dispersion_parameter_method="ml"`` only works without regularization, you disable regularization by setting ``lambda`` equal to an array of ``0.0``.
+   For Tweedie family, you need the dispersion parameter estimate. When the parameter ``calc_like`` is set to ``True``, the ``dispersion_parameter_method`` is set to ``"ml"`` which provides you with the best log likelihood estimation.
 
 Final AIC Calculation
 ^^^^^^^^^^^^^^^^^^^^^
@@ -1501,12 +1495,13 @@ The final AIC in the output metric is calculated using the standard formula, uti
 
 where
 
-- :math:`p` is the number of parameters estimated in the model
+- :math:`p` is the number of non-zero coefficients estimated in the model
 - :math:`LL` is the log likelihood
 
-To manage computational intensity, ``calc_like`` is used. This parameter was previously only used for HGLM models, but its utilization has been expanded. By default, ``calc_like=False``, but you can set it to ``True`` to enable the calculation of the full log likelihood and full AIC. This computation is performed during the final scoring phase after the model finishes building.
+To manage computational intensity, ``calc_like`` is used. This parameter was previously only used for HGLM models, but its utilization has been expanded. By default, ``calc_like=False``, but you can set it to ``True`` and the parameter ``HGLM`` to ``False`` to enable the calculation of the full log likelihood and full AIC. This computation is performed during the final scoring phase after the model finishes building.
 
-**Tweedie Likelihood Calculation**
+Tweedie Likelihood Calculation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 There are three different estimations you calculate Tweedie likelihood for:
 

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -41,7 +41,7 @@ Algorithm-specific parameters
 
 - **build_null_model**: If set, will build a model with only the intercept.  This option defaults to ``False``.
 
--  **calc_like**: Specify whether to return likelihood function value for HGLM or normal GLM. Setting this option to ``True`` while disabling ``HGLM`` will enable the calculation of the full log likelihood and full AIC. This option defaults to ``False`` (disabled).
+-  **calc_like**: Specify whether to return likelihood function value for HGLM or normal GLM. Setting this option to ``True`` while disabling ``HGLM`` will enable the calculation of the full log likelihood and full AIC. This option defaults to ``False`` (disabled). 
 
 - **dispersion_epsilon**: If changes in dispersion parameter estimation or loglikelihood value is smaller than ``dispersion_epsilon``, this will break out of the dispersion parameter estimation loop using maximum likelihood. This option defaults to ``0.0001``.
 


### PR DESCRIPTION
For: [PUBDEV-9090](https://h2oai.atlassian.net/browse/PUBDEV-9090)

This PR introduces a new likelihood section to the user guide. I shifted the maximum likelihood section from the GLM algorithm section up to this new likelihood section and shifted the subsequent tweedie variance likelihood from Tomas's PR to this section as well.

In the booklet, I added the likelihood & AIC information to the Model Statistics section.

Please let me know if I need to update or shift anything!

[PUBDEV-9090]: https://h2oai.atlassian.net/browse/PUBDEV-9090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ