### PR TITLE
GH-16779: update estimators to support sklearn 1.6+

### DIFF
--- a/h2o-py/h2o/sklearn/wrapper.py
+++ b/h2o-py/h2o/sklearn/wrapper.py
@@ -313,9 +313,19 @@ class BaseEstimatorMixin(object):
         return hasattr(self, distribution_prop) and getattr(self, distribution_prop) not in (None,)+self._classifier_distributions
 
     def is_classifier(self):
+        est_type = getattr(self, "_estimator_type", None)
+        if est_type == "classifier":
+            return True
+        if est_type == "regressor":
+            return False
         return is_classifier(self) or self._is_classifier_distribution()
 
     def is_regressor(self):
+        est_type = getattr(self, "_estimator_type", None)
+        if est_type == "regressor":
+            return True
+        if est_type == "classifier":
+            return False
         return is_regressor(self) or self._is_regressor_distribution()
 
 
@@ -445,7 +455,7 @@ class H2OConnectionMonitorMixin(object):
 
 class BaseSklearnEstimator(BaseEstimator, BaseEstimatorMixin, H2OConnectionMonitorMixin):
 
-    _reserved_params = ('data_conversion',)
+    _reserved_params = ('data_conversion', 'init_connection_args', 'estimator_type')
     """Params required when `sklearn` is cloning the estimator (e.g. in search estimators),
     but that should not be forwarded to the original wrapped estimator"""
 
@@ -471,6 +481,7 @@ class BaseSklearnEstimator(BaseEstimator, BaseEstimatorMixin, H2OConnectionMonit
         self._estimator = None
         self._estimator_cls = estimator_cls
         estimator_type = self._get_custom_param('default_estimator_type', estimator_type)
+        self.estimator_type = estimator_type
         if estimator_type:
             self._estimator_type = estimator_type
 
@@ -481,7 +492,25 @@ class BaseSklearnEstimator(BaseEstimator, BaseEstimatorMixin, H2OConnectionMonit
         self.set_params(**estimator_params)
 
         self._frame_params = None
+        self.init_connection_args = init_connection_args
         self._init_connection_args = init_connection_args
+
+    def __sklearn_tags__(self):
+        """
+        Keep sklearn estimator type tags aligned with wrappers that set `_estimator_type`
+        dynamically (generic wrappers) to support newer sklearn type-dispatch logic.
+        """
+        parent = super(BaseSklearnEstimator, self)
+        if hasattr(parent, '__sklearn_tags__') and callable(parent.__sklearn_tags__):
+            tags = parent.__sklearn_tags__()
+            est_type = getattr(self, "_estimator_type", None)
+            if est_type in ("classifier", "regressor") and hasattr(tags, "estimator_type"):
+                tags.estimator_type = est_type
+                target_tags = getattr(tags, "target_tags", None)
+                if target_tags is not None and hasattr(target_tags, "required"):
+                    target_tags.required = True
+            return tags
+        return {}
 
 
     @classmethod
@@ -528,6 +557,14 @@ class BaseSklearnEstimator(BaseEstimator, BaseEstimatorMixin, H2OConnectionMonit
             if delim:
                 nested_params[key][sub_key] = value
             else:
+                if key == 'init_connection_args':
+                    self._init_connection_args = value
+                elif key == 'estimator_type':
+                    assert value in (None, 'classifier', 'regressor')
+                    if value:
+                        self._estimator_type = value
+                    elif hasattr(self, '_estimator_type'):
+                        del self._estimator_type
                 setattr(self, self._no_conflict(key), value)
 
         for key, sub_params in nested_params.items():
@@ -546,6 +583,9 @@ class BaseSklearnEstimator(BaseEstimator, BaseEstimatorMixin, H2OConnectionMonit
         :return: Parameter names mapped to their values.
         """
         params = {k: getattr(self, self._no_conflict(k), None) for k in self._estimator_param_names}
+        params.update(init_connection_args=getattr(self, '_init_connection_args', None))
+        if self.__class__.__name__.endswith('Estimator'):
+            params.update(estimator_type=getattr(self, '_estimator_type', None))
         if deep:
             out = dict()
             for k, v in params.items():

--- a/h2o-py/tests/testdir_sklearn/pyunit_sklearn_api.py
+++ b/h2o-py/tests/testdir_sklearn/pyunit_sklearn_api.py
@@ -1,4 +1,5 @@
 import importlib, inspect, os, sys
+from sklearn.base import clone, is_classifier, is_regressor
 
 sys.path.insert(1, os.path.join("..",".."))
 from tests import pyunit_utils
@@ -84,8 +85,52 @@ def test_transformers_exposed_in_h2o_sklean_transforms_module():
             _check_exposed_in_h2o_sklearn_module(cls)
 
 
+def test_classifier_and_regressor_identification():
+    mod = importlib.import_module('h2o.sklearn')
+    clf = mod.H2OGradientBoostingClassifier()
+    reg = mod.H2OGradientBoostingRegressor()
+    generic_as_clf = mod.H2OGradientBoostingEstimator(estimator_type='classifier')
+    generic_as_reg = mod.H2OGradientBoostingEstimator(estimator_type='regressor')
+
+    assert is_classifier(clf), "{} should be recognized as classifier".format(clf.__class__.__name__)
+    assert not is_regressor(clf), "{} should not be recognized as regressor".format(clf.__class__.__name__)
+    assert is_regressor(reg), "{} should be recognized as regressor".format(reg.__class__.__name__)
+    assert not is_classifier(reg), "{} should not be recognized as classifier".format(reg.__class__.__name__)
+    assert is_classifier(generic_as_clf), "{} should be classifier when estimator_type is set".format(generic_as_clf.__class__.__name__)
+    assert is_regressor(generic_as_reg), "{} should be regressor when estimator_type is set".format(generic_as_reg.__class__.__name__)
+
+
+def test_clone_preserves_estimator_type_semantics():
+    mod = importlib.import_module('h2o.sklearn')
+    original = mod.H2OGradientBoostingEstimator(estimator_type='classifier')
+    cloned = clone(original)
+    assert is_classifier(cloned), "{} clone should preserve classifier semantics".format(cloned.__class__.__name__)
+    assert not is_regressor(cloned), "{} clone should not become a regressor".format(cloned.__class__.__name__)
+
+
+def test_sklearn_tags_estimator_type_when_available():
+    mod = importlib.import_module('h2o.sklearn')
+    generic_as_clf = mod.H2OGradientBoostingEstimator(estimator_type='classifier')
+    generic_as_reg = mod.H2OGradientBoostingEstimator(estimator_type='regressor')
+
+    for est, expected in [(generic_as_clf, 'classifier'), (generic_as_reg, 'regressor')]:
+        if not hasattr(est, '__sklearn_tags__'):
+            continue
+        tags = est.__sklearn_tags__()
+        if isinstance(tags, dict):
+            continue  # older sklearn API
+        if hasattr(tags, 'estimator_type'):
+            assert tags.estimator_type == expected, \
+                "Unexpected estimator_type tag for {}: {}".format(est.__class__.__name__, tags.estimator_type)
+        if hasattr(tags, 'target_tags') and hasattr(tags.target_tags, 'required'):
+            assert tags.target_tags.required is True
+
+
 pyunit_utils.run_tests([
     test_automl_estimators_exposed_in_h2o_sklearn_automl_module,
     test_algos_estimators_exposed_in_h2o_sklearn_estimators_module,
     test_transformers_exposed_in_h2o_sklean_transforms_module,
+    test_classifier_and_regressor_identification,
+    test_clone_preserves_estimator_type_semantics,
+    test_sklearn_tags_estimator_type_when_available,
 ])


### PR DESCRIPTION
Fixes #16779

## Summary

`h2o.sklearn` wrappers need compatibility updates for newer scikit-learn APIs, especially around estimator type semantics and tags behavior in scikit-learn 1.6+. scikit-learn revamped estimator tags in **1.6.0 (December 2024)** and introduced `__sklearn_tags__` as the preferred API (with `Tags` objects). This affects third-party estimator wrappers and type-dispatch behavior (`is_classifier`, `is_regressor`, clone/check tooling).

For generic H2O sklearn wrappers (e.g. `H2OGradientBoostingEstimator(estimator_type='classifier')`), semantics can drift in sklearn integration paths (notably clone + tags/type checks) unless wrapper params and `_estimator_type` are propagated consistently.

## Proposed / implemented fix

In `h2o-py/h2o/sklearn/wrapper.py`:
- Keep explicit `_estimator_type` precedence in classifier/regressor checks.
- Include `estimator_type` and `init_connection_args` in sklearn parameter flow (`get_params`/`set_params`) so clone semantics are preserved.
- Keep these params reserved from forwarding to underlying H2O estimators.
- Implement `__sklearn_tags__` handling for newer sklearn tags API when available.

In `h2o-py/tests/testdir_sklearn/pyunit_sklearn_api.py`:
- Add regression tests for:
  - classifier/regressor identification
  - clone preserving estimator_type semantics
  - sklearn tags estimator_type behavior (when available)

## Validation run

- `testdir_sklearn/pyunit_sklearn_api.py` → PASS
- `testdir_sklearn/pyunit_sklearn_params.py` → PASS

## Dependency notes

- No H2O package dependency changes are required for this fix itself.
- Compatibility validation was performed with latest scikit-learn 1.x available in test env: **1.6.1**.
- Local environment note: running older sklearn wheels with incompatible NumPy can cause ABI errors; this was an environment concern, not a required project dependency change.
