### PR TITLE
GH-16360: Fix R package for Windows

### DIFF
--- a/h2o-core/src/main/java/water/api/CloudHandler.java
+++ b/h2o-core/src/main/java/water/api/CloudHandler.java
@@ -40,7 +40,7 @@ class CloudHandler extends Handler {
     cloud.consensus = Paxos._commonKnowledge;
     cloud.locked = Paxos._cloudLocked;
     cloud.internal_security_enabled = H2OSecurityManager.instance().securityEnabled;
-
+    cloud.web_ip = H2O.ARGS.web_ip;
 
     // set leader
     H2ONode leader = H2O.CLOUD.leaderOrNull(); // leader might be null in client mode if clouding didn't finish yet

--- a/h2o-core/src/main/java/water/api/schemas3/CloudV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/CloudV3.java
@@ -110,6 +110,9 @@ public class CloudV3 extends RequestSchemaV3<Iced, CloudV3> {
   @API(help="leader_idx", direction=API.Direction.OUTPUT)
   public int leader_idx = -1;
 
+  @API(help="web_ip", direction=API.Direction.OUTPUT)
+  public String web_ip=null;
+  
   // Output fields one-per-JVM
   public static class NodeV3 extends SchemaV3<Iced, NodeV3> {
     public NodeV3() {}

--- a/h2o-py/tests/testdir_misc/pyunit_cluster.py
+++ b/h2o-py/tests/testdir_misc/pyunit_cluster.py
@@ -11,9 +11,9 @@ def test_cluster_status():
 
 def test_cluster_properties():
     cl = h2o.cluster()
-    assert len(cl._schema_attrs_) == 24 
+    assert len(cl._schema_attrs_) == 25
     for k in cl._schema_attrs_.keys():
-        assert getattr(cl, k) is not None
+        assert getattr(cl, k) is not None or k == "web_ip"
     
 
 def test_exception_on_unknown_cluster_property():

--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -968,6 +968,11 @@ h2o.clusterInfo <- function() {
   if (res$build_too_old) {
     warning(sprintf("\nYour H2O cluster version is (%s) old. There may be a newer version available.\nPlease download and install the latest version from: https://h2o-release.s3.amazonaws.com/h2o/latest_stable.html", res$build_age))
   }
+    
+  if (is.null(res$web_ip)){
+     warning("SECURITY_WARNING: web_ip is not specified. H2O Rest API is listening on all available interfaces.")
+  }
+
 }
 
 .h2o.translateJobType <- function(type) {

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -237,17 +237,6 @@ h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, start
 
         stop("H2O failed to start, stopping execution.")
       }
-
-      securityWarnings <- ""
-      if (file.info(stdout)$size > 0) {
-        securityWarnings <- grep("SECURITY_WARNING", readLines(stdout), value=TRUE)
-      }
-      if (length(securityWarnings) > 0) {
-        msg = paste(
-        "Server process startup raise a security warning:",
-        paste(securityWarnings, collapse = "\n"), sep = "\n")
-        warning(msg)
-      }
     } else
       stop("Can only start H2O launcher if IP address is localhost.")
   }


### PR DESCRIPTION
#16360 

The Windows usually [don't allow opening one file by multiple processes](https://en.wikipedia.org/wiki/File_locking#In_Microsoft_Windows) and that seems to cause this issue. 

In python, it seems like we are using the[ same process group](https://github.com/h2oai/h2o-3/blob/cb35f0bc2a2732a7b2146636f737486beb4fbbd0/h2o-py/h2o/backend/server.py#L340-L350) which IIRC could mitigate the issue we're seeing in R.

Last time I programmed on Windows, Delphi was a big thing and Windows XP was the latest version so my knowledge of that "operating system" is pretty limited. So I'm trying to keep it simple and multiplatform without delving into windows' and R's internals.

My solution is to add the `web_ip` to the json we send when H2O connects and then check on R side if it's null and if so print the warning. This way we print it every time on `h2o.init` and also on `h2o.connect` (which I think is a good thing) but it makes the behavior between R and Python diverge a bit.

@mmalohlava JFYI this related to https://github.com/h2oai/h2o-3/issues/15683 which you were involved in.