### PR TITLE
Update benchmark intervals [nocheck]

### DIFF
--- a/scripts/jenkins/groovy/buildConfig.groovy
+++ b/scripts/jenkins/groovy/buildConfig.groovy
@@ -369,7 +369,7 @@ class BuildConfig {
   }
 
   static enum NodeLabels {
-    LABELS_C1('docker && !mr-0xc8', 'mr-0xc9', 'gpu && !2gpu', 'mr-dl3'), //master or nightly build
+    LABELS_C1('docker && !mr-0xc8', 'mr-0xc9', 'gpu && !2gpu', 'mr-0xk10'), //master or nightly build
     LABELS_B4('docker', 'docker', 'gpu && !2gpu', 'docker')  //PR build
 
     static Map<String, NodeLabels> LABELS_MAP = [

--- a/scripts/jenkins/groovy/compareBenchmarksStage.groovy
+++ b/scripts/jenkins/groovy/compareBenchmarksStage.groovy
@@ -158,7 +158,7 @@ def call(final pipelineContext, final stageConfig, final benchmarkFolderConfig) 
                     'train_time_max': 15
                 ],
                 [100, "gpu"]: [
-                    'train_time_min': 8,
+                    'train_time_min': 4,
                     'train_time_max': 26
                 ]
             ],
@@ -172,8 +172,8 @@ def call(final pipelineContext, final stageConfig, final benchmarkFolderConfig) 
                     'train_time_max': 80
                 ],
                 [100, "gpu"]: [
-                    'train_time_min': 22,
-                    'train_time_max': 52
+                    'train_time_min': 10,
+                    'train_time_max': 40
                 ]
             ],
             'higgs': [
@@ -186,8 +186,8 @@ def call(final pipelineContext, final stageConfig, final benchmarkFolderConfig) 
                     'train_time_max': 143
                 ],
                 [100, "gpu"]: [
-                    'train_time_min': 35,
-                    'train_time_max': 57
+                    'train_time_min': 15,
+                    'train_time_max': 37
                 ]
             ],
             'cox2': [

--- a/scripts/jenkins/groovy/compareBenchmarksStage.groovy
+++ b/scripts/jenkins/groovy/compareBenchmarksStage.groovy
@@ -262,7 +262,7 @@ def call(final pipelineContext, final stageConfig, final benchmarkFolderConfig) 
             ],
             'fileSize100millionRows2ColsallxyFF': [
                 [100000000, 2]: [
-                    'train_time_min': 30,
+                    'train_time_min': 25,
                     'train_time_max': 37
                 ]
             ],

--- a/scripts/jenkins/groovy/compareBenchmarksStage.groovy
+++ b/scripts/jenkins/groovy/compareBenchmarksStage.groovy
@@ -165,11 +165,11 @@ def call(final pipelineContext, final stageConfig, final benchmarkFolderConfig) 
             'airlines-10m': [
                 [100, "cpu"]: [
                     'train_time_min': 54,
-                    'train_time_max': 70
+                    'train_time_max': 78
                 ],
                 [100, "ext"]: [
                     'train_time_min': 65,
-                    'train_time_max': 75
+                    'train_time_max': 80
                 ],
                 [100, "gpu"]: [
                     'train_time_min': 22,
@@ -223,7 +223,7 @@ def call(final pipelineContext, final stageConfig, final benchmarkFolderConfig) 
             'higgs': [
                 100: [
                     'train_time_min': 50,
-                    'train_time_max': 60
+                    'train_time_max': 65
                 ]
             ]
         ],
@@ -237,7 +237,7 @@ def call(final pipelineContext, final stageConfig, final benchmarkFolderConfig) 
             'airlines-10m': [
                 100: [
                     'train_time_min': 61,
-                    'train_time_max': 75
+                    'train_time_max': 78
                 ]
             ],
             'higgs': [

--- a/scripts/jenkins/groovy/compareBenchmarksStage.groovy
+++ b/scripts/jenkins/groovy/compareBenchmarksStage.groovy
@@ -29,7 +29,7 @@ def call(final pipelineContext, final stageConfig, final benchmarkFolderConfig) 
                 ],
                 200: [
                     'train_time_min': 90,
-                    'train_time_max': 110
+                    'train_time_max': 115
                 ]
             ],
             'springleaf': [

--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -300,7 +300,8 @@ def call(final pipelineContext) {
       nodeLabel: pipelineContext.getBuildConfig().getBenchmarkNodeLabel(),
       healthCheckSuppressed: true,
       image: 'harbor.h2o.ai/opsh2oai/h2o-3/dev-r-3.5.3-graalvm-17:42', // manually build, see Dockerfile-graalvm
-      javaVersion: 17
+      javaVersion: 17,
+      pythonVersion: '3.6'
     ],
     [
       stageName: 'GBM Benchmark noscoring-java8', executionScript: 'h2o-3/scripts/jenkins/groovy/benchmarkStage.groovy',


### PR DESCRIPTION
The XGBoost GPU node was changed and the tests are slightly quicker.

GBM, MERGE and other xgboost was slightly out of range (1-2s) and I extend the interval for them.

Run graalvm on python 3.6 because 3.7 is not installed in the image there.