### PR TITLE
export `h2o.shallow_copy`

### DIFF
--- a/h2o-py/h2o/__init__.py
+++ b/h2o-py/h2o/__init__.py
@@ -25,7 +25,7 @@ __no_export = set(dir())  # variables defined above this are not exported
 
 from h2o.h2o import (connect, init, api, connection, resume,
                      lazy_import, upload_file, import_file, import_sql_table, import_sql_select, import_hive_table,
-                     parse_setup, parse_raw, assign, deep_copy, models, get_model, get_grid, get_frame,
+                     parse_setup, parse_raw, assign, deep_copy, shallow_copy, models, get_model, get_grid, get_frame,
                      show_progress, no_progress, enable_expr_optimizations, is_expr_optimizations_enabled,
                      log_and_echo, remove, remove_all, rapids,
                      ls, frame, frames, create_frame, load_frame,

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -104,7 +104,7 @@ class H2OFrame(Keyed, H2ODisplay):
 
         self._is_frame = True  # Indicate that this is an actual frame, allowing typechecks to be made
         if isinstance(python_obj, H2OFrame):
-            sc = h2o.h2o.shallow_copy(python_obj, destination_frame)
+            sc = h2o.shallow_copy(python_obj, destination_frame)
             if skipped_columns:
                 sc = sc.drop(skipped_columns)
             if column_names:

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -1053,7 +1053,21 @@ def deep_copy(data, xid):
     assign(duplicate, xid)
     return duplicate
 
-def shallow_copy(data, xid):
+def shallow_copy(data, xid=None):
+    """
+    Create a shallow clone of the frame ``data``.
+
+    :param data: an H2OFrame to be cloned
+    :param xid: (internal) id to be assigned to the new frame.
+    :returns: new :class:`H2OFrame` which is the clone of the passed frame.
+
+    :examples:
+
+    >>> training_data = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate.csv.zip")
+    >>> new_name = "new_frame"
+    >>> training_copy = h2o.shallow_copy(training_data, new_name)
+    >>> training_copy
+    """
     assert_is_type(data, H2OFrame)
     assert_is_type(xid, None, str)
     duplicate = H2OFrame._expr(expr=ExprNode("cols_py", data, slice(data.ncols)))


### PR DESCRIPTION
This is a useful function but I noticed it was not exported/hard to find. Could also be nice to implement an `H2OFrame.copy` method, like `pd.DataFrame.copy`.

Note that I added a default of `None` for `xid`. It seems convenient to not have to specify it.