### PR TITLE
GH-16026: remove custom_metric_func and nparallelism from schema. 

### DIFF
--- a/h2o-algos/src/main/java/hex/anovaglm/ANOVAGLMModel.java
+++ b/h2o-algos/src/main/java/hex/anovaglm/ANOVAGLMModel.java
@@ -84,7 +84,7 @@ public class ANOVAGLMModel extends Model<ANOVAGLMModel, ANOVAGLMModel.ANOVAGLMPa
     public int _nfolds = 0; // disable cross-validation
     public Key<Frame> _plug_values = null;
     public boolean _save_transformed_framekeys = false; // for debugging, save the transformed predictors/interaction
-    public int _nparallelism = 4;
+    public int _nparallelism = H2O.NUMCPUS;
 
     @Override
     public String algoName() {

--- a/h2o-algos/src/main/java/hex/modelselection/ModelSelection.java
+++ b/h2o-algos/src/main/java/hex/modelselection/ModelSelection.java
@@ -167,12 +167,6 @@ public class ModelSelection extends ModelBuilder<hex.modelselection.ModelSelecti
                         _numPredictors + ")in the dataset.");
         }
         
-        if (_parms._nparallelism < 0) 
-            error("nparallelism", "must be >= 0.");
-        
-        if (_parms._nparallelism == 0)
-            _parms._nparallelism = H2O.NUMCPUS;
-        
         if (maxrsweep.equals(_parms._mode))
             warn("validation_frame", " is not used in choosing the best k subset for ModelSelection" +
                     " models with maxrsweep.");

--- a/h2o-algos/src/main/java/hex/modelselection/ModelSelectionModel.java
+++ b/h2o-algos/src/main/java/hex/modelselection/ModelSelectionModel.java
@@ -73,7 +73,7 @@ public class ModelSelectionModel extends Model<ModelSelectionModel, ModelSelecti
         public Key<Frame> _plug_values = null;
         public int _max_predictor_number = 1;
         public int _min_predictor_number = 1;
-        public int _nparallelism = 0;
+        public int _nparallelism = H2O.NUMCPUS;   // adaptive to the system it is run on.
         public double _p_values_threshold = 0;
         public double _tweedie_variance_power;
         public double _tweedie_link_power;

--- a/h2o-algos/src/main/java/hex/schemas/ANOVAGLMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/ANOVAGLMV3.java
@@ -47,7 +47,6 @@ public class ANOVAGLMV3 extends ModelBuilderSchema<ANOVAGLM, ANOVAGLMV3, ANOVAGL
             "max_runtime_secs",
             "save_transformed_framekeys",
             "highest_interaction_term",
-            "nparallelism",
             "type" // GLM SS Type, only support 3 right now
     };
 
@@ -157,8 +156,5 @@ public class ANOVAGLMV3 extends ModelBuilderSchema<ANOVAGLM, ANOVAGLMV3, ANOVAGL
 
     @API(help="true to save the keys of transformed predictors and interaction column.")
     public boolean save_transformed_framekeys;
-
-    @API(help="Number of models to build in parallel.  Default to 4.  Adjust according to your system.")
-    public int nparallelism;
   }
 }

--- a/h2o-algos/src/main/java/hex/schemas/ModelSelectionV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/ModelSelectionV3.java
@@ -64,8 +64,6 @@ public class ModelSelectionV3 extends ModelBuilderSchema<ModelSelection, ModelSe
                 "max_after_balance_size",
                 "max_confusion_matrix_size",
                 "max_runtime_secs",
-                "custom_metric_func",
-                "nparallelism",
                 "max_predictor_number",  // denote maximum number of predictors to build models for
                 "min_predictor_number",
                 "mode", // naive, maxr, maxrsweep, backward
@@ -278,10 +276,6 @@ public class ModelSelectionV3 extends ModelBuilderSchema<ModelSelection, ModelSe
                 "models starting with all predictors to be included.  Defaults to 1.",
                 level = API.Level.secondary, direction = API.Direction.INPUT)
         public int min_predictor_number;
-
-        @API(help = "number of models to build in parallel.  Defaults to 0.0 which is adaptive to the system capability",
-                level = API.Level.secondary, gridable = true)
-        public int nparallelism;
 
         @API(help = "For mode='backward' only.  If specified, will stop the model building process when all coefficients" +
                 "p-values drop below this threshold ", level = API.Level.expert)

--- a/h2o-py/h2o/estimators/anovaglm.py
+++ b/h2o-py/h2o/estimators/anovaglm.py
@@ -64,7 +64,6 @@ class H2OANOVAGLMEstimator(H2OEstimator):
                  max_runtime_secs=0.0,  # type: float
                  save_transformed_framekeys=False,  # type: bool
                  highest_interaction_term=0,  # type: int
-                 nparallelism=4,  # type: int
                  type=0,  # type: int
                  ):
         """
@@ -201,9 +200,6 @@ class H2OANOVAGLMEstimator(H2OEstimator):
                only, 3 for three columns and so on...  Default to 2.
                Defaults to ``0``.
         :type highest_interaction_term: int
-        :param nparallelism: Number of models to build in parallel.  Default to 4.  Adjust according to your system.
-               Defaults to ``4``.
-        :type nparallelism: int
         :param type: Refer to the SS type 1, 2, 3, or 4.  We are currently only supporting 3
                Defaults to ``0``.
         :type type: int
@@ -245,7 +241,6 @@ class H2OANOVAGLMEstimator(H2OEstimator):
         self.max_runtime_secs = max_runtime_secs
         self.save_transformed_framekeys = save_transformed_framekeys
         self.highest_interaction_term = highest_interaction_term
-        self.nparallelism = nparallelism
         self.type = type
         self._parms["_rest_version"] = 3
 
@@ -744,20 +739,6 @@ class H2OANOVAGLMEstimator(H2OEstimator):
     def highest_interaction_term(self, highest_interaction_term):
         assert_is_type(highest_interaction_term, None, int)
         self._parms["highest_interaction_term"] = highest_interaction_term
-
-    @property
-    def nparallelism(self):
-        """
-        Number of models to build in parallel.  Default to 4.  Adjust according to your system.
-
-        Type: ``int``, defaults to ``4``.
-        """
-        return self._parms.get("nparallelism")
-
-    @nparallelism.setter
-    def nparallelism(self, nparallelism):
-        assert_is_type(nparallelism, None, int)
-        self._parms["nparallelism"] = nparallelism
 
     @property
     def type(self):

--- a/h2o-py/h2o/estimators/model_selection.py
+++ b/h2o-py/h2o/estimators/model_selection.py
@@ -81,8 +81,6 @@ class H2OModelSelectionEstimator(H2OEstimator):
                  max_after_balance_size=5.0,  # type: float
                  max_confusion_matrix_size=20,  # type: int
                  max_runtime_secs=0.0,  # type: float
-                 custom_metric_func=None,  # type: Optional[str]
-                 nparallelism=0,  # type: int
                  max_predictor_number=1,  # type: int
                  min_predictor_number=1,  # type: int
                  mode="maxr",  # type: Literal["allsubsets", "maxr", "maxrsweep", "backward"]
@@ -290,13 +288,6 @@ class H2OModelSelectionEstimator(H2OEstimator):
         :param max_runtime_secs: Maximum allowed runtime in seconds for model training. Use 0 to disable.
                Defaults to ``0.0``.
         :type max_runtime_secs: float
-        :param custom_metric_func: Reference to custom evaluation function, format: `language:keyName=funcName`
-               Defaults to ``None``.
-        :type custom_metric_func: str, optional
-        :param nparallelism: number of models to build in parallel.  Defaults to 0.0 which is adaptive to the system
-               capability
-               Defaults to ``0``.
-        :type nparallelism: int
         :param max_predictor_number: Maximum number of predictors to be considered when building GLM models.  Defaults
                to 1.
                Defaults to ``1``.
@@ -383,8 +374,6 @@ class H2OModelSelectionEstimator(H2OEstimator):
         self.max_after_balance_size = max_after_balance_size
         self.max_confusion_matrix_size = max_confusion_matrix_size
         self.max_runtime_secs = max_runtime_secs
-        self.custom_metric_func = custom_metric_func
-        self.nparallelism = nparallelism
         self.max_predictor_number = max_predictor_number
         self.min_predictor_number = min_predictor_number
         self.mode = mode
@@ -1123,34 +1112,6 @@ class H2OModelSelectionEstimator(H2OEstimator):
     def max_runtime_secs(self, max_runtime_secs):
         assert_is_type(max_runtime_secs, None, numeric)
         self._parms["max_runtime_secs"] = max_runtime_secs
-
-    @property
-    def custom_metric_func(self):
-        """
-        Reference to custom evaluation function, format: `language:keyName=funcName`
-
-        Type: ``str``.
-        """
-        return self._parms.get("custom_metric_func")
-
-    @custom_metric_func.setter
-    def custom_metric_func(self, custom_metric_func):
-        assert_is_type(custom_metric_func, None, str)
-        self._parms["custom_metric_func"] = custom_metric_func
-
-    @property
-    def nparallelism(self):
-        """
-        number of models to build in parallel.  Defaults to 0.0 which is adaptive to the system capability
-
-        Type: ``int``, defaults to ``0``.
-        """
-        return self._parms.get("nparallelism")
-
-    @nparallelism.setter
-    def nparallelism(self, nparallelism):
-        assert_is_type(nparallelism, None, int)
-        self._parms["nparallelism"] = nparallelism
 
     @property
     def max_predictor_number(self):

--- a/h2o-r/h2o-package/R/anovaglm.R
+++ b/h2o-r/h2o-package/R/anovaglm.R
@@ -77,7 +77,6 @@
 #' @param save_transformed_framekeys \code{Logical}. true to save the keys of transformed predictors and interaction column. Defaults to FALSE.
 #' @param highest_interaction_term Limit the number of interaction terms, if 2 means interaction between 2 columns only, 3 for three columns and
 #'        so on...  Default to 2. Defaults to 0.
-#' @param nparallelism Number of models to build in parallel.  Default to 4.  Adjust according to your system. Defaults to 4.
 #' @param type Refer to the SS type 1, 2, 3, or 4.  We are currently only supporting 3 Defaults to 0.
 #' @examples
 #' \dontrun{
@@ -126,7 +125,6 @@ h2o.anovaglm <- function(x,
                          max_runtime_secs = 0,
                          save_transformed_framekeys = FALSE,
                          highest_interaction_term = 0,
-                         nparallelism = 4,
                          type = 0)
 {
   # Validate required training_frame first and other frame args: should be a valid key or an H2OFrame object
@@ -213,8 +211,6 @@ h2o.anovaglm <- function(x,
     parms$save_transformed_framekeys <- save_transformed_framekeys
   if (!missing(highest_interaction_term))
     parms$highest_interaction_term <- highest_interaction_term
-  if (!missing(nparallelism))
-    parms$nparallelism <- nparallelism
   if (!missing(type))
     parms$type <- type
 
@@ -256,7 +252,6 @@ h2o.anovaglm <- function(x,
                                          max_runtime_secs = 0,
                                          save_transformed_framekeys = FALSE,
                                          highest_interaction_term = 0,
-                                         nparallelism = 4,
                                          type = 0,
                                          segment_columns = NULL,
                                          segment_models_id = NULL,
@@ -348,8 +343,6 @@ h2o.anovaglm <- function(x,
     parms$save_transformed_framekeys <- save_transformed_framekeys
   if (!missing(highest_interaction_term))
     parms$highest_interaction_term <- highest_interaction_term
-  if (!missing(nparallelism))
-    parms$nparallelism <- nparallelism
   if (!missing(type))
     parms$type <- type
 

--- a/h2o-r/h2o-package/R/modelselection.R
+++ b/h2o-r/h2o-package/R/modelselection.R
@@ -108,9 +108,6 @@
 #' @param max_after_balance_size Maximum relative size of the training data after balancing class counts (can be less than 1.0). Requires
 #'        balance_classes. Defaults to 5.0.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
-#' @param custom_metric_func Reference to custom evaluation function, format: `language:keyName=funcName`
-#' @param nparallelism number of models to build in parallel.  Defaults to 0.0 which is adaptive to the system capability Defaults to
-#'        0.
 #' @param max_predictor_number Maximum number of predictors to be considered when building GLM models.  Defaults to 1. Defaults to 1.
 #' @param min_predictor_number For mode = 'backward' only.  Minimum number of predictors to be considered when building GLM models starting
 #'        with all predictors to be included.  Defaults to 1. Defaults to 1.
@@ -190,8 +187,6 @@ h2o.modelSelection <- function(x,
                                class_sampling_factors = NULL,
                                max_after_balance_size = 5.0,
                                max_runtime_secs = 0,
-                               custom_metric_func = NULL,
-                               nparallelism = 0,
                                max_predictor_number = 1,
                                min_predictor_number = 1,
                                mode = c("allsubsets", "maxr", "maxrsweep", "backward"),
@@ -315,10 +310,6 @@ h2o.modelSelection <- function(x,
     parms$max_after_balance_size <- max_after_balance_size
   if (!missing(max_runtime_secs))
     parms$max_runtime_secs <- max_runtime_secs
-  if (!missing(custom_metric_func))
-    parms$custom_metric_func <- custom_metric_func
-  if (!missing(nparallelism))
-    parms$nparallelism <- nparallelism
   if (!missing(max_predictor_number))
     parms$max_predictor_number <- max_predictor_number
   if (!missing(min_predictor_number))
@@ -387,8 +378,6 @@ h2o.modelSelection <- function(x,
                                                class_sampling_factors = NULL,
                                                max_after_balance_size = 5.0,
                                                max_runtime_secs = 0,
-                                               custom_metric_func = NULL,
-                                               nparallelism = 0,
                                                max_predictor_number = 1,
                                                min_predictor_number = 1,
                                                mode = c("allsubsets", "maxr", "maxrsweep", "backward"),
@@ -517,10 +506,6 @@ h2o.modelSelection <- function(x,
     parms$max_after_balance_size <- max_after_balance_size
   if (!missing(max_runtime_secs))
     parms$max_runtime_secs <- max_runtime_secs
-  if (!missing(custom_metric_func))
-    parms$custom_metric_func <- custom_metric_func
-  if (!missing(nparallelism))
-    parms$nparallelism <- nparallelism
   if (!missing(max_predictor_number))
     parms$max_predictor_number <- max_predictor_number
   if (!missing(min_predictor_number))


### PR DESCRIPTION
Issue resolved: https://github.com/h2oai/h2o-3/issues/16026

Removed custom_metric_func from schema:  not supported.
Removed nparallelism from schema: set by deployment environment.