### PR TITLE
GH-16186: Updating user guide pages for Cloud Integration to reflect makersaurus guidelines

### DIFF
--- a/h2o-docs/src/product/cloud-integration.rst
+++ b/h2o-docs/src/product/cloud-integration.rst
@@ -1,7 +1,7 @@
-Cloud Integration
------------------
+Cloud integration
+=================
 
-H2O is supported on a number of cloud environments, including
+H2O is supported on a number of cloud environments:
 
 - EC2 Instances and S3 Storage (RedHat AMI, Amazon Linux AMI, and Ubuntu AMI)
 - Amazon AWS
@@ -11,7 +11,10 @@ H2O is supported on a number of cloud environments, including
 - Nimbix Cloud
 - Kubernetes
 
-Refer to the following topics:
+H2O on cloud environments
+-------------------------
+
+Refer to the following topics for more information:
 
 .. toctree::
    :maxdepth: 1

--- a/h2o-docs/src/product/cloud-integration/aws.rst
+++ b/h2o-docs/src/product/cloud-integration/aws.rst
@@ -1,6 +1,6 @@
 Using H2O with Amazon AWS
-~~~~~~~~~~~~~~~~~~~~~~~~~
+=========================
 
 The old `H2O Artificial Intelligence instance <https://aws.amazon.com/marketplace/pp/prodview-76ewxkmzkvr3m>`_ is no longer available.
 
-Please see `Training and serving H2O models using Amazon SageMaker <https://aws.amazon.com/blogs/machine-learning/training-and-serving-h2o-models-using-amazon-sagemaker/>`_.
+Please see `Training and serving H2O models using Amazon SageMaker <https://aws.amazon.com/blogs/machine-learning/training-and-serving-h2o-models-using-amazon-sagemaker/>`_ for more information.

--- a/h2o-docs/src/product/cloud-integration/aws.rst
+++ b/h2o-docs/src/product/cloud-integration/aws.rst
@@ -1,5 +1,5 @@
-Using H2O with Amazon AWS
-=========================
+Use H2O with Amazon AWS
+=======================
 
 The old `H2O Artificial Intelligence instance <https://aws.amazon.com/marketplace/pp/prodview-76ewxkmzkvr3m>`_ is no longer available.
 

--- a/h2o-docs/src/product/cloud-integration/azure-dsvm.rst
+++ b/h2o-docs/src/product/cloud-integration/azure-dsvm.rst
@@ -1,56 +1,58 @@
-Using H2O with Microsoft Azure Linux Data Science VM
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Use H2O with Microsoft Azure Linux Data Science VM
+==================================================
 
 The Data Science Virtual Machine (DSVM) for Linux is an Ubuntu-based virtual machine image that makes it easy to get started with deep learning on Azure. CNTK, TensorFlow, MXNet, Caffe, Caffe2, DIGITS, H2O, Keras, Theano, and Torch are built, installed, and configured, so they are ready to run immediately. The NVIDIA driver, CUDA, and cuDNN are also included. All frameworks are the GPU versions but work on the CPU as well. Many sample Jupyter notebooks are included.
 
-You can view a full list of installed tools for the Linux edition `here <https://docs.microsoft.com/en-us/azure/machine-learning/machine-learning-data-science-virtual-machine-overview>`__.
+You can `view a full list of installed tools for the Linux edition here <https://docs.microsoft.com/en-us/azure/machine-learning/machine-learning-data-science-virtual-machine-overview>`__.
 
-Follow the steps below to create the H2O Artificial Intelligence VM.
+Create the H2O Artificial Intelligence VM
+-----------------------------------------
 
-1. Log in to your Azure portal at `https://portal.azure.com <https://portal.azure.com>`__, and click the **New** button.  
+Follow these steps to create the H2O Artificial Intelligence VM.
+
+1. Log in to your `Azure portal <https://portal.azure.com>`__, and click **New**.  
 
   .. figure:: ../images/azurelin_new.png
-     :alt: Create a new VM
+     :alt: Create a new VM page on Microsoft Azure.
 
-2. Search in the Marketplace for “H2O”. The result will show all of the H2O offering in the Azure Marketplace. Select the Data Science Virtual Machine for Linux (Ubuntu), and click the **Create** button.
+2. Search in the Marketplace for “H2O”. The result will show all of the H2O offerings in the Azure Marketplace. Select the Data Science Virtual Machine for Linux (Ubuntu), and click **Create**.
 
   .. figure:: ../images/azurelin_h2o_dsvm.png
-     :alt: Data Science VM for Linux
+     :alt: Data Science VM for Linux panel outlining how DSVM for Linux works and which tools are contained in it.
 
 3. Follow the UI instructions and fill the Basic settings: 
    
-   - Username and Password that you will be using to connect to the VM
-   - Subscriptions where you want to create the VM
-   - The new resource group name
-   - The location where the VM is going to be created
-   - Size of the VM. 
-
-   Optional: For VMs with GPU, select the HDD disk option, and search for the N-Series VM. For more information, click `here <http://gpu.azure.com/>`__. 
+   - Username and Password that you will be using to connect to the VM.
+   - Subscriptions where you want to create the VM.
+   - The new resource group name.
+   - The location where the VM is going to be created.
+   - Size of the VM.
+   - (Optional for VMs with GPU) Select the HDD disk option, and search for the N-Series VM. See more on `GPU optimized virtual machine sizes <http://gpu.azure.com/>`__.
 
 4. Wait for the VM Solution to be created. The expected creation time is around 10 minutes.
 
-5. After your deployment is created, locate your network security group. Your Network Security Group is named by the default as **<your VM name>-nsg**. After you locate the security group, look at the inbound security rules.  
+5. Locate your network security group after your deployment is created. Your Network Security Group is named by the default as **<your VM name>-nsg**. After you locate the security group, look at the inbound security rules.  
 
   .. figure:: ../images/azurelin_inbound_secrules.png
-     :alt: Inbound security rules
+     :alt: Inbound and outbound security rules overview page with three inbound security rules.
 
 6. Click **Add** to add a new Inbound Security Rule, and create a TCP Rule with Port Range 54321. Click **OK** when you are done.
 
   .. figure:: ../images/azurelin_add_inbound_secrule.png
-     :alt: Add inbound security rule
+     :alt: Add inbound security rule panel where the new TCP rule with a port range of 54321 has been added.
 
-7. After the new Inbound Security Rule is added, then you are ready to start using your Linux DSVM with H2O. Simply connect to your Jupyter notebooks and look at the examples in the **h2o > python** folder to create your first H2O Model on Azure. 
+7. After the new Inbound Security Rule is added, you are ready to start using your Linux DSVM with H2O. Connect to your Jupyter notebooks and look at the examples in the **h2o > python** folder to create your first H2O Model on Azure. 
 
    1. Connect to Jupyter Notebook by going to **https://<<VM DNS Name or IP Address>>:8000/**.
    2. Connect to H2O Flow by going to **http://<<VM DNS Name or IP Address>>:54321/**.
 
-Troubleshooting Tips
-'''''''''''''''''''' 
+Tips for troubleshooting
+------------------------
 
-- Be aware that Azure subscriptions by default allow only 20 cores. If you get a Validation error on template deployment, this might be the cause. To increase the cores limit, follow these steps: `https://blogs.msdn.microsoft.com/girishp/2015/09/20/increasing-core-quota-limits-in-azure/ <https://blogs.msdn.microsoft.com/girishp/2015/09/20/increasing-core-quota-limits-in-azure/>`__
-- OS Disk by default is small (approx 30GB). In this case, you will have approximately 16GB of free space to start with. This is the same for all VM sizes. It is recommended that you add an SSD data disk by following these instructions: `https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-classic-attach-disk/ <https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-classic-attach-disk/>`__
-- Pick a VM size that provides RAM of at least 4x the size of your dataset. More information on Azure VM sizes is available here: `https://azure.microsoft.com/en-us/pricing/details/virtual-machines/ <https://azure.microsoft.com/en-us/pricing/details/virtual-machines/>`__
-- The included examples use a ``locate`` function for importing data. This function is not available to end users. For example:
+- Be aware that Azure subscriptions only allow 20 cores by default. If you get a Validation error on template deployment, this might be the cause. Follow these `steps to increase your core quota limits <https://blogs.msdn.microsoft.com/girishp/2015/09/20/increasing-core-quota-limits-in-azure/>`__.
+- OS Disk by default is small (approx 30GB). In this case, you will have approximately 16GB of free space to start with. This is the same for all VM sizes. Follow these `steps to add an SSD data disk <https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-classic-attach-disk/>`__.
+- Pick a VM size that provides RAM of at least 4x the size of your dataset. See more about `Azure VM sizes <https://azure.microsoft.com/en-us/pricing/details/virtual-machines/>`__.
+- The previous examples use a ``locate`` function for importing data. This function is not available to end users. For example:
 
   :: 
 
@@ -58,7 +60,7 @@ Troubleshooting Tips
 
  To retrieve the datasets, use one of the following methods instead:
 
-  - Replace this path with a pointer to a raw github file at **https://raw.github.com/h2o.ai/h2o/master/..**. For example, ``air_path="https://raw.github.com/h2oai/h2o/master/smalldata/airlines/allyears2k_headers.zip"``
+  - Replace this path with a pointer to a raw github file at **https://raw.github.com/h2o.ai/h2o/master/..**. For example, ``air_path="https://raw.github.com/h2oai/h2o/master/smalldata/airlines/allyears2k_headers.zip"``.
   - Use ``wget`` to retrieve the files.
 
  A list of the datasets used in the examples along with their locate path is available in the **h2o > python > README** file.

--- a/h2o-docs/src/product/cloud-integration/azure-dsvm.rst
+++ b/h2o-docs/src/product/cloud-integration/azure-dsvm.rst
@@ -50,7 +50,7 @@ Tips for troubleshooting
 ------------------------
 
 - Be aware that Azure subscriptions only allow 20 cores by default. If you get a Validation error on template deployment, this might be the cause. Follow these `steps to increase your core quota limits <https://blogs.msdn.microsoft.com/girishp/2015/09/20/increasing-core-quota-limits-in-azure/>`__.
-- OS Disk by default is small (approx 30GB). In this case, you will have approximately 16GB of free space to start with. This is the same for all VM sizes. Follow these `steps to add an SSD data disk <https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-classic-attach-disk/>`__.
+- OS Disk by default is small (approx 30GB). In this case, you will have approximately 16GB of free space to start with. This is the same for all VM sizes. Follow these `steps to add an SSD data disk <https://learn.microsoft.com/en-us/azure/devtest-labs/devtest-lab-attach-detach-data-disk>`__.
 - Pick a VM size that provides RAM of at least 4x the size of your dataset. See more about `Azure VM sizes <https://azure.microsoft.com/en-us/pricing/details/virtual-machines/>`__.
 - The previous examples use a ``locate`` function for importing data. This function is not available to end users. For example:
 
@@ -58,9 +58,14 @@ Tips for troubleshooting
 
     air_path = [_locate("smalldata/airlines/allyears2k_headers.zip")]
 
- To retrieve the datasets, use one of the following methods instead:
+  To retrieve the datasets, use one of the following methods instead:
 
-  - Replace this path with a pointer to a raw github file at **https://raw.github.com/h2o.ai/h2o/master/..**. For example, ``air_path="https://raw.github.com/h2oai/h2o/master/smalldata/airlines/allyears2k_headers.zip"``.
-  - Use ``wget`` to retrieve the files.
+    - Replace this path with a pointer to an Amazon S3 file at **http://s3.amazonaws.com/h2o-public-test-data/..**. For example: 
 
- A list of the datasets used in the examples along with their locate path is available in the **h2o > python > README** file.
+    ::
+
+      air_path="http://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/allyears2k_headers.zip"
+
+    - Use ``wget`` to retrieve the files.
+
+  A list of the datasets used in the examples along with their locate path is available in the **h2o > python > README** file.

--- a/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
+++ b/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
@@ -1,4 +1,4 @@
-EC2 Instances & S3 Storage
+EC2 instances & S3 storage
 ==========================
 
 *Tested on Redhat AMI, Amazon Linux AMI, and Ubuntu AMI*
@@ -14,7 +14,7 @@ For security reasons, we recommend writing a script to read the access credentia
  - You can only specify one S3 endpoint. This means you can either read data from AWS S3 or Minio S3, not from both.
  - We recommend using S3 for data ingestion and S3N for data export. 
 
-AWS Standalone Instance
+AWS Standalone instance
 -----------------------
 
 When running H2O in standalone mode using the simple Java launch command, you can pass in the S3 credentials in three ways. H2O supports the following:
@@ -117,7 +117,7 @@ Just like regular AWS credentials, temporary credentials using an AWS SESSION TO
 
 .. _Core-site.xml:
 
-Core-site.xml Example
+Core-site.xml example
 ~~~~~~~~~~~~~~~~~~~~~
 
 The following is an example ``core-site.xml`` file:
@@ -207,7 +207,7 @@ Build a cluster of EC2 instances by running the following commands on the host t
 
 .. _minio:
 
-Minio Instance
+Minio instance
 --------------
 
 Minio Cloud Storage is an alternative to Amazon AWS S3. When connecting to a Minio server, the following additional parameters are specified in the Java launch command:
@@ -259,8 +259,8 @@ To pass in credentials, create a ``core-site.xml`` file that contains your Acces
     h2o.importFile(path = "s3://bucket/path/to/file.csv")
 
 
-Launching H2O
--------------
+Launch H2O
+----------
 
 .. note:: 
 
@@ -278,8 +278,8 @@ Select your operating system and the virtualization type of the prebuilt AMI on 
 See `Amazon virtualization <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html>`__ for more information about virtualization types.
 
 
-Configuring the instance
-~~~~~~~~~~~~~~~~~~~~~~~~
+Configure the instance
+~~~~~~~~~~~~~~~~~~~~~~
 
 1. Select the IAM role and policy to use to launch the instance. H2O detects the temporary access keys associated with the instance, so you don't need to copy your AWS credentials to the instances.
 
@@ -335,8 +335,8 @@ Otherwise, you can download `PuTTY <https://www.putty.org/>`_ and follow these i
     :alt: PuTTY security alert about the server's host key not cached in the registry.
 
 
-Downloading Java and H2O
-~~~~~~~~~~~~~~~~~~~~~~~~
+Download Java and H2O
+~~~~~~~~~~~~~~~~~~~~~
 
 1. Download `Java <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements>`__ (JDK 1.8 or later) if it is not already available on the instance.
 2. Download H2O with the ``wget`` command and the link to the ZIP file available on our `website <http://h2o.ai/download/>`__ by copying the link associated with the **Download** button for the selected H2O build.

--- a/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
+++ b/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
@@ -1,5 +1,5 @@
 EC2 Instances & S3 Storage
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+==========================
 
 *Tested on Redhat AMI, Amazon Linux AMI, and Ubuntu AMI*
 
@@ -9,117 +9,118 @@ To use the `Minio Cloud Storage <https://minio.io/>`__, you will need to pass an
 
 For security reasons, we recommend writing a script to read the access credentials that are stored in a separate file. This will not only keep your credentials from propagating to other locations, but it will also make it easier to change the credential information later.
 
-**Notes**: 
+.. note::
 
  - You can only specify one S3 endpoint. This means you can either read data from AWS S3 or Minio S3, not from both.
  - We recommend using S3 for data ingestion and S3N for data export. 
 
 AWS Standalone Instance
-'''''''''''''''''''''''
+-----------------------
 
-When running H2O in standalone mode using the simple Java launch command, we can pass in the S3 credentials in three ways.
-H2O supports both AWS Credentials (pair consisting of AWS SECRET KEY and AWS SECRET ACCESS KEY) and temporary authentication using Session token
-(a triplet consisting of AWS SECRET KEY, AWS SECRET ACCESS KEY and AWS SESSION TOKEN).
+When running H2O in standalone mode using the simple Java launch command, you can pass in the S3 credentials in three ways. H2O supports the following:
 
--  You can pass in AWS Credentials in standalone mode by creating a ``core-site.xml`` file and passing it in with the flag ``-hdfs_config``. For an example ``core-site.xml`` file, refer to `Core-site.xml`_.
+- AWS credentials: Pair consisting of AWS SECRET KEY and AWS SECRET ACCESS KEY.
+- Session token (temporary authentication): Triplet consisting of AWS SECRET KEY, AWS SECRET ACCESS KEY and AWS SESSION TOKEN.
 
-   1. Edit the properties in the core-site.xml file to include your Access Key ID, Access Key, and Session Token as shown in the following example:
+.. note::
+  
+  Passing credentials into the URL (e.g. ``h2o.importFile(path = "s3://<AWS_ACCESS_KEY>:<AWS_SECRET_KEY>:<AWS_SESSION_TOKEN>@bucket/path/to/file.csv")``) is deprecated and considered a security risk.
 
-     ::
+AWS credentials
+~~~~~~~~~~~~~~~
 
-       <property>
-         <name>fs.s3.awsAccessKeyId</name>
-         <value>[AWS SECRET KEY]</value>
-       </property>
+You can pass in AWS Credentials in standalone mode by creating a ``core-site.xml`` file and passing it in with the flag ``-hdfs_config``. See `Core-site.xml`_ for an example ``core-site.xml`` file.
 
-       <property>
-         <name>fs.s3.awsSecretAccessKey</name>
-         <value>[AWS SECRET ACCESS KEY]</value>
-       </property>
+1. Edit the properties in the ``core-site.xml`` file to include your Access Key ID, Access Key, and Session Token:
 
+  ::
 
-   2. Launch with the configuration file ``core-site.xml`` by entering the following in the command line:
+    <property>
+      <name>fs.s3.awsAccessKeyID</name>
+      <value>[AWS SECRET KEY]</value>
+    </property>
 
-     ::
+    <property>
+      <name>fs.s3.awsSecretAccessKey</name>
+      <value>[AWS SECRET ACCESS KEY]</value>
+    </property>
 
-       java -jar h2o.jar -hdfs_config core-site.xml
+2. Launch with the configuration file ``core-site.xml``:
 
-   3. Set the credentials dynamically before accessing the bucket (where ``AWS_ACCESS_KEY`` represents your user name, and ``AWS_SECRET_KEY`` represents your password).
+  ::
 
-    -  To set the credentials dynamically using the R API:
+    java -jar h2o.jar -hdfs_config core-site.xml
 
-      ::
+3. Set the credentials dynamically before accessing the bucket (where ``AWS_ACCESS_KEY`` represents your user name, and ``AWS_SECRET_KEY`` represents your password):
 
-        h2o.set_s3_credentials("AWS_ACCESS_KEY", "AWS_SECRET_KEY")
-        h2o.importFile(path = "s3://bucket/path/to/file.csv")
+  .. tabs::
+    .. code-tab:: python
 
-    -  To set the credentials dynamically using the Python API:
+      from h2o.persist import set_s3_credentials
+      set_s3_credentials("AWS_ACCESS_KEY", "AWS_SECRET_KEY")
+      h2o.import_file(path = "s3://bucket/path/to/file.csv")
 
-      ::
+    .. code-tab:: r R
 
-        from h2o.persist import set_s3_credentials
-        set_s3_credentials("AWS_ACCESS_KEY", "AWS_SECRET_KEY")
-        h2o.import_file(path = "s3://bucket/path/to/file.csv")
-
-        
--  Just like regular AWS credentials, temporary credentials using AWS SESSION TOKEN can be passed in standalone mode by creating a ``core-site.xml`` file and passing it in with the flag ``-hdfs_config``. For an example ``core-site.xml`` file, refer to `Core-site.xml`_. The only difference lies in specifying a triplet of (AWS SECRET KEY, AWS SECRET ACCESS KEY and AWS SESSION TOKEN) and defining a credentials provider capable of resolving temporary credentials.
-
-   1. Edit the properties in the core-site.xml file to include your Access Key ID, Access Key, and Session Token as shown in the following example:
-
-     ::
-
-       <property>
-         <name>fs.s3a.aws.credentials.provider</name>
-         <value>org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider</value>
-       </property>
-
-       <property>
-         <name>fs.s3a.access.key</name>
-         <value>[AWS SECRET KEY]</value>
-       </property>
-
-       <property>
-         <name>fs.s3a.secret.key</name>
-         <value>[AWS SECRET ACCESS KEY]</value>
-       </property>
-
-       <property>
-         <name>fs.s3a.session.token</name>
-         <value>[AWS SESSION TOKEN]<value>
-       <property>
+      h2o.set_s3_credentials("AWS_ACCESS_KEY", "AWS_SECRET_KEY")
+      h2o.importFile(path = "s3://bucket/path/to/file.csv")
 
 
-   2. Launch with the configuration file ``core-site.xml`` by entering the following in the command line:
+Session token
+~~~~~~~~~~~~~
 
-     ::
+Just like regular AWS credentials, temporary credentials using an AWS SESSION TOKEN can be passed in standalone mode by creating a ``core-site.xml`` file and passing it in with the flag ``-hdfs_config``. The only difference between the two lies in specifying a triplet of (AWS SECRET KEY, AWS SECRET ACCESS KEY and AWS SESSION TOKEN) and defining a credentials provider capable of resolving temporary credentials. See `Core-site.xml`_ for an example ``core-site.xml`` file. 
 
-       java -jar h2o.jar -hdfs_config core-site.xml
+1. Edit the properties in the ``core-site.xml`` file to include your Access Key ID, Access Key, and Session Token:
 
-   3. Set the credentials dynamically before accessing the bucket (where ``AWS_ACCESS_KEY`` represents your user name, ``AWS_SECRET_KEY`` represents your password and ``AWS_SESSION_TOKEN`` represents temporary session token).
+  ::
 
-    -  To set the credentials dynamically using the R API:
+    <property>
+     <name>fs.s3a.aws.credentials.provider</name>
+     <value>org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider</value>
+    </property>
 
-      ::
+    <property>
+     <name>fs.s3a.access.key</name>
+     <value>[AWS SECRET KEY]</value>
+    </property>
 
-        h2o.set_s3_credentials("AWS_ACCESS_KEY", "AWS_SECRET_KEY", "AWS_SESSION_TOKEN")
-        h2o.importFile(path = "s3://bucket/path/to/file.csv")
+    <property>
+     <name>fs.s3a.secret.key</name>
+     <value>[AWS SECRET ACCESS KEY]</value>
+    </property>
 
-    -  To set the credentials dynamically using the Python API:
+    <property>
+     <name>fs.s3a.session.token</name>
+     <value>[AWS SESSION TOKEN]<value>
+    <property>
 
-      ::
+2. Launch with the configuration file ``core-site.xml``:
 
-        from h2o.persist import set_s3_credentials
-        set_s3_credentials("AWS_ACCESS_KEY", "AWS_SECRET_KEY", "AWS_SESSION_TOKEN")
-        h2o.import_file(path = "s3://bucket/path/to/file.csv")
+  ::
 
-**Note**: Passing credentials in the URL, e.g. ``h2o.importFile(path = "s3://<AWS_ACCESS_KEY>:<AWS_SECRET_KEY>:<AWS_SESSION_TOKEN>@bucket/path/to/file.csv")``, is considered a security risk and is deprecated. 
+    java -jar h2o.jar -hdfs_config core-site.xml
+
+3. Set he credentials dynamically before accessing the bucket (where AWS_ACCESS_KEY represents your user name, AWS_SECRET_KEY represents your password and AWS_SESSION_TOKEN represents temporary session token):
+
+.. tabs::
+  .. code-tab:: python
+
+    from h2o.persist import set_s3_credentials
+    set_s3_credentials("AWS_ACCESS_KEY", "AWS_SECRET_KEY", "AWS_SESSION_TOKEN")
+    h2o.import_file(path = "s3://bucket/path/to/file.csv")
+
+  .. code-tab:: r R
+
+    h2o.set_s3_credentials("AWS_ACCESS_KEY", "AWS_SECRET_KEY", "AWS_SESSION_TOKEN")
+    h2o.importFile(path = "s3://bucket/path/to/file.csv")
 
 .. _Core-site.xml:
 
 Core-site.xml Example
-'''''''''''''''''''''
+~~~~~~~~~~~~~~~~~~~~~
 
-The following is an example core-site.xml file:
+The following is an example ``core-site.xml`` file:
 
 ::
 
@@ -153,63 +154,70 @@ The following is an example core-site.xml file:
         </property>
     </configuration>
 
-AWS Multi-Node Instance
-'''''''''''''''''''''''
+AWS multi-node instance
+-----------------------
+`Python and the boto <http://boto.readthedocs.org/en/latest/>`_ Python library are required to launch a multi-node instance of H2O on EC2. Ensure these dependencies are installed before proceeding.
 
-`Python <http://www.amazon.com/Python-and-AWS-Cookbook-ebook/dp/B005ZTO0UW/ref=sr_1_1?ie=UTF8&qid=1379879111&sr=8-1&keywords=python+aws>`_ and the `boto <http://boto.readthedocs.org/en/latest/>`_ Python library are required to launch a multi-node instance of H2O on EC2. Confirm these dependencies are installed before proceeding.
+See the `H2O EC2 repo <https://github.com/h2oai/h2o-3/tree/master/ec2>`_ for more information.
 
-For more information, refer to the `H2O EC2 repo <https://github.com/h2oai/h2o-3/tree/master/ec2>`_.
+Create an AWS multi-node instance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Build a cluster of EC2 instances by running the following commands on the host that can access the nodes using a public DNS name.
 
-1. Edit `h2o-cluster-launch-instances.py` to include your SSH key name and security group name, as well as any other environment-specific variables.
+1. Edit ``h2o-cluster-launch-instances.py`` to include your SSH key name and security group name (as well as any other environment-specific variables).
 
  ::
 
     ./h2o-cluster-launch-instances.py
     ./h2o-cluster-distribute-h2o.sh
-
- --OR--
-
- ::
-
+    # -- OR --
     ./h2o-cluster-launch-instances.py
     ./h2o-cluster-download-h2o.sh
 
- **Note**: The second method may be faster than the first because download pulls from S3.
+.. note:: 
+  
+  The second method may be faster than the first because download pulls from S3.
 
 2. Distribute the credentials using ``./h2o-cluster-distribute-aws-credentials.sh``.
 
-  **Note**: If you are running H2O using an IAM role, it is not necessary to distribute the AWS credentials to all the nodes in the cluster. The latest version of H2O can access the temporary access key.
+    .. note:: 
+      
+      If you are running H2O using an IAM role, it's not necessary to distribute the AWS credentials to all the nodes in the cluster. The latest version of H2O can access the temporary access key.
 
-  **Caution**: Distributing both regular AWS credentials and temporary AWS credentials using session token copies the Amazon AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and optionally (if temporary credentials are used) AWS_SESSION_TOKEN to the instances to enable S3 and S3N access. Use caution when adding your security keys to the cloud.
+    .. warning::
+      
+      Distributing both regular AWS credentials and temporary AWS credentials using a session token copies the Amazon AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and optionally (if temporary credentials are used) AWS_SESSION_TOKEN to the instances to enable S3 and S3N access. Use caution when adding your security keys to the cloud.
 
-3. Start H2O by launching one H2O node per EC2 instance:
+3. Start H2O by launching one H2O node per EC2 instance (wait 60 seconds after entering the command before entering it on the next node):
 
  ::
 
     ./h2o-cluster-start-h2o.sh
 
- Wait 60 seconds after entering the command before entering it on the next node.
+4. Substitute any of the public DNS node addresses for *IP_ADDRESS* in your internet browser for the following example: ``http://IP_ADDRESS:54321``
 
-4. In your internet browser, substitute any of the public DNS node addresses for *IP_ADDRESS* in the following example: ``http://IP_ADDRESS:54321``
-
-  - To start H2O: ``./h2o-cluster-start-h2o.sh``
-  - To stop H2O: ``./h2o-cluster-stop-h2o.sh``
+  - To start H2O: ``./h2o-cluster-start-h2o.sh``.
+  - To stop H2O: ``./h2o-cluster-stop-h2o.sh``.
   - To shut down the cluster, use your `Amazon AWS console <http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/UsingEMR_TerminateJobFlow.html>`_ to shut down the cluster manually.
 
-  **Note**: To successfully import data, the data must reside in the same location on all nodes.
+  .. note:: 
+
+    To successfully import data, the data must reside in the same location on all nodes.
 
 .. _minio:
 
 Minio Instance
-''''''''''''''
+--------------
 
 Minio Cloud Storage is an alternative to Amazon AWS S3. When connecting to a Minio server, the following additional parameters are specified in the Java launch command:
 
 - ``endpoint``: Specifies a Minio server instance (including address and port). This overrides the existing endpoint, which is currently hardcoded to be AWS S3.
 
 - ``enable.path.style``: Specifies to override the default S3 behavior to expose every bucket as a full DNS enabled path. Note that this is a Minio recommendation.
+
+Create a Minio instance
+~~~~~~~~~~~~~~~~~~~~~~~
 
 To pass in credentials, create a ``core-site.xml`` file that contains your Access Key ID and Secret Access Key and use the flag ``-hdfs_config`` flag when launching:
 
@@ -231,98 +239,107 @@ To pass in credentials, create a ``core-site.xml`` file that contains your Acces
 
       java -Dsys.ai.h2o.persist.s3.endPoint=https://play.min.io:9000 -Dsys.ai.h2o.persist.s3.enable.path.style=true -jar h2o.jar -hdfs_config core-site.xml
 
-  **Note**: https://play.min.io:9000 is an example Minio server URL.
+  .. note:: 
 
-2. Import the data using ``importFile`` with the Minio S3 url path: **s3://bucket/path/to/file.csv**.
+    https://play.min.io:9000 is an example Minio server URL.
 
- - To import the data from the Flow API:
+2. Import the data using ``importFile`` with the Minio S3 url path: ``s3://bucket/path/to/file.csv``.
 
-  ::
+.. tabs::
+  .. code-tab:: bash Flow
 
-   importFiles [ "s3://bucket/path/to/file.csv" ]
+    importFiles [ "s3://bucket/path/to/file.csv" ]
 
- - To import the data from the R API:
+  .. code-tab:: python
 
-  ::
+    h2o.import_file(path = "s3://bucket/path/to/file.csv")
 
-   h2o.importFile(path = "s3://bucket/path/to/file.csv")
+  .. code-tab:: r R
 
- - To import the data from the Python API:
+    h2o.importFile(path = "s3://bucket/path/to/file.csv")
 
-  ::
-
-   h2o.import_file(path = "s3://bucket/path/to/file.csv")
 
 Launching H2O
-'''''''''''''
+-------------
 
-**Note**: Before launching H2O on an EC2 cluster, verify that ports ``54321`` and ``54322`` are both accessible by TCP.
+.. note:: 
 
-**Selecting the Operating System and Virtualization Type**
+  Before launching H2O on an EC2 cluster, verify that ports ``54321`` and ``54322`` are both accessible by TCP.
+
+Select the operating system and virtualization type
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Select your operating system and the virtualization type of the prebuilt AMI on Amazon. If you are using Windows, you will need to use a hardware-assisted virtual machine (HVM). If you are using Linux, you can choose between para-virtualization (PV) and HVM. These selections determine the type of instances you can launch.
 
 .. figure:: ../EC2_images/ec2_system.png
-   :alt: EC2 Systems
+   :alt: EC2 systems page where you select your amazon machine image.
 
 
-For more information about virtualization types, refer to `Amazon <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html>`__.
+See `Amazon virtualization <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html>`__ for more information about virtualization types.
 
 
-**Configuring the Instance**
+Configuring the instance
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Select the IAM role and policy to use to launch the instance. H2O detects the temporary access keys associated with the instance, so you don't need to copy your AWS credentials to the instances.
 
   .. figure:: ../EC2_images/ec2_config.png
-     :alt: EC2 Configuration
+     :alt: EC2 page where you configure your instance details.
 
-2. When launching the instance, select an accessible key pair.
+2. Select an accessible key pair when launching the instance.
 
   .. figure:: ../EC2_images/ec2_key_pair.png
-     :alt: EC2 Key Pair
+     :alt: EC2 panel where you select an existing key pair or create a new key pair.
 
 
-**(Windows Users) Tunneling into the Instance**
+(Windows users) Tunnel into the instance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For Windows users who do not have the ability to use ``ssh`` from the terminal, either download Cygwin or a Git Bash that has the capability to run ``ssh``:
+For Windows users who do not have the ability to use ``ssh`` from the terminal, either download `Cygwin <https://www.cygwin.com/>`_ or a Git Bash that has the capability to run ``ssh``:
 
   ::
 
     ssh -i amy_account.pem ec2-user@54.165.25.98
 
-Otherwise, download PuTTY and follow these instructions:
+PuTTY to tunnel into the instance
+'''''''''''''''''''''''''''''''''
+
+Otherwise, you can download `PuTTY <https://www.putty.org/>`_ and follow these instructions:
 
 1. Launch the PuTTY Key Generator.
 2. Load your downloaded AWS pem key file.
 
- **Note:** To see the file, change the browser file type to "All".
+ .. note:: 
 
-3. Save the private key as a .ppk file.
+  To see the file, change the browser file type to "All".
+
+3. Save the private key as a PPK file.
 
  .. figure:: ../EC2_images/ec2_putty_key.png
-    :alt: Private Key
+    :alt: PuTTy key generator with a PuTTYgen notice about successfully importing a foreign key.
 
 4. Launch the PuTTY client.
-5. In the *Session* section, enter the host name or IP address. For Ubuntu users, the default host name is ``ubuntu@<ip-address>``. For Linux users, the default host name is ``ec2-user@<ip-address>``.
+5. Enter the host name or IP address in the *Session* section. For Ubuntu users, the default host name is ``ubuntu@<ip-address>``. For Linux users, the default host name is ``ec2-user@<ip-address>``.
 
  .. figure:: ../EC2_images/ec2_putty_connect_1.png
-    :alt: Configuring Session
+    :alt: PuTTY configuring session with default settings in the saved sessions section and the host name filled in.
 
 6. Select *SSH*, then *Auth* in the sidebar, and click the **Browse** button to select the private key file for authentication.
 
  .. figure:: ../EC2_images/ec2_putty_connect_2.png
+  :alt: PuTTY configuration with display pre-authentication banner and attempt authentication using Pageant selected.
 
-7. Start a new session and click the **Yes** button to confirm caching of the server's rsa2 key fingerprint and continue connecting.
+7. Start a new session and click **Yes** to confirm caching of the server's rsa2 key fingerprint and continue connecting.
 
  .. figure:: ../EC2_images/ec2_putty_alert.png
-    :alt: PuTTY Alert
+    :alt: PuTTY security alert about the server's host key not cached in the registry.
 
 
 Downloading Java and H2O
-''''''''''''''''''''''''
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Download `Java <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements>`__ (JDK 1.8 or later) if it is not already available on the instance.
-2. To download H2O, run the ``wget`` command with the link to the zip file available on our `website <http://h2o.ai/download/>`__ by copying the link associated with the **Download** button for the selected H2O build.
+2. Download H2O with the ``wget`` command and the link to the ZIP file available on our `website <http://h2o.ai/download/>`__ by copying the link associated with the **Download** button for the selected H2O build.
 
    ::
 
@@ -331,5 +348,5 @@ Downloading Java and H2O
        cd h2o-{{project_version}}
        java -Xmx4g -jar h2o.jar
 
-3. From your browser, navigate to ``<Private_IP_Address>:54321`` or ``<Public_DNS>:54321`` to use H2O's web interface.
+3. Navigate to ``<Private_IP_Address>:54321`` or ``<Public_DNS>:54321`` to use H2O's web interface from your browser.
 

--- a/h2o-docs/src/product/cloud-integration/gcs.rst
+++ b/h2o-docs/src/product/cloud-integration/gcs.rst
@@ -1,14 +1,14 @@
-Using H2O with Google Cloud Storage
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Use H2O with Google Cloud Storage
+=================================
 
 To use the Google Cloud Storage solution, you will have to ensure your GCS credentials are provided to H2O. This will allow you to access your data on GCS when importing data frames with path prefixes ``gs://...``.
 
-Under the hood **https://github.com/google/google-auth-library-java** is used to authenticate requests. It supports a wide range of authentication types.
+Under the hood, **https://github.com/google/google-auth-library-java** is used to authenticate requests. It supports a wide range of authentication types.
 
 The following are searched (in order) to find the Application Default Credentials:
 
-  * Credentials file pointed to by the ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable
-  * Credentials provided by the Google Cloud SDK ``gcloud auth application-default login`` command
-  * Google App Engine built-in credentials
-  * Google Cloud Shell built-in credentials
-  * Google Compute Engine built-in credentials
+  - Credentials file pointed to by the ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable
+  - Credentials provided by the Google Cloud SDK ``gcloud auth application-default login`` command
+  - Google App Engine built-in credentials
+  - Google Cloud Shell built-in credentials
+  - Google Compute Engine built-in credentials

--- a/h2o-docs/src/product/cloud-integration/google-compute.rst
+++ b/h2o-docs/src/product/cloud-integration/google-compute.rst
@@ -1,29 +1,31 @@
 .. _install-on-google-cloud:
 
-Install H2O on the Google Cloud Platform Offering
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Install H2O on the Google Cloud Platform offering
+=================================================
 
 This section describes how to install and start H2O Flow (H2O-3 web offering) in a Google Compute environment using the available Cloud Launcher offering.
 
-Before You Begin
-''''''''''''''''
+Before you begin
+----------------
 
-If you are trying GCP for the first time and have just created an account, please check your Google Compute Engine (GCE) resource quota limits. Our default recommendation for launching H2O-3 is 4 CPUs, 15 GB RAM, and 3 nodes. By default, GCP allocates a maximum of 8 CPUs, so most H2O-3 users can easily run without reaching a quota limit. Some users of H2O, however, may require more resources. If necessary, you can change these settings to match your quota limit, or you can request more resources from GCP. Refer to https://cloud.google.com/compute/quotas for more information, including information on how to check your quota and request additional quota.
+If you are trying GCP for the first time and have just created an account, please check your Google Compute Engine (GCE) resource quota limits. Our default recommendation for launching H2O-3 is 4 CPUs, 15 GB RAM, and 3 nodes. By default, GCP allocates a maximum of 8 CPUs, so most H2O-3 users can easily run without reaching a quota limit. Some users of H2O, however, may require more resources. If necessary, you can change these settings to match your quota limit, or you can request more resources from GCP. See the `documentation on quotas <https://cloud.google.com/compute/quotas>`__ for more information,including information on how to check your quota and request additional quota.
 
-Installation Procedure
-''''''''''''''''''''''
+Installation procedure
+----------------------
 
-1. In your browser, log in to the Google Compute Engine Console at https://console.cloud.google.com/. 
+1. In your browser, `log in to the Google Compute Engine Console <https://console.cloud.google.com/>`__. 
 
 2. In the left navigation panel, select **Marketplace**.
 
   .. image:: ../images/google_cloud_marketplace.png
+     :alt: Google Cloud Platform sidebar showing the location of Marketplace.
      :align: center
      :scale: 70%
 
 3. On the Cloud Launcher page, search for **H2O** and select the H2O-3 offering. 
 
   .. image:: ../images/google_h2o_offering.png
+     :alt: Google Cloud Platform H2O-3 cluster launcher page with blue button to launch on compute engine. There is an overview section and information about H2O.ai and its pricing.
      :align: center
 
 4. Click **Launch on Compute Engine**.
@@ -35,24 +37,28 @@ Installation Procedure
  - Specify the boot disk type and size (in GB).
  - Specify the network and subnetwork names. 
 
- Click **Deploy** when you are done. H2O-3 will begin deploying. Note that this can take several minutes. 
+5. Click **Deploy** when you are done. H2O-3 will begin deploying. This can take several minutes. 
 
  .. image:: ../images/google_deploy_compute_engine.png
+  :alt: H2O-3 cluster launcher deployment page with the deloyment settings on the left and the cluster launcher overview on the right.
   :align: center
 
-5. A summary page displays when the compute engine is successfully deployed. This page includes the instance ID and the username (always **h2oai**) and password that will be required when starting H2O-3. Click on the Instance link to retrieve the external IP address for starting H2O-3.
+6. A summary page displays when the compute engine is successfully deployed. This page includes the instance ID and the username (always **h2oai**) and password that will be required when starting H2O-3. Click on the Instance link to retrieve the external IP address for starting H2O-3.
 
   .. image:: ../images/google_deploy_summary.png
+     :alt: H2O-3 cluster summary page outlining cluster information (such as instance ID, instance zone, username/password, etc), get started next steps, a link to documentation, and support.
      :align: center
 
-6. Connecto to the H2O-3 Cluster using one of the following methods:
+7. Connect to to the H2O-3 Cluster using one of the following methods:
 
 .. tabs::
-  .. group-tab:: R
+  .. group-tab:: Flow
 
-    .. code-block:: bash
+    In your browser, go to https://[External_IP]:54321 to start Flow. Enter your username and password when prompted. 
 
-       h2o.connect(ip="[external ip]", port=54321, https=TRUE, username=username, password=password)
+    .. note:: 
+
+      When starting H2O Flow, you may receive a message indicating that the connection is not private. Note that the connection is secure and encrypted, but H2O uses a self-signed certificate to handle Nginx encryption, which prompts the warning. You can avoid this message by using your own self-signed certificate. 
 
   .. group-tab:: Python
 
@@ -60,8 +66,9 @@ Installation Procedure
 
        h2o.connect(url="https://[external ip]:54321", auth=(username, password))
 
-  .. group-tab:: Flow
+  .. group-tab:: R
 
-    In your browser, go to https://[External_IP]:54321 to start Flow. Enter your username and password when prompted. 
+    .. code-block:: bash
 
-    **Note**: When starting H2O Flow, you may receive a message indicating that the connection is not private. Note that the connection is secure and encrypted, but H2O uses a self-signed certificate to handle Nginx encryption, which prompts the warning. You can avoid this message by using your own self-signed certificate. 
+       h2o.connect(ip="[external ip]", port=54321, https=TRUE, username=username, password=password)
+

--- a/h2o-docs/src/product/cloud-integration/ibm-dsx.rst
+++ b/h2o-docs/src/product/cloud-integration/ibm-dsx.rst
@@ -1,32 +1,40 @@
-Using H2O with IBM Data Science Experience
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Use H2O with IBM Data Science Experience
+========================================
 
 The IBM Data Science Experience (DSX) provides an interactive, collaborative, cloud-based environment where data scientists can use multiple tools to activate their insights. With DSX, Data scientists can use the best of open source tools such as R and Python, tap into IBMs unique features, grow their capabilities, and share their successes.
 
-This section shows how simple it is to use H2O R with IBM DSX.
+H2O R with IBM DSX
+------------------
 
-1. Sign in to `datascience.ibm.com <http://datascience.ibm.com>`__. (Or select **Sign Up** if you do not yet have an account.)
+This section shows how to use H2O R with IBM DSX.
+
+1. Sign in to `DSX <http://datascience.ibm.com>`__ (or select **Sign Up** if you do not yet have an account).
 
   .. figure:: ../images/ibm-datasciencesite.png
-      :alt: Sign in
+      :alt: Sign in/sign up page for IBM Data Science Experience. 
 
 2. Click the dropdown in the upper-left corner, and select RStudio.
 
   .. figure:: ../images/ibm-select-r-studio.png
-      :alt: Start RStudio
+      :alt: How to start RStudio from the left sidebar. This covers the DSX Community page.
 
-3. Install and start H2O R using the instructions included on the `H2O Download site <http://h2o-release.s3.amazonaws.com/h2o/latest_stable.html>`__. Note that this page opens by default to the **Download and Run** tab. Be sure to select the **Install in R** tab for R installation instructions. |install|
+3. Install and start H2O R using the instructions included on the `H2O Download site <http://h2o-release.s3.amazonaws.com/h2o/latest_stable.html>`__. This page opens by default to the **Download and Run** tab. Be sure to select the **Install in R** tab for R installation instructions. |install|
 
-  You can also view a quick start video of installing and starting H2O in R by clicking `here <https://www.youtube.com/embed/zzV1kTCnmR0?list=PLNtMya54qvOHbBdA1x8FNRSpMBEHmhxr0>`__.
+  You can also `view a quick start video of installing and starting H2O in R <https://www.youtube.com/embed/zzV1kTCnmR0?list=PLNtMya54qvOHbBdA1x8FNRSpMBEHmhxr0>`__.
 
   .. |install| image:: ../images/ibm_install_in_r.png
      :height: 24
      :width: 204
 
   .. figure:: ../images/ibm-start-h2o.png
-      :alt: Install and start H2O
+      :alt: Install and start H2O in RStudio launched from DSX. The console shows the startup sequence from launching H2O-3.
 
-After H2O is installed and running, you are ready to use H2O in DSX! Refer to any of the following references for more information about using H2O with R:
+After H2O is installed and running, you are ready to use H2O in DSX! 
+
+Additional resources
+~~~~~~~~~~~~~~~~~~~~
+
+Refer to any of the following references for more information about using H2O with R:
 
 - `New User Quick Start <https://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#new-user-quick-start>`__
 - `R Booklet <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/booklets/RBooklet.pdf>`__

--- a/h2o-docs/src/product/cloud-integration/nimbix.rst
+++ b/h2o-docs/src/product/cloud-integration/nimbix.rst
@@ -1,5 +1,5 @@
-Using H2O with Nimbix
-~~~~~~~~~~~~~~~~~~~~~
+Use H2O with Nimbix
+===================
 
 The Nimbix Cloud is a high performance computing (HPC) platform. Through either a portal or a processing API, the Nimbix Cloud runs compute-intensive applications on bare-metal machines. These applications can include CPU, GPU, FPGA systems, or a supercomputing cluster.
 
@@ -10,17 +10,19 @@ This section shows to run H2O on the Nimbix Cloud and walks you through the foll
 - Pulling applications
 - Running applications
 
-This assumes that you have a Nimbix account. If you do not, then contact your administrator or sign up for one at `http://www.nimbix.net <https://www.nimbix.net/>`__.
+.. note::
 
-Initial Setup
-'''''''''''''
+   This assumes that you have a `Nimbix account <http://www.nimbix.net>`__. If you do not, then contact your administrator or sign up for one.
 
-1. Log in to your Nimbix account at `https://mc.jarvice.com/ <https://mc.jarvice.com/>`__.
+Initial setup
+-------------
+
+1. Log in to your `Nimbix account <https://mc.jarvice.com/>`__.
 
 2. Click the **Nimbix** logo in the upper right corner to expand the Nimbix sidebar.
 
    .. figure:: ../images/nimbix_menu_bar.png
-      :alt: Nimbix menu
+      :alt: Nimbix menu with compute, dashboard, pushtocompute, account, log out, and recent as available options.
       :height: 337
       :width: 153
 
@@ -28,81 +30,95 @@ Initial Setup
 
   Your API key is important for SFTP file transfer. Every account has a specific file storage that is distributed among all of your applications. To access this, you can use SFTP on the command-line or another SFTP client such as Cyberduck or Filezilla.
 
-  Example: 
+Example
+~~~~~~~
 
-  ::
+::
 
-    sftp <username>@drop.jarvice.com
-    password: <API KEY>
+   sftp <username>@drop.jarvice.com
+   password: <API KEY>
 
-  **Warning**: To avoid issues with Jupyter Notebooks opening to an empty folder, we suggest placing at least 1 file into your file storage before continuing.
+.. warning::
+   
+   To avoid issues with Jupyter Notebooks opening to an empty folder, we suggest placing at least 1 file into your file storage before continuing.
 
-  Alternatively, you can launch the Nimbix File Manager, which is a GUI based application that runs inside of Nimbix. 
+   Alternatively, you can launch the Nimbix File Manager, which is a GUI based application that runs inside of Nimbix. 
 
-Initial Application Creation
-''''''''''''''''''''''''''''
+Initial application creation
+----------------------------
 
-This section describes how to create the following applications. Note that when specifying the Docker repository, H2O.ai principal repo is "opsh2oai", and all h2o images have "nae" appended. 
+This section describes how to create the following applications. 
 
-- H2o3 Core: Docker repository opsh2oai/h2o3-nae
-- H2oAI: Docker repository opsh2oai/h2oai_nae
+.. note::
+   
+   When specifying the Docker repository, H2O.ai principal repo is "``opsh2oai``", and all h2o images have "``nae``" appended. 
+
+- H2O-3 Core: Docker repository ``opsh2oai/h2o3-nae``
+- H2OAI: Docker repository ``opsh2oai/h2oai_nae``
 
 1. In the right-side menu, select the **PushToCompute™** menu option, then click the **New** icon. 
 
    .. figure:: ../images/nimbix_new.png
-      :alt: New application
+      :alt: New application button on Nimbux menu.
       :height: 159
       :width: 200
 
-2. Specify a name for your application, for example "h2o3".
-3. Enter the docker repository. For example "opsh2oai/h2o3_nae".
+2. Specify a name for your application (for example "h2o3").
+3. Enter the docker repository (for example "``opsh2oai/h2o3_nae``").
 4. Select "Intel x86 64-bit (x86_64)" from the **System Architecture** drop down.
 
    .. figure:: ../images/nimbix_create_app.png
-      :alt: Create application
+      :alt: Create application panel where you name your app ID, docker repo, git source, and system architecture.
       :height: 307
       :width: 458
 
 5. Click **OK** when you are done. 
 6. Repeat steps 1 through 5 for the following applications:
 
- - H2oAI: Docker repository opsh2oai/h2oai_nae
- - H2o3 for Power8: Docker repository opsh2oai/h2o3_power_nae. **Note**: For H2o3 for Power8, DO NOT use "Intel x86 64-bit (x86_64)". Instead, select "IBM Power 64-bit, Little Endian (ppc64le)" from the **System Architecture** drop-down menu.
+ - H2OAI: Docker repository ``opsh2oai/h2oai_nae``.
+ - H2O-3 for Power8: Docker repository ``opsh2oai/h2o3_power_nae``. 
 
-Pull Applications
-'''''''''''''''''
+ .. note::
+
+   For H2O-3 for Power8, don't use "Intel x86 64-bit (x86_64)". Instead, select "IBM Power 64-bit, Little Endian (ppc64le)" from the **System Architecture** drop-down menu.
+
+Pull applications
+-----------------
 
 After applications are created, the next step is to pull each application. For each application, click the menu icon (three lines) in the upper-left corner of the application, then click **Pull**. 
 
 .. figure:: ../images/nimbix_pull.png
-   :alt: Pull application
+   :alt: Pull application button on the All Apps page.
    :height: 347
    :width: 374
 
 Once you start a pull, you will receive an email from Nimbix stating that a Pull has been scheduled followed by another when the Pull is completed. After you receive the final email stating that the Pull has completed, your application is ready to use.
 
-**Note**: To avoid UI issues with Nimbix, we recommend logging out and then logging back in to ensure that the template and UI for the Application has been properly loaded into the NAE framework.
+.. note::
+   
+   To avoid UI issues with Nimbix, we recommend logging out and then logging back in to ensure that the template and UI for the Application have been properly loaded into the NAE framework.
 
-Running Applications
-''''''''''''''''''''
+Running applications
+--------------------
 
-This section shows how easy it is to run applications after they are built and pulled.
+This section shows how to run applications after they are built and pulled.
 
 1. Select the Application and the desired launch type (for example Batch, H2O-3 Cluster, Jupyter Notebook, or SSH).
 
-
   .. figure:: ../images/nimbix_start_app.png
-     :alt: Start application
+     :alt: Start application panel where you select which application launch type you would like.
      :height: 312
      :width: 551
 
 2. Select the Machine Type and the number of cores, then click **Submit**.
 
   .. figure:: ../images/nimbix_machine_type.png
-     :alt: Select machine type and number of cores
+     :alt: Select machine type and number of cores for the H2O-3 cluster.
      :height: 194
      :width: 416
 
 That's it! At this point, you are now running your H2O applications in Nimbix.
 
-**Warning**: Be sure to shut off your instances when you are done. 
+.. warning::
+   
+   Be sure to shut off your instances when you are done. 


### PR DESCRIPTION
#16186 

This PR updates the cloud integration pages to adhere to the style guide.

Question: I was testing out all the links and found that the ones for the IBM Data Science Experience page kept 404-ing. I tried to find it by searching IBM and couldn't. Any idea on if that still exists?

Another question: On nimbux, the repo we mention doesn't exist anymore: ``opsh2oai``. Any idea what it is now?