### PR TITLE
Fix security vulnerabilities in `h2o-3:3.46.0.2` 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ doUploadUBenchResults=false
 #
 # Internal Nexus location
 #
-localNexusLocation=http://nexus.0xdata.loc:8081/nexus/repository
+localNexusLocation=http://nexus.h2o.local:8081/nexus/repository
 
 #
 # Public Nexus location
@@ -60,7 +60,7 @@ defaultWebserverModule=h2o-jetty-9
 jetty8version=8.2.0.v20160908
 # jetty 9 version is used for compilation of h2o-jetty-9 module and serves as base jetty hadoop version for hadoop 3.0 
 # packages. Each hadoop package can upgrade its jetty version.
-jetty9version=9.4.11.v20180605
+jetty9version=9.4.54.v20240208
 # jetty 9 version is used in the main standalone assembly
 jetty9MainVersion=9.4.53.v20231009
 # jetty-minimal 9 version is used in the minimal standalone assembly


### PR DESCRIPTION
Port PR https://github.com/h2oai/h2o-3/pull/16294 to `driverlessai-3.46.0.2` branch to fix CVE-2023-40167, CVE-2023-26048, CVE-2023-44487, CVE-2023-41900, CVE-2023-40167 security vulnerabilities.