### PR TITLE
Fix for issue `skipped_columns` not working #15947

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -146,6 +146,12 @@ class H2OFrame(Keyed, H2ODisplay):
         if not column_names:
             column_names = col_header
 
+        if skipped_columns:
+            column_names = [column_name for column_name in column_names[:len(column_names)-len(skipped_columns)]]
+
+        if not column_names:
+            raise H2OValueError("skipped_columns cannot contain all columns")
+
         # create a temporary file that will be written to
         tmp_handle, tmp_path = tempfile.mkstemp(suffix=".csv")
         tmp_file = os.fdopen(tmp_handle, 'w', **H2OFrame.__fdopen_kwargs)

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -147,10 +147,23 @@ class H2OFrame(Keyed, H2ODisplay):
             column_names = col_header
 
         if skipped_columns:
-            column_names = [column_name for column_name in column_names[:len(column_names)-len(skipped_columns)]]
+            if isinstance(skipped_columns[0], str):
+                skipped_colsidx = []
+                for col_name in skipped_columns:
+                    if col_name in column_names:
+                        skipped_colsidx.append(column_names.index(col_name))
+                    else:
+                        raise H2OValueError("`skipped_columns` must be valid column names")
+
+                skipped_columns = skipped_colsidx
+            
+            if column_names == col_header:
+                column_names = column_names[:len(column_names)-len(skipped_columns)]
+            else:
+                column_names = [column_names[index] for index in range(len(column_names)) if index not in skipped_columns]
 
         if not column_names:
-            raise H2OValueError("skipped_columns cannot contain all columns")
+            raise H2OValueError("`skipped_columns` cannot contain all columns")
         
         # create a temporary file that will be written to
         tmp_handle, tmp_path = tempfile.mkstemp(suffix=".csv")

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -167,19 +167,21 @@ class H2OFrame(Keyed, H2ODisplay):
         
         # create a temporary file that will be written to
         tmp_handle, tmp_path = tempfile.mkstemp(suffix=".csv")
-        tmp_file = os.fdopen(tmp_handle, 'w', **H2OFrame.__fdopen_kwargs)
-        # create a new csv writer object thingy
-        csv_writer = csv.writer(tmp_file, dialect="excel", quoting=csv.QUOTE_NONNUMERIC)
-        csv_writer.writerow(column_names)
-        if data_to_write and isinstance(data_to_write[0], dict):
-            for row in data_to_write:
-                csv_writer.writerow([row.get(k, None) for k in col_header])
-        else:
-            csv_writer.writerows(data_to_write)
-        tmp_file.close()  # close the streams
-        self._upload_parse(tmp_path, destination_frame, 1, separator, column_names, column_types, na_strings,
-                           skipped_columns, force_col_types)
-        os.remove(tmp_path)  # delete the tmp file
+        try:
+            tmp_file = os.fdopen(tmp_handle, 'w', **H2OFrame.__fdopen_kwargs)
+            # create a new csv writer object thingy
+            csv_writer = csv.writer(tmp_file, dialect="excel", quoting=csv.QUOTE_NONNUMERIC)
+            csv_writer.writerow(column_names)
+            if data_to_write and isinstance(data_to_write[0], dict):
+                for row in data_to_write:
+                    csv_writer.writerow([row.get(k, None) for k in col_header])
+            else:
+                csv_writer.writerows(data_to_write)
+            tmp_file.close()  # close the streams
+            self._upload_parse(tmp_path, destination_frame, 1, separator, column_names, column_types, na_strings,
+                            skipped_columns, force_col_types)
+        finally:
+            os.remove(tmp_path)  # delete the tmp file
 
     def _upload_sparse_matrix(self, matrix, destination_frame=None):
         import scipy.sparse as sp

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -146,12 +146,6 @@ class H2OFrame(Keyed, H2ODisplay):
         if not column_names:
             column_names = col_header
 
-        if skipped_columns:
-            column_names = [column_name for column_name in column_names[:len(column_names)-len(skipped_columns)]]
-
-        if not column_names:
-            raise H2OValueError("skipped_columns cannot contain all columns")
-
         # create a temporary file that will be written to
         tmp_handle, tmp_path = tempfile.mkstemp(suffix=".csv")
         tmp_file = os.fdopen(tmp_handle, 'w', **H2OFrame.__fdopen_kwargs)
@@ -3214,21 +3208,8 @@ class H2OFrame(Keyed, H2ODisplay):
         assert_is_type(y, H2OFrame, None)
         assert_is_type(na_rm, bool)
         assert_is_type(use, None, "everything", "all.obs", "complete.obs")
-        y_categorical = any(y[col_name].isfactor() for col_name in y)
-        
         if y is None:
             y = self
-
-        if y_categorical:
-            num_unique_levels = {col: self[col].nlevels()[0] for col in y}
-            multi_categorical = any(num_levels > 2 for num_levels in num_unique_levels.values())
-
-        if multi_categorical:
-            import warnings
-            for col, nlevel in num_unique_levels.items():
-                if nlevel > 2:
-                    warnings.warn("Column {} contains {} levels. Only numerical and categorical columns are supported.".format(col, nlevel))
-
         if use is None: use = "complete.obs" if na_rm else "everything"
         if self.nrow == 1 or (self.ncol == 1 and y.ncol == 1): return ExprNode("cor", self, y, use, method)._eager_scalar()
         return H2OFrame._expr(expr=ExprNode("cor", self, y, use, method))._frame()

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -146,6 +146,12 @@ class H2OFrame(Keyed, H2ODisplay):
         if not column_names:
             column_names = col_header
 
+        if skipped_columns:
+            column_names = [column_name for column_name in column_names[:len(column_names)-len(skipped_columns)]]
+
+        if not column_names:
+            raise H2OValueError("skipped_columns cannot contain all columns")
+        
         # create a temporary file that will be written to
         tmp_handle, tmp_path = tempfile.mkstemp(suffix=".csv")
         tmp_file = os.fdopen(tmp_handle, 'w', **H2OFrame.__fdopen_kwargs)

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame.py
@@ -125,10 +125,16 @@ def H2OFrame_from_H2OFrame():
     assert dupl4.columns == ["n1", "s1"]
 
 
-def H2OFrame_skipped_columns_is_BUGGY():
+def H2OFrame_skipped_columns():
     try:
-        h2o.H2OFrame(data, skipped_columns=[1])
-        assert False, "skipped_columns handling may be fixed now"  # parse_setup is absolutely weird, with only half parameters passed to build the ParseSetup, and then a bunch of logic done locally, that's why it's buggy: see issue https://github.com/h2oai/h2o-3/issues/15947 
+        fr = h2o.H2OFrame([
+            [1, "a",  1],
+            [2, "b",  0],
+            [3,  "", 1],
+            ]
+        )
+        skipped_columns_frame = h2o.H2OFrame(data, skipped_columns=[1])
+        assert skipped_columns_frame == fr # parse_setup is absolutely weird, with only half parameters passed to build the ParseSetup, and then a bunch of logic done locally, that's why it's buggy: see issue https://github.com/h2oai/h2o-3/issues/15947 
     except ValueError as e:
         assert "length of col_names should be equal to the number of columns parsed: 4 vs 3" in str(e)
 

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame.py
@@ -126,17 +126,67 @@ def H2OFrame_from_H2OFrame():
 
 
 def H2OFrame_skipped_columns():
+    fr = h2o.H2OFrame([
+        [1, "a",  1],
+        [2, "b",  0],
+        [3,  "", 1],
+        ]
+    )
+    skipped_columns_frame = h2o.H2OFrame(data, skipped_columns=[1])
+    assert skipped_columns_frame == fr  # parse_setup is absolutely weird, with only half parameters passed to build the ParseSetup, and then a bunch of logic done locally, that's why it's buggy: see issue https://github.com/h2oai/h2o-3/issues/15947 
+
+def H2OFrame_column_names_with_skipped_columns():
+    skipped_columns_frame = h2o.H2OFrame(
+        [
+            [1, 2,  3],
+            [4, 5,  6],
+        ],
+        column_names=['a', 'b', 'c'],
+        skipped_columns=[0, 1]
+    )
+
+    fr = h2o.H2OFrame(
+        [
+            [3],
+            [6],
+        ],
+        column_names=['c'],
+    )
+
+    assert skipped_columns_frame == fr  # parse_setup is absolutely weird, with only half parameters passed to build the ParseSetup, and then a bunch of logic done locally, that's why it's buggy: see issue https://github.com/h2oai/h2o-3/issues/15947 
+
+def H2OFrame_column_names_with_str_skipped_columns():
+    skipped_columns_frame = h2o.H2OFrame(
+        [
+            [1, 2,  3],
+            [4, 5,  6],
+        ],
+        column_names=['a', 'b', 'c'],
+        skipped_columns=['a', 'b']
+    )
+
+    fr = h2o.H2OFrame(
+        [
+            [3],
+            [6],
+        ],
+        column_names=['c'],
+    )
+
+    assert skipped_columns_frame == fr  # parse_setup is absolutely weird, with only half parameters passed to build the ParseSetup, and then a bunch of logic done locally, that's why it's buggy: see issue https://github.com/h2oai/h2o-3/issues/15947 
+
+def H2OFrame_str_skipped_columns_without_column_names():
     try:
-        fr = h2o.H2OFrame([
-            [1, "a",  1],
-            [2, "b",  0],
-            [3,  "", 1],
-            ]
+        invalid_frame = h2o.H2OFrame(
+            [
+                [1, 2,  3],
+                [4, 5,  6],
+            ],
+            skipped_columns=['a', 'b']
         )
-        skipped_columns_frame = h2o.H2OFrame(data, skipped_columns=[1])
-        assert skipped_columns_frame == fr  # parse_setup is absolutely weird, with only half parameters passed to build the ParseSetup, and then a bunch of logic done locally, that's why it's buggy: see issue https://github.com/h2oai/h2o-3/issues/15947 
+
     except ValueError as e:
-        assert "length of col_names should be equal to the number of columns parsed: 4 vs 3" in str(e)
+        assert "`skipped_columns` must be valid column names" in str(e)
 
 
 pu.run_tests([
@@ -147,5 +197,8 @@ pu.run_tests([
     H2OFrame_from_pandas,
     H2OFrame_from_scipy,
     H2OFrame_from_H2OFrame,
-    H2OFrame_skipped_columns_is_BUGGY
+    H2OFrame_skipped_columns,
+    H2OFrame_column_names_with_skipped_columns,
+    H2OFrame_column_names_with_str_skipped_columns,
+    H2OFrame_str_skipped_columns_without_column_names
 ])

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame.py
@@ -125,16 +125,10 @@ def H2OFrame_from_H2OFrame():
     assert dupl4.columns == ["n1", "s1"]
 
 
-def H2OFrame_skipped_columns():
+def H2OFrame_skipped_columns_is_BUGGY():
     try:
-        fr = h2o.H2OFrame([
-            [1, "a",  1],
-            [2, "b",  0],
-            [3,  "", 1],
-            ]
-        )
-        skipped_columns_frame = h2o.H2OFrame(data, skipped_columns=[1])
-        assert skipped_columns_frame == fr # parse_setup is absolutely weird, with only half parameters passed to build the ParseSetup, and then a bunch of logic done locally, that's why it's buggy: see issue https://github.com/h2oai/h2o-3/issues/15947 
+        h2o.H2OFrame(data, skipped_columns=[1])
+        assert False, "skipped_columns handling may be fixed now"  # parse_setup is absolutely weird, with only half parameters passed to build the ParseSetup, and then a bunch of logic done locally, that's why it's buggy: see issue https://github.com/h2oai/h2o-3/issues/15947 
     except ValueError as e:
         assert "length of col_names should be equal to the number of columns parsed: 4 vs 3" in str(e)
 

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame.py
@@ -125,10 +125,16 @@ def H2OFrame_from_H2OFrame():
     assert dupl4.columns == ["n1", "s1"]
 
 
-def H2OFrame_skipped_columns_is_BUGGY():
+def H2OFrame_skipped_columns():
     try:
-        h2o.H2OFrame(data, skipped_columns=[1])
-        assert False, "skipped_columns handling may be fixed now"  # parse_setup is absolutely weird, with only half parameters passed to build the ParseSetup, and then a bunch of logic done locally, that's why it's buggy: see issue https://github.com/h2oai/h2o-3/issues/15947 
+        fr = h2o.H2OFrame([
+            [1, "a",  1],
+            [2, "b",  0],
+            [3,  "", 1],
+            ]
+        )
+        skipped_columns_frame = h2o.H2OFrame(data, skipped_columns=[1])
+        assert skipped_columns_frame == fr  # parse_setup is absolutely weird, with only half parameters passed to build the ParseSetup, and then a bunch of logic done locally, that's why it's buggy: see issue https://github.com/h2oai/h2o-3/issues/15947 
     except ValueError as e:
         assert "length of col_names should be equal to the number of columns parsed: 4 vs 3" in str(e)
 

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -2903,13 +2903,6 @@ h2o.cor <- function(x, y=NULL,na.rm = FALSE, use, method="Pearson"){
     stop("Correlation method must be specified.")
   }
 
-  # Check for categorical columns in x and y
-  x_categorical <- any(h2o.isfactor(x))
-  y_categorical <- any(h2o.isfactor(y))
-
-  if ((x_categorical && length(unique(h2o.levels(x))) > 2) || (y_categorical && length(unique(h2o.levels(y))) > 2)) {
-    warning("Column x or y contains more than 2 levels. Only numerical and categorical columns are supported.")
-  
   # Eager, mostly to match prior semantics but no real reason it need to be
   expr <- .newExpr("cor",x,y,.quote(use), .quote(method))
   if( (nrow(x)==1L || (ncol(x)==1L && ncol(y)==1L)) ) .eval.scalar(expr)

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -2902,6 +2902,13 @@ h2o.cor <- function(x, y=NULL,na.rm = FALSE, use, method="Pearson"){
   if (is.null(method) || is.na(method)) {
     stop("Correlation method must be specified.")
   }
+
+  # Check for categorical columns in x and y
+  x_categorical <- any(h2o.isfactor(x))
+  y_categorical <- any(h2o.isfactor(y))
+
+  if ((x_categorical && length(unique(h2o.levels(x))) > 2) || (y_categorical && length(unique(h2o.levels(y))) > 2)) {
+    warning("Column x or y contains more than 2 levels. Only numerical and categorical columns are supported.")
   
   # Eager, mostly to match prior semantics but no real reason it need to be
   expr <- .newExpr("cor",x,y,.quote(use), .quote(method))


### PR DESCRIPTION
Closes https://github.com/h2oai/h2o-3/issues/15947

The changes done in `frame.py` have been validated with the required tests of `H2OFrame` being tested in `/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame.py`

![image](https://github.com/h2oai/h2o-3/assets/43195822/96e93aea-e1da-4fd1-b06f-806406bccf94)

`skipped_columns` parameter is now functional and all tests are passing.