### PR TITLE
[GH-15764] Specify Versions of commons-compress and protobuf-java in Main Standalone Jar

### DIFF
--- a/h2o-assemblies/main/build.gradle
+++ b/h2o-assemblies/main/build.gradle
@@ -50,6 +50,10 @@ dependencies {
         exclude group: "org.apache.thrift", module: "libthrift"
     }
 
+    // Upgrade dependencies coming from Hadoop to address vulnerabilities 
+    api "org.apache.commons:commons-compress:1.21"
+    api "com.google.protobuf:protobuf-java:3.21.7"
+
     constraints {
         api('com.fasterxml.jackson.core:jackson-databind:2.13.4.2') {
             because 'Fixes CVE-2022-42003'


### PR DESCRIPTION
Closes #15764 

`META-INF/maven` contains pom files for all versions. Prisma scan seems to use this path for vulnerability scan although the below command and Snyk scan say different:

`./gradlew :h2o-assemblies:main:dependencyInsight --dependency protobuf-java --configuration runtimeClasspath`

Explicit version specification should fix the problem.