### PR TITLE
[NOCHECK] Remove Python Constraint from Release Pipeline

### DIFF
--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
@@ -356,7 +356,7 @@ EOF
 
                         final def condaS3Dir = "${env.S3_ROOT}/${env.BRANCH_NAME}/${currentBuild.number}/Python/Conda"
                         final def artifacts = ['main', 'client']
-                        final def pyVersions = pipelineContext.getBuildConfig().PYTHON_VERSIONS.findAll { Double.parseDouble(it) >= 3.6 }
+                        final def pyVersions = pipelineContext.getBuildConfig().PYTHON_VERSIONS
 
                         // build for all Python versions
                         for (artifact in artifacts) {


### PR DESCRIPTION
The version comparison in the constraint causes that pipeline ignores Python versions 3.10 and 3.11. The constraint was introduced in d5868082 to avoid Conda problems with Python 2.7 and 3.5. This constraint can be safely removed since these two Python versions are not supported anymore.