### PR TITLE
GH-15683 web_ip parameter warning

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -2395,6 +2395,11 @@ final public class H2O {
 
     // Validate arguments
     validateArguments();
+    
+    // Raise user warnings
+    if (H2O.ARGS.web_ip == null) {
+      Log.warn("web_ip is not specified. H2O Rest API is listening on all available interface.");
+    }
 
     Log.info("X-h2o-cluster-id: " + H2O.CLUSTER_ID);
     Log.info("User name: '" + H2O.ARGS.user_name + "'");

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -2398,7 +2398,7 @@ final public class H2O {
     
     // Raise user warnings
     if (H2O.ARGS.web_ip == null) {
-      Log.warn("SECURITY_WARNING: web_ip is not specified. H2O Rest API is listening on all available interface.");
+      Log.warn("SECURITY_WARNING: web_ip is not specified. H2O Rest API is listening on all available interfaces.");
     }
 
     Log.info("X-h2o-cluster-id: " + H2O.CLUSTER_ID);

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -2398,7 +2398,7 @@ final public class H2O {
     
     // Raise user warnings
     if (H2O.ARGS.web_ip == null) {
-      Log.warn("web_ip is not specified. H2O Rest API is listening on all available interface.");
+      Log.warn("SECURITY_WARNING: web_ip is not specified. H2O Rest API is listening on all available interface.");
     }
 
     Log.info("X-h2o-cluster-id: " + H2O.CLUSTER_ID);

--- a/h2o-py/h2o/backend/server.py
+++ b/h2o-py/h2o/backend/server.py
@@ -372,6 +372,16 @@ class H2OLocalServer(object):
                 raise H2OServerError("Server wasn't able to start in %f seconds." % elapsed_time)
             time.sleep(0.2)
 
+        security_warning_message = ""
+        if os.stat(self._stdout).st_size > 0:
+            stdout_file = open(self._stdout, encoding='utf-8')
+            for line in stdout_file:
+                if re.search("SECURITY_WARNING", line):
+                    security_warning_message += line + "\n"
+            stdout_file.close()
+        if security_warning_message:
+            warn("\nServer process startup raise a security warning:\n" + str(security_warning_message))
+
     @staticmethod
     def _check_java(java, verbose):
         jver_bytes = subprocess.check_output([java, "-version"], stderr=subprocess.STDOUT)

--- a/h2o-py/tests/testdir_apis/H2O_Init/h2o.init_test.py
+++ b/h2o-py/tests/testdir_apis/H2O_Init/h2o.init_test.py
@@ -7,6 +7,7 @@ from h2o.exceptions import H2OConnectionError, H2OServerError, H2OValueError
 import tempfile
 import shutil
 import os
+import warnings
 
 def h2oinit():
     """
@@ -125,12 +126,26 @@ def h2oinit_with_extra_classpath():
     finally:
         h2o.cluster().shutdown()
 
+def h2oinit_bind_to_localhost_false():
+    warnings.filterwarnings("error", category=UserWarning)
+    try:
+        h2o.init(strict_version_check=False, bind_to_localhost=False, port=44000)
+        assert False
+    except UserWarning as warning:
+        print(str(warning))
+        assert "SECURITY_WARNING" in str(warning)
+    finally:
+        warnings.resetwarnings()
+        h2o.connect(port=44000)
+        h2o.cluster().shutdown()
+
 # None of the tests below need a pre initialized instance
 h2oinit_default_log_dir()
 h2oinit_custom_log_dir()
 h2oinit_fail_invalid_log_level()
 h2oinitname()
 h2oinit_with_extra_classpath()
+h2oinit_bind_to_localhost_false()
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oinit)

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -237,6 +237,17 @@ h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, start
 
         stop("H2O failed to start, stopping execution.")
       }
+
+      securityWarnings <- ""
+      if (file.info(stdout)$size > 0) {
+        securityWarnings <- grep("SECURITY_WARNING", readLines(stdout), value=TRUE)
+      }
+      if (length(securityWarnings) > 0) {
+        msg = paste(
+        "Server process startup raise a security warning:",
+        paste(securityWarnings, collapse = "\n"), sep = "\n")
+        warning(msg)
+      }
     } else
       stop("Can only start H2O launcher if IP address is localhost.")
   }


### PR DESCRIPTION
Closes #15683

I have prepare mechanism that all `SECURITY_WARNING` logs will be exposed to the fronted clients. `web_ip` is not exposed to the clients, we have `bind_to_localhost` parameter that set `web_ip` to localhost. Warning look like this

* Java

<img width="961" alt="image" src="https://github.com/h2oai/h2o-3/assets/11332003/03024c99-bc97-4756-95c6-21387ccd43c9">

* Python

<img width="1118" alt="image" src="https://github.com/h2oai/h2o-3/assets/11332003/a9c647df-38f0-403b-b58c-69b89358bfe1">

* R

<img width="888" alt="image" src="https://github.com/h2oai/h2o-3/assets/11332003/36815b52-56fc-46c7-a161-22289150fc5d">
