### PR TITLE
[GH-15750][FOLLOWUP] Upgrade nimbus-jose-jwt to get rid of json-smart lib

### DIFF
--- a/h2o-assemblies/main/build.gradle
+++ b/h2o-assemblies/main/build.gradle
@@ -54,9 +54,6 @@ dependencies {
         api('com.fasterxml.jackson.core:jackson-databind:2.13.4.2') {
             because 'Fixes CVE-2022-42003'
         }
-        api('net.minidev:json-smart:2.4.10') {
-            because 'Fixes CVE-2023-1370'
-        }
         api('org.jetbrains.kotlin:kotlin-stdlib:1.6.21') {
             because 'Fixes CVE-2020-29582'
             because 'Fixes CVE-2022-24329'

--- a/h2o-assemblies/steam/build.gradle
+++ b/h2o-assemblies/steam/build.gradle
@@ -55,9 +55,6 @@ dependencies {
             because 'Fixes CVE-2022-42003'
             because 'Fixes PRISMA-2023-0067'
         }
-        api('net.minidev:json-smart:2.4.10') {
-            because 'Fixes CVE-2023-1370'
-        }
         api('org.codehaus.jettison:jettison:1.5.4') {
             because 'Fixes CVE-2023-1436'
             because 'Fixes CVE-2022-45693'

--- a/h2o-persist-hdfs/build.gradle
+++ b/h2o-persist-hdfs/build.gradle
@@ -21,7 +21,7 @@ dependencies {
         transitive = false
     }
     
-    api("com.nimbusds:nimbus-jose-jwt:9.11.3")
+    api("com.nimbusds:nimbus-jose-jwt:9.24.4")
 
     testImplementation project(":h2o-test-support")
     testImplementation "org.apache.hadoop:hadoop-common:$defaultHadoopVersion"


### PR DESCRIPTION
Closes #15750

The Prisma scan still reports the version 2.4.7. It looks nimbus-jose-jwt relocates the package and the version is still captured in META-INF/maven.

The new version nimbus-jose-jwt doesn't seem to reference json-smart lib.