### PR TITLE
[PUBDEV-9112] Fix CVE-2023-2976

### DIFF
--- a/h2o-assemblies/main/build.gradle
+++ b/h2o-assemblies/main/build.gradle
@@ -27,7 +27,8 @@ dependencies {
         api('com.fasterxml.jackson.core:jackson-databind:2.13.4.2') {
             because 'Fixes CVE-2022-42003'
         }
-        api('com.google.guava:guava:31.1-jre') {
+        api('com.google.guava:guava:32.0.1-jre') {
+            because 'Fixes CVE-2023-2976'
             because 'Fixes CVE-2020-8908'
             because 'Fixes CVE-2018-10237'
         }

--- a/h2o-assemblies/minimal/build.gradle
+++ b/h2o-assemblies/minimal/build.gradle
@@ -23,7 +23,8 @@ dependencies {
     api project(":h2o-persist-http")
 
     constraints {
-        api('com.google.guava:guava:31.1-jre') {
+        api('com.google.guava:guava:32.0.1-jre') {
+            because 'Fixes CVE-2023-2976'
             because 'Fixes CVE-2020-8908'
             because 'Fixes CVE-2018-10237'
         }

--- a/h2o-assemblies/steam/build.gradle
+++ b/h2o-assemblies/steam/build.gradle
@@ -76,7 +76,8 @@ dependencies {
         api('org.jetbrains.kotlin:kotlin-stdlib:1.4.32') {
             because 'Fixes CVE-2020-29582'
         }
-        api('com.google.guava:guava:31.1-jre') {
+        api('com.google.guava:guava:32.0.1-jre') {
+            because 'Fixes CVE-2023-2976'
             because 'Fixes CVE-2020-8908'
             because 'Fixes CVE-2018-10237'
         }


### PR DESCRIPTION
A new vulnerability CVE-2023-2976 has been reported by prisma scan.

GH issue: https://github.com/h2oai/h2o-3/issues/15594
Jira: https://h2oai.atlassian.net/browse/PUBDEV-9112