### PR TITLE
GH-6440: move [GH-16333] fix pyplot warning (#16381) to rel-3.46.0 [nocheck]

### DIFF
--- a/h2o-py/h2o/plot/_matplotlib.py
+++ b/h2o-py/h2o/plot/_matplotlib.py
@@ -5,7 +5,10 @@ def get_matplotlib_pyplot(server, raise_if_not_available=False):
         # noinspection PyUnresolvedReferences
         import matplotlib
         if server:
-            matplotlib.use("Agg")
+            if matplotlib.get_backend() != "Agg":
+                import matplotlib.pyplot as plt
+                plt.close('all')
+                matplotlib.use("Agg")
         try:
             # noinspection PyUnresolvedReferences
             import matplotlib.pyplot as plt


### PR DESCRIPTION
Sorry, missed this one and it is in master.  I need it to be in the rel-3.46.0 for a customer fix.  GH: https://github.com/h2oai/h2o-3/issues/16440