### PR TITLE
GH-16342 - Fix vulnerabilities in dnsjava

### DIFF
--- a/h2o-assemblies/main/build.gradle
+++ b/h2o-assemblies/main/build.gradle
@@ -88,6 +88,11 @@ dependencies {
         api('org.apache.commons:commons-configuration2:2.10.1') {
             because 'Fixes CVE-2024-29131'
         }
+        api('dnsjava:dnsjava:3.6.0') {
+            because 'Fixes SNYK-JAVA-DNSJAVA-7547403'
+            because 'Fixes SNYK-JAVA-DNSJAVA-7547404'
+            because 'Fixes SNYK-JAVA-DNSJAVA-7547405'
+        }
     }
 }
 

--- a/h2o-assemblies/main/build.gradle
+++ b/h2o-assemblies/main/build.gradle
@@ -92,6 +92,7 @@ dependencies {
             because 'Fixes SNYK-JAVA-DNSJAVA-7547403'
             because 'Fixes SNYK-JAVA-DNSJAVA-7547404'
             because 'Fixes SNYK-JAVA-DNSJAVA-7547405'
+            because 'Fixes CVE-2024-25638'
         }
     }
 }

--- a/h2o-assemblies/steam/build.gradle
+++ b/h2o-assemblies/steam/build.gradle
@@ -84,6 +84,11 @@ dependencies {
         api('org.apache.commons:commons-configuration2:2.10.1') {
             because 'Fixes CVE-2024-29131'
         }
+        api('dnsjava:dnsjava:3.6.0') {
+            because 'Fixes SNYK-JAVA-DNSJAVA-7547403'
+            because 'Fixes SNYK-JAVA-DNSJAVA-7547404'
+            because 'Fixes SNYK-JAVA-DNSJAVA-7547405'
+        }
     }
 }
 

--- a/h2o-assemblies/steam/build.gradle
+++ b/h2o-assemblies/steam/build.gradle
@@ -88,6 +88,7 @@ dependencies {
             because 'Fixes SNYK-JAVA-DNSJAVA-7547403'
             because 'Fixes SNYK-JAVA-DNSJAVA-7547404'
             because 'Fixes SNYK-JAVA-DNSJAVA-7547405'
+            because 'Fixes CVE-2024-25638'
         }
     }
 }


### PR DESCRIPTION
Closes #16342.

- SNYK-JAVA-DNSJAVA-7547403
- SNYK-JAVA-DNSJAVA-7547404
- SNYK-JAVA-DNSJAVA-7547405
- CVE-2024-25638