### PR TITLE
Increase timeout for Py3.6 Medium-large to same value as Py3.7 Medium-large [nocheck]

### DIFF
--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -440,7 +440,7 @@ def call(final pipelineContext) {
     ],
     [
       stageName: 'Py3.6 Medium-large', target: 'test-pyunit-medium-large', pythonVersion: '3.6',
-      timeoutValue: 160, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 220, component: pipelineContext.getBuildConfig().COMPONENT_PY
     ],
     [
       stageName: 'R3.3 Medium-large', target: 'test-r-medium-large', rVersion: '3.3.3',


### PR DESCRIPTION
Py3.6 Medium-large keeps timeout and has a same subset of tests as Py3.7. Py3.7 works fine.