### PR TITLE
GH-16423 fix hadoop jars after gcs upgrade

### DIFF
--- a/h2o-assemblies/main/build.gradle
+++ b/h2o-assemblies/main/build.gradle
@@ -33,7 +33,6 @@ dependencies {
         exclude group: "org.apache.curator"
         exclude group: "org.apache.zookeeper"
         exclude group: "org.eclipse.jetty"
-        exclude group: "org.apache.hadoop.thirdparty", module: "hadoop-shaded-protobuf_3_7"
     }
 
     // Upgrade dependencies of h2o-jetty-9


### PR DESCRIPTION
Followup https://github.com/h2oai/h2o-3/issues/16423