### PR TITLE
GH-15584: Fix python explain re-rendering [nocheck]

### DIFF
--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -46,7 +46,7 @@ def _dont_display(object):
     """
     import matplotlib.figure
     plt = get_matplotlib_pyplot(False, raise_if_not_available=True)
-    if isinstance(object, matplotlib.figure.Figure):
+    if isinstance(object, matplotlib.figure.Figure) or is_decorated_plot_result(object) and (object.figure() is not None):
         plt.close()
     return object
 

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -179,7 +179,10 @@ class H2OExplanation(OrderedDict):
     def _ipython_display_(self):
         from IPython.display import display
         for v in self.values():
-            display(v)
+            if is_decorated_plot_result(v):
+                display(v.figure())
+            else:
+                display(v)
 
 
 @contextmanager

--- a/h2o-py/h2o/plot/_plot_result.py
+++ b/h2o-py/h2o/plot/_plot_result.py
@@ -4,10 +4,19 @@ from h2o.exceptions import H2OError
 
 __no_export = set(dir())  # all variables defined above this are not exported
 
+
 class _MObject(object): pass
+
+
 class _MTuple(tuple): pass
+
+
 class _MList(list): pass
+
+
 class _MDict(dict): pass
+
+
 class _MStr(str): pass
 
 
@@ -31,7 +40,7 @@ def decorate_plot_result(res=None, figure=None):
         dec = _MDict(res)
     elif isinstance(res, str):
         dec = _MStr(res)
-    else: # should be an H2O instance, should be mutable
+    else:  # should be an H2O instance, should be mutable
         dec = res
     dec.figure = get_figure
     dec._is_decorated_plot_result = True


### PR DESCRIPTION
#15584 

This bug was introduced with wrapping the plot results in order to be able to return more than just a plot (also data). This caused explanations not to be rendered properly as the figure moved to the `.figure()`.

To reproduce it you can use something like:
```python
df = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv")

response = "quality"

predictors = [
  "fixed acidity", "volatile acidity", "citric acid", "residual sugar", "chlorides", "free sulfur dioxide",
  "total sulfur dioxide", "density", "pH", "sulphates", "alcohol",  "type"
]

aml = H2OAutoML(max_runtime_secs=20, seed=11)
ex = h2o.explain(aml, test)
```
and then in another jupyter cell
```python
ex
```


The result before this fix:
![Screen Shot 2023-06-16 at 11 44 05](https://github.com/h2oai/h2o-3/assets/61695433/33fed904-314d-4559-b5cf-984d65fab811)
