### PR TITLE
GH-16084: Double Java 8 core unit test time.

### DIFF
--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -226,7 +226,7 @@ def call(final pipelineContext) {
     ],
     [
       stageName: 'Java 8 Core JUnit', target: 'test-junit-core-jenkins', pythonVersion: '3.6', javaVersion: 8,
-      timeoutValue: 180, component: pipelineContext.getBuildConfig().COMPONENT_JAVA, 
+      timeoutValue: 360, component: pipelineContext.getBuildConfig().COMPONENT_JAVA, 
       additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY],
       imageSpecifier: 'python-3.6-jdk-8'
     ],


### PR DESCRIPTION
Fixes issue here: https://github.com/h2oai/h2o-3/issues/16084

Double test time of Java 8 Core Unit.