### PR TITLE
GH-15956: Fix R tests - explain and parquet_pubdev7293 by making some internal functions available during the test run

### DIFF
--- a/h2o-r/scripts/h2o-r-test-setup.R
+++ b/h2o-r/scripts/h2o-r-test-setup.R
@@ -198,7 +198,7 @@ function() {
             ".getExpanded", ".str.list", "is.H2OFrame", ".get.session.property", ".set.session.property",
             ".h2o.maximizing_metrics", ".h2o.doSafeGET", ".parse.h2oconfig", ".h2o.check_java_version",
             "cut.H2OFrame", "as.data.frame.H2OFrame", ".h2o.perfect_auc", ".newExpr", ".h2o.doSafeREST",
-            ".h2o.fromJSON"
+            ".h2o.fromJSON", ".shorten_model_ids", ".calculate_pareto_front", ".h2o.__IMPORT"
          )
          
         for (fn in additional_imports)


### PR DESCRIPTION
Make ".shorten_model_ids", ".calculate_pareto_front", ".h2o.__IMPORT" available during the runit run

#15956 