### PR TITLE
Upgrade the Hadoop version to v3.4.1 to fix security vulnerabilities

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -51,7 +51,7 @@ httpClientVersion=4.5.2
 defaultParquetVersion=1.12.3
 
 # Default Hadoop client version
-defaultHadoopVersion=3.3.6
+defaultHadoopVersion=3.4.1
 defaultHdfsDependency=hadoop-hdfs-client
 
 defaultWebserverModule=h2o-jetty-9


### PR DESCRIPTION
This PR upgrades the Hadoop version (`org.apache.hadoop:hadoop-common` and related) to v3.4.1 in order to fix following security vulnerabilities (related to `com.google.protobuf:protobuf-java` and `com.google.protobuf:protobuf-java-util`) reported in `h2o-3:3.46.0.7`.
- CVE-2022-3510
- CVE-2022-3509
- CVE-2022-3171
- CVE-2024-7254
- CVE-2021-22570
- CVE-2021-22569

----
**See:**
- Security scan report: https://docs.google.com/spreadsheets/d/1SSUnvHO4NO_fUq1MsEGppBZ3X3pFG3MI/edit?gid=248833465#gid=248833465
- Related Slack thread: https://h2oai.slack.com/archives/C03HXQSLW/p1750694831389559