### PR TITLE
[GH-16093] Upgrade org.apache.commons:commons-compress to address CVE-2024-26308

### DIFF
--- a/h2o-assemblies/main/build.gradle
+++ b/h2o-assemblies/main/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     }
 
     // Upgrade dependencies coming from Hadoop to address vulnerabilities 
-    api "org.apache.commons:commons-compress:1.24.0"
+    api "org.apache.commons:commons-compress:1.26.0"
     api "com.google.protobuf:protobuf-java:3.21.7"
 
     constraints {

--- a/h2o-assemblies/steam/build.gradle
+++ b/h2o-assemblies/steam/build.gradle
@@ -41,7 +41,7 @@ dependencies {
         exclude group: "org.apache.hadoop.thirdparty", module: "hadoop-shaded-protobuf_3_7"
     }
     // Upgrade dependencies coming from Hadoop to address vulnerabilities 
-    api "org.apache.commons:commons-compress:1.24.0"
+    api "org.apache.commons:commons-compress:1.26.0"
     // Force specific Parquet version to avoid dependency on vulnerable FasterXML jackson-mapper-asl
     api "org.apache.parquet:parquet-hadoop:${defaultParquetVersion}"
     api("org.apache.hadoop:hadoop-mapreduce-client-core:${defaultHadoopVersion}") {


### PR DESCRIPTION
Closes #16093 