### PR TITLE
GH-16154 - Use latest image in XGB benchmarks

### DIFF
--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -334,7 +334,6 @@ def call(final pipelineContext) {
       customData: [algorithm: 'xgb'], makefilePath: pipelineContext.getBuildConfig().BENCHMARK_MAKEFILE_PATH,
       nodeLabel: pipelineContext.getBuildConfig().getBenchmarkNodeLabel(), pythonVersion: '3.7',
       rVersion: '4.0.2',
-      imageVersion: 43,
       healthCheckSuppressed: true
     ],
     [
@@ -354,7 +353,6 @@ def call(final pipelineContext) {
       customData: [algorithm: 'xgb-vanilla'], makefilePath: pipelineContext.getBuildConfig().BENCHMARK_MAKEFILE_PATH,
       nodeLabel: pipelineContext.getBuildConfig().getBenchmarkNodeLabel(), pythonVersion: '3.7',
       rVersion: '4.0.2',
-      imageVersion: 44,
       healthCheckSuppressed: true
     ],
     [
@@ -364,7 +362,6 @@ def call(final pipelineContext) {
       customData: [algorithm: 'xgb-dmlc'], makefilePath: pipelineContext.getBuildConfig().BENCHMARK_MAKEFILE_PATH,
       nodeLabel: pipelineContext.getBuildConfig().getBenchmarkNodeLabel(), pythonVersion: '3.7',
       rVersion: '4.0.2',
-      imageVersion: 43,
       healthCheckSuppressed: true
     ],
     [ 


### PR DESCRIPTION
Part of GH-16154

It was a hot fix for xgboost release - since all the images are now on 44 and updated even for new xgboost, then we can use them properly.