### PR TITLE
[GH-15694] Added GLM to `custom_metric_func` & `upload_custom_metric` and added those params to glm page

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/custom_metric_func.rst
+++ b/h2o-docs/src/product/data-science/algo-params/custom_metric_func.rst
@@ -3,7 +3,7 @@
 ``custom_metric_func``
 ----------------------
 
-- Available in: GBM, DRF 
+- Available in: GBM, DRF, GLM
 - Hyperparameter: no
 
 Description

--- a/h2o-docs/src/product/data-science/algo-params/upload_custom_metric.rst
+++ b/h2o-docs/src/product/data-science/algo-params/upload_custom_metric.rst
@@ -3,7 +3,7 @@
 ``upload_custom_metric``
 ------------------------
 
-- Available in: GBM, DRF
+- Available in: GBM, DRF, GLM
 - Hyperparameter: no
 
 Description

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -43,6 +43,8 @@ Algorithm-specific parameters
 
 -  **calc_like**: Specify whether to return likelihood function value for HGLM or normal GLM. Setting this option to ``True`` while disabling ``HGLM`` will enable the calculation of the full log likelihood and full AIC. This option defaults to ``False`` (disabled). 
 
+- `custom_metric_func <algo-params/custom_metric_func.html>`__: Specify a custom evaluation function.
+
 - **dispersion_epsilon**: If changes in dispersion parameter estimation or loglikelihood value is smaller than ``dispersion_epsilon``, this will break out of the dispersion parameter estimation loop using maximum likelihood. This option defaults to ``0.0001``.
 
 - **dispersion_learning_rate**: (Applicable only when ``dispersion_parameter_method="ml"``) This value controls how much the dispersion parameter estimate will be changed when the calculated loglikelihood actually decreases with the new dispersion. In this case, instead of setting *dispersion = dispersion + change*, it is *dispersion + dispersion_learning_rate* :math:`\times` *change*. This option must be > 0 and defaults to ``0.5``.
@@ -64,6 +66,8 @@ Algorithm-specific parameters
 - **max_iterations_dispersion**: Control the maximum number of iterations in the dispersion parameter estimation loop using maximum likelihood. This option defaults to ``1000000``.
 
 -  `rand_family <algo-params/rand_family.html>`__: The Random Component Family specified as an array. You must include one family for each random component. Currently only ``rand_family=["gaussisan"]`` is supported.
+
+- `upload_custom_metric <algo-params/upload_custom_metric.html>`__: Upload a custom metric into a running H2O cluster.
 
 HGLM parameters
 '''''''''''''''


### PR DESCRIPTION
For: #15694 

I added GLM to the algo-param pages and added those params to the GLM algo page. I put them in the algorithm-specific section -- please let me know if I should move them elsewhere. 