### PR TITLE
GH-16045: Use os.path.realpath to fix MS-DOS compatibility (potential) issue on Windows

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -1971,13 +1971,13 @@ class H2OFrame(Keyed, H2ODisplay):
         if can_use_pandas() and use_pandas:
             import pandas
             if use_multi_thread:
-                with local_context(polars_enabled=True): # turn on multi-thread toolboxes   
-                    if can_use_polars() and can_use_pyarrow(): # can use multi-thread
+                with local_context(polars_enabled=True):  # turn on multi-thread toolboxes
+                    if can_use_polars() and can_use_pyarrow():  # can use multi-thread
                         exportFile = tempfile.NamedTemporaryFile(suffix=".h2oframe2Convert.csv", delete=False)
                         try:
                             exportFile.close()  # needed for Windows
-                            h2o.export_file(self, exportFile.name, force=True)
-                            return self.convert_with_polars(exportFile.name)
+                            h2o.export_file(self, os.path.realpath(exportFile.name), force=True)
+                            return self.convert_with_polars(os.path.realpath(exportFile.name))
                         finally:
                             os.unlink(exportFile.name)
             warnings.warn("Converting H2O frame to pandas dataframe using single-thread.  For faster conversion using"

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_as_data_frame.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_as_data_frame.py
@@ -27,5 +27,10 @@ def h2o_H2OFrame_as_data_frame():
     assert_is_type(small_bike_pandas, DataFrame)
     assert small_bike_pandas.shape == (smallbike.nrow, smallbike.ncol)
 
+    ##multithread = True
+    small_bike_multithread = smallbike.as_data_frame(use_multi_thread=True, header=True)
+    assert_is_type(small_bike_multithread, DataFrame)
+    assert small_bike_multithread.shape == (smallbike.nrow, smallbike.ncol)
+
 
 pyunit_utils.standalone_test(h2o_H2OFrame_as_data_frame)


### PR DESCRIPTION
#16045 

One of our users reported:
```
01-31 10:18:43.312 127.0.0.1:54321       31396  8557915-20  INFO water.default: ExportFiles processing (C:\Users\ROEL~1.VER\AppData\Local\Temp\tmpmg5yuobe.h2oframe2Convert.csv)
01-31 10:18:43.314 127.0.0.1:54321       31396  8557915-20  WARN water.default: File C:\Users\ROEL~1.VER\AppData\Local\Temp\tmpmg5yuobe.h2oframe2Convert.csv exists, but will be overwritten!
01-31 10:18:43.325 127.0.0.1:54321       31396      FJ-1-7 ERROR water.default: 
java.lang.RuntimeException: java.io.FileNotFoundException: C:\Users\ROEL~1.VER\AppData\Local\Temp\tmpmg5yuobe.h2oframe2Convert.csv (The process cannot access the file because it is being used by another process)
```

Since I don't have windows I can't reproduce it. One possible explanation is multiple processes that opened the file another explanation could be MS-DOS style file names (8.3) (the `ROEL~1.VER`). The former should be already fixed in the latest releases, the latter should be fixed by this PR (but I'm not sure if it's necessary).