### PR TITLE
Change bucket name for nightly builds in Jenkinsfile

### DIFF
--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
@@ -600,7 +600,7 @@ EOF
                             } else{
                                 if(env.NIGHTLY_BUILD){
                                     CHART_NAME = "h2o-3-nightly"
-                                    BUCKET = "h2oai-nightly-helm-charts"
+                                    BUCKET = "h2oai-test-helm-charts"
                                     VERSION = THREE_DIGITS_VERSION
                                 } else {
                                     CHART_NAME = "h2o-3"


### PR DESCRIPTION
[16525](https://github.com/h2oai/h2o-3/issues/16525)

The previous bucket was deleted by the DevOps team, so I updated the path to point to the new existing S3 bucket.