### PR TITLE
GH-15947: fixed skipped_column error in Python

### DIFF
--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -871,7 +871,7 @@ def parse_setup(raw_frames, destination_frame=None, header=0, separator=None, co
     if column_names is not None:
         if not isinstance(column_names, list): raise ValueError("col_names should be a list")
         if (skipped_columns is not None) and len(skipped_columns)>0:
-            if (len(column_names)) != parse_column_len:
+            if (len(column_names)-len(skipped_columns)) != parse_column_len:
                 raise ValueError(
                     "length of col_names should be equal to the number of columns parsed: %d vs %d"
                     % (len(column_names), parse_column_len))

--- a/h2o-py/tests/testdir_parser/pyunit_GH_15947_skipped_column_error.py
+++ b/h2o-py/tests/testdir_parser/pyunit_GH_15947_skipped_column_error.py
@@ -3,7 +3,7 @@ sys.path.insert(1,"../../")
 import h2o
 from tests import pyunit_utils
 
-# Seb has reported that skipped_columns does not work here
+# Seb has reported that skipped_columns does not work if skipped_columns is called with h2o.H2OFrame
 def test_skipped_columns():
     data = [[1, 4, "a",  1], [2, 5, "b",  0], [3, 6, "", 1]]
     frame = h2o.H2OFrame(data, skipped_columns=[1, 2])

--- a/h2o-py/tests/testdir_parser/pyunit_GH_15947_skipped_column_error.py
+++ b/h2o-py/tests/testdir_parser/pyunit_GH_15947_skipped_column_error.py
@@ -1,0 +1,15 @@
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+
+# Seb has reported that skipped_columns does not work here
+def test_skipped_columns():
+    data = [[1, 4, "a",  1], [2, 5, "b",  0], [3, 6, "", 1]]
+    frame = h2o.H2OFrame(data, skipped_columns=[1, 2])
+    assert frame.ncol == 2, "Expected column number: 2.  Actual: {0}".format(frame.ncol)
+ 
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_skipped_columns)
+else:
+    test_skipped_columns()


### PR DESCRIPTION
issue: https://github.com/h2oai/h2o-3/issues/15947

The problem here is when called with h2o.H2OFrame, we did not take into account of skipped columns when trying to figure out the final column counts.

Fixed the bug and added Python test from Seb.