### PR TITLE
Rohan/cherry pick 16734 to rel 3.46.0

### DIFF
--- a/.github/workflows/trigger-h2o-3-devops.yml
+++ b/.github/workflows/trigger-h2o-3-devops.yml
@@ -21,12 +21,3 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/h2oai/h2o-3-devops/dispatches \
             -d '{"event_type":"h2o3-push","client_payload":{"branch":"${{ github.ref_name }}","sha":"${{ github.sha }}"}}'
-
-      - name: Trigger Build H2O-3 Public
-        run: |
-          curl -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.H2O_3_DEVOPS_REPO_TOKEN }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/h2oai/h2o-3-devops/dispatches \
-            -d '{"event_type":"h2o3-build-public","client_payload":{"branch":"${{ github.ref_name }}","sha":"${{ github.sha }}"}}'


### PR DESCRIPTION
## Summary
Cherry-pick of #16734 to `rel-3.46.0` branch.

- Adds GitHub Actions workflow to trigger DevOps pipelines in the h2o-3-devops repository
- Triggers vulnerability scanning and public build workflows on push
- Supports manual triggering via `workflow_dispatch`

## Original PR
https://github.com/h2oai/h2o-3/pull/16734
