### PR TITLE
[GH-15598] Updating `import_file` description & add Google Storage support note

### DIFF
--- a/h2o-docs/src/product/getting-data-into-h2o.rst
+++ b/h2o-docs/src/product/getting-data-into-h2o.rst
@@ -8,7 +8,7 @@ The first step toward building and scoring your models is getting your data into
 Supported File Formats
 ----------------------
 
-H2O currently supports the following file types:
+H2O supports the following file types:
 
 - CSV (delimited, UTF-8 only) files (including GZipped CSV)
 - ORC
@@ -18,6 +18,7 @@ H2O currently supports the following file types:
 - XLSX (BIFF 8 only)
 - Avro version 1.8.0 (without multifile parsing or column type modification)
 - Parquet
+- Google Storage (gs://)
 
 **Notes**: 
  

--- a/h2o-py/docs/data.rst
+++ b/h2o-py/docs/data.rst
@@ -40,6 +40,7 @@ The following data sources are supported:
 * A Directory (with many data files inside at the *same* level -- no support for recursive import of data)
 * S3/S3N
 * Native Language Data Structure (c.f. the subsequent section)
+* Google Storage (gs://)
 
 .. code-block:: python
 

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -413,7 +413,7 @@ def import_file(path=None, destination_frame=None, parse=True, header=0, sep=Non
                 na_strings=None, pattern=None, skipped_columns=None, custom_non_data_line_markers=None,
                 partition_by=None, quotechar=None, escapechar=None):
     """
-    Import a dataset that is already on the cluster.
+    Import files into an H2O cluster. The default behavior is to pass-through to the parse phase automatically.
 
     The path to the data must be a valid path for each node in the H2O cluster. If some node in the H2O cluster
     cannot see the file, then an exception will be thrown by the H2O cluster. Does a parallel/distributed


### PR DESCRIPTION
For #15598 

This PR update the language for the `import_file` param description to help reduce confusion about how it imports files and also adds a note on how Google Storage is supported for import.