### PR TITLE
GH-16312 constrainted glm issues [nocheck]

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/ComputationState.java
+++ b/h2o-algos/src/main/java/hex/glm/ComputationState.java
@@ -91,7 +91,6 @@ public final class ComputationState {
   int _totalBetaLength; // actual coefficient length without taking into account active columns only
   int _betaLengthPerClass;
   public boolean _noReg;
-  public boolean _hasConstraints;
   public ConstrainedGLMUtils.ConstraintGLMStates _csGLMState;
   
   public ComputationState(Job job, GLMParameters parms, DataInfo dinfo, BetaConstraint bc, GLM.BetaInfo bi){
@@ -1414,7 +1413,7 @@ public final class ComputationState {
     double obj_reg = _parms._obj_reg;
     if(_glmw == null) _glmw = new GLMModel.GLMWeightsFun(_parms);
     GLMTask.GLMIterationTask gt = new GLMTask.GLMIterationTask(_job._key, activeData, _glmw, beta,
-            _activeClass, _hasConstraints).doAll(activeData._adaptedFrame);
+            _activeClass).doAll(activeData._adaptedFrame);
     gt._gram.mul(obj_reg);
     if (_parms._glmType.equals(GLMParameters.GLMType.gam)) { // add contribution from GAM smoothness factor
         Integer[] activeCols=null;
@@ -1463,7 +1462,7 @@ public final class ComputationState {
     double obj_reg = _parms._obj_reg;
     if(_glmw == null) _glmw = new GLMModel.GLMWeightsFun(_parms);
     GLMTask.GLMIterationTask gt = new GLMTask.GLMIterationTask(_job._key, activeData, _glmw, beta,
-            _activeClass, _hasConstraints).doAll(activeData._adaptedFrame);
+            _activeClass).doAll(activeData._adaptedFrame);
     double[][] fullGram = gt._gram.getXX(); // only extract gram matrix
     mult(fullGram, obj_reg);
     if (_gramEqual != null)

--- a/h2o-algos/src/main/java/hex/glm/ConstrainedGLMUtils.java
+++ b/h2o-algos/src/main/java/hex/glm/ConstrainedGLMUtils.java
@@ -723,7 +723,7 @@ public class ConstrainedGLMUtils {
       state._csGLMState._epsilonkCS = state._csGLMState._epsilonkCS/state._csGLMState._ckCS;
       state ._csGLMState._etakCS = state._csGLMState._etakCS/Math.pow(state._csGLMState._ckCS, parms._constraint_beta);
     } else {  // implement line 31 to 34 of Algorithm 19.1
-      state._csGLMState._ckCS = state._csGLMState._ckCS*parms._constraint_tau;
+      state._csGLMState._ckCS = state._csGLMState._ckCS*parms._constraint_tau; // tau belongs to [4,10]
       state._csGLMState._ckCSHalf = state._csGLMState._ckCS*0.5;
       state._csGLMState._epsilonkCS = state._csGLMState._epsilon0/state._csGLMState._ckCS;
       state._csGLMState._etakCS = parms._constraint_eta0/Math.pow(state._csGLMState._ckCS, parms._constraint_alpha);
@@ -813,13 +813,14 @@ public class ConstrainedGLMUtils {
     if (equalityConstraints != null) // equality constraints
       Arrays.stream(equalityConstraints).forEach(constraint -> {
         evalOneConstraint(constraint, betaCnd, coefNames);
-        constraint._active = (Math.abs(constraint._constraintsVal) > EPS2);
+       // constraint._active = (Math.abs(constraint._constraintsVal) > EPS2);
+        constraint._active = true;
       });
 
     if (lessThanEqualToConstraints != null) // less than or equal to constraints
       Arrays.stream(lessThanEqualToConstraints).forEach(constraint -> {
         evalOneConstraint(constraint, betaCnd, coefNames);
-        constraint._active = constraint._constraintsVal > 0;
+        constraint._active = constraint._constraintsVal >= 0;
       });
   }
   

--- a/h2o-algos/src/main/java/hex/glm/ConstrainedGLMUtils.java
+++ b/h2o-algos/src/main/java/hex/glm/ConstrainedGLMUtils.java
@@ -645,6 +645,16 @@ public class ConstrainedGLMUtils {
     }
   }
   
+  public static void adjustLambda(LinearConstraints[] constraints, double[] lambda) {
+    int numC = constraints.length;
+    LinearConstraints oneC;
+    for (int index=0; index<numC; index++) {
+      oneC = constraints[index];
+      if (!oneC._active)
+        lambda[index]=0.0;
+    }
+  }
+  
   
   public static double[][] sumGramConstribution(ConstraintsGram[] gramConstraints, int numCoefs) {
     if (gramConstraints == null)

--- a/h2o-algos/src/main/java/hex/glm/ConstrainedGLMUtils.java
+++ b/h2o-algos/src/main/java/hex/glm/ConstrainedGLMUtils.java
@@ -140,32 +140,32 @@ public class ConstrainedGLMUtils {
     boolean bothEndsPresent = (betaC._betaUB != null) && (betaC._betaLB != null);
     boolean lowerEndPresentOnly = (betaC._betaUB == null) && (betaC._betaLB != null);
     boolean upperEndPresentOnly = (betaC._betaUB != null) && (betaC._betaLB == null);
-    if (betaC._betaLB != null) {
-      int numCons = betaC._betaLB.length - 1;
-      for (int index = 0; index < numCons; index++) {
-        if (bothEndsPresent && !Double.isInfinite(betaC._betaUB[index]) && (betaC._betaLB[index] == betaC._betaUB[index])) { // equality constraint
-          addBCEqualityConstraint(equalityC, betaC, coefNames, index);
-          betaIndexOnOff.add(1);
-        } else if (bothEndsPresent && !Double.isInfinite(betaC._betaUB[index]) && !Double.isInfinite(betaC._betaLB[index]) &&
-                (betaC._betaLB[index] < betaC._betaUB[index])) { // low < beta < high, generate two lessThanEqualTo constraints
-          addBCGreaterThanConstraint(lessThanEqualToC, betaC, coefNames, index);
-          addBCLessThanConstraint(lessThanEqualToC, betaC, coefNames, index);
-          betaIndexOnOff.add(1);
-          betaIndexOnOff.add(0);
-        } else if ((lowerEndPresentOnly || (betaC._betaUB != null && Double.isInfinite(betaC._betaUB[index]))) && 
-                betaC._betaLB != null && !Double.isInfinite(betaC._betaLB[index])) {  // low < beta < infinity
-          addBCGreaterThanConstraint(lessThanEqualToC, betaC, coefNames, index);
-          betaIndexOnOff.add(1);
-        } else if ((upperEndPresentOnly || (betaC._betaLB != null && Double.isInfinite(betaC._betaLB[index]))) && 
-                betaC._betaUB != null && !Double.isInfinite(betaC._betaUB[index])) { // -infinity < beta < high
-          addBCLessThanConstraint(lessThanEqualToC, betaC, coefNames, index);
-          betaIndexOnOff.add(1);
-        }
+
+    int numCons = betaC._betaLB != null ? betaC._betaLB.length - 1 : betaC._betaUB.length - 1;
+    for (int index = 0; index < numCons; index++) {
+      if (bothEndsPresent && !Double.isInfinite(betaC._betaUB[index]) && (betaC._betaLB[index] == betaC._betaUB[index])) { // equality constraint
+        addBCEqualityConstraint(equalityC, betaC, coefNames, index);
+        betaIndexOnOff.add(1);
+      } else if (bothEndsPresent && !Double.isInfinite(betaC._betaUB[index]) && !Double.isInfinite(betaC._betaLB[index]) &&
+              (betaC._betaLB[index] < betaC._betaUB[index])) { // low < beta < high, generate two lessThanEqualTo constraints
+        addBCGreaterThanConstraint(lessThanEqualToC, betaC, coefNames, index);
+        addBCLessThanConstraint(lessThanEqualToC, betaC, coefNames, index);
+        betaIndexOnOff.add(1);
+        betaIndexOnOff.add(0);
+      } else if ((lowerEndPresentOnly || (betaC._betaUB != null && Double.isInfinite(betaC._betaUB[index]))) &&
+              betaC._betaLB != null && !Double.isInfinite(betaC._betaLB[index])) {  // low < beta < infinity
+        addBCGreaterThanConstraint(lessThanEqualToC, betaC, coefNames, index);
+        betaIndexOnOff.add(1);
+      } else if ((upperEndPresentOnly || (betaC._betaLB != null && Double.isInfinite(betaC._betaLB[index]))) &&
+              betaC._betaUB != null && !Double.isInfinite(betaC._betaUB[index])) { // -infinity < beta < high
+        addBCLessThanConstraint(lessThanEqualToC, betaC, coefNames, index);
+        betaIndexOnOff.add(1);
       }
     }
+
     state.setLinearConstraints(equalityC.toArray(new LinearConstraints[0]),
             lessThanEqualToC.toArray(new LinearConstraints[0]), true);
-    return betaIndexOnOff.size()==0 ? null : betaIndexOnOff.stream().mapToInt(x->x).toArray();
+    return betaIndexOnOff.size() == 0 ? null : betaIndexOnOff.stream().mapToInt(x -> x).toArray();
   }
 
   /***

--- a/h2o-algos/src/main/java/hex/glm/ConstrainedGLMUtils.java
+++ b/h2o-algos/src/main/java/hex/glm/ConstrainedGLMUtils.java
@@ -84,7 +84,7 @@ public class ConstrainedGLMUtils {
     double _ckCS;
     double _ckCSHalf; // = ck/2
     double _epsilonkCS;
-    double _epsilonkCSSquare;
+    public double _epsilonkCSSquare;
     double _etakCS;
     double _etakCSSquare;
     double _epsilon0;
@@ -714,8 +714,8 @@ public class ConstrainedGLMUtils {
                                                 LinearConstraints[] equalConst, LinearConstraints[] lessThanConst, 
                                                 GLMModel.GLMParameters parms) {
     // calculate ||h(beta)|| square, ||gradient|| square
-    double hBetaMag = state._csGLMState._constraintMagSquare;
-    if (hBetaMag <= state._csGLMState._etakCSSquare) {  // implement line 26 to line 29 of Algorithm 19.1
+    double hBetaMagSquare = state._csGLMState._constraintMagSquare;
+    if (hBetaMagSquare <= state._csGLMState._etakCSSquare) {  // implement line 26 to line 29 of Algorithm 19.1
       if (equalConst != null)
         updateLambda(lambdaEqual, state._csGLMState._ckCS, equalConst);
       if (lessThanConst != null)

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -4609,6 +4609,8 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       double[] coeffs = _parms._standardize ? _model._output.getNormBeta() :_model._output.beta();
       if (coeffs == null)
         return;
+      if (bc._betaLB == null && bc._betaUB == null)
+        return;
       int coeffsLen = bc._betaLB != null ? bc._betaLB.length : bc._betaUB.length;
       StringBuffer errorMessage = new StringBuffer();
       boolean lowerBoundNull = bc._betaLB == null;

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -1403,7 +1403,8 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
     }
     // no regularization for constrainted GLM except during testing
     if ((notZeroLambdas(_parms._lambda) || _parms._lambda_search) && !_parms._testCSZeroGram) {
-      error("lambda or lambda_search", "Regularization is not allowed for constrained GLM.");
+      error("lambda or lambda_search", "Regularization is not allowed for constrained GLM.  Set" +
+              " lambda to 0.0.");
       return;
     }
     if ("multinomial".equals(_parms._solver) || "ordinal".equals(_parms._solver)) {
@@ -2353,7 +2354,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
      * hereby use the word the doc to refere to this document.  In particular, we following the algorithm described in
      * Section VII (and table titled Algorithm 19.1) of the doc.  Not as good as when considering magnitude of gradient.
      */
-    private void fitIRLSMCS() {
+    private void fitIRLSMCS9() {
       double[] betaCnd = _checkPointFirstIter ? _model._betaCndCheckpoint : _state.beta();
       double[] tempBeta = _parms._separate_linear_beta ? new double[betaCnd.length] : null;
       List<String> coefNames = Arrays.stream(_state.activeData()._coefNames).collect(Collectors.toList());
@@ -2646,7 +2647,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
     // original implementation but will not quit when magnitude of gradient is small.  If exit condition is triggered 
     // (either ls failed or no progress is made, if the magnitude of gradient is small, we will exit thw while loop
     // but will arrive at the part to change the constrained parameters.  This seems to help.
-    private void fitIRLSMCS4() {
+    private void fitIRLSMCS() {
       double[] betaCnd = _checkPointFirstIter ? _model._betaCndCheckpoint : _state.beta();
       double[] tempBeta = _parms._separate_linear_beta ? new double[betaCnd.length] : null;
       List<String> coefNames = Arrays.stream(_state.activeData()._coefNames).collect(Collectors.toList());

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -2353,7 +2353,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
      * hereby use the word the doc to refere to this document.  In particular, we following the algorithm described in
      * Section VII (and table titled Algorithm 19.1) of the doc.
      */
-    private void fitIRLSMCS() {
+    private void fitIRLSMCS3() {
       double[] betaCnd = _checkPointFirstIter ? _model._betaCndCheckpoint : _state.beta();
       double[] tempBeta = _parms._separate_linear_beta ? new double[betaCnd.length] : null;
       List<String> coefNames = Arrays.stream(_state.activeData()._coefNames).collect(Collectors.toList());
@@ -2447,8 +2447,8 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
             lineSearchSuccess = ls.findAlpha(lambdaEqual, lambdaLessThan, _state, equalityConstraints, 
                     lessThanEqualToConstraints, ginfo);
             gradMagSquare = ArrayUtils.innerProduct(ls._ginfoOriginal._gradient, ls._ginfoOriginal._gradient);
-            gradSmallEnough = gradMagSquare <= _state._csGLMState._epsilonkCSSquare;            
-            if (lineSearchSuccess || gradSmallEnough) {
+            gradSmallEnough = gradMagSquare <= _state._csGLMState._epsilonkCSSquare;
+            if (lineSearchSuccess) {
               betaCnd = ls._newBeta;
               gradientInfo = ls._ginfoOriginal;
             } else {  // ls failed, reset to
@@ -2474,7 +2474,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
             // However, we will only exit the while loop when the gradMagSquare is still too high.  There is no hope
             // for improvement here anymore since the beta values and gradient values are not changing much anymore.
             done = stop_requested() || (_state._iter >= _parms._max_iterations) || _earlyStop;  // time to go
-            if ((!progress(betaCnd, gradientInfo) && !gradSmallEnough) || done) {
+            if (!progress(betaCnd, gradientInfo)) {
               checkKKTConditions(betaCnd, gradientInfo, iterCnt);
               return;
             }
@@ -2483,9 +2483,303 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
                     ((_lslvr != null) ? ", l1solver " + _lslvr : "")));
           } while (!gradSmallEnough);
           // update constraint parameters, ck, lambdas and others
-          updateConstraintParameters(_state, lambdaEqual, lambdaLessThan, equalityConstraints, 
+           updateConstraintParameters(_state, lambdaEqual, lambdaLessThan, equalityConstraints, 
                   lessThanEqualToConstraints, _parms);
           // update gradient calculation with new value (lambda and/or ck).
+          gradientInfo = calGradient(betaCnd, _state, ginfo, lambdaEqual, lambdaLessThan,
+                  equalityConstraints, lessThanEqualToConstraints);
+          _state.updateState(betaCnd, gradientInfo); // update computation state with new info
+        }
+      } catch (NonSPDMatrixException e) {
+        Log.warn(LogMsg("Got Non SPD matrix, stopped."));
+      }
+    }
+
+    // original implementation but will not quit when magnitude of gradient is small.  If exit condition is triggered 
+    // (either ls failed or no progress is made, if the magnitude of gradient is small, we will exit thw while loop
+    // but will arrive at the part to change the constrained parameters.
+    private void fitIRLSMCS() {
+      double[] betaCnd = _checkPointFirstIter ? _model._betaCndCheckpoint : _state.beta();
+      double[] tempBeta = _parms._separate_linear_beta ? new double[betaCnd.length] : null;
+      List<String> coefNames = Arrays.stream(_state.activeData()._coefNames).collect(Collectors.toList());
+      LinearConstraints[] equalityConstraints;
+      LinearConstraints[] lessThanEqualToConstraints;
+      final BetaConstraint bc = _state.activeBC();
+      if (_parms._separate_linear_beta) { // keeping linear and beta constraints separate in this case
+        equalityConstraints = _state._equalityConstraintsLinear;
+        lessThanEqualToConstraints = _state._lessThanEqualToConstraintsLinear;
+      } else {  // combine beta and linear constraints together
+        equalityConstraints = combineConstraints(_state._equalityConstraintsBeta, _state._equalityConstraintsLinear);
+        lessThanEqualToConstraints = combineConstraints(_state._lessThanEqualToConstraintsBeta,
+                _state._lessThanEqualToConstraintsLinear);
+      }
+      boolean hasEqualityConstraints = equalityConstraints != null;
+      boolean hasLessConstraints = lessThanEqualToConstraints != null;
+      double[] lambdaEqual = hasEqualityConstraints ? new double[equalityConstraints.length] : null;
+      double[] lambdaLessThan = hasLessConstraints ? new double[lessThanEqualToConstraints.length] : null;
+      Long startSeed = _parms._seed == -1 ? new Random().nextLong() : _parms._seed;
+      Random randObj = new Random(startSeed);
+      updateConstraintValues(betaCnd, coefNames, equalityConstraints, lessThanEqualToConstraints);
+      if (hasEqualityConstraints) // set lambda values for constraints
+        genInitialLambda(randObj, equalityConstraints, lambdaEqual);
+      if (hasLessConstraints)
+        genInitialLambda(randObj, lessThanEqualToConstraints, lambdaLessThan);
+      ExactLineSearch ls = null;
+      int iterCnt = (_checkPointFirstIter ? _state._iter : 0)+_initIter;
+      // contribution to gradient and hessian from constraints
+      _state.initConstraintDerivatives(equalityConstraints, lessThanEqualToConstraints, coefNames);
+
+      GLMGradientSolver ginfo = gam.equals(_parms._glmType) ? new GLMGradientSolver(_job, _parms, _dinfo, 0,
+              _state.activeBC(), _betaInfo, _penaltyMatrix, _gamColIndices) : new GLMGradientSolver(_job, _parms,
+              _dinfo, 0, _state.activeBC(), _betaInfo);
+      GLMGradientInfo gradientInfo = calGradient(betaCnd, _state, ginfo, lambdaEqual, lambdaLessThan,
+              equalityConstraints, lessThanEqualToConstraints); // add dpenalty/dx to gradient from penalty term
+      _state.setConstraintInfo(gradientInfo, equalityConstraints, lessThanEqualToConstraints, lambdaEqual, lambdaLessThan);  // update state ginfo with contributions from GLMGradientInfo
+      boolean predictorSizeChange;
+      boolean applyBetaConstraints = _parms._separate_linear_beta && _betaConstraintsOn;
+      // short circuit check here: if gradient magnitude is small and all constraints are satisfied, quit right away
+      if (constraintsStop(gradientInfo, _state)) {
+        Log.info(LogMsg("GLM with constraints model building completed successfully!!"));
+        return;
+      }
+      double gradMagSquare = ArrayUtils.innerProduct(gradientInfo._gradient, gradientInfo._gradient);
+      boolean done;
+      boolean gradSmallEnough = (gradMagSquare <= _state._csGLMState._epsilonkCSSquare);
+      int origIter = iterCnt+1;
+      boolean lineSearchSuccess;
+      try {
+        while (true) {
+          do { // implement Algorithm 11.8 of the doc to find coefficients with epsilon k as the precision
+            iterCnt++;
+            long t1 = System.currentTimeMillis();
+            ComputationState.GramGrad gram = _state.computeGram(betaCnd, gradientInfo);  // calculate gram (hessian), xy, objective values
+            if (iterCnt == origIter) {
+              Matrix gramMatrix = new Matrix(gram._gram);
+              if (gramMatrix.cond() >= BAD_CONDITION_NUMBER)
+                if (_parms._init_optimal_glm) {
+                  warn("init_optimal_glm", " should be disabled.  This lead to gram matrix being close to" +
+                          " singular.  Please re-run with init_optimal_glm set to false.");
+                }
+            }
+            predictorSizeChange = !coefNames.equals(Arrays.asList(_state.activeData().coefNames()));
+            if (predictorSizeChange) {  // reset if predictors changed
+              coefNames = changeCoeffBetainfo(_state.activeData()._coefNames);
+              _state.resizeConstraintInfo(equalityConstraints, lessThanEqualToConstraints);
+              ginfo = gam.equals(_parms._glmType) ? new GLMGradientSolver(_job, _parms, _state.activeData(), 0,
+                      _state.activeBC(), _betaInfo, _penaltyMatrix, _gamColIndices) : new GLMGradientSolver(_job, _parms,
+                      _state.activeData(), 0, _state.activeBC(), _betaInfo);
+              tempBeta = new double[coefNames.size()];
+            }
+            // solve for GLM coefficients
+            betaCnd = constraintGLM_solve(gram);  // beta_k+1 = beta_k+dk where dk = beta_k+1-beta_k   
+            predictorSizeChange = !coefNames.equals(Arrays.asList(_state.activeData().coefNames()));
+            if (predictorSizeChange) {  // reset if predictors changed
+              coefNames = changeCoeffBetainfo(_state.activeData()._coefNames);
+              _state.resizeConstraintInfo(equalityConstraints, lessThanEqualToConstraints);
+              ginfo = gam.equals(_parms._glmType) ? new GLMGradientSolver(_job, _parms, _state.activeData(), 0,
+                      _state.activeBC(), _betaInfo, _penaltyMatrix, _gamColIndices) : new GLMGradientSolver(_job, _parms,
+                      _state.activeData(), 0, _state.activeBC(), _betaInfo);
+              tempBeta = new double[betaCnd.length];
+            }
+            // add exact line search for GLM coefficients.  Refer to the doc, Algorithm 11.5
+            if (ls == null)
+              ls = new ExactLineSearch(betaCnd, _state, coefNames);
+            else
+              ls.reset(betaCnd, _state, coefNames);
+
+            // line search can fail when the gradient is close to zero.  In this case, we need to update the 
+            // constraint parameters.
+            lineSearchSuccess = ls.findAlpha(lambdaEqual, lambdaLessThan, _state, equalityConstraints,
+                    lessThanEqualToConstraints, ginfo);
+            gradMagSquare = ArrayUtils.innerProduct(ls._ginfoOriginal._gradient, ls._ginfoOriginal._gradient);
+            gradSmallEnough = gradMagSquare <= _state._csGLMState._epsilonkCSSquare;
+            if (lineSearchSuccess ||gradSmallEnough) {
+              betaCnd = ls._newBeta;
+              gradientInfo = ls._ginfoOriginal;
+            } else {  // ls failed, reset to
+              if (applyBetaConstraints) // separate beta and linear constraints
+                bc.applyAllBounds(_state.beta());
+              ls.setBetaConstraintsDeriv(lambdaEqual, lambdaLessThan, _state, equalityConstraints, lessThanEqualToConstraints,
+                      ginfo, _state.beta());
+              Log.info(LogMsg("Line search failed " + ls));
+              return;
+            }
+
+            if (applyBetaConstraints) { // if beta constraints are applied, may need to update constraints, derivatives, gradientInfo
+              System.arraycopy(betaCnd, 0, tempBeta, 0, betaCnd.length);
+              bc.applyAllBounds(betaCnd);
+              ArrayUtils.subtract(betaCnd, tempBeta, tempBeta);
+              ls.setBetaConstraintsDeriv(lambdaEqual, lambdaLessThan, _state, equalityConstraints,
+                      lessThanEqualToConstraints, ginfo, betaCnd);
+              gradientInfo = ls._ginfoOriginal;
+            }
+
+            // check for stopping conditions which also updates the variables in state.
+            // stopping condition is to stop us getting stuck in improvements that are too insignificant.
+            // However, we will only exit the while loop when the gradMagSquare is still too high.  There is no hope
+            // for improvement here anymore since the beta values and gradient values are not changing much anymore.
+            done = stop_requested() || (_state._iter >= _parms._max_iterations) || _earlyStop;  // time to go
+            if ((!progress(betaCnd, gradientInfo) && !gradSmallEnough) || done) {
+              checkKKTConditions(betaCnd, gradientInfo, iterCnt);
+              return;
+            }
+
+            Log.info(LogMsg("computed in " + (System.currentTimeMillis() - t1)  + "ms, step = " + iterCnt +
+                    ((_lslvr != null) ? ", l1solver " + _lslvr : "")));
+          } while (!gradSmallEnough);
+          // update constraint parameters, ck, lambdas and others
+          updateConstraintParameters(_state, lambdaEqual, lambdaLessThan, equalityConstraints,
+                  lessThanEqualToConstraints, _parms);
+          // update gradient calculation with new value (lambda and/or ck).
+          gradientInfo = calGradient(betaCnd, _state, ginfo, lambdaEqual, lambdaLessThan,
+                  equalityConstraints, lessThanEqualToConstraints);
+          _state.updateState(betaCnd, gradientInfo); // update computation state with new info
+        }
+      } catch (NonSPDMatrixException e) {
+        Log.warn(LogMsg("Got Non SPD matrix, stopped."));
+      }
+    }
+
+    // only has penalty and no constrained multipliers, original algorithm
+    private void fitIRLSMCS2() {
+      double[] betaCnd = _checkPointFirstIter ? _model._betaCndCheckpoint : _state.beta();
+      double[] tempBeta = _parms._separate_linear_beta ? new double[betaCnd.length] : null;
+      List<String> coefNames = Arrays.stream(_state.activeData()._coefNames).collect(Collectors.toList());
+      LinearConstraints[] equalityConstraints;
+      LinearConstraints[] lessThanEqualToConstraints;
+      final BetaConstraint bc = _state.activeBC();
+      if (_parms._separate_linear_beta) { // keeping linear and beta constraints separate in this case
+        equalityConstraints = _state._equalityConstraintsLinear;
+        lessThanEqualToConstraints = _state._lessThanEqualToConstraintsLinear;
+      } else {  // combine beta and linear constraints together
+        equalityConstraints = combineConstraints(_state._equalityConstraintsBeta, _state._equalityConstraintsLinear);
+        lessThanEqualToConstraints = combineConstraints(_state._lessThanEqualToConstraintsBeta,
+                _state._lessThanEqualToConstraintsLinear);
+      }
+      boolean hasEqualityConstraints = equalityConstraints != null;
+      boolean hasLessConstraints = lessThanEqualToConstraints != null;
+      double[] lambdaEqual = hasEqualityConstraints ? new double[equalityConstraints.length] : null;
+      double[] lambdaLessThan = hasLessConstraints ? new double[lessThanEqualToConstraints.length] : null;
+      Long startSeed = _parms._seed == -1 ? new Random().nextLong() : _parms._seed;
+      Random randObj = new Random(startSeed);
+      updateConstraintValues(betaCnd, coefNames, equalityConstraints, lessThanEqualToConstraints);
+/*
+      if (hasEqualityConstraints) // set lambda values for constraints
+        genInitialLambda(randObj, equalityConstraints, lambdaEqual);
+      if (hasLessConstraints)
+        genInitialLambda(randObj, lessThanEqualToConstraints, lambdaLessThan);
+*/
+      ExactLineSearch ls = null;
+      int iterCnt = (_checkPointFirstIter ? _state._iter : 0)+_initIter;
+      // contribution to gradient and hessian from constraints
+      _state.initConstraintDerivatives(equalityConstraints, lessThanEqualToConstraints, coefNames);
+
+      GLMGradientSolver ginfo = gam.equals(_parms._glmType) ? new GLMGradientSolver(_job, _parms, _dinfo, 0,
+              _state.activeBC(), _betaInfo, _penaltyMatrix, _gamColIndices) : new GLMGradientSolver(_job, _parms,
+              _dinfo, 0, _state.activeBC(), _betaInfo);
+      GLMGradientInfo gradientInfo = calGradient(betaCnd, _state, ginfo, lambdaEqual, lambdaLessThan,
+              equalityConstraints, lessThanEqualToConstraints); // add dpenalty/dx to gradient from penalty term
+      _state.setConstraintInfo(gradientInfo, equalityConstraints, lessThanEqualToConstraints, lambdaEqual, lambdaLessThan);  // update state ginfo with contributions from GLMGradientInfo
+      boolean predictorSizeChange;
+      boolean applyBetaConstraints = _parms._separate_linear_beta && _betaConstraintsOn;
+      // short circuit check here: if gradient magnitude is small and all constraints are satisfied, quit right away
+      if (constraintsStop(gradientInfo, _state)) {
+        Log.info(LogMsg("GLM with constraints model building completed successfully!!"));
+        return;
+      }
+      double gradMagSquare = ArrayUtils.innerProduct(gradientInfo._gradient, gradientInfo._gradient);
+      boolean done;
+      boolean gradSmallEnough = (gradMagSquare <= _state._csGLMState._epsilonkCSSquare);
+      int origIter = iterCnt+1;
+      boolean lineSearchSuccess;
+      try {
+        while (true) {
+          do { // implement Algorithm 11.8 of the doc to find coefficients with epsilon k as the precision
+            iterCnt++;
+            long t1 = System.currentTimeMillis();
+            ComputationState.GramGrad gram = _state.computeGram(betaCnd, gradientInfo);  // calculate gram (hessian), xy, objective values
+            if (iterCnt == origIter) {
+              Matrix gramMatrix = new Matrix(gram._gram);
+              if (gramMatrix.cond() >= BAD_CONDITION_NUMBER)
+                if (_parms._init_optimal_glm) {
+                  warn("init_optimal_glm", " should be disabled.  This lead to gram matrix being close to" +
+                          " singular.  Please re-run with init_optimal_glm set to false.");
+                }
+            }
+            predictorSizeChange = !coefNames.equals(Arrays.asList(_state.activeData().coefNames()));
+            if (predictorSizeChange) {  // reset if predictors changed
+              coefNames = changeCoeffBetainfo(_state.activeData()._coefNames);
+              _state.resizeConstraintInfo(equalityConstraints, lessThanEqualToConstraints);
+              ginfo = gam.equals(_parms._glmType) ? new GLMGradientSolver(_job, _parms, _state.activeData(), 0,
+                      _state.activeBC(), _betaInfo, _penaltyMatrix, _gamColIndices) : new GLMGradientSolver(_job, _parms,
+                      _state.activeData(), 0, _state.activeBC(), _betaInfo);
+              tempBeta = new double[coefNames.size()];
+            }
+            // solve for GLM coefficients
+            betaCnd = constraintGLM_solve(gram);  // beta_k+1 = beta_k+dk where dk = beta_k+1-beta_k   
+            predictorSizeChange = !coefNames.equals(Arrays.asList(_state.activeData().coefNames()));
+            if (predictorSizeChange) {  // reset if predictors changed
+              coefNames = changeCoeffBetainfo(_state.activeData()._coefNames);
+              _state.resizeConstraintInfo(equalityConstraints, lessThanEqualToConstraints);
+              ginfo = gam.equals(_parms._glmType) ? new GLMGradientSolver(_job, _parms, _state.activeData(), 0,
+                      _state.activeBC(), _betaInfo, _penaltyMatrix, _gamColIndices) : new GLMGradientSolver(_job, _parms,
+                      _state.activeData(), 0, _state.activeBC(), _betaInfo);
+              tempBeta = new double[betaCnd.length];
+            }
+            // add exact line search for GLM coefficients.  Refer to the doc, Algorithm 11.5
+            if (ls == null)
+              ls = new ExactLineSearch(betaCnd, _state, coefNames);
+            else
+              ls.reset(betaCnd, _state, coefNames);
+
+            // line search can fail when the gradient is close to zero.  In this case, we need to update the 
+            // constraint parameters.
+            lineSearchSuccess = ls.findAlpha(lambdaEqual, lambdaLessThan, _state, equalityConstraints,
+                    lessThanEqualToConstraints, ginfo);
+            if (lineSearchSuccess) {
+              betaCnd = ls._newBeta;
+              gradientInfo = ls._ginfoOriginal;
+              gradMagSquare = ArrayUtils.innerProduct(ls._ginfoOriginal._gradient, ls._ginfoOriginal._gradient);
+              gradSmallEnough = gradMagSquare <= _state._csGLMState._epsilonkCSSquare;
+            } else {  // ls failed, reset to
+              if (applyBetaConstraints) // separate beta and linear constraints
+                bc.applyAllBounds(_state.beta());
+              ls.setBetaConstraintsDeriv(lambdaEqual, lambdaLessThan, _state, equalityConstraints, lessThanEqualToConstraints,
+                      ginfo, _state.beta());
+              Log.info(LogMsg("Line search failed " + ls));
+              return;
+            }
+
+            if (applyBetaConstraints) { // if beta constraints are applied, may need to update constraints, derivatives, gradientInfo
+              System.arraycopy(betaCnd, 0, tempBeta, 0, betaCnd.length);
+              bc.applyAllBounds(betaCnd);
+              ArrayUtils.subtract(betaCnd, tempBeta, tempBeta);
+              ls.setBetaConstraintsDeriv(lambdaEqual, lambdaLessThan, _state, equalityConstraints,
+                      lessThanEqualToConstraints, ginfo, betaCnd);
+              gradientInfo = ls._ginfoOriginal;
+            }
+
+            // check for stopping conditions which also updates the variables in state.
+            // stopping condition is to stop us getting stuck in improvements that are too insignificant.
+            // However, we will only exit the while loop when the gradMagSquare is still too high.  There is no hope
+            // for improvement here anymore since the beta values and gradient values are not changing much anymore.
+            done = stop_requested() || (_state._iter >= _parms._max_iterations) || _earlyStop;  // time to go
+            if (!progress(betaCnd, gradientInfo)) {
+              checkKKTConditions(betaCnd, gradientInfo, iterCnt);
+              return;
+            }
+
+            Log.info(LogMsg("computed in " + (System.currentTimeMillis() - t1)  + "ms, step = " + iterCnt +
+                    ((_lslvr != null) ? ", l1solver " + _lslvr : "")));
+          } while (!gradSmallEnough);
+          // update constraint parameters, ck, lambdas and others
+          updateConstraintParameters(_state, lambdaEqual, lambdaLessThan, equalityConstraints,
+                  lessThanEqualToConstraints, _parms);
+          // update gradient calculation with new value (lambda and/or ck).
+          // set lambda to all zeros
+          lambdaEqual = hasEqualityConstraints ? new double[lambdaEqual.length] : null;
+          lambdaLessThan = hasLessConstraints ? new double[lambdaLessThan.length] : null;
+          
           gradientInfo = calGradient(betaCnd, _state, ginfo, lambdaEqual, lambdaLessThan,
                   equalityConstraints, lessThanEqualToConstraints);
           _state.updateState(betaCnd, gradientInfo); // update computation state with new info

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -1440,13 +1440,12 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
     String[] constraintCoefficientNames = constraintNames.toArray(new String[0]);
     if (countNumConst(_state) > coefNames.length)
       warn("number of constraints", " exceeds the number of coefficients.  The system is" +
-              " over-constraints, and probably may not yield a valid solution due to possible conflicting " +
-              "constraints.  Consider reducing the number of constraints.");
+              " over-constraints with duplicated constraints.  Consider reducing the number of constraints.");
     List<String> redundantConstraints = foundRedundantConstraints(_state, initConstraintMatrix);
     if (redundantConstraints != null) {
       int numRedundant = redundantConstraints.size();
       for (int index = 0; index < numRedundant; index++)
-        error("redundant and possibly conflicting linear constraints", redundantConstraints.get(index));
+        error("redundant linear constraints", redundantConstraints.get(index));
     } else {
       _state._csGLMState = new ConstraintGLMStates(constraintCoefficientNames, initConstraintMatrix, _parms);
     }

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -2754,7 +2754,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
               return;
             }
 
-            if (applyBetaConstraints) { // if beta constraints are applied, may need to update constraints, derivatives, gradientInfo
+            if (applyBetaConstraints) { // if beta constraints are applied separately, may need to update constraints, derivatives, gradientInfo
               System.arraycopy(betaCnd, 0, tempBeta, 0, betaCnd.length);
               bc.applyAllBounds(betaCnd);
               ArrayUtils.subtract(betaCnd, tempBeta, tempBeta);

--- a/h2o-algos/src/main/java/hex/glm/GLMTask.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMTask.java
@@ -1547,15 +1547,6 @@ public abstract class GLMTask  {
       _c = c;
     }
 
-    public  GLMIterationTask(Key jobKey, DataInfo dinfo, GLMWeightsFun glmw, double [] beta, int c, boolean hasConst) {
-      super(null,dinfo,jobKey);
-      _beta = beta;
-      _ymu = null;
-      _glmf = glmw;
-      _c = c;
-      _hasConstraints = hasConst;
-    }
-
     @Override public boolean handlesSparseData(){return true;}
 
     transient private double _sparseOffset;

--- a/h2o-algos/src/main/java/hex/optimization/OptimizationUtils.java
+++ b/h2o-algos/src/main/java/hex/optimization/OptimizationUtils.java
@@ -554,6 +554,7 @@ public class OptimizationUtils {
                              ConstrainedGLMUtils.LinearConstraints[] lessThanEqualToConstraints,
                              GLM.GLMGradientSolver gradientSolver) {
       if (_currGradDirIP > 0) {
+        _newBeta = _originalBeta;
         return false;
       }
       GLM.GLMGradientInfo newGrad;

--- a/h2o-algos/src/test/java/hex/glm/GLMConstrainedTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMConstrainedTest.java
@@ -642,7 +642,7 @@ public class GLMConstrainedTest extends TestUtil {
       Scope.track_generic(glm2);
       assert 1==2 : "Should have thrown an error due to duplicated constraints.";
     } catch(IllegalArgumentException ex) {
-      assert ex.getMessage().contains("rredundant linear constraints:") : "Wrong error message.  Error should be about" +
+      assert ex.getMessage().contains("redundant linear constraints") : "Wrong error message.  Error should be about" +
               " redundant linear constraints";
     } finally {
       Scope.exit();

--- a/h2o-algos/src/test/java/hex/glm/GLMConstrainedTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMConstrainedTest.java
@@ -614,7 +614,7 @@ public class GLMConstrainedTest extends TestUtil {
       Scope.track_generic(glm2);
       assert 1==2 : "Should have thrown an error due to duplicated constraints.";
     } catch(IllegalArgumentException ex) {
-      assert ex.getMessage().contains("redundant and possibly conflicting linear constraints") : "Wrong error message.  Error should be about" +
+      assert ex.getMessage().contains("redundant linear constraints:") : "Wrong error message.  Error should be about" +
               " redundant linear constraints";
     } finally {
       Scope.exit();
@@ -642,7 +642,7 @@ public class GLMConstrainedTest extends TestUtil {
       Scope.track_generic(glm2);
       assert 1==2 : "Should have thrown an error due to duplicated constraints.";
     } catch(IllegalArgumentException ex) {
-      assert ex.getMessage().contains("redundant and possibly conflicting linear constraints") : "Wrong error message.  Error should be about" +
+      assert ex.getMessage().contains("rredundant linear constraints:") : "Wrong error message.  Error should be about" +
               " redundant linear constraints";
     } finally {
       Scope.exit();

--- a/h2o-algos/src/test/java/hex/glm/GLMConstrainedTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMConstrainedTest.java
@@ -324,15 +324,16 @@ public class GLMConstrainedTest extends TestUtil {
                     _coeffNames1.get(19), _coeffNames1.get(20), _coeffNames1.get(21), _coeffNames1.get(22), "constant",
                     _coeffNames1.get(4), _coeffNames1.get(5), _coeffNames1.get(6), "constant", _coeffNames1.get(6),
                     _coeffNames1.get(33), _coeffNames1.get(7), _coeffNames1.get(24), _coeffNames1.get(25), "constant",
-                    _coeffNames1.get(1), _coeffNames1.get(coefLen-3), "constant"})
+                    _coeffNames1.get(1), _coeffNames1.get(coefLen-3), "constant", _coeffNames1.get(0), _coeffNames1.get(1), "constant"})
             .withDataForCol(1, new double [] {-0.3, 0.5, 1.0, -3.0, 3, -4, 0.5, 0.1, -0.2, 2.0, -0.1, -0.4,
-                    0.8, 0.1, -0.5, 0.7, -1.1, 2.0, 0.5, -0.3, 0.5, -1.5, -0.3, -1.0, 1.0, -9.0})
+                    0.8, 0.1, -0.5, 0.7, -1.1, 2.0, 0.5, -0.3, 0.5, -1.5, -0.3, -1.0, 1.0, -9.0,-1, -1, 0})
             .withDataForCol(2, new String[] {"lessthanequal", "lessthanequal", "lessthanequal", "lessthanequal",
                     "lessthanequal", "lessthanequal", "lessthanequal", "equal", "equal", "lessthanequal",
                     "lessthanequal", "lessthanequal", "lessthanequal", "equal", "equal", "equal", "equal", "equal",
-                    "equal", "equal", "equal", "equal", "equal", "lessthanequal", "lessthanequal", "lessthanequal"})
+                    "equal", "equal", "equal", "equal", "equal", "lessthanequal", "lessthanequal", "lessthanequal", 
+                    "lessthanequal", "lessthanequal", "lessthanequal"})
             .withDataForCol(3, new int[]{0, 0, 0, 0, 1, 1, 1, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 6, 6,
-                    6, 7, 7 ,7}).build();
+                    6, 7, 7 ,7, 8, 8, 8}).build();
     Scope.track(_linearConstraint4);
   }
 

--- a/h2o-py/tests/testdir_algos/glm/pyunit_GH_16312_contrained_GLM_bad_constraints_large.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_GH_16312_contrained_GLM_bad_constraints_large.py
@@ -1,0 +1,144 @@
+import h2o
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+from tests import pyunit_utils
+import numpy as np
+import pandas as pd
+
+# no need to check anything, this test just needs to run into completion duplicating/conflicting constraints
+def data_prep(seed):
+    np.random.seed(seed)
+    x1 = np.random.normal(0, 10, 100000)
+    x2 = np.random.normal(10, 100 , 100000)
+    x3 = np.random.normal(20, 200, 100000)
+    x4 = np.random.normal(30, 3000, 100000)
+    x5 = np.random.normal(400, 4000, 100000)
+
+    y_raw = np.sin(x1)*100 + np.sin(x2)*100 + x3/20 + x3/30 + x5/400
+    y = np.random.normal(y_raw, 20)
+
+    data = {
+        'x1': x1,
+        'x2': x2,
+        'x3': x3,
+        'x4': x4,
+        'x5': x5,
+        'y': y,
+    }
+    return h2o.H2OFrame(pd.DataFrame(data))
+
+def test_bad_lambda_specification():
+    train_data = data_prep(123)
+    family = 'gaussian'
+    link = 'identity'
+    nfolds = 0
+    lambda_ = 0.0
+    seed = 1234
+    calc_like = True
+    compute_p_values = True
+    solver = 'irlsm'
+    predictors = ['x1', 'x2', 'x3', 'x4', 'x5']
+    response = "y"
+
+    linear_constraints2 = []
+    
+    name = "x2"
+    values = 1
+    types = "LessThanEqual"
+    contraint_numbers = 0
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    name = "x3"
+    values = -1
+    types = "LessThanEqual"
+    contraint_numbers = 0
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    name = "constant"
+    values = 0
+    types = "LessThanEqual"
+    contraint_numbers = 0
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    name = "x3"
+    values = 1
+    types = "LessThanEqual"
+    contraint_numbers = 1
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    name = "x4"
+    values = -1
+    types = "LessThanEqual"
+    contraint_numbers = 1
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    name = "constant"
+    values = 0
+    types = "LessThanEqual"
+    contraint_numbers = 1
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    name = "x2"
+    values = 1
+    types = "LessThanEqual"
+    contraint_numbers = 2
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    name = "x3"
+    values = 1
+    types = "LessThanEqual"
+    contraint_numbers = 2
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    name = "x4"
+    values = 1
+    types = "LessThanEqual"
+    contraint_numbers = 2
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    name = "constant"
+    values = 0
+    types = "LessThanEqual"
+    contraint_numbers = 2
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    linear_constraints = h2o.H2OFrame(linear_constraints2)
+    linear_constraints.set_names(["names", "values", "types", "constraint_numbers"])
+
+    params = {
+        "family" : family,
+        "link": link,
+        "lambda_" : lambda_,
+        "seed" : seed,
+        "nfolds" : nfolds,
+        "compute_p_values" : compute_p_values,
+        "calc_like" : calc_like,
+        "solver" : solver,
+        "linear_constraints": linear_constraints    
+    }
+
+    model = glm(**params)
+    model.train(x = predictors, y = response, training_frame = train_data)
+    print(model.coef())
+    coef_constrained = model.coef()
+    print(glm.getConstraintsInfo(model))
+
+    params = {
+        "family" : family,
+        "link": link,
+        "lambda_" : lambda_,
+        "seed" : seed,
+        "nfolds" : nfolds,
+        "compute_p_values" : compute_p_values,
+        "calc_like" : calc_like,
+        "solver" : solver,
+    }
+
+    model_no_constraints = glm(**params)
+    model_no_constraints.train(x = predictors, y = response, training_frame = train_data)
+    coef_no_constraints = model_no_constraints.coef()
+    print(coef_no_constraints)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_bad_lambda_specification)
+else:
+    test_bad_lambda_specification()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_GH_16312_contrained_GLM_beta_constraint_NPE_large.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_GH_16312_contrained_GLM_beta_constraint_NPE_large.py
@@ -137,7 +137,7 @@ def test_bad_lambda_specification():
     print(coefs)
     print(glm.getConstraintsInfo(model))
     # beta constraints should be satisfied
-    assert coefs["x1"] >= 0.03, "beta constraint x1 ({0}) >= 0.03 is violated!".format(coefs["x1"])
+    assert coefs["x1"] >= 0.03 or abs(coefs["x1"]-0.03) < 1e-6, "beta constraint x1 ({0}) >= 0.03 is violated!".format(coefs["x1"])
 
     # beta constraints
     bc = []
@@ -155,7 +155,7 @@ def test_bad_lambda_specification():
     print(coefs)
     print(glm.getConstraintsInfo(model))
     # beta constraints should always be satisfied
-    assert coefs["x1"] <= 1.5, "beta constraint x1 ({0}) >= 1.5 is violated.".format(coefs["x1"])
+    assert coefs["x1"] <= 1.5 or abs(1.5-coefs["x1"])<1e-6, "beta constraint x1 ({0}) >= 1.5 is violated.".format(coefs["x1"])
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(test_bad_lambda_specification)

--- a/h2o-py/tests/testdir_algos/glm/pyunit_GH_16312_contrained_GLM_beta_constraint_NPE_large.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_GH_16312_contrained_GLM_beta_constraint_NPE_large.py
@@ -4,8 +4,8 @@ from tests import pyunit_utils
 import numpy as np
 import pandas as pd
 
-# no need to check anything, this test just needs to run into completion without NPE error for both model building
-# process where only the upper_bounds or lower_bounds are specified
+# For beta constraints, if only upper_bounds are specified, there are NPE errors because the code expects both upper
+# and lower bounds to be specified.  I have since fixed this error.
 def data_prep(seed):
     np.random.seed(seed)
     x1 = np.random.normal(0, 10, 100000)
@@ -133,8 +133,11 @@ def test_bad_lambda_specification():
 
     model = glm(**params)
     model.train(x = predictors, y = response, training_frame = train_data)
-    print(model.coef())
+    coefs = model.coef()
+    print(coefs)
     print(glm.getConstraintsInfo(model))
+    # beta constraints should be satisfied
+    assert coefs["x1"] >= 0.03, "beta constraint x1 ({0}) >= 0.03 is violated!".format(coefs["x1"])
 
     # beta constraints
     bc = []
@@ -148,8 +151,11 @@ def test_bad_lambda_specification():
     params['beta_constraints'] = beta_constraints2
     model = glm(**params)
     model.train(x = predictors, y = response, training_frame = train_data)
-    print(model.coef())
+    coefs = model.coef()
+    print(coefs)
     print(glm.getConstraintsInfo(model))
+    # beta constraints should always be satisfied
+    assert coefs["x1"] <= 1.5, "beta constraint x1 ({0}) >= 1.5 is violated.".format(coefs["x1"])
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(test_bad_lambda_specification)

--- a/h2o-py/tests/testdir_algos/glm/pyunit_GH_16312_contrained_GLM_lambda_test_large.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_GH_16312_contrained_GLM_lambda_test_large.py
@@ -1,0 +1,131 @@
+import h2o
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+from tests import pyunit_utils
+import numpy as np
+import pandas as pd
+
+# no need to check anything, this test just needs to run into completion without NPE error.
+def data_prep(seed):
+    np.random.seed(seed)
+    x1 = np.random.normal(0, 10, 100000)
+    x2 = np.random.normal(10, 100 , 100000)
+    x3 = np.random.normal(20, 200, 100000)
+    x4 = np.random.normal(30, 3000, 100000)
+    x5 = np.random.normal(400, 4000, 100000)
+
+    y_raw = np.sin(x1)*100 + np.sin(x2)*100 + x3/20 + x3/30 + x5/400
+    y = np.random.normal(y_raw, 20)
+
+    data = {
+        'x1': x1,
+        'x2': x2,
+        'x3': x3,
+        'x4': x4,
+        'x5': x5,
+        'y': y,
+    }
+    return h2o.H2OFrame(pd.DataFrame(data))
+
+def test_bad_lambda_specification():
+    train_data = data_prep(123)
+    family = 'gaussian'
+    link = 'identity'
+    nfolds = 0
+    lambda_ = 0.0
+    seed = 1234
+    calc_like = True
+    compute_p_values = True
+    solver = 'irlsm'
+    predictors = ['x1', 'x2', 'x3', 'x4', 'x5']
+    response = "y"
+
+    linear_constraints2 = []
+    
+    name = "x2"
+    values = 1
+    types = "LessThanEqual"
+    contraint_numbers = 0
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    name = "x3"
+    values = -1
+    types = "LessThanEqual"
+    contraint_numbers = 0
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    name = "constant"
+    values = 0
+    types = "LessThanEqual"
+    contraint_numbers = 0
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    name = "x3"
+    values = 1
+    types = "LessThanEqual"
+    contraint_numbers = 1
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    name = "x4"
+    values = -1
+    types = "LessThanEqual"
+    contraint_numbers = 1
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    name = "constant"
+    values = 0
+    types = "LessThanEqual"
+    contraint_numbers = 1
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    name = "x2"
+    values = 1
+    types = "LessThanEqual"
+    contraint_numbers = 2
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    name = "x3"
+    values = 1
+    types = "LessThanEqual"
+    contraint_numbers = 2
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    name = "x4"
+    values = 1
+    types = "LessThanEqual"
+    contraint_numbers = 2
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    name = "constant"
+    values = 0
+    types = "LessThanEqual"
+    contraint_numbers = 2
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    
+    linear_constraints = h2o.H2OFrame(linear_constraints2)
+    linear_constraints.set_names(["names", "values", "types", "constraint_numbers"])
+
+    linear_constraints = h2o.H2OFrame(linear_constraints2)
+    linear_constraints.set_names(["names", "values", "types", "constraint_numbers"])
+    # check lower bound of beta constraint will not generate error but lambda will.
+    params = {
+        "family" : family,
+        "link": link,
+        "lambda_" : lambda_,
+        "seed" : seed,
+        "nfolds" : nfolds,
+        "compute_p_values" : compute_p_values,
+        "calc_like" : calc_like,
+        "solver" : solver,
+        "linear_constraints": linear_constraints
+    }
+
+    model = glm(**params)
+    model.train(x = predictors, y = response, training_frame = train_data)
+    print(model.coef())
+        
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_bad_lambda_specification)
+else:
+    test_bad_lambda_specification()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_GH_16312_contrained_GLM_test_large.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_GH_16312_contrained_GLM_test_large.py
@@ -1,0 +1,131 @@
+import h2o
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+from tests import pyunit_utils
+from tests.pyunit_utils import utils_for_glm_tests
+import numpy as np
+import pandas as pd
+from h2o.grid.grid_search import H2OGridSearch
+
+def data_prep(seed):
+    np.random.seed(seed)
+    x1 = np.random.normal(0, 10, 100000)
+    x2 = np.random.normal(10, 100 , 100000)
+    x3 = np.random.normal(20, 200, 100000)
+    x4 = np.random.normal(30, 3000, 100000)
+    x5 = np.random.normal(400, 4000, 100000)
+
+    y_raw = np.sin(x1)*100 + np.sin(x2)*100 + x3/20 + x3/30 + x5/400
+    y = np.random.normal(y_raw, 20)
+
+    data = {
+        'x1': x1,
+        'x2': x2,
+        'x3': x3,
+        'x4': x4,
+        'x5': x5,
+        'y': y,
+    }
+    return h2o.H2OFrame(pd.DataFrame(data))
+
+def test_bad_linear_constraints():
+    train_data = data_prep(123)
+    family = 'gaussian'
+    link = 'identity'
+    nfolds = 0
+    lambda_ = 0
+    seed = 1234
+    calc_like = True
+    compute_p_values = True
+    solver = 'irlsm'
+    predictors = ['x1', 'x2', 'x3', 'x4', 'x5']
+    response = "y"
+
+    linear_constraints2 = []
+
+    name = "x2"
+    values = 1
+    types = "Equal"
+    contraint_numbers = 0
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    name = "x3"
+    values = 1
+    types = "Equal"
+    contraint_numbers = 0
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    name = "constant"
+    values = 0
+    types = "Equal"
+    contraint_numbers = 0
+    linear_constraints2.append([name, values, types, contraint_numbers])
+    
+    
+    linear_constraints = h2o.H2OFrame(linear_constraints2)
+    linear_constraints.set_names(["names", "values", "types", "constraint_numbers"])
+    
+    params3 = {
+        "family" : family,
+        "link": link,
+        "lambda_" : lambda_,
+        "seed" : seed,
+        "nfolds" : nfolds,
+        "compute_p_values" : compute_p_values,
+        "calc_like" : calc_like,
+        "solver" : solver,
+        "linear_constraints": linear_constraints,
+        "standardize": True,
+        #"startval": list(np.random.rand(6))
+    }
+    
+    # add grid search
+    # set hyperparameter search
+    constraint_eta0 = [0.05, 0.1, 0.1258925, 0.5, 1.1]
+    constraint_tau = [1.5, 5, 10, 20, 50, 60] # increase penalty
+    constraint_alpha = [0.1, 0.5, 0.9]
+    constraint_beta = [0.1, 0.5, 0.9]
+    constraint_c0 = [1.5, 2, 5, 10, 15, 20] # initial value, controls precision of line search
+    
+    # best hyperparameters
+    # constraint_eta0 = [0.05, 0.1, 0.1258925]
+    # constraint_tau = [1.5, 5, 10, 20, 50, 60] # increase penalty
+    # constraint_alpha = [0.5]
+    # constraint_beta = [0.1]
+    # constraint_c0 = [1.5] # initial value, controls precision of line search
+    
+    hyper_parameters = {"constraint_eta0":constraint_eta0, "constraint_tau":constraint_tau, "constraint_alpha":constraint_alpha,
+                       "constraint_beta":constraint_beta, "constraint_c0":constraint_c0}
+    # glmGrid = H2OGridSearch(glm(**params3), hyper_params=hyper_parameters)
+    # glmGrid.train(x=predictors, y=response, training_frame=train_data)
+    # sortedGrid = glmGrid.get_grid()
+    # print(sortedGrid)
+    # best_model = h2o.get_model(sortedGrid.model_ids[0])
+    # print(best_model.coef())
+
+
+
+    glm3 = glm(**params3)
+
+    model3 = glm3.train(x = predictors, y = response, training_frame = train_data)
+    print(model3.coef())
+
+    params2 = {
+        "family" : family,
+        "link": link,
+        "lambda_" : lambda_,
+        "seed" : seed,
+        "nfolds" : nfolds,
+        "compute_p_values" : compute_p_values,
+        "calc_like" : calc_like,
+        "solver" : solver
+    }
+    glm2 = glm(**params2)
+
+    model2 = glm2.train(x = predictors, y = response, training_frame = train_data)
+    print(model2.coef())
+    # check x2 + X3 <= 0
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_bad_linear_constraints)
+else:
+    test_bad_linear_constraints()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_GH_6722_beta_equality_loose_lessthan_linear_constraints_binomial.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_GH_6722_beta_equality_loose_lessthan_linear_constraints_binomial.py
@@ -195,13 +195,13 @@ def test_constraints_binomial():
     print(glm.getConstraintsInfo(h2o_glm_default_init))
 
 
-    assert abs(logloss-init_logloss)<2e-6, "logloss from optimal GLM {0} and logloss from GLM with loose constraints " \
+    assert abs(logloss-init_logloss)<1e-6, "logloss from optimal GLM {0} and logloss from GLM with loose constraints " \
                                            "and initialized with optimal GLM {1} should equal but is not." \
                                            "".format(logloss, init_logloss)
-    assert logloss <= init_random_logloss, "logloss from optimal GLM {0} should be less than GLM with constraints " \
+    assert abs(logloss-init_random_logloss)<1e-6, "logloss from optimal GLM {0} should be close to GLM with constraints " \
                                                    "and with random initial coefficients {1} but is" \
                                                    " not.".format(logloss, init_random_logloss)
-    assert logloss <= default_init_logloss, "logloss from optimal GLM {0} should be less than GLM with constraints " \
+    assert abs(logloss-default_init_logloss)<1e-6, "logloss from optimal GLM {0} should be close to GLM with constraints " \
                                             "and with default initial coefficients {1} but is" \
                                             " not.".format(logloss, default_init_logloss)
 

--- a/h2o-py/tests/testdir_algos/glm/pyunit_GH_6722_equality_constraints_only_binomial.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_GH_6722_equality_constraints_only_binomial.py
@@ -124,8 +124,9 @@ def test_equality_constraints_only_binomial():
           "".format(default_init_logloss, h2o_glm_default_init._model_json["output"]["model_summary"].cell_values[0][6]))
     print(glm.getConstraintsInfo(h2o_glm_default_init))
     
-    assert init_random_logloss >= logloss, "Random initialization logloss with constraints should be worst than GLM " \
-                                           "without constraints but is not."
+    assert abs(init_random_logloss - logloss) < 1e-6, \
+        "Random initialization logloss {0} with constraints should be similary to than GLM without constraints {1} but" \
+        " is not.".format(init_random_logloss, logloss)
  
 
 if __name__ == "__main__":

--- a/h2o-py/tests/testdir_algos/glm/pyunit_GH_6722_equality_loose_lessthan_linear_constraints_binomial.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_GH_6722_equality_loose_lessthan_linear_constraints_binomial.py
@@ -156,13 +156,13 @@ def test_equality_linear_constraints_binomial():
           " taken to build the model: {1}".format(default_init_logloss, utils_for_glm_tests.find_glm_iterations(h2o_glm_default_init)))
     print(glm.getConstraintsInfo(h2o_glm_default_init))
 
-    assert abs(logloss-init_logloss)<2e-6, "logloss from optimal GLM {0} and logloss from GLM with loose constraints " \
+    assert abs(logloss-init_logloss)<1e-6, "logloss from optimal GLM {0} and logloss from GLM with loose constraints " \
                                            "and initialized with optimal GLM {1} should equal but is not." \
                                            "".format(logloss, init_logloss)
-    assert logloss<=init_random_logloss, "logloss from optimal GLM {0} should be lower than GLM with constraints " \
+    assert abs(logloss-init_random_logloss)<1e-6, "logloss from optimal GLM {0} should be close to GLM with constraints " \
                                                    "and with random initial coefficients {1} but is" \
                                                    " not.".format(logloss, init_random_logloss)
-    assert logloss<=default_init_logloss, "logloss from optimal GLM {0} should be less than GLM with constraints " \
+    assert abs(logloss-default_init_logloss)<1e-6, "logloss from optimal GLM {0} should be close to GLM with constraints " \
                                             "and with default initial coefficients {1} but is" \
                                             " not.".format(logloss, default_init_logloss)
 

--- a/h2o-py/tests/testdir_algos/glm/pyunit_GH_6722_light_tight_equality_lessthan_constraints_binomial.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_GH_6722_light_tight_equality_lessthan_constraints_binomial.py
@@ -173,7 +173,7 @@ def test_light_tight_linear_constraints_only_binomial():
           "{1}".format(random_init_logloss, utils_for_glm_tests.find_glm_iterations(h2o_glm_random_init)))
     print(glm.getConstraintsInfo(h2o_glm_random_init))
 
-    assert logloss <= optimal_init_logloss, "logloss from optimal GLM {0} should be lower than logloss from GLM with light tight" \
+    assert abs(logloss - optimal_init_logloss)<1e-6, "logloss from optimal GLM {0} should be close to logloss from GLM with light tight" \
                                      " constraints and initialized with optimal GLM {1} but is not.".format(logloss, optimal_init_logloss)
 
     assert logloss <= default_init_logloss, "logloss from optimal GLM {0} should be lower than logloss from GLM with light tight" \

--- a/h2o-py/tests/testdir_algos/glm/pyunit_GH_6722_light_tight_linear_constraints_only_binomial.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_GH_6722_light_tight_linear_constraints_only_binomial.py
@@ -189,7 +189,7 @@ def test_light_tight_linear_constraints_only_binomial():
     print(glm.getConstraintsInfo(h2o_glm_random_init))
     print("All constraints satisfied: {0}".format(glm.allConstraintsPassed(h2o_glm_random_init)))
 
-    assert logloss <= optimal_init_logloss, "logloss from optimal GLM {0} should be lower than logloss from GLM with light tight" \
+    assert abs(logloss - optimal_init_logloss)<1e-6, "logloss from optimal GLM {0} should be close to logloss from GLM with light tight" \
                                      " constraints and initialized with optimal GLM {1} but is not.".format(logloss, optimal_init_logloss)
 
     assert logloss <= default_init_logloss, "logloss from optimal GLM {0} should be lower than logloss from GLM with light tight" \

--- a/h2o-py/tests/testdir_algos/glm/pyunit_GH_6722_redundant_constraints.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_GH_6722_redundant_constraints.py
@@ -198,7 +198,7 @@ def test_redundant_constraints():
     except Exception as ex:
         print(ex)
         temp = str(ex)
-        assert ("redundant and possibly conflicting linear constraints" in temp), "Wrong exception was received."
+        assert ("redundant linear constraints:" in temp), "Wrong exception was received."
         print("redundant constraint test passed!")
 
 if __name__ == "__main__":

--- a/h2o-py/tests/testdir_algos/glm/pyunit_GH_6722_tight_equality_linear_constraints_binomial.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_GH_6722_tight_equality_linear_constraints_binomial.py
@@ -225,7 +225,7 @@ def test_tight_equality_linear_constraints_binomial():
     print(glm.getConstraintsInfo(h2o_glm_random_init))
     print("All constraints satisfied: {0}".format(glm.allConstraintsPassed(h2o_glm_random_init)))
 
-    assert logloss <= optimal_init_logloss, "logloss from optimal GLM {0} should be lower than logloss from GLM with light tight" \
+    assert abs(logloss - optimal_init_logloss)<1e-6, "logloss from optimal GLM {0} should be close to logloss from GLM with light tight" \
                                      " constraints and initialized with optimal GLM {1} but is not.".format(logloss, optimal_init_logloss)
 
     assert logloss <= default_init_logloss, "logloss from optimal GLM {0} should be lower than logloss from GLM with light tight" \

--- a/h2o-py/tests/testdir_algos/glm/pyunit_GH_6722_tight_linear_constraints_only_binomial.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_GH_6722_tight_linear_constraints_only_binomial.py
@@ -189,7 +189,7 @@ def test_tight_linear_constraints_binomial():
     print(glm.getConstraintsInfo(h2o_glm_random_init))
     print("All constraints satisfied: {0}".format(glm.allConstraintsPassed(h2o_glm_random_init)))
 
-    assert logloss <= optimal_init_logloss, "logloss from optimal GLM {0} should be lower than logloss from GLM with light tight" \
+    assert abs(logloss - optimal_init_logloss)<1e-6, "logloss from optimal GLM {0} should be close to logloss from GLM with light tight" \
                                      " constraints and initialized with optimal GLM {1} but is not.".format(logloss, optimal_init_logloss)
 
     assert logloss <= default_init_logloss, "logloss from optimal GLM {0} should be lower than logloss from GLM with light tight" \

--- a/h2o-r/tests/testdir_algos/glm/runit_GH_6722_redundant_constraints.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_GH_6722_redundant_constraints.R
@@ -24,7 +24,7 @@ test_constraints_redundant <- function() {
   }, error = function(e) {
     print("***")
     print(e)
-    expect_true(grepl("redundant and possibly conflicting linear constraints:", e))
+    expect_true(grepl("redundant linear constraints:", e))
   })
 }
 

--- a/h2o-r/tests/testdir_algos/glm/runit_pubdev_4641_glm_beta_constraints_bad_results.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_pubdev_4641_glm_beta_constraints_bad_results.R
@@ -3,8 +3,8 @@ source("../../../scripts/h2o-r-test-setup.R")
 
 # add test from Erin Ledell
 glmBetaConstraints <- function() {
-  df <- h2o.importFile("https://s3.amazonaws.com/erin-data/higgs/higgs_train_10k.csv")
-  test <- h2o.importFile("https://s3.amazonaws.com/erin-data/higgs/higgs_test_5k.csv")
+  df <- h2o.importFile(locate("smalldata/higgs/higgs_train_10k.csv"))
+  test <- h2o.importFile(locate("smalldata/higgs/higgs_test_5k.csv"))
 
   y <- "response"
   x <- setdiff(names(df), y)


### PR DESCRIPTION
This PR fixes problems in https://github.com/h2oai/h2o-3/issues/16312

I fixed three issues here:

1. constrained GLM finished before constraint conditions are satisfied.  There is a bug in gradient check and I fixed it.  However, the constraint conditions are not satisfied at the end of the iteration.  This is caused by either line search failure or no progress was made.  However, if you compare the results with and without the constraints, the coefficients with constraints are closer to the constraints then the ones from model without constraints.
2. When specifying beta constraints with only the lower bounds, npe values occurred.  I fixed this one by checking to make sure the beta constraint is not null before accessing its elements.
3. A set of three linear constraints are evaluated to be duplicated or conflicting when the constraints are neither.  I fixed this error also because I dropped the last column/rows which are supposed to be for the constant.  However, in generating the constraints matrix, I did not include the constant.