### PR TITLE
[GH-15799] Upgrade snappy-java in Standalone Jars to Address CVE-2023-43642

### DIFF
--- a/h2o-assemblies/main/build.gradle
+++ b/h2o-assemblies/main/build.gradle
@@ -77,10 +77,11 @@ dependencies {
         api('com.squareup.okio:okio:3.5.0') {
             because 'Fixes CVE-2023-3635'
         }
-        api('org.xerial.snappy:snappy-java:1.1.10.3') {
+        api('org.xerial.snappy:snappy-java:1.1.10.5') {
             because 'Fixes CVE-2023-34455'
             because 'Fixes CVE-2023-34454'
             because 'Fixes CVE-2023-34453'
+            because 'Fixes CVE-2023-43642'
         }
     }
 }

--- a/h2o-assemblies/steam/build.gradle
+++ b/h2o-assemblies/steam/build.gradle
@@ -74,10 +74,11 @@ dependencies {
         api('com.squareup.okio:okio:3.5.0') {
             because 'Fixes CVE-2023-3635'
         }
-        api('org.xerial.snappy:snappy-java:1.1.10.3') {
+        api('org.xerial.snappy:snappy-java:1.1.10.5') {
             because 'Fixes CVE-2023-34455'
             because 'Fixes CVE-2023-34454'
             because 'Fixes CVE-2023-34453'
+            because 'Fixes CVE-2023-43642'
         }
     }
 }


### PR DESCRIPTION
Closes #15799

State after the change in the main jar: 
```
> Task :h2o-assemblies:main:dependencyInsight
org.xerial.snappy:snappy-java:1.1.10.5
   variant "runtime" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-runtime
      org.gradle.libraryelements     = jar
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.environment     = standard-jvm
         org.gradle.jvm.version         = 8
   ]
   Selection reasons:
      - By constraint : Fixes CVE-2023-43642
      - By conflict resolution : between versions 1.1.10.5, 1.1.8.2 and 1.1.8.3

org.xerial.snappy:snappy-java:1.1.10.5
\--- runtimeClasspath

org.xerial.snappy:snappy-java:1.1.8.2 -> 1.1.10.5
\--- org.apache.hadoop:hadoop-common:3.3.6
     \--- runtimeClasspath

org.xerial.snappy:snappy-java:1.1.8.3 -> 1.1.10.5
\--- org.apache.parquet:parquet-hadoop:1.12.3
     \--- project :h2o-parquet-parser
          \--- runtimeClasspath
```

State after the change in the steam jar: 
```
> Task :h2o-assemblies:steam:dependencyInsight
org.xerial.snappy:snappy-java:1.1.10.5
   variant "runtime" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-runtime
      org.gradle.libraryelements     = jar
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.environment     = standard-jvm
         org.gradle.jvm.version         = 8
   ]
   Selection reasons:
      - By constraint : Fixes CVE-2023-43642
      - By conflict resolution : between versions 1.1.10.5, 1.1.8.2 and 1.1.8.3

org.xerial.snappy:snappy-java:1.1.10.5
\--- runtimeClasspath

org.xerial.snappy:snappy-java:1.1.8.2 -> 1.1.10.5
\--- org.apache.hadoop:hadoop-common:3.3.6
     \--- runtimeClasspath

org.xerial.snappy:snappy-java:1.1.8.3 -> 1.1.10.5
\--- org.apache.parquet:parquet-hadoop:1.12.3
     +--- runtimeClasspath
     \--- project :h2o-parquet-parser
          \--- runtimeClasspath
```