### PR TITLE
PUBDEV-9097: Fix infogram CV with weights

### DIFF
--- a/h2o-admissibleml/src/main/java/hex/Infogram/EstimateCMI.java
+++ b/h2o-admissibleml/src/main/java/hex/Infogram/EstimateCMI.java
@@ -5,47 +5,47 @@ import water.fvec.Chunk;
 import water.fvec.Frame;
 
 public class EstimateCMI extends MRTask<EstimateCMI> {
-  public int _nonZeroRows;
-  public double _accumulatedCMI;
-  public double _meanCMI;
-  public static final double _scale = 1.0/Math.log(2);
-  public final int _responseColumn;
+    public int _nonZeroRows;
+    public double _accumulatedCMI;
+    public double _meanCMI;
+    public static final double _scale = 1.0 / Math.log(2);
+    public final int _responseColumn;
 
-  public final int _nclass;
+    public final int _nclass;
 
-  public EstimateCMI(Frame fr, int nclasses) {
-    _meanCMI = 0.0;
-    _responseColumn = fr.numCols()-1;
-    _nclass = nclasses;
-  }
-
-  @Override
-  public void map(Chunk[] ck) {
-    _nonZeroRows = 0;
-    _accumulatedCMI = 0.0;
-    int nchunks = ck.length-1;
-    boolean weightIncluded = nchunks-_nclass == 2;
-    int numRow = ck[0].len();
-    for (int rowIndex = 0; rowIndex < numRow; rowIndex++) {
-      if (!weightIncluded || (weightIncluded && ck[nchunks].atd(rowIndex) > 0)) {
-        int prediction = (int) ck[_responseColumn].atd(rowIndex);
-        double predictionProb = ck[prediction + 1].atd(rowIndex);
-        if (!Double.isNaN(predictionProb) && predictionProb > 0) {
-          _nonZeroRows++;
-          _accumulatedCMI += Math.log(predictionProb);
-        }
-      }
+    public EstimateCMI(Frame fr, int nclasses, String response) {
+        _meanCMI = 0.0;
+        _responseColumn = fr.find(response);
+        _nclass = nclasses;
     }
-  }
 
-  @Override
-  public void reduce(EstimateCMI other) {
-    _nonZeroRows += other._nonZeroRows;
-    _accumulatedCMI += other._accumulatedCMI;
-  }
+    @Override
+    public void map(Chunk[] ck) {
+        _nonZeroRows = 0;
+        _accumulatedCMI = 0.0;
+        int nchunks = ck.length - 1;
+        boolean weightIncluded = nchunks - _nclass == 2;
+        int numRow = ck[0].len();
+        for (int rowIndex = 0; rowIndex < numRow; rowIndex++) {
+            if (!weightIncluded || (weightIncluded && ck[nchunks].atd(rowIndex) > 0)) {
+                int prediction = (int) ck[_responseColumn].atd(rowIndex);
+                double predictionProb = ck[prediction + 1].atd(rowIndex);
+                if (!Double.isNaN(predictionProb) && predictionProb > 0) {
+                    _nonZeroRows++;
+                    _accumulatedCMI += Math.log(predictionProb);
+                }
+            }
+        }
+    }
 
-  @Override
-  public void postGlobal() {
-    _meanCMI = _scale*_accumulatedCMI/_nonZeroRows;
-  }
+    @Override
+    public void reduce(EstimateCMI other) {
+        _nonZeroRows += other._nonZeroRows;
+        _accumulatedCMI += other._accumulatedCMI;
+    }
+
+    @Override
+    public void postGlobal() {
+        _meanCMI = _scale * _accumulatedCMI / _nonZeroRows;
+    }
 }

--- a/h2o-admissibleml/src/test/java/hex/Infogram/InfogramCVValidTest.java
+++ b/h2o-admissibleml/src/test/java/hex/Infogram/InfogramCVValidTest.java
@@ -375,11 +375,10 @@ public class InfogramCVValidTest  extends TestUtil {
     
     public static void assertCorrectCVCore(InfogramModel infogramModel, InfogramModel.InfogramParameters params, Frame trainF) {
         long[] validNonZeroRows = new long[]{285, 284};
-        double[][] cmiRaw = new double[][]{{0,0,0,0,0},{0.1154018143206148, 0.0, 0.059270071809912395, 
-                0.053851119106329115, 0.0}};
-        String[][] validColNames = new String[][]{{"concave_points_worst", "radius_worst", "perimeter_worst",
-                "texture_worst", "area_worst"},{"concave_points_worst", "concave_points_mean", "area_worst", 
-                "radius_worst", "texture_worst"}};
+        double[][] cmiRaw = new double [][]{{0.0740886597141513, 0.06680054529745522, 0.0, 0.010589279492509235, 0.00354537095549301},
+                {0.07689334414132229, 0.0, 0.028545715203748073, 0.002795096913999734, 0.006658503429222945}};
+        String[][] validColNames = new String[][]{{"concave_points_worst", "texture_worst", "radius_worst", "area_worst", "perimeter_worst"},
+                {"texture_worst", "concave_points_mean", "area_worst", "concave_points_worst", "radius_worst"}};
         double[] mainRelevance = new double[]{0.34372355964840223, 1.0, 0.22668974589585472, 0.04829270617635511, 
                 0.12967891871933077};
         String[] mainColNames = new String[]{"concave_points_worst", "radius_worst", "concave_points_mean", 
@@ -421,7 +420,7 @@ public class InfogramCVValidTest  extends TestUtil {
             }
         }
         assertArrayEquals(calculatedCmiRaw, cmiRawManual, 1e-6);    // compare cmi_raw calculations
-        // generate cmi and check that is is correct
+        // generate cmi and check that is correct
         double[] calculatedCmi = vec2array(relCmiKeyCV.vec(4));
         double[] manualCmi = new double[numPred];
         double oneOvermaxCMI = 1.0/ArrayUtils.maxValue(cmiRawManual);
@@ -618,16 +617,10 @@ public class InfogramCVValidTest  extends TestUtil {
 
     public static void assertCorrectCVSafe(InfogramModel infogramModel) {
         long[] validNonZeroRows = new long[]{3454,3453};
-        double[][] cmiRaw = new double[][]{{0.0112466313376575760, 0, 0.011181541634240677, 0.005919207126032999, 
-                0.003763971206082628, 0.0, 0.0016720556657749963, 2.1858827102438916E-4, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 
-                0.0}, {0.008229504140717436, 0.0, 0.007422460612105386, 0.004307029194700496, 0.003067660070028344, 
-                0.0, 8.305386172429152E-4, 0.0, 0.0, 2.9469488065148042E-5, 0.0, 0.0, 0.0, 0.0, 0.0}};
-        String[][] validColNames = new String[][]{{"c_charge_degree", "end", "juv_misd_count", "juv_fel_count", 
-                "juv_other_count", "event", "days_b_screening_arrest", "start", "priors_count", "decile_score", 
-                "v_decile_score", "score_text", "v_score_text", "priors_count.1", "decile_score.1"}, 
-                {"juv_other_count", "end", "days_b_screening_arrest", "juv_fel_count", "start", "event", 
-                        "juv_misd_count", "decile_score", "priors_count", "v_score_text", "score_text", 
-                        "v_decile_score", "c_charge_degree", "decile_score.1", "priors_count.1"}};
+        double[][] cmiRaw = new double[][]{{0.5724240823304241, 0.49538631399928285, 0.08931514015582542, 0.08931514015582542, 0.07769862704423769, 0.07769862704423769, 0.06339896155155711, 0.04204048453203135, 0.025171185599880297, 0.017537162997962152, 0.009121361241773651, 0.011998999469123306, 0.010971434455554263, 0.008674291823460023, 0.0076452997045523},
+                {0.5463757380373683, 0.5044681055598337, 0.09110353480455802, 0.09110353480455802, 0.06541477175441757, 0.06541477175441757, 0.05996846597569727, 0.03708853658710587, 0.027427326130934904, 0.016798382736979645, 0.013812236652105958, 0.01150201605853618, 0.00716852653446054, 0.00694939077877077, 0.005481070985486669}};
+        String[][] validColNames = new String[][]{{"end", "event", "priors_count", "priors_count.1", "decile_score", "decile_score.1", "score_text", "v_decile_score", "v_score_text", "days_b_screening_arrest", "start", "c_charge_degree", "juv_other_count", "juv_fel_count", "juv_misd_count"},
+                {"end", "event", "priors_count", "priors_count.1", "decile_score", "decile_score.1", "score_text", "v_decile_score", "v_score_text", "juv_other_count", "days_b_screening_arrest", "start", "juv_misd_count", "juv_fel_count", "c_charge_degree"}};
         double[] mainRelevance = new double[]{1.0,  0.22232788946634713, 0.010488736091117714, 0.0, 
                 0.016795647759374355, 0.0, 0.0018857970710325917, 0.00401633133386085, 0.01452655439713657, 
                 2.574920854711118E-4, 0.004113058086770913, 0.0012933419572252322, 0.0014052131829135543, 

--- a/h2o-py/tests/testdir_algos/infogram/pyunit_PUBDEV_9097_infogram_cv_with_weights.py
+++ b/h2o-py/tests/testdir_algos/infogram/pyunit_PUBDEV_9097_infogram_cv_with_weights.py
@@ -1,0 +1,38 @@
+from __future__ import print_function
+
+import os
+import sys
+
+sys.path.insert(1, os.path.join("..", "..", ".."))
+import h2o
+from h2o.estimators.infogram import H2OInfogram
+from tests import pyunit_utils
+
+
+def test_inforgram_cv_with_weights_does_not_fail():
+    fr = h2o.import_file(path=pyunit_utils.locate("smalldata/admissibleml_test/Bank_Personal_Loan_Modelling.csv"))
+    target = "Personal Loan"
+    fr[target] = fr[target].asfactor()
+    x = ["Experience", "Income", "Family", "CCAvg", "Education", "Mortgage",
+         "Securities Account", "CD Account", "Online", "CreditCard"]
+
+    splits = fr.split_frame(ratios=[0.80])
+    train = splits[0]
+    weight = pyunit_utils.random_dataset_real_only(train.nrow, 1, misFrac=0)
+    weight = weight.abs()
+    weight.set_name(0, "weight_column")
+    train = train.cbind(weight)
+    test = splits[1]
+    infogram_model_cv_v = H2OInfogram(seed=12345, protected_columns=["Age", "ZIP Code"], nfolds=3,
+                                      weights_column="weight_column")
+    infogram_model_cv_v.train(x=x, y=target, training_frame=train, validation_frame=test)
+
+    pyunit_utils.checkLogWeightWarning("weight_column", wantWarnMessage=True)
+    pyunit_utils.checkLogWeightWarning("infogram_internal_cv_weights_", wantWarnMessage=False)
+    pyunit_utils.checkLogWeightWarning("infogram_internal_cv_weights_", wantWarnMessage=False)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_inforgram_cv_with_weights_does_not_fail)
+else:
+    test_inforgram_cv_with_weights_does_not_fail()


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-9097
https://github.com/h2oai/h2o-3/issues/15423

I encountered two issues:
- hard-coded position of the response (last column) which isn't the case when weights are used
- calculation of CMI from raw CMI when `top_n_features < #predictors` uses the worst score from all not just from the `top_n_features` for normalization and the tests expected just to use the worst score from the `top_n_features`

**NOTE**: I accidentally reformatted the `EstimateCMI.java`. You can skip the white spaces changes in the review using the options.
![Screen Shot 2023-05-29 at 18 53 47](https://github.com/h2oai/h2o-3/assets/61695433/e3629e4c-3983-4b98-b809-aef6ee104087)
