### PR TITLE
Pass along verbose option at exit connection

### DIFF
--- a/h2o-py/h2o/backend/connection.py
+++ b/h2o-py/h2o/backend/connection.py
@@ -420,7 +420,7 @@ class H2OConnection(h2o_meta()):
                         print("Closing connection %s at exit" % con.session_id)
                     con.close()
 
-            atexit.register(exit_close, verbose=self.verbose)
+            atexit.register(exit_close, verbose=verbose)
         except Exception:
             # Reset _session_id so that we know the connection was not initialized properly.
             conn._stage = 0


### PR DESCRIPTION
When a connection is closed with an h2o backend, the message `Closing connection _sid_861a at exit` is printed regardless of the `verbose` parameter.

This PR add a new parameter to the `exit_close()` function and passes the `verbose` parameter to it.