### PR TITLE
fix: remove obsolete Hortonworks repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -251,12 +251,6 @@ subprojects {
                 url "https://repository.cloudera.com/artifactory/cloudera-repos/"
             }
             maven {
-                url "https://repo.hortonworks.com/content/repositories/releases/"
-            }
-            maven {
-                url "https://repo.hortonworks.com/content/repositories/jetty-hadoop/"
-            }
-            maven {
                 url "https://repository.mapr.com/maven/"
             }
             maven {


### PR DESCRIPTION
EXPERIMENTAL: Following solution https://github.com/hail-is/hail/pull/9418 that simply
removes affected repositories.
