### PR TITLE
GH-15643: Fix wrong {in,ex}clude_explanation parameter validation

### DIFF
--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -2967,17 +2967,17 @@ def _process_explanation_lists(
         exclude_explanations = [exclude_explanations]
     include_explanations = [exp.lower() for exp in include_explanations]
     exclude_explanations = [exp.lower() for exp in exclude_explanations]
+    for exp in exclude_explanations + include_explanations:
+        if exp not in possible_explanations and exp != "all":
+            raise H2OValueError("Unknown explanation \"{}\". Please use one of: {}".format(
+                exp, possible_explanations))
     if len(exclude_explanations) == 0:
         explanations = possible_explanations if "all" in include_explanations \
             else include_explanations
     else:
         if "all" not in include_explanations:
-            raise RuntimeError(
+            raise H2OValueError(
                 "Only one of include_explanations or exclude_explanation should be specified!")
-        for exp in exclude_explanations:
-            if exp not in possible_explanations:
-                raise RuntimeError("Unknown explanation \"{}\". Please use one of: {}".format(
-                    exp, possible_explanations))
         explanations = [exp for exp in possible_explanations if exp not in exclude_explanations]
     return explanations
 

--- a/h2o-py/tests/testdir_misc/pyunit_explain.py
+++ b/h2o-py/tests/testdir_misc/pyunit_explain.py
@@ -868,6 +868,32 @@ def test_pd_plot_row_value():
     assert_row_value(gbm.pd_plot(train, "sex", row_index=i).figure(), train[i, "sex"], "sex")
 
 
+def test_include_exclude_validation():
+    from h2o.exceptions import H2OValueError
+    train = h2o.upload_file(pyunit_utils.locate("smalldata/titanic/titanic_expanded.csv"))
+    train["name"] = train["name"].asfactor()
+    y = "fare"
+    
+    gbm = H2OGradientBoostingEstimator(seed=1234, model_id="my_awesome_model", ntrees=3)
+    gbm.train(y=y, training_frame=train)
+
+    try:
+        gbm.explain(train, include_explanations=["lorem"])
+        assert False, "Should fail as 'lorem' is not a valid explanation"
+    except H2OValueError:
+        pass
+
+    try:
+        gbm.explain(train, exclude_explanations=["lorem"])
+        assert False, "Should fail as 'lorem' is not a valid explanation"
+    except H2OValueError:
+        pass
+
+    assert isinstance(gbm.explain(train, include_explanations=["varimp"]), H2OExplanation)
+
+    assert isinstance(gbm.explain(train, exclude_explanations=["pdp", "shap_summary", "ice", "residual_analysis"]), H2OExplanation)
+
+
 pyunit_utils.run_tests([
     test_get_xy,
     test_varimp,
@@ -888,4 +914,5 @@ pyunit_utils.run_tests([
     test_pareto_front_corner_cases,
     test_pd_plot_row_value,
     test_fairness_plots,
+    test_include_exclude_validation,
     ])


### PR DESCRIPTION
https://github.com/h2oai/h2o-3/issues/15643

#15643

Validate both  include_explanations and exclude_explantations.

---

For now it fails due to:
> The associated GitHub issue #15643 must be mentioned in the description of the PR.

I tried to mention the issue both using the link and the `#xxxxx` but didn't seem to work, so I copy pasted the message to make sure I include correct characters because i have no other clue why this fails. Let's see if it works!