### PR TITLE
python grid search `hyper_params` input validation

### DIFF
--- a/h2o-py/h2o/grid/grid_search.py
+++ b/h2o-py/h2o/grid/grid_search.py
@@ -92,7 +92,7 @@ class H2OGridSearch(h2o_meta(Keyed, H2ODisplay)):
         if not (model is None or is_type(model, H2OEstimator)): model = model()
         self._id = grid_id
         self.model = model
-        self.hyper_params = dict(hyper_params)
+        self.hyper_params = {k: v if isinstance(v, list) else [v] for k, v in hyper_params.items()}
         self.search_criteria = None if search_criteria is None else dict(search_criteria)
         self.export_checkpoints_dir = export_checkpoints_dir
         self.recovery_dir = recovery_dir


### PR DESCRIPTION
https://github.com/h2oai/h2o-3/blob/6e2e5f143cdf2c25d93cb7bfd8aa592651eebf67/h2o-py/h2o/grid/grid_search.py#L816
The above line will throw an error if any of the `hyper_params` are not a `list`, but it will only do so after all the training is done.

Propose helping users out by updating any single values to a `list`.