### PR TITLE
GH-15893: rename 'partial_plot' 'data' param to 'frame' for consistency

### DIFF
--- a/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_pojo_import.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_pojo_import.py
@@ -30,8 +30,8 @@ def prostate_pojo_import():
     assert_frame_equal(preds_original.as_data_frame(), preds_imported.as_data_frame())
 
     # 2. check we can get PDPs
-    pdp_original = model.partial_plot(data=prostate, cols=['AGE'], server=True, plot=False)
-    pdp_imported = model_imported.partial_plot(data=prostate, cols=['AGE'], server=True, plot=False)
+    pdp_original = model.partial_plot(frame=prostate, cols=['AGE'], server=True, plot=False)
+    pdp_imported = model_imported.partial_plot(frame=prostate, cols=['AGE'], server=True, plot=False)
     assert_frame_equal(pdp_original[0].as_data_frame(), pdp_imported[0].as_data_frame())
 
 

--- a/h2o-py/tests/testdir_algos/glm/pyunit_plot_functions__add_saving_parameter_and_decorate_plot_result.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_plot_functions__add_saving_parameter_and_decorate_plot_result.py
@@ -151,8 +151,8 @@ def partial_plots():
     with TemporaryDirectory() as tmpdir:
         path1 = "{}/plot1.png".format(tmpdir)
         path2 = "{}/plot2.png".format(tmpdir)
-        test_plot_result_saving(gbm_model.partial_plot(data=data, cols=['AGE'], server=True, plot=True, row_index=1), path2,
-                                gbm_model.partial_plot(data=data, cols=['AGE'], server=True, plot=True, row_index=1, save_plot_path=path1), path1)
+        test_plot_result_saving(gbm_model.partial_plot(frame=data, cols=['AGE'], server=True, plot=True, row_index=1), path2,
+                                gbm_model.partial_plot(frame=data, cols=['AGE'], server=True, plot=True, row_index=1, save_plot_path=path1), path1)
 
 
 def partial_plots_multinomial():
@@ -178,9 +178,9 @@ def partial_plots_multinomial():
     
         test_plot_result_saving(model.plot(), path2, model.plot(save_plot_path=path1), path1)
         
-        test_plot_result_saving(model.partial_plot(data=iris, cols=cols, targets=targets, plot_stddev=True, plot=True,
+        test_plot_result_saving(model.partial_plot(frame=iris, cols=cols, targets=targets, plot_stddev=True, plot=True,
                                                    server=True), path2,
-                                model.partial_plot(data=iris, cols=cols, targets=targets, plot_stddev=True, plot=True,
+                                model.partial_plot(frame=iris, cols=cols, targets=targets, plot_stddev=True, plot=True,
                                                    server=True, save_to_file=path1), path1)
 
 def roc_pr_curve():

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_7705.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_7705.py
@@ -15,8 +15,8 @@ def partial_plot_row_index():
     gbm_model.train(x=x, y=y, training_frame=data)
 
     # Generate Partial Dependence for row index -1 and row index 0, they should differ
-    pdp = gbm_model.partial_plot(data=data, cols=['RACE'], plot=False, plot_stddev=False, row_index=-1)
-    pdp0 = gbm_model.partial_plot(data=data, cols=['RACE'], plot=False, plot_stddev=False, row_index=0)
+    pdp = gbm_model.partial_plot(frame=data, cols=['RACE'], plot=False, plot_stddev=False, row_index=-1)
+    pdp0 = gbm_model.partial_plot(frame=data, cols=['RACE'], plot=False, plot_stddev=False, row_index=0)
     assert not(pyunit_utils.equal_two_arrays(pdp[0][1], pdp0[0][1], throw_error=False))
 
 

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_7949_pdp.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_7949_pdp.py
@@ -20,7 +20,7 @@ def test_pdp_user_splits_no_cardinality_check():
     user_splits = {
         "AGE": ["64", "75"]
     }
-    pdp = gbm_model.partial_plot(data=data, cols=['AGE'], user_splits=user_splits, plot=False)
+    pdp = gbm_model.partial_plot(frame=data, cols=['AGE'], user_splits=user_splits, plot=False)
     assert len(pdp[0].cell_values) == 2
 
 

--- a/h2o-py/tests/testdir_misc/pyunit_partial_plots.py
+++ b/h2o-py/tests/testdir_misc/pyunit_partial_plots.py
@@ -23,7 +23,7 @@ def partial_plot_test():
     gbm_model.train(x=x, y=y, training_frame=data)
 
     # Plot Partial Dependence for one feature then for both
-    pdp1 = gbm_model.partial_plot(data=data, cols=['AGE'], server=True, plot=True)
+    pdp1 = gbm_model.partial_plot(frame=data, cols=['AGE'], server=True, plot=True)
     # Manual test
     h2o_mean_response_pdp1 = pdp1[0]["mean_response"]
     h2o_stddev_response_pdp1 = pdp1[0]["stddev_response"]
@@ -34,7 +34,7 @@ def partial_plot_test():
     assert h2o_stddev_response_pdp1 == pdp_manual[1]
     assert h2o_std_error_mean_response_pdp1 == pdp_manual[2]
 
-    pdp2=gbm_model.partial_plot(data=data, cols=['AGE', 'RACE'], server=True, plot=False)
+    pdp2=gbm_model.partial_plot(frame=data, cols=['AGE', 'RACE'], server=True, plot=False)
     # Manual test
     h2o_mean_response_pdp2 = pdp2[0]["mean_response"]
     h2o_stddev_response_pdp2 = pdp2[0]["stddev_response"]
@@ -56,7 +56,7 @@ def partial_plot_test():
     assert h2o_std_error_mean_response_pdp2_race == pdp_manual[2]
 
     # Plot Partial Dependence for one row 
-    pdp_row = gbm_model.partial_plot(data=data, cols=['AGE'], server=True, plot=True, row_index=1)
+    pdp_row = gbm_model.partial_plot(frame=data, cols=['AGE'], server=True, plot=True, row_index=1)
     # Manual test
     h2o_mean_response_pdp_row = pdp_row[0]["mean_response"]
     h2o_stddev_response_pdp_row = pdp_row[0]["stddev_response"]

--- a/h2o-py/tests/testdir_misc/pyunit_partial_plots_multinomial.py
+++ b/h2o-py/tests/testdir_misc/pyunit_partial_plots_multinomial.py
@@ -32,55 +32,55 @@ def partial_plot_test():
     # one class target
     cols = ["petal_len"]
     targets = ["Iris-setosa"]
-    pdp_petal_len_se = model.partial_plot(data=iris, cols=cols, targets=targets, plot_stddev=False, 
+    pdp_petal_len_se = model.partial_plot(frame=iris, cols=cols, targets=targets, plot_stddev=False, 
                                           plot=True, server=True)
     print(pdp_petal_len_se)
     
-    pdp_petal_len_se_std = model.partial_plot(data=iris, cols=cols, targets=targets, plot_stddev=True, 
+    pdp_petal_len_se_std = model.partial_plot(frame=iris, cols=cols, targets=targets, plot_stddev=True, 
                                               plot=True, server=True)
     print(pdp_petal_len_se_std)
     
     # two clasess target
     targets = ["Iris-setosa", "Iris-virginica"]
-    pdp_petal_len_se_vi = model.partial_plot(data=iris, cols=cols, targets=targets, plot_stddev=False, 
+    pdp_petal_len_se_vi = model.partial_plot(frame=iris, cols=cols, targets=targets, plot_stddev=False, 
                                              plot=True, server=True)
     print(pdp_petal_len_se_vi)
     
-    pdp_petal_len_se_vi_std = model.partial_plot(data=iris, cols=cols, targets=targets, plot_stddev=True, 
+    pdp_petal_len_se_vi_std = model.partial_plot(frame=iris, cols=cols, targets=targets, plot_stddev=True, 
                                                  plot=True, server=True)
     print(pdp_petal_len_se_vi_std)
     
     # three classes target
     targets = ["Iris-setosa", "Iris-virginica", "Iris-versicolor"]
-    pdp_petal_len_se_vi_ve_std = model.partial_plot(data=iris, cols=cols, targets=targets, plot_stddev=True, 
+    pdp_petal_len_se_vi_ve_std = model.partial_plot(frame=iris, cols=cols, targets=targets, plot_stddev=True, 
                                                     plot=True, server=True)
     print(pdp_petal_len_se_vi_ve_std)
     
     # two columns and three classes target
     cols = ["sepal_len", "petal_len"]
-    pdp_petal_len_sepal_len_se_vi_ve_std = model.partial_plot(data=iris, cols=cols, targets=targets, plot_stddev=True, 
+    pdp_petal_len_sepal_len_se_vi_ve_std = model.partial_plot(frame=iris, cols=cols, targets=targets, plot_stddev=True, 
                                                               plot=True, server=True)
     print(pdp_petal_len_sepal_len_se_vi_ve_std)
     
     # three columns and three classes target  
     cols = ["sepal_len","petal_len", "sepal_wid"]
-    pdp_petal_len_sepal_len_sepal_wid_se_vi_ve = model.partial_plot(data=iris, cols=cols, targets=targets, 
+    pdp_petal_len_sepal_len_sepal_wid_se_vi_ve = model.partial_plot(frame=iris, cols=cols, targets=targets, 
                                                                     plot_stddev=False, plot=True, server=True)
     print(pdp_petal_len_sepal_len_sepal_wid_se_vi_ve)
     
-    pdp_petal_len_sepal_len_sepal_wid_se_vi_ve_std = model.partial_plot(data=iris, cols=cols, targets=targets, 
+    pdp_petal_len_sepal_len_sepal_wid_se_vi_ve_std = model.partial_plot(frame=iris, cols=cols, targets=targets, 
                                                                         plot_stddev=True, plot=True, server=True)
     print(pdp_petal_len_sepal_len_sepal_wid_se_vi_ve_std)
     
     # categorical column - nonsense column, just for testing
     cols = ["random_cat"]
     targets = ["Iris-setosa"]
-    pdp_petal_len_cat = model.partial_plot(data=iris, cols=cols, targets=targets, plot_stddev=False, plot=True, 
+    pdp_petal_len_cat = model.partial_plot(frame=iris, cols=cols, targets=targets, plot_stddev=False, plot=True, 
                                            server=True)
     print(pdp_petal_len_cat)
 
     targets = ["Iris-setosa", "Iris-versicolor"]
-    pdp_petal_len_cat_std = model.partial_plot(data=iris, cols=cols, targets=targets, plot_stddev=True, plot=True, 
+    pdp_petal_len_cat_std = model.partial_plot(frame=iris, cols=cols, targets=targets, plot_stddev=True, plot=True, 
                                                server=True)
     print(pdp_petal_len_cat_std)
 

--- a/h2o-py/tests/testdir_misc/pyunit_pubdev_5706_usersplits_pdp.py
+++ b/h2o-py/tests/testdir_misc/pyunit_pubdev_5706_usersplits_pdp.py
@@ -34,10 +34,10 @@ def partial_plot_test_with_user_splits():
     # pdp without weight or NA
     with pyunit_utils.TemporaryDirectory() as tmpdir:
         file, filename = tempfile.mkstemp(suffix=".png", dir=tmpdir)
-        pdpOrig = gbm_model.partial_plot(data=data,cols=['AGE', 'RACE', 'DPROS'],server=True, plot=True, save_to_file=filename)
+        pdpOrig = gbm_model.partial_plot(frame=data,cols=['AGE', 'RACE', 'DPROS'],server=True, plot=True, save_to_file=filename)
         assert os.path.getsize(filename) > 0
 
-    pdpUserSplit = gbm_model.partial_plot(data=data,cols=['AGE', 'RACE', 'DPROS'],server=True, plot=True,
+    pdpUserSplit = gbm_model.partial_plot(frame=data,cols=['AGE', 'RACE', 'DPROS'],server=True, plot=True,
                                           user_splits=user_splits)
 
     # compare results

--- a/h2o-py/tests/testdir_misc/pyunit_pubdev_5761_pdp_NA.py
+++ b/h2o-py/tests/testdir_misc/pyunit_pubdev_5761_pdp_NA.py
@@ -47,16 +47,16 @@ def partial_plot_test():
     gbm_model.train(x=x, y=y, training_frame=data)
 
     # pdp without weight or NA
-    pdpOrig = gbm_model.partial_plot(data=data,cols=['AGE', 'RACE'],server=True, plot=True)
+    pdpOrig = gbm_model.partial_plot(frame=data,cols=['AGE', 'RACE'],server=True, plot=True)
     # pdp with constant weight and NA
-    pdpcWNA = gbm_model.partial_plot(data=data, cols=['AGE', 'RACE'], server=True, plot=True,
+    pdpcWNA = gbm_model.partial_plot(frame=data, cols=['AGE', 'RACE'], server=True, plot=True,
                                      weight_column="constWeight", include_na=True)
 
     # compare results
     pyunit_utils.assert_H2OTwoDimTable_equal_upto(pdpOrig[0], pdpcWNA[0], pdpOrig[0].col_header, tolerance=1e-10)
     pyunit_utils.assert_H2OTwoDimTable_equal_upto(pdpOrig[1], pdpcWNA[1], pdpOrig[1].col_header, tolerance=1e-10)
     # pdp with changing weight NA
-    pdpvWNA = gbm_model.partial_plot(data=data, cols=['AGE', 'RACE'], server=True, plot=True,
+    pdpvWNA = gbm_model.partial_plot(frame=data, cols=['AGE', 'RACE'], server=True, plot=True,
                                      weight_column="variWeight", include_na=True)
     ageList = pyunit_utils.extract_col_value_H2OTwoDimTable(pdpvWNA[0], "age")
     raceList = pyunit_utils.extract_col_value_H2OTwoDimTable(pdpvWNA[1], "race")

--- a/h2o-py/tests/testdir_misc/pyunit_pubdev_5921_na_prints_large.py
+++ b/h2o-py/tests/testdir_misc/pyunit_pubdev_5921_na_prints_large.py
@@ -24,11 +24,11 @@ def partial_plot_test():
     gbm_model.train(x=x, y=y, training_frame=data)
 
     # pdp with weight and no NA
-    pdpw = gbm_model.partial_plot(data=test, cols=["Input_miss", "Distance"], server=True, plot=False,
+    pdpw = gbm_model.partial_plot(frame=test, cols=["Input_miss", "Distance"], server=True, plot=False,
                                   weight_column=WC)
 
     # pdp with weight and NA
-    pdpwNA = gbm_model.partial_plot(data=test, cols=["Input_miss", "Distance"], server=True, plot=False,
+    pdpwNA = gbm_model.partial_plot(frame=test, cols=["Input_miss", "Distance"], server=True, plot=False,
                                     weight_column=WC, include_na = True)
     input_miss_list = pyunit_utils.extract_col_value_H2OTwoDimTable(pdpwNA[0], "input_miss")
     assert math.isnan(input_miss_list[-1]), "Expected last element to be nan but is not."

--- a/h2o-py/tests/testdir_misc/pyunit_pubdev_6438_2D_pdp.py
+++ b/h2o-py/tests/testdir_misc/pyunit_pubdev_6438_2D_pdp.py
@@ -32,12 +32,12 @@ def partial_plot_test_with_user_splits():
                           67.63157894736842, 69.52631578947368, 71.42105263157895, 73.3157894736842,
                           75.21052631578948, 77.10526315789474]
     user_splits['RACE'] = ["Black", "White"]
-    pdpUserSplit2D = gbm_model.partial_plot(data=data,server=True, plot=True, user_splits=user_splits, 
+    pdpUserSplit2D = gbm_model.partial_plot(frame=data,server=True, plot=True, user_splits=user_splits, 
                                             col_pairs_2dpdp=[['AGE', 'PSA'], ['AGE', 'RACE']], save_to_file=filename)  
-    pdpUserSplit1D2D = gbm_model.partial_plot(data=data, cols=['AGE', 'RACE', 'DCAPS'], server=True, plot=True, 
+    pdpUserSplit1D2D = gbm_model.partial_plot(frame=data, cols=['AGE', 'RACE', 'DCAPS'], server=True, plot=True, 
                                               user_splits=user_splits, 
                                               col_pairs_2dpdp=[['AGE', 'PSA'], ['AGE', 'RACE']], save_to_file=filename)
-    pdpUserSplit1D = gbm_model.partial_plot(data=data,cols=['AGE', 'RACE', 'DCAPS'], server=True, plot=True, 
+    pdpUserSplit1D = gbm_model.partial_plot(frame=data,cols=['AGE', 'RACE', 'DCAPS'], server=True, plot=True, 
                                             user_splits=user_splits, save_to_file=filename)
     if os.path.isfile(filename):
         os.remove(filename)

--- a/h2o-py/tests/testdir_misc/pyunit_pubdev_6775_2D_pdp_xgboost.py
+++ b/h2o-py/tests/testdir_misc/pyunit_pubdev_6775_2D_pdp_xgboost.py
@@ -20,9 +20,9 @@ def partial_plot_test_with_no_user_splits_no_1DPDP():
     gbm_model.train(x=x, y=y, training_frame=data)
 
     # pdp without weight or NA
-    pdp2dOnly = gbm_model.partial_plot(data=data, server=True, plot=False, 
+    pdp2dOnly = gbm_model.partial_plot(frame=data, server=True, plot=False, 
         col_pairs_2dpdp=[['AGE', 'PSA'],['AGE', 'RACE']])
-    pdp1D2D = gbm_model.partial_plot(data=data, cols=['AGE', 'RACE', 'DCAPS'], server=True, plot=False,
+    pdp1D2D = gbm_model.partial_plot(frame=data, cols=['AGE', 'RACE', 'DCAPS'], server=True, plot=False,
                                               col_pairs_2dpdp=[['AGE', 'PSA'], ['AGE', 'RACE']])
     # compare results 2D pdp 
     pyunit_utils.assert_H2OTwoDimTable_equal_upto(pdp2dOnly[0], pdp1D2D[3],

--- a/h2o-py/tests/testdir_misc/pyunit_pubdev_7828_show_NAs_in_numeric_PDP.py
+++ b/h2o-py/tests/testdir_misc/pyunit_pubdev_7828_show_NAs_in_numeric_PDP.py
@@ -31,20 +31,20 @@ def show_NAs_numeric_pdp_test():
     model.train(x=predictors, y=response, training_frame=train, validation_frame=valid)
     col = ["petal_len"]
     # 1 class target
-    model.partial_plot(data=iris, cols=col, targets=["Iris-setosa"], plot_stddev=False, include_na=True,
+    model.partial_plot(frame=iris, cols=col, targets=["Iris-setosa"], plot_stddev=False, include_na=True,
                                       plot=True, server=True)
-    model.partial_plot(data=iris, cols=col, targets=["Iris-setosa"], plot_stddev=True, include_na=True,
+    model.partial_plot(frame=iris, cols=col, targets=["Iris-setosa"], plot_stddev=True, include_na=True,
                        plot=True, server=True)
     # 2 class target
-    model.partial_plot(data=iris, cols=col, targets=["Iris-setosa", "Iris-virginica"], plot_stddev=False, include_na=True,
+    model.partial_plot(frame=iris, cols=col, targets=["Iris-setosa", "Iris-virginica"], plot_stddev=False, include_na=True,
                                              plot=True, server=True)
-    model.partial_plot(data=iris, cols=col, targets=["Iris-setosa", "Iris-virginica"], plot_stddev=True, include_na=True,
+    model.partial_plot(frame=iris, cols=col, targets=["Iris-setosa", "Iris-virginica"], plot_stddev=True, include_na=True,
                        plot=True, server=True)
     # 3 class target
-    model.partial_plot(data=iris, cols=col, targets=["Iris-setosa", "Iris-virginica", "Iris-versicolor"], plot_stddev=True, include_na=True,
+    model.partial_plot(frame=iris, cols=col, targets=["Iris-setosa", "Iris-virginica", "Iris-versicolor"], plot_stddev=True, include_na=True,
                                                     plot=True, server=True)
     # 2 cols 3 classes
-    model.partial_plot(data=iris, cols=["sepal_len", "petal_len"], targets=["Iris-setosa", "Iris-virginica", "Iris-versicolor"], plot_stddev=True,
+    model.partial_plot(frame=iris, cols=["sepal_len", "petal_len"], targets=["Iris-setosa", "Iris-virginica", "Iris-versicolor"], plot_stddev=True,
                                                               include_na=True, plot=True, server=True)
 
 

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -5624,16 +5624,15 @@ h2o.cross_validation_predictions <- function(object) {
 h2o.partialPlot <- function(object, newdata, cols, destination_key, nbins=20, plot = TRUE, plot_stddev = TRUE,
                             weight_column=-1, include_na=FALSE, user_splits=NULL, col_pairs_2dpdp=NULL, save_to=NULL,
                             row_index=-1, targets=NULL, ...) {
-  if ('data' %in% ...names()) {
-      warning("argument 'data' is deprecated; please use 'newdata' instead.")
-      if (missing(newdata))
-          newdata <- ...elt(which('data' == ...names()))
-      else
-          warning("ignoring 'data' as 'newdata' was also provided.")
-  }
-  if (...length() > 0) {
-      unused_args <- ...names()[! ...names() %in% c('data')]
-      if (length(unused_args) > 0) stop(paste("unused arguments", toString(unused_args)))
+  varargs <- list(...)
+  for (arg in names(varargs)) {
+      if (arg == 'data') {
+          warning("argument 'data' is deprecated; please use 'newdata' instead.")
+          if (missing(newdata))
+              newdata <- varargs$data else warning("ignoring 'data' as 'newdata' was also provided.")
+      } else {
+          stop(paste("unused argument", arg))
+      }
   }
   if(!is(object, "H2OModel")) stop("object must be an H2Omodel")
   if( is(object, "H2OOrdinalModel")) stop("object must be a regression model or binary and multinomial classfier")
@@ -5677,7 +5676,6 @@ h2o.partialPlot <- function(object, newdata, cols, destination_key, nbins=20, pl
       stop("weight_column_index should be one of your columns in your data frame.")
     else
       weight_column <- match(weight_column, h2o.names(newdata))-1
-  }
   }
   
   if (!is.numeric(row_index)) {

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -5593,6 +5593,7 @@ h2o.cross_validation_predictions <- function(object) {
 #' @return Plot and list of calculated mean response tables for each feature requested.
 #' @param row_index Row for which partial dependence will be calculated instead of the whole input frame.
 #' @param targets Target classes for multinomial model.    
+#' @param ... Mainly used for backwards compatibility, to allow deprecated parameters.
 #' @examples
 #' \dontrun{
 #' library(h2o)

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -5624,6 +5624,13 @@ h2o.partialPlot <- function(object, newdata, cols, destination_key, nbins=20, pl
                             weight_column=-1, include_na=FALSE, user_splits=NULL, col_pairs_2dpdp=NULL, save_to=NULL,
                             row_index=-1, targets=NULL, ...) {
   varargs <- list(...)
+  for (arg in names(varargs)) {
+      if (arg == 'data') {
+          warning("argument 'data' is deprecated; please use 'newdata' instead.")
+          if (missing(newdata))
+              newdata <- varargs$data else warning("ignoring 'data' as 'newdata' was also provided.")
+      }
+  }
   if(!is(object, "H2OModel")) stop("object must be an H2Omodel")
   if( is(object, "H2OOrdinalModel")) stop("object must be a regression model or binary and multinomial classfier")
   if(!is(newdata, "H2OFrame")) stop("newdata must be H2OFrame")
@@ -5635,12 +5642,6 @@ h2o.partialPlot <- function(object, newdata, cols, destination_key, nbins=20, pl
     if(is.null(targets)) stop("targets parameter has to be set for multinomial classification")
     for(i in 1:length(targets)){
         if(!is.character(targets[i])) stop("targets parameter must be a list of string values")
-    }
-  }
-  for (arg in names(varargs)) {
-    if (arg == 'data') {
-      warning("argument 'data' is deprecated; please use 'newdata' instead.")
-      if (missing(newdata)) newdata <- varargs$data else warning("ignoring 'data' as 'newdata' was also provided.")
     }
   }
   

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -5623,13 +5623,16 @@ h2o.cross_validation_predictions <- function(object) {
 h2o.partialPlot <- function(object, newdata, cols, destination_key, nbins=20, plot = TRUE, plot_stddev = TRUE,
                             weight_column=-1, include_na=FALSE, user_splits=NULL, col_pairs_2dpdp=NULL, save_to=NULL,
                             row_index=-1, targets=NULL, ...) {
-  varargs <- list(...)
-  for (arg in names(varargs)) {
-      if (arg == 'data') {
-          warning("argument 'data' is deprecated; please use 'newdata' instead.")
-          if (missing(newdata))
-              newdata <- varargs$data else warning("ignoring 'data' as 'newdata' was also provided.")
-      }
+  if ('data' %in% ...names()) {
+      warning("argument 'data' is deprecated; please use 'newdata' instead.")
+      if (missing(newdata))
+          newdata <- ...elt(which('data' == ...names()))
+      else
+          warning("ignoring 'data' as 'newdata' was also provided.")
+  }
+  if (...length() > 0) {
+      unused_args <- ...names()[! ...names() %in% c('data')]
+      if (length(unused_args) > 0) stop(paste("unused arguments", toString(unused_args)))
   }
   if(!is(object, "H2OModel")) stop("object must be an H2Omodel")
   if( is(object, "H2OOrdinalModel")) stop("object must be a regression model or binary and multinomial classfier")

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -5572,7 +5572,7 @@ h2o.cross_validation_predictions <- function(object) {
 #' partial dependence the mean response (probabilities) is returned rather than the mean of the log class probability.
 #'
 #' @param object An \linkS4class{H2OModel} object.
-#' @param data An H2OFrame object used for scoring and constructing the plot.
+#' @param newdata An H2OFrame object used for scoring and constructing the plot.
 #' @param cols Feature(s) for which partial dependence will be calculated.
 #' @param destination_key An key reference to the created partial dependence tables in H2O.
 #' @param nbins Number of bins used. For categorical columns make sure the number of bins exceeds the level count.
@@ -5613,19 +5613,20 @@ h2o.cross_validation_predictions <- function(object) {
 #' iris_gbm <- h2o.gbm(x = c(1:4), y = 5, training_frame = iris_hex)
 #'
 #' # one target class
-#' h2o.partialPlot(object = iris_gbm, data = iris_hex, cols="Petal.Length", targets=c("setosa"))
+#' h2o.partialPlot(object = iris_gbm, newdata = iris_hex, cols="Petal.Length", targets=c("setosa"))
 #' # three target classes
-#' h2o.partialPlot(object = iris_gbm, data = iris_hex, cols="Petal.Length", 
+#' h2o.partialPlot(object = iris_gbm, newdata = iris_hex, cols="Petal.Length", 
 #'                  targets=c("setosa", "virginica", "versicolor"))
 #' }
 #' @export
 
-h2o.partialPlot <- function(object, data, cols, destination_key, nbins=20, plot = TRUE, plot_stddev = TRUE,
-                            weight_column=-1, include_na=FALSE, user_splits=NULL, col_pairs_2dpdp=NULL, save_to=NULL, 
-                            row_index=-1, targets=NULL) {
+h2o.partialPlot <- function(object, newdata, cols, destination_key, nbins=20, plot = TRUE, plot_stddev = TRUE,
+                            weight_column=-1, include_na=FALSE, user_splits=NULL, col_pairs_2dpdp=NULL, save_to=NULL,
+                            row_index=-1, targets=NULL, ...) {
+  varargs <- list(...)
   if(!is(object, "H2OModel")) stop("object must be an H2Omodel")
   if( is(object, "H2OOrdinalModel")) stop("object must be a regression model or binary and multinomial classfier")
-  if(!is(data, "H2OFrame")) stop("data must be H2OFrame")
+  if(!is(newdata, "H2OFrame")) stop("newdata must be H2OFrame")
   if(!is.numeric(nbins) | !(nbins > 0) ) stop("nbins must be a positive numeric")
   if(!is.logical(plot)) stop("plot must be a logical value")
   if(!is.logical(plot_stddev)) stop("plot must be a logical value")
@@ -5636,61 +5637,67 @@ h2o.partialPlot <- function(object, data, cols, destination_key, nbins=20, plot 
         if(!is.character(targets[i])) stop("targets parameter must be a list of string values")
     }
   }
+  for (arg in names(varargs)) {
+    if (arg == 'data') {
+      warning("argument 'data' is deprecated; please use 'newdata' instead.")
+      if (missing(newdata)) newdata <- varargs$data else warning("ignoring 'data' as 'newdata' was also provided.")
+    }
+  }
   
-  noPairs = missing(col_pairs_2dpdp)
-  noCols = missing(cols)
-  if(noCols && noPairs) cols =  object@parameters$x # set to default only if both are missing
+  noPairs <- missing(col_pairs_2dpdp)
+  noCols <- missing(cols)
+  if(noCols && noPairs) cols <- object@parameters$x # set to default only if both are missing
 
-  y = object@parameters$y
-  numCols = 0
-  numColPairs = 0    
+  y <- object@parameters$y
+  numCols <- 0
+  numColPairs <- 0    
   if (!missing(cols)) { # check valid cols in cols for 1d pdp
     x <- cols
-    args <- .verify_dataxy(data, x, y)
+    args <- .verify_dataxy(newdata, x, y)
   }
   cpairs <- NULL
   if (!missing(col_pairs_2dpdp))   { # verify valid cols for 2d pdp
     for (onePair in col_pairs_2dpdp) {
-      pargs <- .verify_dataxy(data, onePair, y)
+      pargs <- .verify_dataxy(newdata, onePair, y)
       cpairs <-
         c(cpairs, paste0("[", paste (pargs$x, collapse = ','), "]"))
     }
-    numColPairs = length(cpairs)
+    numColPairs <- length(cpairs)
   }
 
   if (is.numeric(weight_column) && (weight_column != -1)) {
       stop("weight_column should be a column name of your data frame.")
   } else if (is.character(weight_column)) { # weight_column_index is column name
-    if (!weight_column %in% h2o.names(data))
+    if (!weight_column %in% h2o.names(newdata))
       stop("weight_column_index should be one of your columns in your data frame.")
     else
-      weight_column <- match(weight_column, h2o.names(data))-1
+      weight_column <- match(weight_column, h2o.names(newdata))-1
   }
   
   if (!is.numeric(row_index)) {
     stop("row_index should be numeric.")
   }
   
-  parms = list()
+  parms <- list()
   if (!missing(col_pairs_2dpdp)) {
     parms$col_pairs_2dpdp <- paste0("[", paste (cpairs, collapse = ','), "]")
   }
   if (!missing(cols)) {
     parms$cols <- paste0("[", paste (args$x, collapse = ','), "]")
-    numCols = length(cols)
+    numCols <- length(cols)
   }
   if(is.null(targets)){
     num_1d_pp_data <- numCols
   } else {
     num_1d_pp_data <- numCols * length(targets)
   }
-  noCols = missing(cols)
+  noCols <- missing(cols)
   parms$model_id  <- attr(object, "model_id")
-  parms$frame_id <- attr(data, "id")
+  parms$frame_id <- attr(newdata, "id")
   parms$nbins <- nbins
   parms$weight_column_index <- weight_column
   parms$add_missing_na <- include_na
-  parms$row_index = row_index
+  parms$row_index <- row_index
 
   if (is.null(user_splits) || length(user_splits) == 0) {
     parms$user_cols <- NULL
@@ -5700,15 +5707,15 @@ h2o.partialPlot <- function(object, data, cols, destination_key, nbins=20, plot 
     user_cols <- c()
     user_values <- c()
     user_num_splits <- c()
-    column_names <- h2o.names(data)
+    column_names <- h2o.names(newdata)
     for (ind in c(1:length(user_splits))) {
       aList <- user_splits[[ind]]
-      csname = aList[1]
+      csname <- aList[1]
       if (csname %in% column_names) {
-        if (h2o.isnumeric(data[csname]) || h2o.isfactor(data[csname]) || h2o.getTypes(data)[[which(names(data) == csname)]] == "time") {
+        if (h2o.isnumeric(newdata[csname]) || h2o.isfactor(newdata[csname]) || h2o.getTypes(newdata)[[which(names(data) == csname)]] == "time") {
           nVal <- length(aList)-1
-          if (h2o.isfactor(data[csname])) {
-            domains <- h2o.levels(data[csname]) # enum values
+          if (h2o.isfactor(newdata[csname])) {
+            domains <- h2o.levels(newdata[csname]) # enum values
             tempVal <- aList[2:length(aList)]
             intVals <- c(1:length(tempVal))
             for (eleind in c(1:nVal)) {
@@ -5769,7 +5776,7 @@ h2o.partialPlot <- function(object, data, cols, destination_key, nbins=20, plot 
       max_upper <- max(max_upper, pp[,2] + pp[,3])
       if (i <= num_1d_pp_data) {
         if(is.null(targets)){
-          col_name_index = i
+          col_name_index <- i
           title <- paste("Partial dependency plot for", cols[col_name_index]) 
         } else if(!is.null(targets)){
           if(length(cols) > 1 && i %% length(cols) == 0) {
@@ -5798,8 +5805,8 @@ h2o.partialPlot <- function(object, data, cols, destination_key, nbins=20, plot 
       }
     }
   }
-  col_types = unlist(h2o.getTypes(data))
-  col_names = names(data)
+  col_types <- unlist(h2o.getTypes(newdata))
+  col_names <- names(newdata)
     
   pp.plot.1d <- function(pp) {
     if(!all(is.na(pp))) {
@@ -5820,8 +5827,8 @@ h2o.partialPlot <- function(object, data, cols, destination_key, nbins=20, plot 
       ## Plot one standard deviation above and below the mean
       if(plot_stddev) {
         ## Added upper and lower std dev confidence bound
-        upper = y + stddev
-        lower = y - stddev
+        upper <- y + stddev
+        lower <- y - stddev
         plot(pp[,1:2], type = line_type, pch=pch, medpch=pch, medcol="red", medlty=0, staplelty=0, boxlty=0, col="red", main = attr(pp,"description"), ylim  = c(min(lower), max(upper)))
         pp.plot.1d.plotNA(pp, type, "red")
         polygon(pp.plot.1d.proccessDataForPolygon(c(pp[,1], rev(pp[,1])), c(lower, rev(upper))) , col = adjustcolor("red", alpha.f = 0.1), border = F)
@@ -5840,7 +5847,7 @@ h2o.partialPlot <- function(object, data, cols, destination_key, nbins=20, plot 
         
   pp.plot.1d.plotNA <- function(pp, type, color) {
     ## Plot NA value if numerical
-    NAsIds = which(is.na(pp[,1:1]))
+    NAsIds <- which(is.na(pp[,1:1]))
     if (type != "enum" && include_na && length(NAsIds) != 0) {
         points(pp[,1:1],array(pp[NAsIds, 2:2], dim = c(length(pp[,1:1]), 1)), col=color, type="l", lty=5)
         if (is.null(targets)) {
@@ -5880,10 +5887,10 @@ h2o.partialPlot <- function(object, data, cols, destination_key, nbins=20, plot 
     
   pp.plot.1d.proccessDataForPolygon <- function(X, Y) {
     ## polygon can't handle NAs
-    NAsIds = which(is.na(X))
+    NAsIds <- which(is.na(X))
     if (length(NAsIds) != 0) {
-      X = X[-NAsIds]
-      Y = Y[-NAsIds]
+      X <- X[-NAsIds]
+      Y <- Y[-NAsIds]
     }
     return(cbind(X, Y))
   }        
@@ -5972,10 +5979,10 @@ h2o.partialPlot <- function(object, data, cols, destination_key, nbins=20, plot 
       ## Plot one standard deviation above and below the mean
       if (plot_stddev) {
         ## Added upper and lower std dev confidence bound
-        upper = pp[, 3] + pp[, 4]
-        lower = pp[, 3] - pp[, 4]
-        Zupper = matrix(upper, ncol=dim(XX)[2], byrow=F)
-        Zlower = matrix(lower, ncol=dim(XX)[2], byrow=F)
+        upper <- pp[, 3] + pp[, 4]
+        lower <- pp[, 3] - pp[, 4]
+        Zupper <- matrix(upper, ncol=dim(XX)[2], byrow=F)
+        Zlower <- matrix(lower, ncol=dim(XX)[2], byrow=F)
         rgl::open3d()
         plot3Drgl::persp3Drgl(XX, YY, ZZ, theta=30, phi=15, axes=TRUE,scale=2, box=TRUE, nticks=5,
                 ticktype="detailed", xlab=names(pp)[1], ylab=names(pp)[2], zlab="2D partial plots",
@@ -6015,7 +6022,7 @@ h2o.partialPlot <- function(object, data, cols, destination_key, nbins=20, plot 
   pp.plot.save.2d <- function(pp, nBins=nbins, user_cols=NULL, user_num_splits=NULL) {
     # If user accidentally provides one of the most common suffixes in R, it is removed.
     save_to <- gsub(replacement = "", pattern = "(\\.png)|(\\.jpg)|(\\.pdf)", x = save_to)
-    colnames = paste0(names(pp)[1], "_", names(pp)[2])
+    colnames <- paste0(names(pp)[1], "_", names(pp)[2])
     destination_file <- paste0(save_to,"_",colnames,'.png')
     pp.plot.2d(pp, nbins, user_cols, user_num_splits)
     rgl::snapshot3d(destination_file)
@@ -6033,7 +6040,7 @@ h2o.partialPlot <- function(object, data, cols, destination_key, nbins=20, plot 
       from <- 1
       to <- length(targets)
       for(i in 1:numCols) {
-        pp = pps[from:to]
+        pp <- pps[from:to]
         pp.plot.1d.multinomial(pp)
         if(!is.null(save_to)){
           pp.plot.save.1d.multinomial(pp)

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -5608,7 +5608,7 @@ h2o.cross_validation_predictions <- function(object) {
 #'                         ntrees = 10,
 #'                         max_depth = 5,
 #'                         learn_rate = 0.1)
-#' h2o.partialPlot(object = prostate_gbm, data = prostate, cols = c("AGE", "RACE"))
+#' h2o.partialPlot(object = prostate_gbm, newdata = prostate, cols = c("AGE", "RACE"))
 #'
 #' iris_hex <- as.h2o(iris)
 #' iris_gbm <- h2o.gbm(x = c(1:4), y = 5, training_frame = iris_hex)
@@ -5677,6 +5677,7 @@ h2o.partialPlot <- function(object, newdata, cols, destination_key, nbins=20, pl
       stop("weight_column_index should be one of your columns in your data frame.")
     else
       weight_column <- match(weight_column, h2o.names(newdata))-1
+  }
   }
   
   if (!is.numeric(row_index)) {

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -5716,7 +5716,7 @@ h2o.partialPlot <- function(object, newdata, cols, destination_key, nbins=20, pl
       aList <- user_splits[[ind]]
       csname <- aList[1]
       if (csname %in% column_names) {
-        if (h2o.isnumeric(newdata[csname]) || h2o.isfactor(newdata[csname]) || h2o.getTypes(newdata)[[which(names(data) == csname)]] == "time") {
+        if (h2o.isnumeric(newdata[csname]) || h2o.isfactor(newdata[csname]) || h2o.getTypes(newdata)[[which(names(newdata) == csname)]] == "time") {
           nVal <- length(aList)-1
           if (h2o.isfactor(newdata[csname])) {
             domains <- h2o.levels(newdata[csname]) # enum values

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -5624,12 +5624,12 @@ h2o.cross_validation_predictions <- function(object) {
 h2o.partialPlot <- function(object, newdata, cols, destination_key, nbins=20, plot = TRUE, plot_stddev = TRUE,
                             weight_column=-1, include_na=FALSE, user_splits=NULL, col_pairs_2dpdp=NULL, save_to=NULL,
                             row_index=-1, targets=NULL, ...) {
-  varargs <- list(...)
-  for (arg in names(varargs)) {
+  dots <- list(...)
+  for (arg in names(dots)) {
       if (arg == 'data') {
           warning("argument 'data' is deprecated; please use 'newdata' instead.")
           if (missing(newdata))
-              newdata <- varargs$data else warning("ignoring 'data' as 'newdata' was also provided.")
+              newdata <- dots$data else warning("ignoring 'data' as 'newdata' was also provided.")
       } else {
           stop(paste("unused argument", arg))
       }

--- a/h2o-r/tests/testdir_jira/runit_pubdev_4897.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_4897.R
@@ -8,7 +8,7 @@ test.pubdev_4897 <- function() {
     model <- h2o.gbm(x = "Var2", y = "Var1", training_frame = data, ntrees = 50)
     pdf("plot")
     dev.control(displaylist="enable")
-    h2o.partialPlot(object = model, data = data, cols = "Var2", plot = TRUE)
+    h2o.partialPlot(object = model, newdata = data, cols = "Var2", plot = TRUE)
     recordedPlot <- recordPlot()
     dev.off()
     unlink("plot")

--- a/h2o-r/tests/testdir_jira/runit_pubdev_6122.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_6122.R
@@ -9,7 +9,7 @@ test.pdp.save <- function() {
     model <- h2o.gbm(x=cols, y = "CAPSULE", training_frame = data)
 
     temp_filename_no_extension <- tempfile(pattern = "pdp", tmpdir = tempdir(), fileext = "")
-    plot <- h2o.partialPlot(object = model, data = data, save_to = temp_filename_no_extension)
+    plot <- h2o.partialPlot(object = model, newdata = data, save_to = temp_filename_no_extension)
     expect_false(is.null(plot))
 
     check_file <- function(feature){

--- a/h2o-r/tests/testdir_misc/runit_PUBDEV-6775-2D-pdp.R
+++ b/h2o-r/tests/testdir_misc/runit_PUBDEV-6775-2D-pdp.R
@@ -12,10 +12,10 @@ test <- function() {
   temp_filename_no_extension <- tempfile(pattern = "pdp", tmpdir = tempdir(), fileext = "")
   ## Calculate partial dependence using h2o.partialPlot for columns "AGE" and "RACE"
   prostate_drf = h2o.randomForest(x = c("AGE", "RACE"), y = "CAPSULE", training_frame = prostate_hex, ntrees = 50, seed = 12345)
-  h2o_pp_1d_2d = h2o.partialPlot(object = prostate_drf, data = prostate_hex, cols = c("RACE", "AGE"), 
+  h2o_pp_1d_2d = h2o.partialPlot(object = prostate_drf, newdata = prostate_hex, cols = c("RACE", "AGE"), 
                                  col_pairs_2dpdp=list(c("RACE", "AGE"), c("AGE", "PSA")), plot = T, 
                                  save_to=temp_filename_no_extension)
-  h2o_pp_2d_only = h2o.partialPlot(object = prostate_drf, data = prostate_hex, col_pairs_2dpdp=list(c("RACE", "AGE"), c("AGE", "PSA")),
+  h2o_pp_2d_only = h2o.partialPlot(object = prostate_drf, newdata = prostate_hex, col_pairs_2dpdp=list(c("RACE", "AGE"), c("AGE", "PSA")),
                                    plot = FALSE)
   # compare 2d pdp results from 2d pdp only and from 1d and 2d pdps  
   assert_partialPlots_twoDTable_equal(h2o_pp_1d_2d[[3]],h2o_pp_2d_only[[1]])  # 2d pdp RACE and AGE

--- a/h2o-r/tests/testdir_misc/runit_PUBDEV_6438_2D_pdp.R
+++ b/h2o-r/tests/testdir_misc/runit_PUBDEV_6438_2D_pdp.R
@@ -17,15 +17,15 @@ test <- function() {
   user_splits_list = list(c("AGE", ageSplit))
   temp_filename_no_extension <- tempfile(pattern = "pdp", tmpdir = tempdir(), fileext = "")
   ## Calculate partial dependence using h2o.partialPlot for columns "AGE" and "RACE"
-  h2o_pp_1d_2d = h2o.partialPlot(object = prostate_drf, data = prostate_hex, cols = c("RACE", "AGE"), 
+  h2o_pp_1d_2d = h2o.partialPlot(object = prostate_drf, newdata = prostate_hex, cols = c("RACE", "AGE"), 
                                  col_pairs_2dpdp=list(c("RACE", "AGE"), c("AGE", "PSA")), plot = TRUE, 
                                  user_splits=user_splits_list, save_to=temp_filename_no_extension)
   if (file.exists(temp_filename_no_extension)) 
     file.remove(temp_filename_no_extension)
   
-  h2o_pp_2d_only = h2o.partialPlot(object = prostate_drf, data = prostate_hex, col_pairs_2dpdp=list(c("RACE", "AGE"), c("AGE", "PSA")), plot = FALSE,
+  h2o_pp_2d_only = h2o.partialPlot(object = prostate_drf, newdata = prostate_hex, col_pairs_2dpdp=list(c("RACE", "AGE"), c("AGE", "PSA")), plot = FALSE,
                                    user_splits=user_splits_list)
-  h2o_pp_1d_only = h2o.partialPlot(object = prostate_drf, data = prostate_hex, cols = c("RACE", "AGE"), plot = FALSE, user_splits=user_splits_list)
+  h2o_pp_1d_only = h2o.partialPlot(object = prostate_drf, newdata = prostate_hex, cols = c("RACE", "AGE"), plot = FALSE, user_splits=user_splits_list)
 
    # compare 1d pdp results from 1d pdp only and from 1d and 2d pdps 
   assert_partialPlots_twoDTable_equal(h2o_pp_1d_2d[[1]],h2o_pp_1d_only[[1]])  # compare RACE

--- a/h2o-r/tests/testdir_misc/runit_PUBDEV_7828_show_NAs_in_numeric_PDP.R
+++ b/h2o-r/tests/testdir_misc/runit_PUBDEV_7828_show_NAs_in_numeric_PDP.R
@@ -8,16 +8,16 @@ test <- function() {
     seed=1234
     prostate_drf = h2o.randomForest(x = c("AGE", "RACE"), y = "CAPSULE", training_frame = prostate_hex, ntrees = 25, seed = seed)
     
-    h2o.partialPlot(object = prostate_drf, data = prostate_hex, cols = "RACE", plot = TRUE, include_na = TRUE, plot_stddev = TRUE)
-    h2o.partialPlot(object = prostate_drf, data = prostate_hex, cols = "RACE", plot = TRUE, include_na = FALSE, plot_stddev = TRUE)
-    h2o.partialPlot(object = prostate_drf, data = prostate_hex, cols = "RACE", plot = TRUE, include_na = FALSE, plot_stddev = FALSE)
-    h2o.partialPlot(object = prostate_drf, data = prostate_hex, cols = "RACE", plot = TRUE, include_na = TRUE, plot_stddev = FALSE)
+    h2o.partialPlot(object = prostate_drf, newdata = prostate_hex, cols = "RACE", plot = TRUE, include_na = TRUE, plot_stddev = TRUE)
+    h2o.partialPlot(object = prostate_drf, newdata = prostate_hex, cols = "RACE", plot = TRUE, include_na = FALSE, plot_stddev = TRUE)
+    h2o.partialPlot(object = prostate_drf, newdata = prostate_hex, cols = "RACE", plot = TRUE, include_na = FALSE, plot_stddev = FALSE)
+    h2o.partialPlot(object = prostate_drf, newdata = prostate_hex, cols = "RACE", plot = TRUE, include_na = TRUE, plot_stddev = FALSE)
 
     # 1D multiple cols
-    h2o.partialPlot(object = prostate_drf, data = prostate_hex, cols = c("AGE", "RACE", "DCAPS"), plot = TRUE, include_na = TRUE, plot_stddev = TRUE)
-    h2o.partialPlot(object = prostate_drf, data = prostate_hex, cols = c("AGE", "RACE", "DCAPS"), plot = TRUE,  include_na = FALSE, plot_stddev = TRUE)
-    h2o.partialPlot(object = prostate_drf, data = prostate_hex, cols = c("AGE", "RACE", "DCAPS"), plot = TRUE,  include_na = FALSE, plot_stddev = FALSE)
-    h2o.partialPlot(object = prostate_drf, data = prostate_hex, cols = c("AGE", "RACE", "DCAPS"), plot = TRUE,  include_na = TRUE, plot_stddev = FALSE)
+    h2o.partialPlot(object = prostate_drf, newdata = prostate_hex, cols = c("AGE", "RACE", "DCAPS"), plot = TRUE, include_na = TRUE, plot_stddev = TRUE)
+    h2o.partialPlot(object = prostate_drf, newdata = prostate_hex, cols = c("AGE", "RACE", "DCAPS"), plot = TRUE,  include_na = FALSE, plot_stddev = TRUE)
+    h2o.partialPlot(object = prostate_drf, newdata = prostate_hex, cols = c("AGE", "RACE", "DCAPS"), plot = TRUE,  include_na = FALSE, plot_stddev = FALSE)
+    h2o.partialPlot(object = prostate_drf, newdata = prostate_hex, cols = c("AGE", "RACE", "DCAPS"), plot = TRUE,  include_na = TRUE, plot_stddev = FALSE)
 
     # 1D multiple cols && targets
     iris[,'random'] <- as.factor(as.data.frame(unlist(sample(x = 1:4, size = length(iris[[1]]), replace=TRUE)))[[1]])
@@ -25,12 +25,12 @@ test <- function() {
     iris_gbm <- h2o.gbm(x = c(1:4,6), y = 5, training_frame = iris_hex)
 
     # one column  
-    h2o.partialPlot(object = iris_gbm, data = iris_hex, cols = "Petal.Length", targets = c("setosa"), plot = TRUE, include_na = TRUE, plot_stddev = TRUE )
-    h2o.partialPlot(object = iris_gbm, data = iris_hex, cols = "Petal.Length", targets = c("setosa", "virginica", "versicolor"), plot = TRUE, include_na = TRUE, plot_stddev = TRUE)
+    h2o.partialPlot(object = iris_gbm, newdata = iris_hex, cols = "Petal.Length", targets = c("setosa"), plot = TRUE, include_na = TRUE, plot_stddev = TRUE )
+    h2o.partialPlot(object = iris_gbm, newdata = iris_hex, cols = "Petal.Length", targets = c("setosa", "virginica", "versicolor"), plot = TRUE, include_na = TRUE, plot_stddev = TRUE)
     
     # two colums  
-    h2o.partialPlot(object = iris_gbm, data = iris_hex, cols=c("Petal.Length", "Sepal.Length"), targets=c("setosa"))
-    h2o.partialPlot(object = iris_gbm, data = iris_hex, cols=c("Petal.Length", "Sepal.Length"), targets=c("setosa"), include_na = FALSE, plot_stddev = TRUE)
+    h2o.partialPlot(object = iris_gbm, newdata = iris_hex, cols=c("Petal.Length", "Sepal.Length"), targets=c("setosa"))
+    h2o.partialPlot(object = iris_gbm, newdata = iris_hex, cols=c("Petal.Length", "Sepal.Length"), targets=c("setosa"), include_na = FALSE, plot_stddev = TRUE)
 
 }
 

--- a/h2o-r/tests/testdir_misc/runit_partialPlot.R
+++ b/h2o-r/tests/testdir_misc/runit_partialPlot.R
@@ -178,6 +178,7 @@ test <- function() {
   ## Check deprecated params
   expect_warning(h2o.partialPlot(object = iris_gbm, data = iris_hex, cols="Petal.Length", targets=c("setosa")), "argument 'data' is deprecated")
   expect_warning(h2o.partialPlot(object = iris_gbm, newdata = iris_hex, data = iris_hex, cols="Petal.Length", targets=c("setosa")), "ignoring 'data' as 'newdata' was also provided")
+  expect_error(h2o.partialPlot(object = iris_gbm, newdata = iris_hex, wrong_data = iris_hex, cols="Petal.Length", targets=c("setosa")), "unused arguments wrong_data")
 
   ## Check failure cases
   ## 1) Selection of incorrect columns 

--- a/h2o-r/tests/testdir_misc/runit_partialPlot.R
+++ b/h2o-r/tests/testdir_misc/runit_partialPlot.R
@@ -32,14 +32,14 @@ test <- function() {
   # r_race_pp = partialPlot(x = prostate_rf, pred.data = prostate_df, x.var = "RACE")
   
   ## Import prostate dataset
-  prostate_hex = h2o.uploadFile(locate("smalldata/logreg/prostate.csv"), "prostate.hex")
+  prostate_hex <- h2o.uploadFile(locate("smalldata/logreg/prostate.csv"), "prostate.hex")
 
   ## Change CAPSULE to Enum
-  prostate_hex[, "CAPSULE"] = as.factor(prostate_hex[, "CAPSULE"])
+  prostate_hex[, "CAPSULE"] <- as.factor(prostate_hex[, "CAPSULE"])
   ## Run Random Forest in H2O
-  seed = .Random.seed[1]
+  seed <- .Random.seed[1]
   Log.info(paste0("Random seed used = ", seed))
-  prostate_drf = h2o.randomForest(x = c("AGE", "RACE"), y = "CAPSULE", training_frame = prostate_hex, ntrees = 25, seed = seed)
+  prostate_drf <- h2o.randomForest(x = c("AGE", "RACE"), y = "CAPSULE", training_frame = prostate_hex, ntrees = 25, seed = seed)
   
   ## Calculate the partial dependence manually using breaks from results of h2o.partialPlot
   ## Define function
@@ -75,14 +75,14 @@ test <- function() {
   }
   
   ## Calculate partial dependence using h2o.partialPlot for columns "AGE" and "RACE"
-  h2o_race_pp = h2o.partialPlot(object = prostate_drf, data = prostate_hex, cols = "RACE", plot = FALSE)
-  h2o_age_pp = h2o.partialPlot(object = prostate_drf, data = prostate_hex, cols = "AGE", plot = FALSE)
-  h2o_age_pp_2 = partialDependence(object = prostate_drf, pred.data = prostate_hex, xname = "AGE", h2o.pp = h2o_age_pp)
-  h2o_race_pp_2 = partialDependence(object = prostate_drf, pred.data = prostate_hex, xname = "RACE", h2o.pp = h2o_race_pp)
+  h2o_race_pp <- h2o.partialPlot(object = prostate_drf, newdata = prostate_hex, cols = "RACE", plot = FALSE)
+  h2o_age_pp <- h2o.partialPlot(object = prostate_drf, newdata = prostate_hex, cols = "AGE", plot = FALSE)
+  h2o_age_pp_2 <- partialDependence(object = prostate_drf, pred.data = prostate_hex, xname = "AGE", h2o.pp = h2o_age_pp)
+  h2o_race_pp_2 <- partialDependence(object = prostate_drf, pred.data = prostate_hex, xname = "RACE", h2o.pp = h2o_race_pp)
   
   ## Calculate partial dependence uisng h2o.partialPlot for column "AGE" on row 1
-  h2o_row1_age_pp = h2o.partialPlot(object = prostate_drf, data = prostate_hex, cols = "AGE", plot = FALSE, row_index=1)
-  h2o_row1_age_pp_2 = partialDependence(object = prostate_drf, pred.data = prostate_hex[1,], xname = "AGE", h2o.pp = h2o_age_pp)
+  h2o_row1_age_pp <- h2o.partialPlot(object = prostate_drf, newdata = prostate_hex, cols = "AGE", plot = FALSE, row_index=1)
+  h2o_row1_age_pp_2 <- partialDependence(object = prostate_drf, pred.data = prostate_hex[1,], xname = "AGE", h2o.pp = h2o_age_pp)
     
   #Mean response
   checkEqualsNumeric(h2o_age_pp_2[,"mean_response"], h2o_age_pp[,"mean_response"])
@@ -103,8 +103,8 @@ test <- function() {
   checkEqualsNumeric(h2o_row1_age_pp_2[,"std_error_mean_response"], h2o_row1_age_pp[,"std_error_mean_response"])
     
   ## Check spliced/subsetted datasets
-  prostate_hex[, "RACE"] = as.factor(prostate_hex[, "RACE"])
-  prostate_drf = h2o.randomForest(x = c("AGE", "RACE"), y = "CAPSULE", training_frame = prostate_hex, ntrees = 25, seed = seed)
+  prostate_hex[, "RACE"] <- as.factor(prostate_hex[, "RACE"])
+  prostate_drf <- h2o.randomForest(x = c("AGE", "RACE"), y = "CAPSULE", training_frame = prostate_hex, ntrees = 25, seed = seed)
   
   ## Subset prostate_hex by RACE
   prostate_hex_race_0 <- prostate_hex[prostate_hex$RACE == "0", ]
@@ -112,14 +112,14 @@ test <- function() {
   prostate_hex_race_2 <- prostate_hex[prostate_hex$RACE == "2", ]
   
   ## Calculate partial plot on the subsetted dataset
-  h2o_pp_race_0 = h2o.partialPlot(object = prostate_drf, data = prostate_hex_race_0, cols = "RACE", plot = FALSE)
-  h2o_pp_race_1 = h2o.partialPlot(object = prostate_drf, data = prostate_hex_race_1, cols = "RACE", plot = FALSE)
-  h2o_pp_race_2 = h2o.partialPlot(object = prostate_drf, data = prostate_hex_race_2, cols = "RACE", plot = FALSE)
+  h2o_pp_race_0 <- h2o.partialPlot(object = prostate_drf, newdata = prostate_hex_race_0, cols = "RACE", plot = FALSE)
+  h2o_pp_race_1 <- h2o.partialPlot(object = prostate_drf, newdata = prostate_hex_race_1, cols = "RACE", plot = FALSE)
+  h2o_pp_race_2 <- h2o.partialPlot(object = prostate_drf, newdata = prostate_hex_race_2, cols = "RACE", plot = FALSE)
   
   ## Calculate the partial dependence manually
-  check_pp_race_0 = partialDependence(object = prostate_drf, pred.data = prostate_hex_race_0, xname = "RACE", h2o.pp = h2o_pp_race_0)
-  check_pp_race_1 = partialDependence(object = prostate_drf, pred.data = prostate_hex_race_1, xname = "RACE", h2o.pp = h2o_pp_race_1)
-  check_pp_race_2 = partialDependence(object = prostate_drf, pred.data = prostate_hex_race_2, xname = "RACE", h2o.pp = h2o_pp_race_2)
+  check_pp_race_0 <- partialDependence(object = prostate_drf, pred.data = prostate_hex_race_0, xname = "RACE", h2o.pp = h2o_pp_race_0)
+  check_pp_race_1 <- partialDependence(object = prostate_drf, pred.data = prostate_hex_race_1, xname = "RACE", h2o.pp = h2o_pp_race_1)
+  check_pp_race_2 <- partialDependence(object = prostate_drf, pred.data = prostate_hex_race_2, xname = "RACE", h2o.pp = h2o_pp_race_2)
   
   ## Check the partial plot from h2o
   
@@ -139,7 +139,7 @@ test <- function() {
   checkEqualsNumeric(check_pp_race_2[,"std_error_mean_response"], h2o_pp_race_2[,"std_error_mean_response"])
   
   ## H2O partial plot on the entire dataset
-  h2o_pp_race  = h2o.partialPlot(object = prostate_drf, data = prostate_hex, cols = "RACE", plot = FALSE)
+  h2o_pp_race <- h2o.partialPlot(object = prostate_drf, newdata = prostate_hex, cols = "RACE", plot = FALSE)
   
   ## Dataset with only one level only scores with the first level in the column domain based off of the model
   checkEquals(h2o_pp_race_0$RACE, "0")
@@ -147,10 +147,10 @@ test <- function() {
   checkEquals(h2o_pp_race_2$RACE, "2")
   
   ## Check column name and column type matches using test dataset iris
-  iris_hex = as.h2o(iris[1:100,])
-  iris_gbm = h2o.gbm(x = 1:4, y = 5, training_frame = iris_hex)
-  iris_pps = h2o.partialPlot(object = iris_gbm, data = iris_hex)
-  iris_pps2 = lapply( iris_pps, function(x) partialDependence(object = iris_gbm, pred.data = iris_hex, xname = names(x)[1], h2o.pp = x))
+  iris_hex <- as.h2o(iris[1:100,])
+  iris_gbm <- h2o.gbm(x = 1:4, y = 5, training_frame = iris_hex)
+  iris_pps <- h2o.partialPlot(object = iris_gbm, data = iris_hex)
+  iris_pps2 <- lapply( iris_pps, function(x) partialDependence(object = iris_gbm, pred.data = iris_hex, xname = names(x)[1], h2o.pp = x))
   checkTrue(all(unlist(lapply(1:4, function(i) checkEqualsNumeric(iris_pps2[[i]]$mean_response, iris_pps[[i]]$mean_response)))))
   checkTrue(all(unlist(lapply(1:4, function(i) checkEqualsNumeric(iris_pps2[[i]]$stddev_response, iris_pps[[i]]$stddev_response)))))
   checkTrue(all(unlist(lapply(1:4, function(i) checkEqualsNumeric(iris_pps2[[i]]$std_error_mean_response, iris_pps[[i]]$std_error_mean_response)))))
@@ -161,38 +161,42 @@ test <- function() {
   iris_gbm <- h2o.gbm(x = c(1:4,6), y = 5, training_frame = iris_hex)
     
   # one column  
-  h2o.partialPlot(object = iris_gbm, data = iris_hex, cols="Petal.Length", targets=c("setosa"))
-  h2o.partialPlot(object = iris_gbm, data = iris_hex, cols="Petal.Length", targets=c("setosa", "virginica", "versicolor"))
+  h2o.partialPlot(object = iris_gbm, newdata = iris_hex, cols="Petal.Length", targets=c("setosa"))
+  h2o.partialPlot(object = iris_gbm, newdata = iris_hex, cols="Petal.Length", targets=c("setosa", "virginica", "versicolor"))
 
-  h2o.partialPlot(object = iris_gbm, data = iris_hex, cols="Petal.Length", targets=c("setosa"), plot_stddev = FALSE)
-  h2o.partialPlot(object = iris_gbm, data = iris_hex, cols="Petal.Length", targets=c("setosa", "virginica", "versicolor"), plot_stddev = FALSE)
+  h2o.partialPlot(object = iris_gbm, newdata = iris_hex, cols="Petal.Length", targets=c("setosa"), plot_stddev = FALSE)
+  h2o.partialPlot(object = iris_gbm, newdata = iris_hex, cols="Petal.Length", targets=c("setosa", "virginica", "versicolor"), plot_stddev = FALSE)
 
   # two colums  
-  h2o.partialPlot(object = iris_gbm, data = iris_hex, cols=c("Petal.Length", "Sepal.Length"), targets=c("setosa"))
-  h2o.partialPlot(object = iris_gbm, data = iris_hex, cols=c("Petal.Length", "Sepal.Length"), targets=c("setosa"), plot_stddev =  FALSE)  
+  h2o.partialPlot(object = iris_gbm, newdata = iris_hex, cols=c("Petal.Length", "Sepal.Length"), targets=c("setosa"))
+  h2o.partialPlot(object = iris_gbm, newdata = iris_hex, cols=c("Petal.Length", "Sepal.Length"), targets=c("setosa"), plot_stddev =  FALSE)  
     
   # categorical column
-  h2o.partialPlot(object = iris_gbm, data = iris_hex, cols=c("random"), targets=c("versicolor"))
-  h2o.partialPlot(object = iris_gbm, data = iris_hex, cols=c("random"), targets=c("versicolor"), plot_stddev = FALSE)
+  h2o.partialPlot(object = iris_gbm, newdata = iris_hex, cols=c("random"), targets=c("versicolor"))
+  h2o.partialPlot(object = iris_gbm, newdata = iris_hex, cols=c("random"), targets=c("versicolor"), plot_stddev = FALSE)
+    
+  ## Check deprecated params
+  expect_warning(h2o.partialPlot(object = iris_gbm, data = iris_hex, cols="Petal.Length", targets=c("setosa")), "argument 'data' is deprecated")
+  expect_warning(h2o.partialPlot(object = iris_gbm, newdata = iris_hex, data = iris_hex, cols="Petal.Length", targets=c("setosa")), "ignoring 'data' as 'newdata' was also provided")
 
   ## Check failure cases
   ## 1) Selection of incorrect columns 
-  expect_error(h2o.partialPlot(object = prostate_drf, data = prostate_hex[-2], cols = "AGE"), "is not a column name")
-  expect_error(h2o.partialPlot(object = prostate_drf, data = prostate_hex, cols = "BLAH"), "Invalid column names")
+  expect_error(h2o.partialPlot(object = prostate_drf, newdata = prostate_hex[-2], cols = "AGE"), "is not a column name")
+  expect_error(h2o.partialPlot(object = prostate_drf, newdata = prostate_hex, cols = "BLAH"), "Invalid column names")
     
   ## 2) Nbins is smaller than cardinality of a categorical column
   prostate_hex[ ,"AGE"] = as.factor(prostate_hex[ ,"AGE"])
-  prostate_gbm = h2o.gbm(x = c("AGE", "RACE"), y = "CAPSULE", training_frame = prostate_hex, ntrees = 10, seed = seed)
-  expect_error(h2o.partialPlot(object = prostate_gbm, data = prostate_hex),"Column AGE's cardinality")
+  prostate_gbm <- h2o.gbm(x = c("AGE", "RACE"), y = "CAPSULE", training_frame = prostate_hex, ntrees = 10, seed = seed)
+  expect_error(h2o.partialPlot(object = prostate_gbm, newdata = prostate_hex),"Column AGE's cardinality")
     
   ## 3) Target is not set for multinomial classification  
-  expect_error(h2o.partialPlot(object = iris_gbm, data = iris_hex, cols="Sepal.Length"), "targets parameter has to be set for multinomial classification")
+  expect_error(h2o.partialPlot(object = iris_gbm, newdata = iris_hex, cols="Sepal.Length"), "targets parameter has to be set for multinomial classification")
 
   ## 4) Target class is not in target domain   
-  expect_error(h2o.partialPlot(object = iris_gbm, data = iris_hex, cols="Sepal.Length", targets=c("Iris")), "\n\nERROR MESSAGE:\n\nIncorrect target class: Iris.\n\n")
+  expect_error(h2o.partialPlot(object = iris_gbm, newdata = iris_hex, cols="Sepal.Length", targets=c("Iris")), "\n\nERROR MESSAGE:\n\nIncorrect target class: Iris.\n\n")
 
   ## 5) Target is set for non multinomial problem
-  expect_error(h2o.partialPlot(object = prostate_drf, data = prostate_hex, targets=c("Iris")), "\n\nERROR MESSAGE:\n\nTargets parameter is available only for multinomial classification.\n\n")
+  expect_error(h2o.partialPlot(object = prostate_drf, newdata = prostate_hex, targets=c("Iris")), "\n\nERROR MESSAGE:\n\nTargets parameter is available only for multinomial classification.\n\n")
 }
 
 doTest("Test Partial Dependence Plots in H2O: ", test)

--- a/h2o-r/tests/testdir_misc/runit_partialPlot.R
+++ b/h2o-r/tests/testdir_misc/runit_partialPlot.R
@@ -178,7 +178,7 @@ test <- function() {
   ## Check deprecated params
   expect_warning(h2o.partialPlot(object = iris_gbm, data = iris_hex, cols="Petal.Length", targets=c("setosa")), "argument 'data' is deprecated")
   expect_warning(h2o.partialPlot(object = iris_gbm, newdata = iris_hex, data = iris_hex, cols="Petal.Length", targets=c("setosa")), "ignoring 'data' as 'newdata' was also provided")
-  expect_error(h2o.partialPlot(object = iris_gbm, newdata = iris_hex, wrong_data = iris_hex, cols="Petal.Length", targets=c("setosa")), "unused arguments wrong_data")
+  expect_error(h2o.partialPlot(object = iris_gbm, newdata = iris_hex, wrong_arg = iris_hex, cols="Petal.Length", targets=c("setosa")), "unused argument wrong_arg")
 
   ## Check failure cases
   ## 1) Selection of incorrect columns 

--- a/h2o-r/tests/testdir_misc/runit_pubdev_5706_usersplits_pdp.R
+++ b/h2o-r/tests/testdir_misc/runit_pubdev_5706_usersplits_pdp.R
@@ -25,7 +25,7 @@ testpdpUserSplits <- function() {
                          training_frame = prostate_hex, ntrees = 50, learn_rate=0.05, seed = 12345)
   
   # build pdp normal
-  h2o_pp = h2o.partialPlot(object = prostate_gbm, data = prostate_hex, cols = c("AGE", "RACE", "DCAPS"), plot = FALSE)
+  h2o_pp = h2o.partialPlot(object = prostate_gbm, newdata = prostate_hex, cols = c("AGE", "RACE", "DCAPS"), plot = FALSE)
   ## Calculate partial dependence using h2o.partialPlot for columns "AGE" and "RACE"
   ageSplit = c(43.0, 44.89473684210526, 46.78947368421053, 48.68421052631579, 50.578947368421055,
                52.473684210526315, 54.368421052631575, 56.26315789473684, 58.1578947368421,
@@ -34,10 +34,10 @@ testpdpUserSplits <- function() {
                75.21052631578948, 77.10526315789474)
   raceSplit = c("Black")  
   user_splits_list = list(c("AGE", ageSplit), c("RACE", raceSplit))
-  h2o_pp_splits = h2o.partialPlot(object = prostate_gbm, data = prostate_hex, cols = c("AGE", "RACE", "DCAPS"), plot = F, user_splits=user_splits_list)
+  h2o_pp_splits = h2o.partialPlot(object = prostate_gbm, newdata = prostate_hex, cols = c("AGE", "RACE", "DCAPS"), plot = F, user_splits=user_splits_list)
   
   # build pdp normal
-  h2o_pp = h2o.partialPlot(object = prostate_gbm, data = prostate_hex, cols = c("AGE", "RACE", "DCAPS"), plot = FALSE)
+  h2o_pp = h2o.partialPlot(object = prostate_gbm, newdata = prostate_hex, cols = c("AGE", "RACE", "DCAPS"), plot = FALSE)
   # compare pdp from both.  They are not the same length.  The user split is one shorter.
   assert_partialPlots_twoDTable_equal(h2o_pp_splits[[1]],h2o_pp[[1]]) # for AGE
   assert_partialPlots_twoDTable_equal(h2o_pp_splits[[2]],h2o_pp[[2]])  # for RACE

--- a/h2o-r/tests/testdir_misc/runit_pubdev_5761_partialPlot_NA.R
+++ b/h2o-r/tests/testdir_misc/runit_pubdev_5761_partialPlot_NA.R
@@ -22,9 +22,9 @@ testPartialPlots <- function() {
   
   ## Calculate partial dependence using h2o.partialPlot for columns "AGE" and "RACE"
   # build pdp without weight or NA
-  h2o_pp <- h2o.partialPlot(object = prostate_gbm, data = prostate_hex, cols = c("AGE", "RACE"), plot = FALSE)
-  h2o_pp_weight_NA <- h2o.partialPlot(object = prostate_gbm, data = prostate_hex, cols = c("AGE", "RACE"), plot = FALSE, weight_column="constWeight", include_na=TRUE)
-  h2o_pp_vweight_NA <- h2o.partialPlot(object = prostate_gbm, data = prostate_hex, cols = c("AGE", "RACE"), plot = FALSE, weight_column="variWeight", include_na=TRUE)
+  h2o_pp <- h2o.partialPlot(object = prostate_gbm, newdata = prostate_hex, cols = c("AGE", "RACE"), plot = FALSE)
+  h2o_pp_weight_NA <- h2o.partialPlot(object = prostate_gbm, newdata = prostate_hex, cols = c("AGE", "RACE"), plot = FALSE, weight_column="constWeight", include_na=TRUE)
+  h2o_pp_vweight_NA <- h2o.partialPlot(object = prostate_gbm, newdata = prostate_hex, cols = c("AGE", "RACE"), plot = FALSE, weight_column="variWeight", include_na=TRUE)
   
   assert_twoDTable_equal(h2o_pp[[1]], h2o_pp_weight_NA[[1]]) # compare RACE pdp
   assert_twoDTable_equal(h2o_pp[[2]], h2o_pp_weight_NA[[2]]) # compare AGE pdp

--- a/h2o-r/tests/testdir_misc/runit_pubdev_5921_na_prints_large.R
+++ b/h2o-r/tests/testdir_misc/runit_pubdev_5921_na_prints_large.R
@@ -9,8 +9,8 @@ testPartialPlots <- function() {
   ## build GBM model
   airlines_gbm <- h2o.gbm(x = x, y = "IsDepDelayed", training_frame = airlines_hex, ntrees = 80, learn_rate=0.1, seed = 12345)
   # build pdp without weight or NA
-  h2o_pp_weight <- h2o.partialPlot(object = airlines_gbm, data = airlines_hex, cols = c("Input_miss", "fDayOfWeek"), plot = TRUE, weight_column=weigth_col)
-  h2o_pp_weight_NA <- h2o.partialPlot(object = airlines_gbm, data =  airlines_hex, cols = c("Input_miss", "fDayOfWeek"), plot = TRUE, weight_column=weigth_col, include_na=TRUE)
+  h2o_pp_weight <- h2o.partialPlot(object = airlines_gbm, newdata = airlines_hex, cols = c("Input_miss", "fDayOfWeek"), plot = TRUE, weight_column=weigth_col)
+  h2o_pp_weight_NA <- h2o.partialPlot(object = airlines_gbm, newdata =  airlines_hex, cols = c("Input_miss", "fDayOfWeek"), plot = TRUE, weight_column=weigth_col, include_na=TRUE)
   
   assert_twoDTable_equal(h2o_pp_weight[[1]], h2o_pp_weight_NA[[1]]) # compare Input_miss pdp
   assert_twoDTable_equal(h2o_pp_weight[[2]], h2o_pp_weight_NA[[2]]) # compare fDayOfWeek pdp

--- a/h2o-r/tests/testdir_misc/runit_pubdev_5928_printNA_H2OTable.R
+++ b/h2o-r/tests/testdir_misc/runit_pubdev_5928_printNA_H2OTable.R
@@ -23,7 +23,7 @@ testPartialPlots <- function() {
   
   ## Calculate partial dependence using h2o.partialPlot for columns "AGE" and "RACE"
   # build pdp without weight or NA
-  h2o_pp_weight_NA <- h2o.partialPlot(object = prostate_gbm, data = prostate_hex, cols = c("AGE", "RACE"), nbins=3, plot = FALSE, weight_column="constWeight", include_na=TRUE)
+  h2o_pp_weight_NA <- h2o.partialPlot(object = prostate_gbm, newdata = prostate_hex, cols = c("AGE", "RACE"), nbins=3, plot = FALSE, weight_column="constWeight", include_na=TRUE)
   h2o2DtablePrintOut <- capture.output(h2o_pp_weight_NA[[1]]) # capture H2OTable print here
   naNum <- sum(grepl("NA", h2o2DtablePrintOut))  # should be 1
 }

--- a/h2o-r/tests/testdir_misc/runit_pubdev_7205_user_pdp.R
+++ b/h2o-r/tests/testdir_misc/runit_pubdev_7205_user_pdp.R
@@ -20,7 +20,7 @@ testpdpUserSplits <- function() {
                       x = 1:4,
                       y = 6,
                       training_frame = iris.hex)
-  pdps <- h2o.partialPlot(object=iris.gbm, data=iris.hex, cols=c("Sepal.Width", "Petal.Length", "Petal.Width"), 
+  pdps <- h2o.partialPlot(object=iris.gbm, newdata=iris.hex, cols=c("Sepal.Width", "Petal.Length", "Petal.Width"), 
   user_splits=list(c("Sepal.Width","0","1"), c("Petal.Length","1","2"),c("Petal.Width", "3","4","5")))
   petalW <- pdps[[3]]$Petal.Width
   expect_true(checkEqualsNumeric(petalW, c(3,4,5)))


### PR DESCRIPTION
Fix for issue: https://github.com/h2oai/h2o-3/issues/15893

## Python client

Deprecating `data` param on function `partial_plot` and forward to new param name `frame` for consistency with other plot functions.

## R client

Deprecating `data` param on function `partialPlot` and forward to new param name `newdata` for consistency with other R plot functions.
Note that the "standard" param name in R is different than in Python. We probably wanted to use a standard R param name instead of prioritizing compatibility with Py API.
