### PR TITLE
Add workflow to trigger vulnerability scan on push events

### DIFF
--- a/.github/workflows/trigger-vulnerability-scan.yml
+++ b/.github/workflows/trigger-vulnerability-scan.yml
@@ -7,6 +7,7 @@ permissions:
 on:
   push:
     branches: [master, rel-3.46.0]
+  workflow_dispatch:
 
 jobs:
   trigger:


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that triggers a vulnerability scan in the h2o-3-devops repository
- Workflow runs on pushes to `master` and `rel-3.46.0` branches
- Sends repository dispatch event with branch name and commit SHA as payload
