### PR TITLE
GH-16468 - fix `load_grid` and `loadGrid` for S3 paths

### DIFF
--- a/h2o-persist-s3/src/main/java/water/persist/PersistS3.java
+++ b/h2o-persist-s3/src/main/java/water/persist/PersistS3.java
@@ -238,6 +238,24 @@ public final class PersistS3 extends Persist {
   }
 
   @Override
+  public String getParent(String path) {
+    String[] bk = decodePath(path);
+    String bucket = bk[0];
+    String key = bk[1];
+    if (key.endsWith("/")) {
+      key = key.substring(0, key.length() - 1);
+    }
+    if (key == null || key.isEmpty()) {
+      throw new IllegalArgumentException("No parent exists for a bucket-only path: " + path);
+    }
+    int lastSlash = key.lastIndexOf("/");
+    if (lastSlash == -1) {
+      return "s3://" + bucket;
+    }
+    return "s3://" + bucket + "/" + key.substring(0, lastSlash);
+  }
+
+  @Override
   public InputStream open(String path) {
     String[] bk = decodePath(path);
     GetObjectRequest r = new GetObjectRequest(bk[0], bk[1]);


### PR DESCRIPTION
- Closes #16468 

**Please provide any constructive feedback. I have not written java before so this is a first attempt at a java contribution.**

I believe S3 path instances of `Persist` simply needed at `getParent` method, which I have tried to provide.

It should do things like:
s3://bucket/path -> s3://bucket
s3://bucket/path/ -> s3://bucket
s3://bucket/path/more -> s3://bucket/path
s3://bucket -> error