### PR TITLE
[PUBDEV-9103] Upgrade Jetty for minimal and steam jar

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -69,7 +69,7 @@ jetty8version=8.2.0.v20160908
 # jetty 9 version is used in the main standalone assembly
 jetty9version=9.4.11.v20180605
 # jetty-minimal 9 version is used in the minimal standalone assembly
-jetty9MinimalVersion=9.4.48.v20220622
+jetty9MinimalVersion=9.4.51.v20230217
 servletApiVersion=3.1.0
 
 # Gson


### PR DESCRIPTION
GH issue: https://github.com/h2oai/h2o-3/issues/15546
JIRA ticket: https://h2oai.atlassian.net/browse/PUBDEV-9103

This change should fix: CVE-2023-26048, CVE-2023-26049