### PR TITLE
GH-16466: Fixed invalid escape sequences in docstrings

### DIFF
--- a/h2o-py/h2o/estimators/xgboost.py
+++ b/h2o-py/h2o/estimators/xgboost.py
@@ -2568,7 +2568,7 @@ class H2OXGBoostEstimator(H2OEstimator):
 
          1. Train the H2OXGBoost model with H2OFrame trainFile and generate a prediction:
 
-          - h2oModelD = H2OXGBoostEstimator(\*\*h2oParamsD) # parameters specified as a dict()
+          - h2oModelD = H2OXGBoostEstimator(\\*\\*h2oParamsD) # parameters specified as a dict()
           - h2oModelD.train(x=myX, y=y, training_frame=trainFile) # train with H2OFrame trainFile
           - h2oPredict = h2oPredictD = h2oModelD.predict(trainFile)
 

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -915,7 +915,7 @@ class ModelBase(h2o_meta(Keyed, H2ODisplay)):
 
         Will return :math:`R^2` for GLM Models. 
 
-        The :math:`R^2` value is defined to be :math:`1 - MSE / var`, where var is computed as :math:`\sigma * \sigma`.
+        The :math:`R^2` value is defined to be :math:`1 - MSE / var`, where var is computed as :math:`\\sigma * \\sigma`.
 
         If all are ``False`` (default), then return the training metric value.
         If more than one option is set to ``True``, then return a dictionary of metrics where the keys are "train",


### PR DESCRIPTION
Allow h2o to be imported without triggering syntax errors.

Closes https://github.com/h2oai/h2o-3/issues/16466