### PR TITLE
update instruction for build project when use reverse proxy

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -43,6 +43,12 @@ localNexusLocation=http://nexus.0xdata.loc:8081/nexus/repository
 #
 publicNexusLocation="http://nexus.h2o.ai:8081/repository"
 
+# If you use a reverse proxy to download source from internet, such as nginx reverse proxy, uncomment line below and put your proxy address
+# systemProp.http.proxyHost=your_proxy_host
+# systemProp.http.proxyPort=your_proxy_port
+# systemProp.https.proxyHost=your_proxy_host
+# systemProp.https.proxyPort=your_proxy_port
+
 ##
 # Version of libraries used inside H2O
 ##


### PR DESCRIPTION
I am using a nginx reverse proxy as a firewall to restrict down/up load source. Because build process will download some dependencies, I must config to build script understand. This change will add more detail for instruct any one who have same context like me. 