### PR TITLE
GH-16351: fix vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2024-5979

### DIFF
--- a/h2o-r/tests/testdir_munging/runit_GH_16351_AstRunTool_bad_commands.R
+++ b/h2o-r/tests/testdir_munging/runit_GH_16351_AstRunTool_bad_commands.R
@@ -1,0 +1,40 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+# Test to make sure that when we pass an illegal command to
+# AstRunTool will not crash H2O.
+
+test.astRunTimeBadCommands <- function() {
+  iris_path_gz <- locate("smalldata/junit/iris.csv.gz")
+  iris_path_gz_aes <- file.path(sandbox(), "iris.csv.gz.aes")
+
+  keystore_path <- locate("smalldata/extdata/keystore.jks")
+  keystore <- h2o.importFile(keystore_path, parse = FALSE)
+  decrypt_tool <- h2o.decryptionSetup(keystore, key_alias = "secretKeyAlias",
+                                      password = "Password123", cipher = "AES/ECB/PKCS5Padding")
+
+  args <- c(keystore_path, "JCEKS", "secretKeyAlias", "Password123", "AES/ECB/PKCS5Padding", 
+            iris_path_gz, iris_path_gz_aes)
+  # command is wrong
+  tryCatch({  
+    tool_result <- h2o.rapids(sprintf('(run_tool "EncryptionTools" ["%s"])', paste(args, collapse = '", "')))},
+    error = function(e) {print(e)})
+  iris_file <- h2o.importFile(locate("smalldata/junit/iris.csv.gz"))
+  expect_true(h2o.clusterIsUp())
+  # passcode is wrong
+  args[4] <- "password"
+  tryCatch({  
+    tool_result <- h2o.rapids(sprintf('(run_tool "EncryptionTool" ["%s"])', paste(args, collapse = '", "')))},
+    error = function(e) {print(e)})
+  iris_file <- h2o.importFile(locate("smalldata/junit/iris.csv.gz"))
+  expect_true(h2o.clusterIsUp())
+  # keystore_path is bad
+  args[4] = "Password123"
+  args[1] = "/bad/Directory"
+  tryCatch({  
+    tool_result <- h2o.rapids(sprintf('(run_tool "EncryptionTool" ["%s"])', paste(args, collapse = '", "')))},
+    error = function(e) {print(e)})
+  expect_true(h2o.clusterIsUp())
+}
+
+doTest("Test AstRunTool.java when passed with illegal commands will not crash.", test.astRunTimeBadCommands)


### PR DESCRIPTION
This PR addresses this issue: https://github.com/h2oai/h2o-3/issues/16351

A complaint was brought to our attention that AstRunTool.java will crash H2O-3 when improper arguments are passed to it.  However, we are not able to reproduce this error.  I tried to do the following:
1. pass the wrong command;
2. pass the correct command but with wrong arguments.

I did add a test to try to crash H2O-3 cluster multiple times but the cluster stays up.  Hence, this is not an issue for us right now.