### PR TITLE
GH-16480 - fix CVE-2024-5046 with mina-core upgrade to 2.2.4

### DIFF
--- a/h2o-jetty-9/build.gradle
+++ b/h2o-jetty-9/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     testImplementation "org.mockito:mockito-core:2.23.0"
 
     constraints{
-        api("org.apache.mina:mina-core:2.2.3") {
+        api("org.apache.mina:mina-core:2.2.4") {
             because 'Fixes CVE-2024-52046'
         }
     }


### PR DESCRIPTION
#16480 