### PR TITLE
GH-15666: showcase GBM can use checkpoint like other models.[nocheck]

### DIFF
--- a/h2o-py/tests/testdir_algos/gbm/pyunit_GH_15666_GBM_checkpoint.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_GH_15666_GBM_checkpoint.py
@@ -5,39 +5,34 @@ from tests import pyunit_utils
 
 
 def cars_checkpoint():
-
     cars = h2o.upload_file(pyunit_utils.locate("smalldata/junit/cars_20mpg.csv"))
     predictors = ["displacement","power","weight","acceleration","year"]
     response_col = "economy"
     distribution = "gaussian"
 
     # build first model
-
     from h2o.estimators.gbm import H2OGradientBoostingEstimator
-    model1 = H2OGradientBoostingEstimator(ntrees=10,max_depth=2, min_rows=10, distribution=distribution)
+    model1 = H2OGradientBoostingEstimator(ntrees=10,max_depth=2, min_rows=10, distribution=distribution, seed=12345)
     model1.train(x=predictors,y=response_col,training_frame=cars)
 
-    # model1 = h2o.gbm(x=cars[predictors],y=cars[response_col],ntrees=10,max_depth=2, min_rows=10,
-    #                  distribution=distribution)
 
     # continue building the model
-    model2 = H2OGradientBoostingEstimator(ntrees=11,max_depth=3, min_rows=9,r2_stopping=0.8,
-                                          distribution=distribution,checkpoint=model1._id)
+    model2 = H2OGradientBoostingEstimator(ntrees=model1.actual_params['ntrees']+2, max_depth=model1.actual_params['max_depth'],
+                                          min_rows=model1.actual_params['min_rows'], distribution=distribution,checkpoint=model1._id)
     model2.train(x=predictors,y=response_col,training_frame=cars)
 
-    # model2 = h2o.gbm(x=cars[predictors],y=cars[response_col],ntrees=11,max_depth=3, min_rows=9,r2_stopping=0.8,
-    #                  distribution=distribution,checkpoint=model1._id)
+    # build complete model without stopping and then continue
+    model3 = H2OGradientBoostingEstimator(ntrees=12,max_depth=2, min_rows=10, distribution=distribution, seed=12345)
+    model3.train(x=predictors,y=response_col,training_frame=cars)
 
-    #   erroneous, not MODIFIABLE_BY_CHECKPOINT_FIELDS
-    # PUBDEV-1833
-    #   learn_rate
+    # model2 and model3 should have the same model metrics
+    assert abs(model2.r2() - model3.r2())<1e-6, "Expected R2: {0}, Actual R2: {1} and they are different.".format(model2.r2(), model3.r2())
+    assert abs(model2.mse() - model3.mse())<1e-6, "Expected MSE: {0}, Actual MSE: {1} and they are different.".format(model2.mse(), model3.mse())   
+
     try:
         model = H2OGradientBoostingEstimator(learn_rate=0.00001,distribution=distribution,
                                              checkpoint=model1._id)
         model.train(x=predictors,y=response_col,training_frame=cars)
-
-        # model = h2o.gbm(y=cars[response_col], x=cars[predictors],learn_rate=0.00001,distribution=distribution,
-        #                 checkpoint=model1._id)
         assert False, "Expected model-build to fail because learn_rate not modifiable by checkpoint"
     except EnvironmentError:
         assert True
@@ -48,9 +43,6 @@ def cars_checkpoint():
         model = H2OGradientBoostingEstimator(nbins_cats=99,distribution=distribution,
                                              checkpoint=model1._id)
         model.train(x=predictors,y=response_col,training_frame=cars)
-
-        # model = h2o.gbm(y=cars[response_col], x=cars[predictors],nbins_cats=99,distribution=distribution,
-        #                 checkpoint=model1._id)
         assert False, "Expected model-build to fail because nbins_cats not modifiable by checkpoint"
     except EnvironmentError:
         assert True
@@ -60,9 +52,6 @@ def cars_checkpoint():
         model = H2OGradientBoostingEstimator(balance_classes=True,distribution=distribution,
                                              checkpoint=model1._id)
         model.train(x=predictors,y=response_col,training_frame=cars)
-
-        # model = h2o.gbm(y=cars[response_col], x=cars[predictors],balance_classes=True,distribution=distribution,
-        #                 checkpoint=model1._id)
         assert False, "Expected model-build to fail because balance_classes not modifiable by checkpoint"
     except EnvironmentError:
         assert True
@@ -72,8 +61,6 @@ def cars_checkpoint():
         model = H2OGradientBoostingEstimator(nbins=99,distribution=distribution,
                                              checkpoint=model1._id)
         model.train(x=predictors,y=response_col,training_frame=cars)
-        # model = h2o.gbm(y=cars[response_col], x=cars[predictors],nbins=99,distribution=distribution,
-        #                 checkpoint=model1._id)
         assert False, "Expected model-build to fail because nbins not modifiable by checkpoint"
     except EnvironmentError:
         assert True
@@ -83,8 +70,6 @@ def cars_checkpoint():
         model = H2OGradientBoostingEstimator(nfolds=3,distribution=distribution,
                                              checkpoint=model1._id)
         model.train(x=predictors,y=response_col,training_frame=cars)
-        # model = h2o.gbm(y=cars[response_col], x=cars[predictors],nfolds=3,distribution=distribution,
-        #                 checkpoint=model1._id)
         assert False, "Expected model-build to fail because nfolds not modifiable by checkpoint"
     except EnvironmentError:
         assert True


### PR DESCRIPTION
This PR fixes this issue: https://github.com/h2oai/h2o-3/issues/15666

I just changed the no_pass test and fix it so that it works when we try to use checkpoint on GBM models like the other models (GLM, ...).