### PR TITLE
GH-6605 fix feature interaction for trees with depth 0

### DIFF
--- a/h2o-core/src/main/java/hex/FeatureInteractions.java
+++ b/h2o-core/src/main/java/hex/FeatureInteractions.java
@@ -43,6 +43,9 @@ public class FeatureInteractions {
     }
 
     public int maxDepth() {
+        if (this.entrySet().size() == 0){
+            return 0;
+        }
         return Collections.max(this.entrySet(), Comparator.comparingInt(entry -> entry.getValue().depth)).getValue().depth;
     }
     

--- a/h2o-r/tests/testdir_algos/gbm/runit_GBM_feature_interaction_cv.R
+++ b/h2o-r/tests/testdir_algos/gbm/runit_GBM_feature_interaction_cv.R
@@ -1,0 +1,28 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+library(ggplot2)
+
+test.feature_interaction_with_cv <- function() {
+    diamonds <- ggplot2::diamonds
+    diamonds$cut <- factor(diamonds$cut, ordered = FALSE)
+    diamonds$color <- factor(diamonds$color, ordered = FALSE)
+    diamonds$clarity <- factor(diamonds$clarity, ordered = FALSE)
+    diamonds <- as.h2o(diamonds)
+    diamonds$expensive <- h2o.asfactor(ifelse(diamonds$price == 5000, 1, 0))
+
+    train <- diamonds
+    train$fold <- h2o.kfold_column(data = train, nfolds = 3, seed = 123)
+    
+    params <- list( x = setdiff(names(diamonds), "expensive"), y = "expensive", fold_column = "fold", training_frame = as.name("train"), validation_frame = NULL, distribution = "bernoulli", learn_rate = 0.1, ntrees = 500, min_split_improvement = 1e-3, stopping_rounds = 3, stopping_tolerance = 0.001, seed = 456 )
+    my_gbm <- do.call(what = "h2o.gbm", args = params)
+    
+    # feature interaction with main model
+    print(h2o.feature_interaction(model = my_gbm))
+    
+    # feature interaction with cv model where tree depth = 0
+    my_cv_gbm <- h2o.getModel(my_gbm@model$cross_validation_models[[1]]$name)
+    print(h2o.feature_interaction(model = my_cv_gbm))
+}
+
+doTest("Test Empty Model Metrics", test.feature_interaction_with_cv)


### PR DESCRIPTION
The first part was fixed here: #15689. 

But I found another bug: when the CV model tree has depth 0, it failed. So this PR fixed this bug. 

Closes: #6605 