### PR TITLE
GH-15682 - log is fixed when we_ip is used

### DIFF
--- a/h2o-core/src/main/java/water/H2OStarter.java
+++ b/h2o-core/src/main/java/water/H2OStarter.java
@@ -39,7 +39,10 @@ public class H2OStarter {
     if (!H2O.ARGS.disable_web) {
       Log.info("");
       String message = H2O.ARGS.disable_flow ? "Connect to H2O from your R/Python client: " : "Open H2O Flow in your web browser: ";
-      Log.info(message + H2O.getURL(NetworkInit.h2oHttpView.getScheme()));
+      message += H2O.ARGS.web_ip == null ?
+              H2O.getURL(NetworkInit.h2oHttpView.getScheme()) :
+              H2O.getURL(NetworkInit.h2oHttpView.getScheme(), H2O.ARGS.web_ip, H2O.API_PORT, H2O.ARGS.context_path);
+      Log.info(message);
       Log.info("");
     }
   }


### PR DESCRIPTION
Closes #15682 

> 1. Providing `-ip` option hides the fact that IP of the web UI was not modified in boot message after running `java -jar h2o.jar -ip 127.0.0.1`

Fixed in #15683

> 2. Furthermore, if the user specify `-web_ip localhost` and **DO NOT** specify `-ip` then still the value of `IP` is used in the log message `Open H2O Flow in your web browser: http://172.16.2.110:54321/`

Fixed in this PR