### PR TITLE
[GH-6554] Updating `nfolds` param definition [nocheck]

### DIFF
--- a/h2o-py/h2o/automl/_estimator.py
+++ b/h2o-py/h2o/automl/_estimator.py
@@ -158,11 +158,10 @@ class H2OAutoML(H2OAutoMLBaseMixin, Keyed):
                  **kwargs):
         """
         Create a new H2OAutoML instance.
-        
-        :param int nfolds: Number of folds for k-fold cross-validation.
-            Use ``0`` to disable cross-validation; this will also disable Stacked Ensemble (thus decreasing the overall model performance).
-            Defaults to ``-1``.
 
+        :param int nfolds: Specify a value >= 2 for the number of folds for k-fold cross-validation for the models in the AutoML or specify ``-1`` (default)
+            to let AutoML choose what it will do. If the data is big enough (depending on the cluster resources), it will create a blending frame
+            and will not do cross-validation. Otherwise, it will use 5 fold cross-validation.        
         :param bool balance_classes: Specify whether to oversample the minority classes to balance the class distribution. This option can increase
             the data frame size. This option is only applicable for classification. If the oversampled size of the dataset exceeds the maximum size
             calculated using the ``max_after_balance_size`` parameter, then the majority classes will be undersampled to satisfy the size limit.


### PR DESCRIPTION
For: https://github.com/h2oai/h2o-3/issues/6554

This PR updates the definition in the python docs for `nfolds`.


However, I did find that the rendering for a lot of the params is off. It seems to be the params with types (`int`, `str`, etc), the first line of description is treated as a secondary header. I've only seen this issue with AutoML, though. The style of how AutoML params are written is different from the other estimators. Types for the other estimators are written on a separate line. Tried doing that for AutoML and that errored, so they must be set up differently. Any ideas?
<img width="695" alt="Screen Shot 2023-07-10 at 12 04 52 PM" src="https://github.com/h2oai/h2o-3/assets/52463461/96553b9f-fec3-42a8-a069-ffbce04f5b93">
<img width="695" alt="Screen Shot 2023-07-10 at 12 05 03 PM" src="https://github.com/h2oai/h2o-3/assets/52463461/fe45bb5a-55aa-4681-9dc1-1eae9e01aaa6">
