### PR TITLE
GH-16026: remove custom_metric_func from schema.

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/ModelSelectionV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/ModelSelectionV3.java
@@ -64,7 +64,6 @@ public class ModelSelectionV3 extends ModelBuilderSchema<ModelSelection, ModelSe
                 "max_after_balance_size",
                 "max_confusion_matrix_size",
                 "max_runtime_secs",
-                "custom_metric_func",
                 "nparallelism",
                 "max_predictor_number",  // denote maximum number of predictors to build models for
                 "min_predictor_number",

--- a/h2o-py/h2o/estimators/model_selection.py
+++ b/h2o-py/h2o/estimators/model_selection.py
@@ -81,7 +81,6 @@ class H2OModelSelectionEstimator(H2OEstimator):
                  max_after_balance_size=5.0,  # type: float
                  max_confusion_matrix_size=20,  # type: int
                  max_runtime_secs=0.0,  # type: float
-                 custom_metric_func=None,  # type: Optional[str]
                  nparallelism=0,  # type: int
                  max_predictor_number=1,  # type: int
                  min_predictor_number=1,  # type: int
@@ -290,9 +289,6 @@ class H2OModelSelectionEstimator(H2OEstimator):
         :param max_runtime_secs: Maximum allowed runtime in seconds for model training. Use 0 to disable.
                Defaults to ``0.0``.
         :type max_runtime_secs: float
-        :param custom_metric_func: Reference to custom evaluation function, format: `language:keyName=funcName`
-               Defaults to ``None``.
-        :type custom_metric_func: str, optional
         :param nparallelism: number of models to build in parallel.  Defaults to 0.0 which is adaptive to the system
                capability
                Defaults to ``0``.
@@ -383,7 +379,6 @@ class H2OModelSelectionEstimator(H2OEstimator):
         self.max_after_balance_size = max_after_balance_size
         self.max_confusion_matrix_size = max_confusion_matrix_size
         self.max_runtime_secs = max_runtime_secs
-        self.custom_metric_func = custom_metric_func
         self.nparallelism = nparallelism
         self.max_predictor_number = max_predictor_number
         self.min_predictor_number = min_predictor_number
@@ -1123,20 +1118,6 @@ class H2OModelSelectionEstimator(H2OEstimator):
     def max_runtime_secs(self, max_runtime_secs):
         assert_is_type(max_runtime_secs, None, numeric)
         self._parms["max_runtime_secs"] = max_runtime_secs
-
-    @property
-    def custom_metric_func(self):
-        """
-        Reference to custom evaluation function, format: `language:keyName=funcName`
-
-        Type: ``str``.
-        """
-        return self._parms.get("custom_metric_func")
-
-    @custom_metric_func.setter
-    def custom_metric_func(self, custom_metric_func):
-        assert_is_type(custom_metric_func, None, str)
-        self._parms["custom_metric_func"] = custom_metric_func
 
     @property
     def nparallelism(self):

--- a/h2o-r/h2o-package/R/modelselection.R
+++ b/h2o-r/h2o-package/R/modelselection.R
@@ -108,7 +108,6 @@
 #' @param max_after_balance_size Maximum relative size of the training data after balancing class counts (can be less than 1.0). Requires
 #'        balance_classes. Defaults to 5.0.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
-#' @param custom_metric_func Reference to custom evaluation function, format: `language:keyName=funcName`
 #' @param nparallelism number of models to build in parallel.  Defaults to 0.0 which is adaptive to the system capability Defaults to
 #'        0.
 #' @param max_predictor_number Maximum number of predictors to be considered when building GLM models.  Defaults to 1. Defaults to 1.
@@ -190,7 +189,6 @@ h2o.modelSelection <- function(x,
                                class_sampling_factors = NULL,
                                max_after_balance_size = 5.0,
                                max_runtime_secs = 0,
-                               custom_metric_func = NULL,
                                nparallelism = 0,
                                max_predictor_number = 1,
                                min_predictor_number = 1,
@@ -315,8 +313,6 @@ h2o.modelSelection <- function(x,
     parms$max_after_balance_size <- max_after_balance_size
   if (!missing(max_runtime_secs))
     parms$max_runtime_secs <- max_runtime_secs
-  if (!missing(custom_metric_func))
-    parms$custom_metric_func <- custom_metric_func
   if (!missing(nparallelism))
     parms$nparallelism <- nparallelism
   if (!missing(max_predictor_number))
@@ -387,7 +383,6 @@ h2o.modelSelection <- function(x,
                                                class_sampling_factors = NULL,
                                                max_after_balance_size = 5.0,
                                                max_runtime_secs = 0,
-                                               custom_metric_func = NULL,
                                                nparallelism = 0,
                                                max_predictor_number = 1,
                                                min_predictor_number = 1,
@@ -517,8 +512,6 @@ h2o.modelSelection <- function(x,
     parms$max_after_balance_size <- max_after_balance_size
   if (!missing(max_runtime_secs))
     parms$max_runtime_secs <- max_runtime_secs
-  if (!missing(custom_metric_func))
-    parms$custom_metric_func <- custom_metric_func
   if (!missing(nparallelism))
     parms$nparallelism <- nparallelism
   if (!missing(max_predictor_number))


### PR DESCRIPTION
issue: https://github.com/h2oai/h2o-3/issues/16026

Remove declaration to custom_func_metrics from ANOVAGLM and ModelSelection.