### PR TITLE
GH-6707: added extended message to h2o.init to help user get around version mismatch error [nocheck]

### DIFF
--- a/h2o-py/h2o/backend/cluster.py
+++ b/h2o-py/h2o/backend/cluster.py
@@ -218,16 +218,19 @@ class H2OCluster(H2OSchema):
             if build_number_h2o is None or build_number_h2o == "unknown":
                 message = ("Version mismatch. H2O is version {0}, but the h2o-python package is version {1}. "
                            "Upgrade H2O and h2o-Python to latest stable version - "
-                           "http://h2o-release.s3.amazonaws.com/h2o/latest_stable.html"
+                           "http://h2o-release.s3.amazonaws.com/h2o/latest_stable.html.  To circumvent this error "
+                           "message (not recommended), you can set strict_version_check=False."
                            ).format(ver_h2o, ver_pkg)
             elif build_number_h2o == "99999":
                 message = ("Version mismatch. H2O is version {0}, but the h2o-python package is version {1}. "
-                           "This is a developer build, please contact your developer."
+                           "This is a developer build, please contact your developer.  To circumvent this error "
+                           "message (not recommended), you can set strict_version_check=False."
                            ).format(ver_h2o, ver_pkg)
             else:
                 message = ("Version mismatch. H2O is version {0}, but the h2o-python package is version {1}. "
                            "Install the matching h2o-Python version from - "
-                           "http://h2o-release.s3.amazonaws.com/h2o/{2}/{3}/index.html."
+                           "http://h2o-release.s3.amazonaws.com/h2o/{2}/{3}/index.html.  To circumvent this error "
+                           "message (not recommended), you can set strict_version_check=False."
                            ).format(ver_h2o, ver_pkg, branch_name_h2o, build_number_h2o)
             if strict:
                 raise H2OConnectionError(message)

--- a/h2o-py/h2o/backend/cluster.py
+++ b/h2o-py/h2o/backend/cluster.py
@@ -218,18 +218,18 @@ class H2OCluster(H2OSchema):
             if build_number_h2o is None or build_number_h2o == "unknown":
                 message = ("Version mismatch. H2O is version {0}, but the h2o-python package is version {1}. "
                            "Upgrade H2O and h2o-Python to latest stable version - "
-                           "http://h2o-release.s3.amazonaws.com/h2o/latest_stable.html.  To circumvent this error "
+                           "http://h2o-release.s3.amazonaws.com/h2o/latest_stable.html.  To avoid this error "
                            "message (not recommended), you can set strict_version_check=False."
                            ).format(ver_h2o, ver_pkg)
             elif build_number_h2o == "99999":
                 message = ("Version mismatch. H2O is version {0}, but the h2o-python package is version {1}. "
-                           "This is a developer build, please contact your developer.  To circumvent this error "
+                           "This is a developer build, please contact your developer.  To avoid this error "
                            "message (not recommended), you can set strict_version_check=False."
                            ).format(ver_h2o, ver_pkg)
             else:
                 message = ("Version mismatch. H2O is version {0}, but the h2o-python package is version {1}. "
                            "Install the matching h2o-Python version from - "
-                           "http://h2o-release.s3.amazonaws.com/h2o/{2}/{3}/index.html.  To circumvent this error "
+                           "http://h2o-release.s3.amazonaws.com/h2o/{2}/{3}/index.html.  To avoid this error "
                            "message (not recommended), you can set strict_version_check=False."
                            ).format(ver_h2o, ver_pkg, branch_name_h2o, build_number_h2o)
             if strict:

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -261,18 +261,22 @@ h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, start
 
       if( is.null( build_number_H2O ) ){
         stop(sprintf("Version mismatch! H2O is running version %s but h2o-R package is version %s.
-        Upgrade H2O and R to latest stable version - https://h2o-release.s3.amazonaws.com/h2o/latest_stable.html",
+        Upgrade H2O and R to latest stable version - https://h2o-release.s3.amazonaws.com/h2o/latest_stable.html.  
+        To circumvent this error message (not recommended), you can set strict_version_check=FALSE.",
         verH2O, toString(verPkg)))
       } else if (build_number_H2O =="unknown"){
         stop(sprintf("Version mismatch! H2O is running version %s but h2o-R package is version %s.
-        Upgrade H2O and R to latest stable version - https://h2o-release.s3.amazonaws.com/h2o/latest_stable.html",
+        Upgrade H2O and R to latest stable version - https://h2o-release.s3.amazonaws.com/h2o/latest_stable.html. 
+         To circumvent this error message (not recommended), you can set strict_version_check=FALSE.",
         verH2O, toString(verPkg)))
       } else if (build_number_H2O =="99999"){
         stop((sprintf("Version mismatch! H2O is running version %s but h2o-R package is version %s.
-        This is a developer build, please contact your developer",verH2O, toString(verPkg) )))
+        This is a developer build, please contact your developer.  To circumvent this error message (not recommended),
+         you can set strict_version_check=FALSE.",verH2O, toString(verPkg) )))
       } else {
          stop(sprintf("Version mismatch! H2O is running version %s but h2o-R package is version %s.
-         Install the matching h2o-R version from - https://h2o-release.s3.amazonaws.com/h2o/%s/%s/index.html",
+         Install the matching h2o-R version from - https://h2o-release.s3.amazonaws.com/h2o/%s/%s/index.html.  To 
+         circumvent this error message (not recommended), you can set strict_version_check=FALSE.",
          verH2O, toString(verPkg),branch_name_H2O,build_number_H2O))
       }
     }

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -262,21 +262,21 @@ h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, start
       if( is.null( build_number_H2O ) ){
         stop(sprintf("Version mismatch! H2O is running version %s but h2o-R package is version %s.
         Upgrade H2O and R to latest stable version - https://h2o-release.s3.amazonaws.com/h2o/latest_stable.html.  
-        To circumvent this error message (not recommended), you can set strict_version_check=FALSE.",
+        To avoid this error message (not recommended), you can set strict_version_check=FALSE.",
         verH2O, toString(verPkg)))
       } else if (build_number_H2O =="unknown"){
         stop(sprintf("Version mismatch! H2O is running version %s but h2o-R package is version %s.
         Upgrade H2O and R to latest stable version - https://h2o-release.s3.amazonaws.com/h2o/latest_stable.html. 
-         To circumvent this error message (not recommended), you can set strict_version_check=FALSE.",
+         To avoid this error message (not recommended), you can set strict_version_check=FALSE.",
         verH2O, toString(verPkg)))
       } else if (build_number_H2O =="99999"){
         stop((sprintf("Version mismatch! H2O is running version %s but h2o-R package is version %s.
-        This is a developer build, please contact your developer.  To circumvent this error message (not recommended),
+        This is a developer build, please contact your developer.  To avoid this error message (not recommended),
          you can set strict_version_check=FALSE.",verH2O, toString(verPkg) )))
       } else {
          stop(sprintf("Version mismatch! H2O is running version %s but h2o-R package is version %s.
          Install the matching h2o-R version from - https://h2o-release.s3.amazonaws.com/h2o/%s/%s/index.html.  To 
-         circumvent this error message (not recommended), you can set strict_version_check=FALSE.",
+         avoid this error message (not recommended), you can set strict_version_check=FALSE.",
          verH2O, toString(verPkg),branch_name_H2O,build_number_H2O))
       }
     }


### PR DESCRIPTION
This PR fixes the problem in GH: https://github.com/h2oai/h2o-3/issues/6707

Apart from getting an error message when the Java backend and the client Python/R versions do not match, the clients have no way to get around it if it is not important to use different backend and client software versions.  I added the method to circumvent this error message by showing the user what to do.  It is not recommended though.

I added two client tests to make sure the new error messages show up.