### PR TITLE
[GH-15881] Added K8s security note 

### DIFF
--- a/h2o-docs/src/product/cloud-integration/kubernetes.rst
+++ b/h2o-docs/src/product/cloud-integration/kubernetes.rst
@@ -26,7 +26,7 @@ After H2O is started, there must be a way for H2O nodes to "find" themselves and
 
 For reproducibility, resource limits and requests should always be set to equal values.
 
-**Note**: Official K8s images don’t apply any security settings. The default user is ROOT. If you require a secure interface with H2O running the image, you need to change the user and execution command to add security parameters before running the image. The following is the default command used in Docker images:
+**Note**: Official K8s images don’t apply any `security settings <../security.html>`__. The default user is ``root``. If you require a secure interface with H2O running the image, you need to change the user and execution command to add security parameters before running the image. The following is the default command used in Docker images:
 
 ::
   

--- a/h2o-docs/src/product/cloud-integration/kubernetes.rst
+++ b/h2o-docs/src/product/cloud-integration/kubernetes.rst
@@ -26,6 +26,13 @@ After H2O is started, there must be a way for H2O nodes to "find" themselves and
 
 For reproducibility, resource limits and requests should always be set to equal values.
 
+**Note**: Official K8s images don’t apply any security settings. The default user is ROOT. If you require a secure interface with h2o running the image, you need to change the user and execution command to add security parameters before running the image. The following is the default command used in Docker images:
+
+::
+  
+  java -Djava.library.path=/opt/h2oai/h2o-3/xgb_lib_dir -XX:+UseContainerSupport -XX:MaxRAMPercentage=50 -jar /opt/h2oai/h2o-3/h2o.jar
+
+
 Headless Service
 ~~~~~~~~~~~~~~~~
 

--- a/h2o-docs/src/product/cloud-integration/kubernetes.rst
+++ b/h2o-docs/src/product/cloud-integration/kubernetes.rst
@@ -26,7 +26,7 @@ After H2O is started, there must be a way for H2O nodes to "find" themselves and
 
 For reproducibility, resource limits and requests should always be set to equal values.
 
-**Note**: Official K8s images don’t apply any security settings. The default user is ROOT. If you require a secure interface with h2o running the image, you need to change the user and execution command to add security parameters before running the image. The following is the default command used in Docker images:
+**Note**: Official K8s images don’t apply any security settings. The default user is ROOT. If you require a secure interface with H2O running the image, you need to change the user and execution command to add security parameters before running the image. The following is the default command used in Docker images:
 
 ::
   


### PR DESCRIPTION
#15881 

This PR adds the K8s security note to the user guide. This same note is already applied to the other two requested docker images (https://hub.docker.com/r/h2oai/h2o-open-source-k8s &  https://hub.docker.com/r/h2oai/h2o-open-source-k8s-minimal). Please let me know if I need to update them.