### PR TITLE
[GH-15802] Upgrade org.apache.avro:avro Library to Address CVE-2023-39410

### DIFF
--- a/h2o-parsers/h2o-avro-parser/build.gradle
+++ b/h2o-parsers/h2o-avro-parser/build.gradle
@@ -6,7 +6,7 @@ description = "H2O Avro Parser"
 dependencies {
   api project(":h2o-core")
   // Avro support
-  api 'org.apache.avro:avro:1.11.0'
+  api 'org.apache.avro:avro:1.11.3'
 
   testImplementation project(":h2o-test-support")
   testRuntimeOnly project(":${defaultWebserverModule}")


### PR DESCRIPTION
Closes #15802

The state after the change:
```
> Task :h2o-assemblies:main:dependencyInsight
project :h2o-avro-parser
   variant "runtimeElements" [
      org.gradle.category            = library
      org.gradle.dependency.bundling = external
      org.gradle.usage               = java-runtime
      org.gradle.libraryelements     = jar
      org.gradle.jvm.version         = 8

      Requested attributes not found in the selected variant:
         org.gradle.jvm.environment     = standard-jvm
   ]

project :h2o-avro-parser
\--- runtimeClasspath

org.apache.avro:avro:1.11.3
   variant "runtime" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-runtime
      org.gradle.libraryelements     = jar
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.environment     = standard-jvm
         org.gradle.jvm.version         = 8
   ]

org.apache.avro:avro:1.11.3
\--- project :h2o-avro-parser
     \--- runtimeClasspath
```