### PR TITLE
GH-15677 Fix Match function bug

### DIFF
--- a/h2o-core/src/main/java/water/rapids/ast/prims/search/AstMatch.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/search/AstMatch.java
@@ -109,7 +109,8 @@ public class AstMatch extends AstPrimitive {
     StrMatchTask(String[] values, double noMatch, int indexes) {
       _mapping = new IcedHashMap<>();
       for (int i = 0; i < values.length; i++) {
-        _mapping.put(values[i], i);
+        String value = values[i];
+        if (!_mapping.containsKey(value)) _mapping.put(values[i], i);
       }
       _sortedValues = values.clone();
       Arrays.sort(_sortedValues);
@@ -141,7 +142,8 @@ public class AstMatch extends AstPrimitive {
     CatMatchTask(String[] values, double noMatch, int startIndex) {
       _mapping = new IcedHashMap<>();
       for (int i = 0; i < values.length; i++) {
-        _mapping.put(values[i], i);
+        String value = values[i];
+        if (!_mapping.containsKey(value)) _mapping.put(values[i], i);
       }
       _sortedValues = values.clone();
       Arrays.sort(_sortedValues);
@@ -172,7 +174,8 @@ public class AstMatch extends AstPrimitive {
     NumMatchTask(double[] values, double noMatch, int startIndex) {
       _mapping = new IcedHashMap<>();
       for (int i = 0; i < values.length; i++) {
-        _mapping.put(values[i], i);
+        double value = values[i];
+        if (!_mapping.containsKey(value)) _mapping.put(values[i], i);
       }
       _sortedValues = values.clone();
       Arrays.sort(_sortedValues);

--- a/h2o-core/src/main/java/water/rapids/ast/prims/search/AstMatch.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/search/AstMatch.java
@@ -65,6 +65,8 @@ public class AstMatch extends AstPrimitive {
       if (startIndex < 0) {
         throw new IllegalArgumentException("Expected number >= 0. Got: " + asts[4].getClass());
       }
+    } else if(asts[4] instanceof AstId) {
+      startIndex = 1;
     } else {
       throw new IllegalArgumentException("Expected number. Got: " + asts[4].getClass());
     }

--- a/h2o-core/src/main/java/water/rapids/ast/prims/search/AstMatch.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/search/AstMatch.java
@@ -15,6 +15,7 @@ import water.util.IcedHashMap;
 import water.util.MathUtils;
 
 import java.util.Arrays;
+import java.util.Map;
 
 /**
  * Makes a vector where an index of value from the table is returned if the value matches; 
@@ -194,7 +195,7 @@ public class AstMatch extends AstPrimitive {
     }
   }
 
-  private static double in(IcedHashMap<String, Integer> matchesIndexes, String[] sortedMatches, IcedHashMap<String, Integer> mapping, String s, double noMatch, int startIndex) {
+  private static double in(Map<String, Integer> matchesIndexes, String[] sortedMatches, IcedHashMap<String, Integer> mapping, String s, double noMatch, int startIndex) {
     Integer mapResult = matchesIndexes.get(s);
     int match;
     if (mapResult == null){
@@ -206,7 +207,7 @@ public class AstMatch extends AstPrimitive {
     return match >= 0 ? applyStartIndex(mapping.get(s), startIndex) : noMatch;
   }
 
-  private static double in(IcedHashMap<Double, Integer> matchesIndexes, double[] sortedMatches, IcedHashMap<Double, Integer> mapping, double d, double noMatch, int startIndex) {
+  private static double in(Map<Double, Integer> matchesIndexes, double[] sortedMatches, IcedHashMap<Double, Integer> mapping, double d, double noMatch, int startIndex) {
     Integer mapResult = matchesIndexes.get(d);
     int match;
     if (mapResult == null){

--- a/h2o-core/src/test/java/water/rapids/ast/prims/search/AstMatchTest.java
+++ b/h2o-core/src/test/java/water/rapids/ast/prims/search/AstMatchTest.java
@@ -22,10 +22,28 @@ public class AstMatchTest extends TestUtil {
     Frame output = null;
     try {
       String numList = idx(data.vec(3), "cB", "cC", "cD");
-      String rapids = "(tmp= tst (match (cols data [3]) [" + numList + "] -1 ignored false))";
+      String rapids = "(tmp= tst (match (cols data [3]) [" + numList + "] -1 0))";
       Val val = Rapids.exec(rapids);
       output = val.getFrame();
       assertVecEquals(data.vec(0), output.vec(0), 0.0);
+    } finally {
+      data.delete();
+      if (output != null) {
+        output.delete();
+      }
+    }
+  }
+
+  @Test
+  public void testMatchNumListStart() {
+    final Frame data = makeTestFrame();
+    Frame output = null;
+    try {
+      String numList = idx(data.vec(3), "cB", "cC", "cD");
+      String rapids = "(tmp= tst (match (cols data [3]) [" + numList + "] 0 1))";
+      Val val = Rapids.exec(rapids);
+      output = val.getFrame();
+      assertVecEquals(data.vec(1), output.vec(0), 0.0);
     } finally {
       data.delete();
       if (output != null) {
@@ -39,7 +57,7 @@ public class AstMatchTest extends TestUtil {
     final Frame data = makeTestFrame();
     Frame output = null;
     try {
-      String rapids = "(tmp= tst (match (cols data [3]) [\"cD\",\"cC\",\"cB\"] -1 ignored false))";
+      String rapids = "(tmp= tst (match (cols data [3]) [\"cB\",\"cC\",\"cD\"] -1 0))";
       Val val = Rapids.exec(rapids);
       output = val.getFrame();
       assertVecEquals(data.vec(0), output.vec(0), 0.0);
@@ -56,7 +74,7 @@ public class AstMatchTest extends TestUtil {
     final Frame data = makeTestFrame();
     Frame output = null;
     try {
-      String rapids = "(tmp= tst (match (cols data [2]) [\"sD\",\"sC\",\"sB\"] -1 ignored false))";
+      String rapids = "(tmp= tst (match (cols data [2]) [\"sB\",\"sC\",\"sD\"] -1 0))";
       Val val = Rapids.exec(rapids);
       output = val.getFrame();
       assertVecEquals(data.vec(0), output.vec(0), 0.0);
@@ -68,78 +86,28 @@ public class AstMatchTest extends TestUtil {
     }
   }
 
-  @Test
-  public void testMatchNumListIndexes() {
-    final Frame data = makeTestFrame();
-    Frame output = null;
-    try {
-      String numList = idx(data.vec(3), "cB", "cC", "cD");
-      String rapids = "(tmp= tst (match (cols data [3]) [" + numList + "] -1 ignored true))";
-      Val val = Rapids.exec(rapids);
-      output = val.getFrame();
-      assertVecEquals(data.vec(1), output.vec(0), 0.0);
-    } finally {
-      data.delete();
-      if (output != null) {
-        output.delete();
-      }
-    }
-  }
-
-  @Test
-  public void testMatchCatListIndexes() {
-    final Frame data = makeTestFrame();
-    Frame output = null;
-    try {
-      String rapids = "(tmp= tst (match (cols data [3]) [\"cB\",\"cC\",\"cD\"] -1 ignored true))";
-      Val val = Rapids.exec(rapids);
-      output = val.getFrame();
-      assertVecEquals(data.vec(1), output.vec(0), 0.0);
-    } finally {
-      data.delete();
-      if (output != null) {
-        output.delete();
-      }
-    }
-  }
-
-  @Test
-  public void testMatchStrListIndexes() {
-    final Frame data = makeTestFrame();
-    Frame output = null;
-    try {
-      String rapids = "(tmp= tst (match (cols data [2]) [\"sB\",\"sC\",\"sD\"] -1 ignored true))";
-      Val val = Rapids.exec(rapids);
-      output = val.getFrame();
-      assertVecEquals(data.vec(1), output.vec(0), 0.0);
-    } finally {
-      data.delete();
-      if (output != null) {
-        output.delete();
-      }
-    }
-  }
+  
 
   private Frame makeTestFrame() {
     Random rnd = new Random();
     final int len = 55000;
     double numData[] = new double[len];
-    double[] numDataIndexes = new double[len];
+    double numDataStart[] = new double[len];
     String[] strData = new String[len];
     String[] catData = new String[len];
     for (int i = 0; i < len; i++) {
       char c = (char) ('A' + rnd.nextInt('Z' - 'A'));
-      numData[i] = c >= 'B' && c <= 'D' ? 1 : -1;
-      numDataIndexes[i] = c == 'B' ? 0 : c == 'C' ? 1 : c == 'D' ? 2 : -1;
+      numData[i] = c == 'B' ? 0 : c == 'C' ? 1 : c == 'D' ? 2 : -1;
+      numDataStart[i] = c == 'B' ? 1 : c == 'C' ? 2 : c == 'D' ? 3 : 0;
       strData[i] = "s" + c;
       catData[i] = "c" + c;
     }
     return new TestFrameBuilder()
             .withName("data")
-            .withColNames("Expected", "Expected_idexes", "Str", "Cat")
+            .withColNames("Expected", "ExpectedStart", "Str", "Cat")
             .withVecTypes(Vec.T_NUM, Vec.T_NUM, Vec.T_STR, Vec.T_CAT)
             .withDataForCol(0, numData)
-            .withDataForCol(1, numDataIndexes)
+            .withDataForCol(1, numDataStart)
             .withDataForCol(2, strData)
             .withDataForCol(3, catData)
             .withChunkLayout(10000, 10000, 10000, 20000, 5000)

--- a/h2o-core/src/test/java/water/rapids/ast/prims/search/AstMatchTest.java
+++ b/h2o-core/src/test/java/water/rapids/ast/prims/search/AstMatchTest.java
@@ -120,7 +120,22 @@ public class AstMatchTest extends TestUtil {
     }
   }
 
-  
+  @Test()
+  public void testMatchSameValueInMatchList() {
+    final Frame data = makeTestFrame();
+    Frame output = null;
+    try {
+      String rapids = "(tmp= tst (match (cols data [3]) [2,1,3,1] -1 0))";
+      Val val = Rapids.exec(rapids);
+      output = val.getFrame();
+      assertVecEquals(data.vec(0), output.vec(0), 0.0);
+    } finally {
+      data.delete();
+      if (output != null) {
+        output.delete();
+      }
+    }
+  }
 
   private Frame makeTestFrame() {
     Random rnd = new Random();

--- a/h2o-core/src/test/java/water/rapids/ast/prims/search/AstMatchTest.java
+++ b/h2o-core/src/test/java/water/rapids/ast/prims/search/AstMatchTest.java
@@ -21,7 +21,7 @@ public class AstMatchTest extends TestUtil {
     final Frame data = makeTestFrame();
     Frame output = null;
     try {
-      String numList = idx(data.vec(3), "cB", "cC", "cD");
+      String numList = idx(data.vec(3), "cC", "cB", "cD");
       String rapids = "(tmp= tst (match (cols data [3]) [" + numList + "] -1 0))";
       Val val = Rapids.exec(rapids);
       output = val.getFrame();
@@ -39,7 +39,7 @@ public class AstMatchTest extends TestUtil {
     final Frame data = makeTestFrame();
     Frame output = null;
     try {
-      String numList = idx(data.vec(3), "cB", "cC", "cD");
+      String numList = idx(data.vec(3), "cC", "cB", "cD");
       String rapids = "(tmp= tst (match (cols data [3]) [" + numList + "] 0 1))";
       Val val = Rapids.exec(rapids);
       output = val.getFrame();
@@ -57,7 +57,7 @@ public class AstMatchTest extends TestUtil {
     final Frame data = makeTestFrame();
     Frame output = null;
     try {
-      String rapids = "(tmp= tst (match (cols data [3]) [\"cB\",\"cC\",\"cD\"] -1 0))";
+      String rapids = "(tmp= tst (match (cols data [3]) [\"cC\",\"cB\",\"cD\"] -1 0))";
       Val val = Rapids.exec(rapids);
       output = val.getFrame();
       assertVecEquals(data.vec(0), output.vec(0), 0.0);
@@ -74,7 +74,7 @@ public class AstMatchTest extends TestUtil {
     final Frame data = makeTestFrame();
     Frame output = null;
     try {
-      String rapids = "(tmp= tst (match (cols data [2]) [\"sB\",\"sC\",\"sD\"] -1 0))";
+      String rapids = "(tmp= tst (match (cols data [2]) [\"sC\",\"sB\",\"sD\"] -1 0))";
       Val val = Rapids.exec(rapids);
       output = val.getFrame();
       assertVecEquals(data.vec(0), output.vec(0), 0.0);
@@ -131,8 +131,8 @@ public class AstMatchTest extends TestUtil {
     String[] catData = new String[len];
     for (int i = 0; i < len; i++) {
       char c = (char) ('A' + rnd.nextInt('Z' - 'A'));
-      numData[i] = c == 'B' ? 0 : c == 'C' ? 1 : c == 'D' ? 2 : -1;
-      numDataStart[i] = c == 'B' ? 1 : c == 'C' ? 2 : c == 'D' ? 3 : 0;
+      numData[i] = c == 'B' ? 1 : c == 'C' ? 0 : c == 'D' ? 2 : -1;
+      numDataStart[i] = c == 'B' ? 2 : c == 'C' ? 1 : c == 'D' ? 3 : 0;
       strData[i] = "s" + c;
       catData[i] = "c" + c;
     }

--- a/h2o-core/src/test/java/water/rapids/ast/prims/search/AstMatchTest.java
+++ b/h2o-core/src/test/java/water/rapids/ast/prims/search/AstMatchTest.java
@@ -86,6 +86,40 @@ public class AstMatchTest extends TestUtil {
     }
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testMatchStrListNumericDomain() {
+    final Frame data = makeTestFrame();
+    Frame output = null;
+    try {
+      String rapids = "(tmp= tst (match (cols data [2]) [1,2,3] -1 0))";
+      Val val = Rapids.exec(rapids);
+      output = val.getFrame();
+      assertVecEquals(data.vec(0), output.vec(0), 0.0);
+    } finally {
+      data.delete();
+      if (output != null) {
+        output.delete();
+      }
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMatchNumListStringDomain() {
+    final Frame data = makeTestFrame();
+    Frame output = null;
+    try {
+      String rapids = "(tmp= tst (match (cols data [3]) [[\"sB\",\"sC\",\"sD\"] -1 0))";
+      Val val = Rapids.exec(rapids);
+      output = val.getFrame();
+      assertVecEquals(data.vec(0), output.vec(0), 0.0);
+    } finally {
+      data.delete();
+      if (output != null) {
+        output.delete();
+      }
+    }
+  }
+
   
 
   private Frame makeTestFrame() {

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -4655,13 +4655,13 @@ class H2OFrame(Keyed, H2ODisplay):
 
     def match(self, table, nomatch=float("nan"), start_index=1):
         """
-        Make a vector where index of value form the table is returned if the value match, nomatch value otherwise. 
+        Makes a vector where an index of value from the table is returned if the value matches; returns ``nomatch`` value otherwise. 
 
-        :param List table: the list of items to match against
-        :param int nomatch: value that should be returned when there is no match. Numeric value or nan. 
-        :param int start_index: index from which start indexing of table list, numeric value >=0, default is 1.
-        :returns: a new H2OFrame containing a vector where index of value form the table is returned if the value match, 
-            nomatch value otherwise. 
+        :param List table: The list of items to match against.
+        :param int nomatch: Value that should be returned when there is no match. Numeric value or ``nan``. 
+        :param int start_index: Index from which this starts the indexing of the table list, numeric value >=0 (default is ``1``).
+        :returns: A new H2OFrame containing a vector where the index of value from the table is returned if the value matches; returns 
+            ``nomatch`` value otherwise. 
 
         :examples:
 
@@ -4669,8 +4669,8 @@ class H2OFrame(Keyed, H2ODisplay):
         >>> match_col = iris["C5"].match(['Iris-setosa', 'Iris-versicolor'])
         >>> match_col.names = ['match']
         >>> iris_match = iris.cbind(match_col)
-        >>> splited = iris_match.split_frame(ratios=[0.05], seed=1)[0]
-        >>> print(splited)
+        >>> iris_split = iris_match.split_frame(ratios=[0.05], seed=1)[0]
+        >>> print(iris_split)
         """
         return H2OFrame._expr(expr=ExprNode("match", self, table, nomatch, start_index))
 

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -4653,13 +4653,12 @@ class H2OFrame(Keyed, H2ODisplay):
         """
         return H2OFrame._expr(expr=ExprNode('h2o.random_stratified_split', self, test_frac, seed))
 
-    def match(self, table, nomatch=None, start_index=1):
+    def match(self, table, nomatch=float("nan"), start_index=1):
         """
         Make a vector where index of value form the table is returned if the value match, nomatch value otherwise. 
 
         :param List table: the list of items to match against
-        :param int nomatch: value that should be returned when there is no match. Numeric value or None. 
-            If nomatch=None, nan values are generated. 
+        :param int nomatch: value that should be returned when there is no match. Numeric value or nan. 
         :param int start_index: index from which start indexing of table list, numeric value >=0, default is 1.
         :returns: a new H2OFrame containing a vector where index of value form the table is returned if the value match, 
             nomatch value otherwise. 
@@ -4667,10 +4666,11 @@ class H2OFrame(Keyed, H2ODisplay):
         :examples:
 
         >>> iris = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/iris/iris.csv")
-        >>> matchFrame = iris["C5"].match(['Iris-versicolor'])
-        >>> matchFrame
-        >>> matchFrame = iris["C5"].match(['Iris-setosa'])
-        >>> matchFrame
+        >>> match_col = iris["C5"].match(['Iris-setosa', 'Iris-versicolor'])
+        >>> match_col.names = ['match']
+        >>> iris_match = iris.cbind(match_col)
+        >>> splited = iris_match.split_frame(ratios=[0.05], seed=1)[0]
+        >>> print(splited)
         """
         return H2OFrame._expr(expr=ExprNode("match", self, table, nomatch, start_index))
 

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -4668,12 +4668,12 @@ class H2OFrame(Keyed, H2ODisplay):
 
         :examples:
 
-        >>> iris = h2o.import_file("h2o://iris")
-        >>> match_col = iris["C5"].match(['Iris-setosa', 'Iris-versicolor'])
+        >>> data = h2o.import_file("h2o://iris")
+        >>> match_col = data["C5"].match(['Iris-setosa', 'Iris-versicolor'])
         >>> match_col.names = ['match']
-        >>> iris_match = iris.cbind(match_col)
-        >>> iris_split = iris_match.split_frame(ratios=[0.05], seed=1)[0]
-        >>> iris_split
+        >>> iris_match = data.cbind(match_col)
+        >>> sample = iris_match.split_frame(ratios=[0.05], seed=1)[0]
+        >>> sample
         """
         return H2OFrame._expr(expr=ExprNode("match", self, table, nomatch, start_index))
 

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -4674,6 +4674,19 @@ class H2OFrame(Keyed, H2ODisplay):
         >>> iris_match = data.cbind(match_col)
         >>> sample = iris_match.split_frame(ratios=[0.05], seed=1)[0]
         >>> sample
+          sepal_len    sepal_wid    petal_len    petal_wid  class              match
+        -----------  -----------  -----------  -----------  ---------------  -------
+                5.2          3.5          1.5          0.2  Iris-setosa            1
+                5            3.5          1.3          0.3  Iris-setosa            1
+                7            3.2          4.7          1.4  Iris-versicolor        2
+                4.9          2.4          3.3          1    Iris-versicolor        2
+                5.5          2.4          3.8          1.1  Iris-versicolor        2
+                5.8          2.7          5.1          1.9  Iris-virginica       nan
+                6.3          2.9          5.6          1.8  Iris-virginica       nan
+                5.8          2.8          5.1          2.4  Iris-virginica       nan
+                7.7          2.6          6.9          2.3  Iris-virginica       nan
+                6.3          2.7          4.9          1.8  Iris-virginica       nan
+        [12 rows x 6 columns]
         """
         return H2OFrame._expr(expr=ExprNode("match", self, table, nomatch, start_index))
 

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -1845,7 +1845,7 @@ class H2OFrame(Keyed, H2ODisplay):
         """
         if is_type(item, list, tuple, set):
             if self.ncols == 1 and (self.type(0) == 'str' or self.type(0) == 'enum'):
-                return self.match(item)
+                return self.match(item, nomatch=0)
             else:
                 return functools.reduce(H2OFrame.__or__, (self == i for i in item))
         else:

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -4655,16 +4655,14 @@ class H2OFrame(Keyed, H2ODisplay):
 
     def match(self, table, nomatch=None, start_index=1):
         """
-        Make a vector of the positions of (first) matches of its first argument in its second.
-
-        Only applicable to single-column categorical/string frames.
+        Make a vector where index of value form the table is returned if the value match, nomatch value otherwise. 
 
         :param List table: the list of items to match against
-        :param int or 'nan' nomatch: value that should be returned when there is no match. Numeric value or 'nan'. 
-        :param int start_index: numeric value >=0, default is 1, 
-            otherwise return 1 if the value is in the list of items to match against and nomatch value otherwise
-        :returns: a new H2OFrame containing for each cell from the source frame the index where
-            the pattern ``table`` first occurs within that cell.
+        :param int nomatch: value that should be returned when there is no match. Numeric value or None. 
+            If nomatch=None, nan values are generated. 
+        :param int start_index: index from which start indexing of table list, numeric value >=0, default is 1.
+        :returns: a new H2OFrame containing a vector where index of value form the table is returned if the value match, 
+            nomatch value otherwise. 
 
         :examples:
 

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -4655,13 +4655,16 @@ class H2OFrame(Keyed, H2ODisplay):
 
     def match(self, table, nomatch=float("nan"), start_index=1):
         """
-        Makes a vector where an index of value from the table is returned if the value matches; returns ``nomatch`` value otherwise. 
+        Makes a vector where an index of value from the table is returned if the value matches; 
+        returns ``nomatch`` value otherwise.
 
-        :param List table: The list of items to match against.
+        :param List table: The list of items to match against. Duplicates are ignored. The index of the first 
+            occurrence will be used.
         :param int nomatch: Value that should be returned when there is no match. Numeric value or ``nan``. 
-        :param int start_index: Index from which this starts the indexing of the table list, numeric value >=0 (default is ``1``).
-        :returns: A new H2OFrame containing a vector where the index of value from the table is returned if the value matches; returns 
-            ``nomatch`` value otherwise. 
+        :param int start_index: Index from which this starts the indexing of the table list, numeric value >=0 
+            (default is ``1``).
+        :returns: A new H2OFrame containing a vector where the index of value from the table is returned if the value 
+            matches; returns ``nomatch`` value otherwise. 
 
         :examples:
 

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -4668,12 +4668,12 @@ class H2OFrame(Keyed, H2ODisplay):
 
         :examples:
 
-        >>> iris = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/iris/iris.csv")
+        >>> iris = h2o.import_file("h2o://iris")
         >>> match_col = iris["C5"].match(['Iris-setosa', 'Iris-versicolor'])
         >>> match_col.names = ['match']
         >>> iris_match = iris.cbind(match_col)
         >>> iris_split = iris_match.split_frame(ratios=[0.05], seed=1)[0]
-        >>> print(iris_split)
+        >>> iris_split
         """
         return H2OFrame._expr(expr=ExprNode("match", self, table, nomatch, start_index))
 

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -4653,15 +4653,15 @@ class H2OFrame(Keyed, H2ODisplay):
         """
         return H2OFrame._expr(expr=ExprNode('h2o.random_stratified_split', self, test_frac, seed))
 
-    def match(self, table, nomatch=0, indexes=False):
+    def match(self, table, nomatch=None, start_index=1):
         """
         Make a vector of the positions of (first) matches of its first argument in its second.
 
         Only applicable to single-column categorical/string frames.
 
         :param List table: the list of items to match against
-        :param int nomatch: value that should be returned when there is no match.
-        :param boolean indexes: if true return index of searched value, 
+        :param int or 'nan' nomatch: value that should be returned when there is no match. Numeric value or 'nan'. 
+        :param int start_index: numeric value >=0, default is 1, 
             otherwise return 1 if the value is in the list of items to match against and nomatch value otherwise
         :returns: a new H2OFrame containing for each cell from the source frame the index where
             the pattern ``table`` first occurs within that cell.
@@ -4674,7 +4674,7 @@ class H2OFrame(Keyed, H2ODisplay):
         >>> matchFrame = iris["C5"].match(['Iris-setosa'])
         >>> matchFrame
         """
-        return H2OFrame._expr(expr=ExprNode("match", self, table, nomatch, None, indexes))
+        return H2OFrame._expr(expr=ExprNode("match", self, table, nomatch, start_index))
 
     def cut(self, breaks, labels=None, include_lowest=False, right=True, dig_lab=3):
         """

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -4653,7 +4653,7 @@ class H2OFrame(Keyed, H2ODisplay):
         """
         return H2OFrame._expr(expr=ExprNode('h2o.random_stratified_split', self, test_frac, seed))
 
-    def match(self, table, nomatch=0):
+    def match(self, table, nomatch=0, indexes=False):
         """
         Make a vector of the positions of (first) matches of its first argument in its second.
 
@@ -4661,6 +4661,8 @@ class H2OFrame(Keyed, H2ODisplay):
 
         :param List table: the list of items to match against
         :param int nomatch: value that should be returned when there is no match.
+        :param boolean indexes: if true return index of searched value, 
+            otherwise return 1 if the value is in the list of items to match against and nomatch value otherwise
         :returns: a new H2OFrame containing for each cell from the source frame the index where
             the pattern ``table`` first occurs within that cell.
 
@@ -4672,7 +4674,7 @@ class H2OFrame(Keyed, H2ODisplay):
         >>> matchFrame = iris["C5"].match(['Iris-setosa'])
         >>> matchFrame
         """
-        return H2OFrame._expr(expr=ExprNode("match", self, table, nomatch, None))
+        return H2OFrame._expr(expr=ExprNode("match", self, table, nomatch, None, indexes))
 
     def cut(self, breaks, labels=None, include_lowest=False, right=True, dig_lab=3):
         """

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_match.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_match.py
@@ -4,8 +4,6 @@ import h2o
 from tests import pyunit_utils
 from h2o.utils.typechecks import assert_is_type
 from h2o.frame import H2OFrame
-from random import randrange
-import numpy as np
 
 
 def h2o_H2OFrame_match():
@@ -15,17 +13,23 @@ def h2o_H2OFrame_match():
     Copied from runit_lstrip.R
     """
     iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
-    matchFrame = iris["C5"].match(['Iris-setosa'])
-    assert_is_type(matchFrame, H2OFrame)    # check return type
-    assert matchFrame.sum()[0,0]==50.0, "h2o.H2OFrame.match() command is not working."  # check return result
+    
+    match_frame = iris["C5"].match(['Iris-setosa'])
+    assert_is_type(match_frame, H2OFrame)    # check return type
+    assert match_frame.sum()[0, 0] == 50.0, "h2o.H2OFrame.match() command is not working."  # check return result
 
-    matchFrame = iris["C5"].match(['Iris-setosa', 'Iris-versicolor'])
-    assert_is_type(matchFrame, H2OFrame)    # check return type
-    assert matchFrame.sum()[0,0]==100.0, "h2o.H2OFrame.match() command is not working."  # check return result
+    match_frame = iris["C5"].match(['Iris-setosa', 'Iris-versicolor'])
+    assert_is_type(match_frame, H2OFrame)    # check return type
+    assert match_frame.sum()[0, 0] == 100.0, "h2o.H2OFrame.match() command is not working."  # check return result
 
-    matchFrame = iris["C5"].match(['Iris-setosa', 'Iris-versicolor', 'Iris-virginica'])
-    assert_is_type(matchFrame, H2OFrame)    # check return type
-    assert matchFrame.sum()[0,0]==150.0, "h2o.H2OFrame.match() command is not working."  # check return result
+    match_frame = iris["C5"].match(['Iris-setosa', 'Iris-versicolor', 'Iris-virginica'])
+    assert_is_type(match_frame, H2OFrame)    # check return type
+    assert match_frame.sum()[0, 0] == 150.0, "h2o.H2OFrame.match() command is not working."  # check return result
+
+    match_frame = iris["C5"].match(['Iris-setosa'])
+    assert_is_type(match_frame, H2OFrame)    # check return type
+    assert match_frame.sum()[0, 0] == 50.0, "h2o.H2OFrame.match() command is not working."  # check return result
+    
 
 
 pyunit_utils.standalone_test(h2o_H2OFrame_match)

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_match.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_match.py
@@ -64,5 +64,12 @@ def h2o_H2OFrame_match():
     assert match_frame[19, 0] == 1, "match value should be 1"
     assert math.isnan(match_frame[1, 0]), "match value should be nan"
     
+    # test example for doc
+    match_col = iris["C5"].match(['Iris-setosa', 'Iris-versicolor'])
+    match_col.names = ['match']
+    iris_match = iris.cbind(match_col)
+    splited = iris_match.split_frame(ratios=[0.05], seed=1)[0]
+    print(splited)
+    
     
 pyunit_utils.standalone_test(h2o_H2OFrame_match)

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_match.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_match.py
@@ -15,6 +15,8 @@ def h2o_H2OFrame_match():
     iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
 
     nomatch = 0
+    
+    # string value
     match_frame = iris["C5"].match(['Iris-setosa'], nomatch=nomatch)
     assert_is_type(match_frame, H2OFrame)    # check return type
     assert match_frame.sum()[0, 0] == 50.0, "h2o.H2OFrame.match() command is not working."  # check return result
@@ -22,6 +24,7 @@ def h2o_H2OFrame_match():
     assert match_frame[50, 0] == nomatch, "match value should be 0"
     assert match_frame[100, 0] == nomatch, "match value should be 0"
 
+    # string values
     match_frame = iris["C5"].match(['Iris-setosa', 'Iris-versicolor'], nomatch=nomatch)
     assert_is_type(match_frame, H2OFrame, nomatch=0)    # check return type
     assert round(match_frame.sum()[0, 0]) == 150, "h2o.H2OFrame.match() command is not working."  # check return result
@@ -29,6 +32,7 @@ def h2o_H2OFrame_match():
     assert match_frame[50, 0] == 2, "match value should be 2"
     assert match_frame[100, 0] == nomatch, "match value should be 0"
 
+    # use default nomatch
     match_values = ['Iris-setosa', 'Iris-versicolor', 'Iris-virginica']
     match_frame = iris["C5"].match(match_values)
     assert_is_type(match_frame, H2OFrame)    # check return type
@@ -38,15 +42,15 @@ def h2o_H2OFrame_match():
     assert match_frame[100, 0] == 3, "match value should be 3"
 
     # set nomatch value to -1
-    match_values = ['Iris-setosa', 'Iris-versicolor']
     nomatch = -1
+    match_values = ['Iris-setosa', 'Iris-versicolor']
     match_frame = iris["C5"].match(match_values, nomatch=nomatch)
     assert round(match_frame.sum()[0, 0]) == 100, "h2o.H2OFrame.match() command is not working."
     assert match_frame[0, 0] == 1, "match value should be 1"
     assert match_frame[50, 0] == 2, "match value should be 2"
     assert match_frame[100, 0] == nomatch, "match value should be -1"
 
-    # start index feature
+    # start index feature = 0
     match_values = ['Iris-setosa', 'Iris-versicolor']
     start_index = 0
     match_frame = iris["C5"].match(match_values, start_index=start_index)
@@ -55,7 +59,7 @@ def h2o_H2OFrame_match():
     assert match_frame[50, 0] == start_index+1, "match value should be 1"
     assert math.isnan(match_frame[100, 0]), "match value should be nan"
 
-    # double value
+    # numeric values
     match_values = [5.1]
     match_frame = iris["C1"].match(match_values)
     assert match_frame.sum()[0, 0] == 9, "h2o.H2OFrame.match() command is not working."
@@ -63,9 +67,18 @@ def h2o_H2OFrame_match():
     assert match_frame[17, 0] == 1, "match value should be 1"
     assert match_frame[19, 0] == 1, "match value should be 1"
     assert math.isnan(match_frame[1, 0]), "match value should be nan"
+
+    # duplicate in match values
+    nomatch = 0
+    match_frame = iris["C5"].match(['Iris-setosa', 'Iris-versicolor', 'Iris-setosa'], nomatch=nomatch)
+    assert_is_type(match_frame, H2OFrame, nomatch=0)    # check return type
+    assert round(match_frame.sum()[0, 0]) == 150, "h2o.H2OFrame.match() command is not working."  # check return result
+    assert match_frame[0, 0] == 1, "match value should be 1"
+    assert match_frame[50, 0] == 2, "match value should be 2"
+    assert match_frame[100, 0] == nomatch, "match value should be 0"
     
     # test example for doc
-    match_col = iris["C5"].match(['Iris-setosa', 'Iris-versicolor'])
+    match_col = iris["C5"].match(['Iris-setosa', 'Iris-versicolor', 'Iris-setosa'])
     match_col.names = ['match']
     iris_match = iris.cbind(match_col)
     splited = iris_match.split_frame(ratios=[0.05], seed=1)[0]

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_match.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_match.py
@@ -78,7 +78,8 @@ def h2o_H2OFrame_match():
     assert match_frame[100, 0] == nomatch, "match value should be 0"
     
     # test example for doc
-    match_col = data["C5"].match(['Iris-setosa', 'Iris-versicolor', 'Iris-setosa'])
+    data = h2o.import_file("h2o://iris")
+    match_col = data['class'].match(['Iris-setosa', 'Iris-versicolor', 'Iris-setosa'])
     match_col.names = ['match']
     iris_match = data.cbind(match_col)
     sample = iris_match.split_frame(ratios=[0.05], seed=1)[0]

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_match.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_match.py
@@ -4,32 +4,65 @@ import h2o
 from tests import pyunit_utils
 from h2o.utils.typechecks import assert_is_type
 from h2o.frame import H2OFrame
+import math
 
 
 def h2o_H2OFrame_match():
     """
     Python API test: h2o.frame.H2OFrame.match(table, nomatch=0)
 
-    Copied from runit_lstrip.R
     """
     iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
-    
-    match_frame = iris["C5"].match(['Iris-setosa'])
+
+    nomatch = 0
+    match_frame = iris["C5"].match(['Iris-setosa'], nomatch=nomatch)
     assert_is_type(match_frame, H2OFrame)    # check return type
     assert match_frame.sum()[0, 0] == 50.0, "h2o.H2OFrame.match() command is not working."  # check return result
+    assert match_frame[0, 0] == 1, "match value should be 1"
+    assert match_frame[50, 0] == nomatch, "match value should be 0"
+    assert match_frame[100, 0] == nomatch, "match value should be 0"
 
-    match_frame = iris["C5"].match(['Iris-setosa', 'Iris-versicolor'])
-    assert_is_type(match_frame, H2OFrame)    # check return type
-    assert match_frame.sum()[0, 0] == 100.0, "h2o.H2OFrame.match() command is not working."  # check return result
+    match_frame = iris["C5"].match(['Iris-setosa', 'Iris-versicolor'], nomatch=nomatch)
+    assert_is_type(match_frame, H2OFrame, nomatch=0)    # check return type
+    assert round(match_frame.sum()[0, 0]) == 150, "h2o.H2OFrame.match() command is not working."  # check return result
+    assert match_frame[0, 0] == 1, "match value should be 1"
+    assert match_frame[50, 0] == 2, "match value should be 2"
+    assert match_frame[100, 0] == nomatch, "match value should be 0"
 
-    match_frame = iris["C5"].match(['Iris-setosa', 'Iris-versicolor', 'Iris-virginica'])
+    match_values = ['Iris-setosa', 'Iris-versicolor', 'Iris-virginica']
+    match_frame = iris["C5"].match(match_values)
     assert_is_type(match_frame, H2OFrame)    # check return type
-    assert match_frame.sum()[0, 0] == 150.0, "h2o.H2OFrame.match() command is not working."  # check return result
+    assert round(match_frame.sum()[0, 0]) == 300, "h2o.H2OFrame.match() command is not working." 
+    assert match_frame[0, 0] == 1, "match value should be 1"
+    assert match_frame[50, 0] == 2, "match value should be 2"
+    assert match_frame[100, 0] == 3, "match value should be 3"
 
-    match_frame = iris["C5"].match(['Iris-setosa'])
-    assert_is_type(match_frame, H2OFrame)    # check return type
-    assert match_frame.sum()[0, 0] == 50.0, "h2o.H2OFrame.match() command is not working."  # check return result
+    # set nomatch value to -1
+    match_values = ['Iris-setosa', 'Iris-versicolor']
+    nomatch = -1
+    match_frame = iris["C5"].match(match_values, nomatch=nomatch)
+    assert round(match_frame.sum()[0, 0]) == 100, "h2o.H2OFrame.match() command is not working."
+    assert match_frame[0, 0] == 1, "match value should be 1"
+    assert match_frame[50, 0] == 2, "match value should be 2"
+    assert match_frame[100, 0] == nomatch, "match value should be -1"
+
+    # start index feature
+    match_values = ['Iris-setosa', 'Iris-versicolor']
+    start_index = 0
+    match_frame = iris["C5"].match(match_values, start_index=start_index)
+    assert match_frame.sum()[0, 0] == 50, "h2o.H2OFrame.match() command is not working."
+    assert match_frame[0, 0] == start_index, "match value should be 0"
+    assert match_frame[50, 0] == start_index+1, "match value should be 1"
+    assert math.isnan(match_frame[100, 0]), "match value should be nan"
+
+    # double value
+    match_values = [5.1]
+    match_frame = iris["C1"].match(match_values)
+    assert match_frame.sum()[0, 0] == 9, "h2o.H2OFrame.match() command is not working."
+    assert match_frame[0, 0] == 1, "match value should be 1"
+    assert match_frame[17, 0] == 1, "match value should be 1"
+    assert match_frame[19, 0] == 1, "match value should be 1"
+    assert math.isnan(match_frame[1, 0]), "match value should be nan"
     
-
-
+    
 pyunit_utils.standalone_test(h2o_H2OFrame_match)

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_match.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_match.py
@@ -12,12 +12,12 @@ def h2o_H2OFrame_match():
     Python API test: h2o.frame.H2OFrame.match(table, nomatch=0)
 
     """
-    iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
+    data = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
 
     nomatch = 0
     
     # string value
-    match_frame = iris["C5"].match(['Iris-setosa'], nomatch=nomatch)
+    match_frame = data["C5"].match(['Iris-setosa'], nomatch=nomatch)
     assert_is_type(match_frame, H2OFrame)    # check return type
     assert match_frame.sum()[0, 0] == 50.0, "h2o.H2OFrame.match() command is not working."  # check return result
     assert match_frame[0, 0] == 1, "match value should be 1"
@@ -25,7 +25,7 @@ def h2o_H2OFrame_match():
     assert match_frame[100, 0] == nomatch, "match value should be 0"
 
     # string values
-    match_frame = iris["C5"].match(['Iris-setosa', 'Iris-versicolor'], nomatch=nomatch)
+    match_frame = data["C5"].match(['Iris-setosa', 'Iris-versicolor'], nomatch=nomatch)
     assert_is_type(match_frame, H2OFrame, nomatch=0)    # check return type
     assert round(match_frame.sum()[0, 0]) == 150, "h2o.H2OFrame.match() command is not working."  # check return result
     assert match_frame[0, 0] == 1, "match value should be 1"
@@ -34,7 +34,7 @@ def h2o_H2OFrame_match():
 
     # use default nomatch
     match_values = ['Iris-setosa', 'Iris-versicolor', 'Iris-virginica']
-    match_frame = iris["C5"].match(match_values)
+    match_frame = data["C5"].match(match_values)
     assert_is_type(match_frame, H2OFrame)    # check return type
     assert round(match_frame.sum()[0, 0]) == 300, "h2o.H2OFrame.match() command is not working." 
     assert match_frame[0, 0] == 1, "match value should be 1"
@@ -44,7 +44,7 @@ def h2o_H2OFrame_match():
     # set nomatch value to -1
     nomatch = -1
     match_values = ['Iris-setosa', 'Iris-versicolor']
-    match_frame = iris["C5"].match(match_values, nomatch=nomatch)
+    match_frame = data["C5"].match(match_values, nomatch=nomatch)
     assert round(match_frame.sum()[0, 0]) == 100, "h2o.H2OFrame.match() command is not working."
     assert match_frame[0, 0] == 1, "match value should be 1"
     assert match_frame[50, 0] == 2, "match value should be 2"
@@ -53,7 +53,7 @@ def h2o_H2OFrame_match():
     # start index feature = 0
     match_values = ['Iris-setosa', 'Iris-versicolor']
     start_index = 0
-    match_frame = iris["C5"].match(match_values, start_index=start_index)
+    match_frame = data["C5"].match(match_values, start_index=start_index)
     assert match_frame.sum()[0, 0] == 50, "h2o.H2OFrame.match() command is not working."
     assert match_frame[0, 0] == start_index, "match value should be 0"
     assert match_frame[50, 0] == start_index+1, "match value should be 1"
@@ -61,7 +61,7 @@ def h2o_H2OFrame_match():
 
     # numeric values
     match_values = [5.1]
-    match_frame = iris["C1"].match(match_values)
+    match_frame = data["C1"].match(match_values)
     assert match_frame.sum()[0, 0] == 9, "h2o.H2OFrame.match() command is not working."
     assert match_frame[0, 0] == 1, "match value should be 1"
     assert match_frame[17, 0] == 1, "match value should be 1"
@@ -70,7 +70,7 @@ def h2o_H2OFrame_match():
 
     # duplicate in match values
     nomatch = 0
-    match_frame = iris["C5"].match(['Iris-setosa', 'Iris-versicolor', 'Iris-setosa'], nomatch=nomatch)
+    match_frame = data["C5"].match(['Iris-setosa', 'Iris-versicolor', 'Iris-setosa'], nomatch=nomatch)
     assert_is_type(match_frame, H2OFrame, nomatch=0)    # check return type
     assert round(match_frame.sum()[0, 0]) == 150, "h2o.H2OFrame.match() command is not working."  # check return result
     assert match_frame[0, 0] == 1, "match value should be 1"
@@ -78,11 +78,11 @@ def h2o_H2OFrame_match():
     assert match_frame[100, 0] == nomatch, "match value should be 0"
     
     # test example for doc
-    match_col = iris["C5"].match(['Iris-setosa', 'Iris-versicolor', 'Iris-setosa'])
+    match_col = data["C5"].match(['Iris-setosa', 'Iris-versicolor', 'Iris-setosa'])
     match_col.names = ['match']
-    iris_match = iris.cbind(match_col)
-    splited = iris_match.split_frame(ratios=[0.05], seed=1)[0]
-    print(splited)
+    iris_match = data.cbind(match_col)
+    sample = iris_match.split_frame(ratios=[0.05], seed=1)[0]
+    print(sample)
     
     
 pyunit_utils.standalone_test(h2o_H2OFrame_match)

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -858,6 +858,7 @@ cut.H2OFrame <- h2o.cut
 #' @param incomparables a vector of calues that cannot be matched. Any value in
 #'        \code{x} matching a value in this vector is assigned the
 #'        \code{nomatch} value.
+#' @param indexes boolean if True change the returned vector from boolean values to indexes of match values
 #' @return Returns a vector of the positions of (first) matches of its first argument in its second
 #' @seealso \code{\link[base]{match}} for base R implementation.
 #' @examples
@@ -867,9 +868,9 @@ cut.H2OFrame <- h2o.cut
 #' h2o.match(iris_hf[, 5], c("setosa", "versicolor"))
 #' }
 #' @export
-h2o.match <- function(x, table, nomatch = 0, incomparables = NULL) {
+h2o.match <- function(x, table, nomatch = 0, incomparables = NULL, indexes=FALSE) {
   if( !is.H2OFrame(table) && length(table)==1 && base::is.character(table) ) table <- .quote(table)
-  .newExpr("match", chk.H2OFrame(x), table, nomatch, incomparables)
+  .newExpr("match", chk.H2OFrame(x), table, nomatch, incomparables, indexes)
 }
 
 #' @rdname h2o.match

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -863,11 +863,11 @@ cut.H2OFrame <- h2o.cut
 #' @examples
 #' \dontrun{
 #' h2o.init()
-#' frame <- as.h2o(iris)
-#' match_col <- h2o.match(frame$Species, c("setosa", "versicolor", "setosa"))
-#' iris_match <- h2o.cbind(frame, match_col)
-#' iris_split <- h2o.splitFrame(iris_match, ratios=0.05, seed=1)
-#' iris_split[1]
+#' data <- as.h2o(iris)
+#' match_col <- h2o.match(data$Species, c("setosa", "versicolor", "setosa"))
+#' iris_match <- h2o.cbind(data, match_col)
+#' sample <- h2o.splitFrame(iris_match, ratios=0.05, seed=1)[1]
+#' sample
 #' }
 #' @export
 h2o.match <- function(x, table, nomatch=NA_integer_, start_index=1) {

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -866,8 +866,15 @@ cut.H2OFrame <- h2o.cut
 #' data <- as.h2o(iris)
 #' match_col <- h2o.match(data$Species, c("setosa", "versicolor", "setosa"))
 #' iris_match <- h2o.cbind(data, match_col)
-#' sample <- h2o.splitFrame(iris_match, ratios=0.05, seed=1)[1]
+#' sample <- h2o.splitFrame(iris_match, ratios=0.05, seed=1)[[1]]
 #' sample
+#' #   Sepal.Length Sepal.Width Petal.Length Petal.Width    Species  C1
+#' #1          5.2         3.5          1.5         0.2     setosa   1
+#' #2          5.0         3.5          1.3         0.3     setosa   1
+#' #3          7.0         3.2          4.7         1.4 versicolor   2
+#' #4          4.9         2.4          3.3         1.0 versicolor   2
+#' #5          5.5         2.4          3.8         1.1 versicolor   2
+#' #6          5.8         2.7          5.1         1.9  virginica NaN
 #' }
 #' @export
 h2o.match <- function(x, table, nomatch=NA_integer_, start_index=1) {

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -862,8 +862,11 @@ cut.H2OFrame <- h2o.cut
 #' @examples
 #' \dontrun{
 #' h2o.init()
-#' iris_hf <- as.h2o(iris)
-#' h2o.match(iris_hf[, 5], c("setosa", "versicolor"))
+#' iris <- as.h2o(iris)
+#' match_col <- h2o.match(iris$Species, c("setosa", "versicolor"))
+#' iris_match <- h2o.cbind(iris, match_col)
+#' splited <- h2o.splitFrame(iris_match, ratios=0.05, seed=1)
+#' print(splited[1])
 #' }
 #' @export
 h2o.match <- function(x, table, nomatch=NA_integer_, start_index=1) {

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -851,12 +851,13 @@ cut.H2OFrame <- h2o.cut
 #' \code{match} and \code{\%in\%} return values similar to the base R generic
 #' functions.
 #'
-#' @param x a categorical vector from an H2OFrame object with
+#' @param x a vector from an H2OFrame object with
 #'        values to be matched.
 #' @param table an R object to match \code{x} against.
-#' @param nomatch the value to be returned in the case when no match is found. Numeric value or 'nan', default is 'nan'.
-#' @param start_index number >=0, default is 1.
-#' @return Returns a vector of the positions of (first) matches of its first argument in its second
+#' @param nomatch the value to be returned in the case when no match is found. Numeric value or NaN, default is NaN.
+#' @param start_index  index from which start indexing of table list, numeric value >=0, default is 1.
+#' @return Returns a new H2OFrame containing a vector where index of value form the table is returned 
+#'        if the value match, nomatch value otherwise.
 #' @seealso \code{\link[base]{match}} for base R implementation.
 #' @examples
 #' \dontrun{

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -855,9 +855,9 @@ cut.H2OFrame <- h2o.cut
 #'        values to be matched.
 #' @param table an R object to match \code{x} against.
 #' @param nomatch the value to be returned in the case when no match is found. Numeric value or NaN, default is NaN.
-#' @param start_index  index from which start indexing of table list, numeric value >=0, default is 1.
-#' @return Returns a new H2OFrame containing a vector where index of value form the table is returned 
-#'        if the value match, nomatch value otherwise.
+#' @param start_index  index from which this starts the indexing of the table list, numeric value >=0, default is 1.
+#' @return Returns a new H2OFrame containing a vector where the index of value from the table is returned 
+#'        if the value matches; returns \code{nomatch} value otherwise.
 #' @seealso \code{\link[base]{match}} for base R implementation.
 #' @examples
 #' \dontrun{
@@ -865,8 +865,8 @@ cut.H2OFrame <- h2o.cut
 #' iris <- as.h2o(iris)
 #' match_col <- h2o.match(iris$Species, c("setosa", "versicolor"))
 #' iris_match <- h2o.cbind(iris, match_col)
-#' splited <- h2o.splitFrame(iris_match, ratios=0.05, seed=1)
-#' print(splited[1])
+#' iris_split <- h2o.splitFrame(iris_match, ratios=0.05, seed=1)
+#' print(iris_split[1])
 #' }
 #' @export
 h2o.match <- function(x, table, nomatch=NA_integer_, start_index=1) {

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -863,11 +863,11 @@ cut.H2OFrame <- h2o.cut
 #' @examples
 #' \dontrun{
 #' h2o.init()
-#' iris <- as.h2o(iris)
-#' match_col <- h2o.match(iris$Species, c("setosa", "versicolor", "setosa"))
-#' iris_match <- h2o.cbind(iris, match_col)
+#' frame <- as.h2o(iris)
+#' match_col <- h2o.match(frame$Species, c("setosa", "versicolor", "setosa"))
+#' iris_match <- h2o.cbind(frame, match_col)
 #' iris_split <- h2o.splitFrame(iris_match, ratios=0.05, seed=1)
-#' print(iris_split[1])
+#' iris_split[1]
 #' }
 #' @export
 h2o.match <- function(x, table, nomatch=NA_integer_, start_index=1) {

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -853,7 +853,8 @@ cut.H2OFrame <- h2o.cut
 #'
 #' @param x a vector from an H2OFrame object with
 #'        values to be matched.
-#' @param table an R object to match \code{x} against.
+#' @param table an R object to match \code{x} against. Duplicates are ignored. The index of the first occurrence 
+#'        will be used.
 #' @param nomatch the value to be returned in the case when no match is found. Numeric value or NaN, default is NaN.
 #' @param start_index  index from which this starts the indexing of the table list, numeric value >=0, default is 1.
 #' @return Returns a new H2OFrame containing a vector where the index of value from the table is returned 
@@ -863,7 +864,7 @@ cut.H2OFrame <- h2o.cut
 #' \dontrun{
 #' h2o.init()
 #' iris <- as.h2o(iris)
-#' match_col <- h2o.match(iris$Species, c("setosa", "versicolor"))
+#' match_col <- h2o.match(iris$Species, c("setosa", "versicolor", "setosa"))
 #' iris_match <- h2o.cbind(iris, match_col)
 #' iris_split <- h2o.splitFrame(iris_match, ratios=0.05, seed=1)
 #' print(iris_split[1])

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -854,11 +854,8 @@ cut.H2OFrame <- h2o.cut
 #' @param x a categorical vector from an H2OFrame object with
 #'        values to be matched.
 #' @param table an R object to match \code{x} against.
-#' @param nomatch the value to be returned in the case when no match is found.
-#' @param incomparables a vector of calues that cannot be matched. Any value in
-#'        \code{x} matching a value in this vector is assigned the
-#'        \code{nomatch} value.
-#' @param indexes boolean if True change the returned vector from boolean values to indexes of match values
+#' @param nomatch the value to be returned in the case when no match is found. Numeric value or 'nan', default is 'nan'.
+#' @param start_index number >=0, default is 1.
 #' @return Returns a vector of the positions of (first) matches of its first argument in its second
 #' @seealso \code{\link[base]{match}} for base R implementation.
 #' @examples
@@ -868,9 +865,9 @@ cut.H2OFrame <- h2o.cut
 #' h2o.match(iris_hf[, 5], c("setosa", "versicolor"))
 #' }
 #' @export
-h2o.match <- function(x, table, nomatch = 0, incomparables = NULL, indexes=FALSE) {
+h2o.match <- function(x, table, nomatch=NA_integer_, start_index=1) {
   if( !is.H2OFrame(table) && length(table)==1 && base::is.character(table) ) table <- .quote(table)
-  .newExpr("match", chk.H2OFrame(x), table, nomatch, incomparables, indexes)
+  .newExpr("match", chk.H2OFrame(x), table, nomatch, start_index)
 }
 
 #' @rdname h2o.match

--- a/h2o-r/tests/testdir_munging/slice/runit_match.R
+++ b/h2o-r/tests/testdir_munging/slice/runit_match.R
@@ -22,6 +22,7 @@ test.match <- function() {
     expect_equal(hh_in, hh_in_base)
     
     # compare h2o and base match
+    # string values, default setting
     sub_h2o_match <- h2o.match(iris$Species, c("setosa", "versicolor"))
     sub_h2o_match <- as.vector(sub_h2o_match)
     expect_equal(sub_h2o_match[1], 1)
@@ -35,12 +36,14 @@ test.match <- function() {
 
     expect_equal(sub_h2o_match, sub_base_match)
 
+    # string values, nomatch=0
     sub_h2o_match <- h2o.match(iris$Species, c("setosa", "versicolor"), nomatch=0)
     sub_h2o_match <- as.vector(sub_h2o_match)
     expect_equal(sub_h2o_match[1], 1)
     expect_equal(sub_h2o_match[51], 2)
     expect_equal(sub_h2o_match[101], 0)
 
+    # string values, start_index=0
     sub_h2o_match <- h2o.match(iris$Species, c("setosa", "versicolor"), start_index=0)
     sub_h2o_match <- as.vector(sub_h2o_match)
     expect_equal(sub_h2o_match[1], 0)
@@ -50,7 +53,8 @@ test.match <- function() {
     sub_h2o_in <- iris$Sepal.Length %in% c(5.1)
     hh_in <- iris[sub_h2o_in,]
     expect_equal(dim(hh_in), c(9,5))
-    
+
+    # numeric value, default setting
     sub_h2o_match <- h2o.match(iris$Sepal.Length, c(5.1))
     sub_h2o_match <- as.vector(sub_h2o_match)
     expect_equal(sub_h2o_match[1], 1)
@@ -58,8 +62,15 @@ test.match <- function() {
     expect_equal(sub_h2o_match[20], 1)
     expect_equal(sub_h2o_match[2], NA_integer_)
 
+    # string values, duplicates in match values
+    sub_h2o_match <- h2o.match(iris$Species, c("setosa", "versicolor", "setosa"))
+    sub_h2o_match <- as.vector(sub_h2o_match)
+    expect_equal(sub_h2o_match[1], 1)
+    expect_equal(sub_h2o_match[51], 2)
+    expect_equal(sub_h2o_match[101], NA_integer_)
+
     # test doc example 
-    match_col <- h2o.match(iris$Species, c("setosa", "versicolor"))
+    match_col <- h2o.match(iris$Species, c("setosa", "versicolor", "setosa"))
     iris_match <- h2o.cbind(iris, match_col)
     splited <- h2o.splitFrame(iris_match, ratios=0.05, seed=1)
     print(splited[1])

--- a/h2o-r/tests/testdir_munging/slice/runit_match.R
+++ b/h2o-r/tests/testdir_munging/slice/runit_match.R
@@ -21,42 +21,48 @@ test.match <- function() {
 
     expect_equal(hh_in, hh_in_base)
     
-    sub_h2o_match <- h2o.match(hex$Species, c("setosa", "versicolor"))
+    # compare h2o and base match
+    sub_h2o_match <- h2o.match(iris$Species, c("setosa", "versicolor"))
     sub_h2o_match <- as.vector(sub_h2o_match)
     expect_equal(sub_h2o_match[1], 1)
     expect_equal(sub_h2o_match[51], 2)
     expect_equal(sub_h2o_match[101], NA_integer_)
     
-    sub_base_match <- base::match(as.vector(hex$Species), c("setosa", "versicolor"))
+    sub_base_match <- base::match(as.vector(iris$Species), c("setosa", "versicolor"))
     expect_equal(sub_base_match[1], 1)
     expect_equal(sub_base_match[51], 2)
     expect_equal(sub_base_match[101], NA_integer_)
 
-    # compare h2o and base
     expect_equal(sub_h2o_match, sub_base_match)
 
-    sub_h2o_match <- h2o.match(hex$Species, c("setosa", "versicolor"), nomatch=0)
+    sub_h2o_match <- h2o.match(iris$Species, c("setosa", "versicolor"), nomatch=0)
     sub_h2o_match <- as.vector(sub_h2o_match)
     expect_equal(sub_h2o_match[1], 1)
     expect_equal(sub_h2o_match[51], 2)
     expect_equal(sub_h2o_match[101], 0)
 
-    sub_h2o_match <- h2o.match(hex$Species, c("setosa", "versicolor"), start_index=0)
+    sub_h2o_match <- h2o.match(iris$Species, c("setosa", "versicolor"), start_index=0)
     sub_h2o_match <- as.vector(sub_h2o_match)
     expect_equal(sub_h2o_match[1], 0)
     expect_equal(sub_h2o_match[51], 1)
     expect_equal(sub_h2o_match[101], NA_integer_)
     
-    sub_h2o_in <- hex$Sepal.Length %in% c(5.1)
-    hh_in <- hex[sub_h2o_in,]
+    sub_h2o_in <- iris$Sepal.Length %in% c(5.1)
+    hh_in <- iris[sub_h2o_in,]
     expect_equal(dim(hh_in), c(9,5))
     
-    sub_h2o_match <- h2o.match(hex$Sepal.Length, c(5.1))
+    sub_h2o_match <- h2o.match(iris$Sepal.Length, c(5.1))
     sub_h2o_match <- as.vector(sub_h2o_match)
     expect_equal(sub_h2o_match[1], 1)
     expect_equal(sub_h2o_match[18], 1)
     expect_equal(sub_h2o_match[20], 1)
     expect_equal(sub_h2o_match[2], NA_integer_)
+
+    # test doc example 
+    match_col <- h2o.match(iris$Species, c("setosa", "versicolor"))
+    iris_match <- h2o.cbind(iris, match_col)
+    splited <- h2o.splitFrame(iris_match, ratios=0.05, seed=1)
+    print(splited[1])
 }
 
 doTest("test match", test.match)

--- a/h2o-r/tests/testdir_munging/slice/runit_match.R
+++ b/h2o-r/tests/testdir_munging/slice/runit_match.R
@@ -4,32 +4,32 @@ source("../../../scripts/h2o-r-test-setup.R")
 
 test.match <- function() {
 
-    frame <- as.h2o(iris)
+    data <- as.h2o(iris)
 
     # compare h2o and base %in%
-    h2o_in <- 'setosa' %in% frame$Species
-    base_in <- base::`%in%`("setosa", as.vector(frame$Species))
+    h2o_in <- 'setosa' %in% data$Species
+    base_in <- base::`%in%`("setosa", as.vector(data$Species))
     expect_equal(h2o_in, base_in)
 
-    sub_h2o_in <- frame$Species %in% c("setosa", "versicolor")
-    hh_in <- frame[sub_h2o_in,]
+    sub_h2o_in <- data$Species %in% c("setosa", "versicolor")
+    hh_in <- data[sub_h2o_in,]
     expect_equal(dim(hh_in), c(100, 5))
 
-    sub_base_in <- base::`%in%`(as.vector(frame$Species), c("setosa", "versicolor"))
-    hh_in_base <- frame[as.h2o(sub_base_in),]
+    sub_base_in <- base::`%in%`(as.vector(data$Species), c("setosa", "versicolor"))
+    hh_in_base <- data[as.h2o(sub_base_in),]
     expect_equal(dim(hh_in_base), c(100, 5))
 
     expect_equal(hh_in, hh_in_base)
     
     # compare h2o and base match
     # string values, default setting
-    sub_h2o_match <- h2o.match(frame$Species, c("setosa", "versicolor"))
+    sub_h2o_match <- h2o.match(data$Species, c("setosa", "versicolor"))
     sub_h2o_match <- as.vector(sub_h2o_match)
     expect_equal(sub_h2o_match[1], 1)
     expect_equal(sub_h2o_match[51], 2)
     expect_equal(sub_h2o_match[101], NA_integer_)
     
-    sub_base_match <- base::match(as.vector(frame$Species), c("setosa", "versicolor"))
+    sub_base_match <- base::match(as.vector(data$Species), c("setosa", "versicolor"))
     expect_equal(sub_base_match[1], 1)
     expect_equal(sub_base_match[51], 2)
     expect_equal(sub_base_match[101], NA_integer_)
@@ -37,25 +37,25 @@ test.match <- function() {
     expect_equal(sub_h2o_match, sub_base_match)
 
     # string values, nomatch=0
-    sub_h2o_match <- h2o.match(frame$Species, c("setosa", "versicolor"), nomatch=0)
+    sub_h2o_match <- h2o.match(data$Species, c("setosa", "versicolor"), nomatch=0)
     sub_h2o_match <- as.vector(sub_h2o_match)
     expect_equal(sub_h2o_match[1], 1)
     expect_equal(sub_h2o_match[51], 2)
     expect_equal(sub_h2o_match[101], 0)
 
     # string values, start_index=0
-    sub_h2o_match <- h2o.match(frame$Species, c("setosa", "versicolor"), start_index=0)
+    sub_h2o_match <- h2o.match(data$Species, c("setosa", "versicolor"), start_index=0)
     sub_h2o_match <- as.vector(sub_h2o_match)
     expect_equal(sub_h2o_match[1], 0)
     expect_equal(sub_h2o_match[51], 1)
     expect_equal(sub_h2o_match[101], NA_integer_)
     
-    sub_h2o_in <- frame$Sepal.Length %in% c(5.1)
-    hh_in <- frame[sub_h2o_in,]
+    sub_h2o_in <- data$Sepal.Length %in% c(5.1)
+    hh_in <- data[sub_h2o_in,]
     expect_equal(dim(hh_in), c(9,5))
 
     # numeric value, default setting
-    sub_h2o_match <- h2o.match(frame$Sepal.Length, c(5.1))
+    sub_h2o_match <- h2o.match(data$Sepal.Length, c(5.1))
     sub_h2o_match <- as.vector(sub_h2o_match)
     expect_equal(sub_h2o_match[1], 1)
     expect_equal(sub_h2o_match[18], 1)
@@ -63,17 +63,17 @@ test.match <- function() {
     expect_equal(sub_h2o_match[2], NA_integer_)
 
     # string values, duplicates in match values
-    sub_h2o_match <- h2o.match(frame$Species, c("setosa", "versicolor", "setosa"))
+    sub_h2o_match <- h2o.match(data$Species, c("setosa", "versicolor", "setosa"))
     sub_h2o_match <- as.vector(sub_h2o_match)
     expect_equal(sub_h2o_match[1], 1)
     expect_equal(sub_h2o_match[51], 2)
     expect_equal(sub_h2o_match[101], NA_integer_)
 
     # test doc example 
-    match_col <- h2o.match(frame$Species, c("setosa", "versicolor", "setosa"))
-    iris_match <- h2o.cbind(frame, match_col)
-    splited <- h2o.splitFrame(iris_match, ratios=0.05, seed=1)
-    print(splited[1])
+    match_col <- h2o.match(data$Species, c("setosa", "versicolor", "setosa"))
+    iris_match <- h2o.cbind(data, match_col)
+    sample <- h2o.splitFrame(iris_match, ratios=0.05, seed=1)[1]
+    print(sample)
 }
 
 doTest("test match", test.match)

--- a/h2o-r/tests/testdir_munging/slice/runit_match.R
+++ b/h2o-r/tests/testdir_munging/slice/runit_match.R
@@ -72,7 +72,7 @@ test.match <- function() {
     # test doc example 
     match_col <- h2o.match(data$Species, c("setosa", "versicolor", "setosa"))
     iris_match <- h2o.cbind(data, match_col)
-    sample <- h2o.splitFrame(iris_match, ratios=0.05, seed=1)[1]
+    sample <- h2o.splitFrame(iris_match, ratios=0.05, seed=1)[[1]]
     print(sample)
 }
 

--- a/h2o-r/tests/testdir_munging/slice/runit_match.R
+++ b/h2o-r/tests/testdir_munging/slice/runit_match.R
@@ -20,6 +20,43 @@ test.match <- function() {
     expect_equal(dim(hh_in_base), c(100, 5))
 
     expect_equal(hh_in, hh_in_base)
+    
+    sub_h2o_match <- h2o.match(hex$Species, c("setosa", "versicolor"))
+    sub_h2o_match <- as.vector(sub_h2o_match)
+    expect_equal(sub_h2o_match[1], 1)
+    expect_equal(sub_h2o_match[51], 2)
+    expect_equal(sub_h2o_match[101], NA_integer_)
+    
+    sub_base_match <- base::match(as.vector(hex$Species), c("setosa", "versicolor"))
+    expect_equal(sub_base_match[1], 1)
+    expect_equal(sub_base_match[51], 2)
+    expect_equal(sub_base_match[101], NA_integer_)
+
+    # compare h2o and base
+    expect_equal(sub_h2o_match, sub_base_match)
+
+    sub_h2o_match <- h2o.match(hex$Species, c("setosa", "versicolor"), nomatch=0)
+    sub_h2o_match <- as.vector(sub_h2o_match)
+    expect_equal(sub_h2o_match[1], 1)
+    expect_equal(sub_h2o_match[51], 2)
+    expect_equal(sub_h2o_match[101], 0)
+
+    sub_h2o_match <- h2o.match(hex$Species, c("setosa", "versicolor"), start_index=0)
+    sub_h2o_match <- as.vector(sub_h2o_match)
+    expect_equal(sub_h2o_match[1], 0)
+    expect_equal(sub_h2o_match[51], 1)
+    expect_equal(sub_h2o_match[101], NA_integer_)
+    
+    sub_h2o_in <- hex$Sepal.Length %in% c(5.1)
+    hh_in <- hex[sub_h2o_in,]
+    expect_equal(dim(hh_in), c(9,5))
+    
+    sub_h2o_match <- h2o.match(hex$Sepal.Length, c(5.1))
+    sub_h2o_match <- as.vector(sub_h2o_match)
+    expect_equal(sub_h2o_match[1], 1)
+    expect_equal(sub_h2o_match[18], 1)
+    expect_equal(sub_h2o_match[20], 1)
+    expect_equal(sub_h2o_match[2], NA_integer_)
 }
 
 doTest("test match", test.match)

--- a/h2o-r/tests/testdir_munging/slice/runit_match.R
+++ b/h2o-r/tests/testdir_munging/slice/runit_match.R
@@ -4,32 +4,32 @@ source("../../../scripts/h2o-r-test-setup.R")
 
 test.match <- function() {
 
-    iris <- as.h2o(iris)
+    frame <- as.h2o(iris)
 
     # compare h2o and base %in%
-    h2o_in <- 'setosa' %in% iris$Species
-    base_in <- base::`%in%`("setosa", as.vector(iris$Species))
+    h2o_in <- 'setosa' %in% frame$Species
+    base_in <- base::`%in%`("setosa", as.vector(frame$Species))
     expect_equal(h2o_in, base_in)
 
-    sub_h2o_in <- iris$Species %in% c("setosa", "versicolor")
-    hh_in <- iris[sub_h2o_in,]
+    sub_h2o_in <- frame$Species %in% c("setosa", "versicolor")
+    hh_in <- frame[sub_h2o_in,]
     expect_equal(dim(hh_in), c(100, 5))
 
-    sub_base_in <- base::`%in%`(as.vector(iris$Species), c("setosa", "versicolor"))
-    hh_in_base <- iris[as.h2o(sub_base_in),]
+    sub_base_in <- base::`%in%`(as.vector(frame$Species), c("setosa", "versicolor"))
+    hh_in_base <- frame[as.h2o(sub_base_in),]
     expect_equal(dim(hh_in_base), c(100, 5))
 
     expect_equal(hh_in, hh_in_base)
     
     # compare h2o and base match
     # string values, default setting
-    sub_h2o_match <- h2o.match(iris$Species, c("setosa", "versicolor"))
+    sub_h2o_match <- h2o.match(frame$Species, c("setosa", "versicolor"))
     sub_h2o_match <- as.vector(sub_h2o_match)
     expect_equal(sub_h2o_match[1], 1)
     expect_equal(sub_h2o_match[51], 2)
     expect_equal(sub_h2o_match[101], NA_integer_)
     
-    sub_base_match <- base::match(as.vector(iris$Species), c("setosa", "versicolor"))
+    sub_base_match <- base::match(as.vector(frame$Species), c("setosa", "versicolor"))
     expect_equal(sub_base_match[1], 1)
     expect_equal(sub_base_match[51], 2)
     expect_equal(sub_base_match[101], NA_integer_)
@@ -37,25 +37,25 @@ test.match <- function() {
     expect_equal(sub_h2o_match, sub_base_match)
 
     # string values, nomatch=0
-    sub_h2o_match <- h2o.match(iris$Species, c("setosa", "versicolor"), nomatch=0)
+    sub_h2o_match <- h2o.match(frame$Species, c("setosa", "versicolor"), nomatch=0)
     sub_h2o_match <- as.vector(sub_h2o_match)
     expect_equal(sub_h2o_match[1], 1)
     expect_equal(sub_h2o_match[51], 2)
     expect_equal(sub_h2o_match[101], 0)
 
     # string values, start_index=0
-    sub_h2o_match <- h2o.match(iris$Species, c("setosa", "versicolor"), start_index=0)
+    sub_h2o_match <- h2o.match(frame$Species, c("setosa", "versicolor"), start_index=0)
     sub_h2o_match <- as.vector(sub_h2o_match)
     expect_equal(sub_h2o_match[1], 0)
     expect_equal(sub_h2o_match[51], 1)
     expect_equal(sub_h2o_match[101], NA_integer_)
     
-    sub_h2o_in <- iris$Sepal.Length %in% c(5.1)
-    hh_in <- iris[sub_h2o_in,]
+    sub_h2o_in <- frame$Sepal.Length %in% c(5.1)
+    hh_in <- frame[sub_h2o_in,]
     expect_equal(dim(hh_in), c(9,5))
 
     # numeric value, default setting
-    sub_h2o_match <- h2o.match(iris$Sepal.Length, c(5.1))
+    sub_h2o_match <- h2o.match(frame$Sepal.Length, c(5.1))
     sub_h2o_match <- as.vector(sub_h2o_match)
     expect_equal(sub_h2o_match[1], 1)
     expect_equal(sub_h2o_match[18], 1)
@@ -63,15 +63,15 @@ test.match <- function() {
     expect_equal(sub_h2o_match[2], NA_integer_)
 
     # string values, duplicates in match values
-    sub_h2o_match <- h2o.match(iris$Species, c("setosa", "versicolor", "setosa"))
+    sub_h2o_match <- h2o.match(frame$Species, c("setosa", "versicolor", "setosa"))
     sub_h2o_match <- as.vector(sub_h2o_match)
     expect_equal(sub_h2o_match[1], 1)
     expect_equal(sub_h2o_match[51], 2)
     expect_equal(sub_h2o_match[101], NA_integer_)
 
     # test doc example 
-    match_col <- h2o.match(iris$Species, c("setosa", "versicolor", "setosa"))
-    iris_match <- h2o.cbind(iris, match_col)
+    match_col <- h2o.match(frame$Species, c("setosa", "versicolor", "setosa"))
+    iris_match <- h2o.cbind(frame, match_col)
     splited <- h2o.splitFrame(iris_match, ratios=0.05, seed=1)
     print(splited[1])
 }


### PR DESCRIPTION
Issue: #15677 

TODO:
- [x] Do not add new parameter indexes, fix the bug in our implementation according to what R::match does. Using the iris dataset and calling match with c(“setosa”, “versicolor”) should generate a new column with value 1 assigned to rows with “setosa” and 2 assigned to rows with “versicolor”). The answer should be the same with all clients. This implies that R and Python should generate the same column values.
- [x]  The default for `nomatch` should be NaN for both R and Python. In addition, only allow NaN or other numerical values for `nomatch` values. No string is supported.
- [x]  Fix the documentation to reflect the changes: `nomatch` is defaulted to NaN and can only be numerical values.  Remove the last sentences for incomparables.
- [x] Add parameter `start_index` with default value = 1, if a user wants to change indexing from 0 for example
- [x] Fix %in% to works as in base library but in different PR #15929
- [x]  Add better example in doc 