### PR TITLE
Change node labels in h2o-3 nightly Pipeline

### DIFF
--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Benchmarks
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Benchmarks
@@ -1,6 +1,6 @@
 @Library('test-shared-library') _
 
-def DEFAULT_NODE_LABEL = 'h2o-3 && docker && !mr-0xc8 && (!micro || micro_21)'
+def DEFAULT_NODE_LABEL = 'h2o-3'
 final int HEALTH_CHECK_RETRIES = 5
 
 def defineTestStages = null

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Coverage
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Coverage
@@ -1,6 +1,6 @@
 @Library('test-shared-library') _
 
-def DEFAULT_NODE_LABEL = 'h2o-3 && docker && !mr-0xc8 && (!micro || micro_21)'
+def DEFAULT_NODE_LABEL = 'h2o-3'
 final int HEALTH_CHECK_RETRIES = 5
 
 def defineTestStages = null

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Hadoop
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Hadoop
@@ -1,6 +1,6 @@
 @Library('test-shared-library') _
 
-def DEFAULT_NODE_LABEL = 'h2o-3 && docker && !mr-0xc8 && (!micro || micro_21)'
+def DEFAULT_NODE_LABEL = 'h2o-3'
 final int HEALTH_CHECK_RETRIES = 5
 
 def defineTestStages = null

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-HadoopMultiNode
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-HadoopMultiNode
@@ -1,6 +1,6 @@
 @Library('test-shared-library') _
 
-def DEFAULT_NODE_LABEL = 'h2o-3 && docker && !mr-0xc8 && (!micro || micro_21)'
+def DEFAULT_NODE_LABEL = 'h2o-3'
 final int HEALTH_CHECK_RETRIES = 5
 
 def defineTestStages = null

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Kerberos
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Kerberos
@@ -1,6 +1,6 @@
 @Library('test-shared-library') _
 
-def DEFAULT_NODE_LABEL = 'h2o-3 && docker && !mr-0xc8 && (!micro || micro_21)'
+def DEFAULT_NODE_LABEL = 'h2o-3'
 final int HEALTH_CHECK_RETRIES = 5
 
 def defineTestStages = null

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Nightly
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Nightly
@@ -1,6 +1,6 @@
 @Library('test-shared-library') _
 
-def DEFAULT_NODE_LABEL = 'h2o-3 && docker && !mr-0xc8 && (!micro || micro_21)'
+def DEFAULT_NODE_LABEL = 'DC && linux && docker'
 final int HEALTH_CHECK_RETRIES = 5
 
 def defineTestStages = null

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Nightly
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Nightly
@@ -1,6 +1,6 @@
 @Library('test-shared-library') _
 
-def DEFAULT_NODE_LABEL = 'DC && linux && docker'
+def DEFAULT_NODE_LABEL = 'h2o-3'
 final int HEALTH_CHECK_RETRIES = 5
 
 def defineTestStages = null

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-NightlyRepeated
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-NightlyRepeated
@@ -1,6 +1,6 @@
 @Library('test-shared-library') _
 
-def DEFAULT_NODE_LABEL = 'h2o-3 && docker && !mr-0xc8 && (!micro || micro_21)'
+def DEFAULT_NODE_LABEL = 'h2o-3'
 final int HEALTH_CHECK_RETRIES = 5
 
 def defineTestStages = null

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-PrismaScan
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-PrismaScan
@@ -48,7 +48,7 @@ def setPrismaScanningStages(assemblyType, stageIndex) {
 }
 
 pipeline {
-    agent { node { label 'linux&&docker' } }
+    agent { node { label 'h2o-3' } }
 
     options {
         ansiColor('xterm')

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Public
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Public
@@ -1,6 +1,6 @@
 @Library('test-shared-library') _
 
-def DEFAULT_NODE_LABEL = 'h2o-3 && docker && !mr-0xc8 && !micro'
+def DEFAULT_NODE_LABEL = 'h2o-3'
 final int HEALTH_CHECK_RETRIES = 5
 
 def defineTestStages = null

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
@@ -1,6 +1,6 @@
 @Library('test-shared-library') _
 
-def NODE_LABEL = 'h2o-3 && docker && !mr-0xc8 && (!micro || micro_21)'
+def NODE_LABEL = 'h2o-3'
 
 def pipelineContext = null
 def result = 'FAILURE'

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Single-Test
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Single-Test
@@ -1,6 +1,6 @@
 @Library('test-shared-library') _
 
-def DEFAULT_NODE_LABEL = 'h2o-3 && docker && !mr-0xc8 && (!micro || micro_21)'
+def DEFAULT_NODE_LABEL = 'h2o-3'
 final int HEALTH_CHECK_RETRIES = 5
 
 def defineTestStages = null

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-XGB
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-XGB
@@ -1,6 +1,6 @@
 @Library('test-shared-library') _
 
-def DEFAULT_NODE_LABEL = 'h2o-3 && docker && !mr-0xc8 && (!micro || micro_21)'
+def DEFAULT_NODE_LABEL = 'h2o-3'
 final int HEALTH_CHECK_RETRIES = 5
 
 def defineTestStages = null


### PR DESCRIPTION
### Description

Change node label in h2o-3-nightly-pipeline and Stick on to DC machines (a subset of machines) only so that others can use the K8s cluster used for dynamic Jenkins agents.

Changed labels to : DC && linux && docker