### PR TITLE
[GH-15634] Avoid CVE-2019-10086 by upgrading MOJO2 lib

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -76,7 +76,7 @@ servletApiVersion=3.1.0
 gsonVersion=2.9.1
 
 # MOJO2 Integration
-mojo2version=2.7.11.1
+mojo2version=2.8.1
 
 # Assembly information
 mainAssemblyName=main


### PR DESCRIPTION
Closes #15634