### PR TITLE
[GH-15706] Upgrade Jetty Server to 9.4.52.v20230823 in Main Jar

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ jetty8version=8.2.0.v20160908
 # packages. Each hadoop package can upgrade its jetty version.
 jetty9version=9.4.11.v20180605
 # jetty 9 version is used in the main standalone assembly
-jetty9MainVersion=9.4.51.v20230217
+jetty9MainVersion=9.4.52.v20230823
 # jetty-minimal 9 version is used in the minimal standalone assembly
 jetty9MinimalVersion=9.4.51.v20230217
 servletApiVersion=3.1.0


### PR DESCRIPTION
Closes #15706 

We need to upgrade jetty-server again since There are two new vulnerabilities associated with the current version [9.4.51.v20230217](https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-server/9.4.51.v20230217):

- CVE-2023-40167
- CVE-2023-36479