### PR TITLE
GH-16170 fix CVE-2024-21634 with aws upgrade - cause was ion_ion-java:1.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,7 +179,7 @@ ext {
     // Versions of libraries shared cross all projects
     //
     junitVersion  = '4.12'
-    awsJavaSdkVersion = '1.12.268'
+    awsJavaSdkVersion = '1.12.705'
 
     //
     // Optional H2O modules which can be included h2o.jar assembly

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oget_timezone_DEPRECATED.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oget_timezone_DEPRECATED.py
@@ -19,7 +19,7 @@ def h2oget_timezone():
     timezones = h2o.list_timezones()
     assert_is_type(timezones, H2OFrame)
 
-    assert timezones.nrow == 467, "h2o.get_timezone() returns frame with wrong row number."
+    assert timezones.nrow == 459, "h2o.get_timezone() returns frame with wrong row number."
     assert timezones.ncol == 1, "h2o.get_timezone() returns frame with wrong column number."
 
 if __name__ == "__main__":

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2olist_timezones_DEPRECATED.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2olist_timezones_DEPRECATED.py
@@ -14,7 +14,7 @@ def h2olist_timezones():
     timezones = h2o.list_timezones()
     assert_is_type(timezones, H2OFrame)
 
-    assert timezones.nrow == 467, "h2o.get_timezone() returns frame with wrong row number."
+    assert timezones.nrow == 459, "h2o.get_timezone() returns frame with wrong row number."
     assert timezones.ncol == 1, "h2o.get_timezone() returns frame with wrong column number."
 
 


### PR DESCRIPTION
Closes #16170