### PR TITLE
Bump gradle-nexus-plugin to fix gradle build failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
     dependencies {
         classpath 'org.ow2.asm:asm:5.1'
         classpath 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
-        classpath 'org.gradle.api.plugins:gradle-nexus-plugin:0.7.1'
+        classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
         classpath 'org.testng:testng:6.8'
         classpath 'me.champeau.gradle:jmh-gradle-plugin:0.5.2'
         // Note: Analyze unused/undefined dependencies for each module - good for debugging


### PR DESCRIPTION
The current point release cannot be found on maven central and causes build failure.
```
     [exec]      [exec] * What went wrong:
     [exec]      [exec] A problem occurred configuring root project 'h2o-3'.
     [exec]      [exec] > Could not resolve all artifacts for configuration ':classpath'.
     [exec]      [exec]    > Could not find org.gradle.api.plugins:gradle-nexus-plugin:0.7.1.
     [exec]      [exec]      Searched in the following locations:
     [exec]      [exec]        - https://plugins.gradle.org/m2/org/gradle/api/plugins/gradle-nexus-plugin/0.7.1/gradle-nexus-plugin-0.7.1.pom
     [exec]      [exec]        - https://repo.maven.apache.org/maven2/org/gradle/api/plugins/gradle-nexus-plugin/0.7.1/gradle-nexus-plugin-0.7.1.pom
     [exec]      [exec]      Required by:
     [exec]      [exec]          project :
     [exec]      [exec]
     [exec]      [exec] * Try:
     [exec]      [exec] Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
     [exec]      [exec]
     [exec]      [exec] * Get more help at https://help.gradle.org
     [exec]      [exec]
```