### PR TITLE
[GH-15815] Upgrade jetty-server to Address CVE-2023-36478 [no check]

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -62,9 +62,9 @@ jetty8version=8.2.0.v20160908
 # packages. Each hadoop package can upgrade its jetty version.
 jetty9version=9.4.11.v20180605
 # jetty 9 version is used in the main standalone assembly
-jetty9MainVersion=9.4.52.v20230823
+jetty9MainVersion=9.4.53.v20231009
 # jetty-minimal 9 version is used in the minimal standalone assembly
-jetty9MinimalVersion=9.4.52.v20230823
+jetty9MinimalVersion=9.4.53.v20231009
 servletApiVersion=3.1.0
 
 # Gson


### PR DESCRIPTION
Closes GH-15815