### PR TITLE
GH_15729: implement multi-thread as-data-frame using datatable [nocheck]

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -29,7 +29,7 @@ from h2o.utils.metaclass import deprecated_fn
 from h2o.utils.shared_utils import (_handle_numpy_array, _handle_pandas_data_frame, _handle_python_dicts,
                                     _handle_python_lists, _is_list, _is_str_list, _py_tmp_key, _quoted,
                                     can_use_pandas, can_use_numpy, quote, normalize_slice, slice_is_normalized, 
-                                    check_frame_id, can_use_polars, can_use_pyarrow)
+                                    check_frame_id, can_use_datatable)
 from h2o.utils.threading import local_context, local_env
 from h2o.utils.typechecks import (assert_is_type, assert_satisfies, Enum, I, is_type, numeric, numpy_ndarray,
                                   numpy_datetime, pandas_dataframe, pandas_timestamp, scipy_sparse, U)
@@ -1936,7 +1936,7 @@ class H2OFrame(Keyed, H2ODisplay):
         :param bool use_pandas: If True (default) then return the H2OFrame as a pandas DataFrame (requires that the
             ``pandas`` library was installed). If False, then return the contents of the H2OFrame as plain nested
             list, in a row-wise order.
-        :param bool multi_thread: if True and if use_pandas is True, will use polars to speedup the conversion from
+        :param bool multi_thread: if True and if use_pandas is True, will use datatable to speedup the conversion from
              H2O frame to pandas frame that uses multi-thread.
         :param bool header: If True (default), then column names will be appended as the first row in list
 
@@ -1957,20 +1957,28 @@ class H2OFrame(Keyed, H2ODisplay):
         if can_use_pandas() and use_pandas:
             import pandas
             if multi_thread:
-                if can_use_polars() and can_use_pyarrow():
+                if can_use_datatable():
                     try:
                         tmpdir = tempfile.mkdtemp()
                         fileName = os.path.join(tmpdir, "h2oframe2Convert.csv")
                         h2o.export_file(self, fileName)
-                        import polars as pl
-                        dt_frame = pl.read_csv(fileName)
+                        #h2o.download_csv(self, fileName)
+                        import datatable as dt
+                        frameTypes = self.types
+                        validFrameTypes = {}
+                        for key, value in frameTypes.items():
+                            if value.startswith('int'):
+                                validFrameTypes[key] = dt.int64
+                            elif value.startswith("real"):
+                                validFrameTypes[key] = dt.float64
+                        dt_frame = dt.fread(fileName, na_strings=[""], columns=validFrameTypes)
                         return dt_frame.to_pandas()
                     finally:
                         os.remove(fileName)
                         os.rmdir(tmpdir)
-                elif not(can_use_polars()) or not(can_use_pyarrow()):
-                    warnings("multi_thread mode can only be used when you have polars "
-                             "and pyarrow modules installed.")                   
+                elif not(can_use_datatable()):
+                    warnings("multi_thread mode can only be used when you have datatable "
+                             "installed.")                   
             return pandas.read_csv(StringIO(self.get_frame_data()), low_memory=False, skip_blank_lines=False)
         from h2o.utils.csv.readers import reader
         frame = [row for row in reader(StringIO(self.get_frame_data()))]

--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -130,11 +130,8 @@ def is_module_available(mod):
 def can_use_pandas():
     return is_module_available('pandas')
 
-def can_use_polars():
-    return is_module_available('polars')
-
-def can_use_pyarrow():
-    return is_module_available('pyarrow')
+def can_use_datatable():
+    return is_module_available('datatable')
 
 def can_use_numpy():
     return is_module_available('numpy')

--- a/h2o-py/tests/testdir_misc/pyunit_gh_15729_datatable_2_pandas.py
+++ b/h2o-py/tests/testdir_misc/pyunit_gh_15729_datatable_2_pandas.py
@@ -1,0 +1,61 @@
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.shared_utils import (can_use_pandas, can_use_datatable)
+import time
+import numpy as np
+import pandas as pd
+
+# if datatable is installed, this test will show that using datatable to convert h2o frame to pandas frame is
+# much faster for large datasets.
+def test_frame_conversion(dataset, compareTime):
+    print("Performing data conversion to pandas for dataset: {0}".format(dataset))
+    h2oFrame = h2o.import_file(pyunit_utils.locate(dataset))
+     # convert frame in single thread
+    startT = time.time()
+    original_pandas_frame = h2oFrame.as_data_frame()
+    oldTime = time.time()-startT
+    print("H2O frame to Pandas frame conversion time: {0}".format(oldTime))
+    # convert frame using datatable
+    startT = time.time()
+    new_pandas_frame = h2oFrame.as_data_frame(multi_thread=True)
+    newTime = time.time()-startT
+    print("H2O frame to Pandas frame conversion time using datatable: {0}".format(newTime))
+    if compareTime: # disable for small dataset.  Multi-thread can be slower due to more overhead
+        assert newTime <= oldTime, " original frame conversion time: {0} should exceed new frame conversion time:" \
+                                   "{1} but is not.".format(oldTime, newTime)
+    # compare two frames column types                
+    new_types = new_pandas_frame.dtypes
+    old_types = original_pandas_frame.dtypes
+    ncol = h2oFrame.ncol
+    nrow = h2oFrame.nrow
+    
+    for ind in list(range(ncol)):
+        assert new_types[ind] == old_types[ind], "Expected column types: {0}, actual column types: " \
+                                                 "{1}".format(old_types[ind], new_types[ind])
+        if new_types[ind] == "object":
+            diff = new_pandas_frame.iloc[:, ind] == original_pandas_frame.iloc[:, ind]
+            if not diff.all(): # difference caused by the presence of NAs
+                newSeries = pd.Series(new_pandas_frame.iloc[:, ind])
+                newNA = newSeries.isna()
+                oldSeries = pd.Series(original_pandas_frame.iloc[:, ind])
+                oldNA = oldSeries.isna()
+                assert (newNA==oldNA).all()       
+        else:
+            diff = (new_pandas_frame.iloc[:, ind] - original_pandas_frame.iloc[:, ind]).abs()
+            assert diff.max() < 1e-10
+            
+def test_polars_pandas():
+    if not(can_use_datatable()):
+        pyunit_utils.install("datatable")
+    import datatable
+    test_frame_conversion("smalldata/titanic/titanic_expanded.csv", False)
+    test_frame_conversion("smalldata/glm_test/multinomial_3Class_10KRow.csv", False)
+    test_frame_conversion("smalldata/timeSeries/CreditCard-ts_train.csv", False)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_polars_pandas)
+else:
+    test_polars_pandas()

--- a/h2o-py/tests/testdir_misc/pyunit_gh_15729_datatable_2_pandas_large.py
+++ b/h2o-py/tests/testdir_misc/pyunit_gh_15729_datatable_2_pandas_large.py
@@ -2,16 +2,15 @@ import sys
 sys.path.insert(1,"../../")
 import h2o
 from tests import pyunit_utils
-from h2o.utils.shared_utils import (can_use_pandas, can_use_polars, can_use_pyarrow)
+from h2o.utils.shared_utils import (can_use_pandas, can_use_datatable)
 import time
-import subprocess
 
-# if polars is installed, this test will show that using polars to convert h2o frame to pandas frame is
+# if datatable is installed, this test will show that using datatable to convert h2o frame to pandas frame is
 # much faster.
 def test_frame_conversion(dataset, compareTime):
     print("Performing data conversion to pandas for dataset: {0}".format(dataset))
     h2oFrame = h2o.import_file(pyunit_utils.locate(dataset))
-     # convert frame not using datatable
+     # convert frame in single thread
     startT = time.time()
     original_pandas_frame = h2oFrame.as_data_frame()
     oldTime = time.time()-startT
@@ -20,32 +19,29 @@ def test_frame_conversion(dataset, compareTime):
     startT = time.time()
     new_pandas_frame = h2oFrame.as_data_frame(multi_thread=True)
     newTime = time.time()-startT
-    print("H2O frame to Pandas frame conversion time using polars: {0}".format(newTime))
+    print("H2O frame to Pandas frame conversion time using datatable: {0}".format(newTime))
     if compareTime: # disable for small dataset.  Multi-thread can be slower due to more overhead
         assert newTime <= oldTime, " original frame conversion time: {0} should exceed new frame conversion time:" \
                                    "{1} but is not.".format(oldTime, newTime)
     # compare two frames column types                
-    original_types = original_pandas_frame.dtypes
     new_types = new_pandas_frame.dtypes
-    for ind in range(0, h2oFrame.ncols):
-        assert str(original_types[ind])==str(new_types[ind]), \
-            "Expected column {0} type: {1}, actual {2}.".format(ind, str(original_types[ind]), str(new_types[ind]))
+    old_types = original_pandas_frame.dtypes
+    ncol = h2oFrame.ncol
+    
+    for ind in range(ncol):
+        assert new_types[ind] == old_types[ind], "Expected column types: {0}, actual column types: " \
+                                                 "{1}".format(old_types[ind], new_types[ind])
+    
 
 def test_polars_pandas():
     if not(can_use_pandas()):
         pyunit_utils.install("pandas")
     import pandas
-    print(pandas.__version__)
-    if float(pandas.__version__[0]) >= 1:
-        if not(can_use_polars()):
-            pyunit_utils.install("polars")
-        if not(can_use_pyarrow()):
-            pyunit_utils.install("pyarrow")
-        test_frame_conversion("smalldata/glm_test/multinomial_3Class_10KRow.csv", True)
-        test_frame_conversion("smalldata/titanic/titanic_expanded.csv", False)
-        test_frame_conversion("smalldata/timeSeries/CreditCard-ts_train.csv", False)
-    else:
-        print("Test skipped due to old pandas version")
+    if not(can_use_datatable()):
+        pyunit_utils.install("datatable")
+    import datatable
+    test_frame_conversion("bigdata/laptop/jira/PUBDEV_5266_merge_with_string_columns/PUBDEV_5266_f1.csv", True)
+
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(test_polars_pandas)


### PR DESCRIPTION
This PR resolves the issue here: https://github.com/h2oai/h2o-3/issues/15729.

Basically, I use python datatable which is controlled by H2O-3 to perform the multi-thread conversion of H2O-3 frame to pandas frame.

In particulare, the column types are specified in the datatable.fread to make sure the data types are not changed.