### PR TITLE
GH-16786: Remove offset effect mojo

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -4,6 +4,7 @@ import hex.*;
 import hex.DataInfo.TransformType;
 import hex.api.MakeGLMModelHandler;
 import hex.deeplearning.DeepLearningModel;
+import hex.genmodel.descriptor.ModelDescriptor;
 import hex.genmodel.utils.DistributionFamily;
 import hex.glm.GLMModel.GLMParameters.Family;
 import hex.glm.GLMModel.GLMParameters.Link;
@@ -2127,12 +2128,12 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     // calculate variable importance which is derived from the standardized coefficients
     public VarImp calculateVarimp(boolean contrVal) {
       String[] names = coefficientNames();
-      
+
       final double [] magnitudes = new double[names.length];
       int len = magnitudes.length - 1;
       if (len == 0) // GLM model contains only intercepts and no predictor coefficients.
         return null;
-      
+
       int[] indices = new int[len];
       for (int i = 0; i < indices.length; ++i)
         indices[i] = i;
@@ -2531,10 +2532,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
 
   @Override
   public boolean haveMojo() {
-    if (_parms._remove_offset_effects) {
-        return false;
-    }
-    if (_parms._control_variables != null && _parms._control_variables.length > 0)
+    if ((_parms._control_variables != null && _parms._control_variables.length > 0) || _parms._remove_offset_effects)
       return _parms.interactionSpec() == null &&
               !_parms._family.equals(Family.multinomial) &&
               !_parms._family.equals(Family.ordinal) &&
@@ -2546,21 +2544,33 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
 
   @Override
   public boolean havePojo() {
-    if (_parms._remove_offset_effects)
-      return false;
-    if (_parms._control_variables != null && _parms._control_variables.length > 0)
+    // POJO doesn't support offset; only allow when offset is absent or remove_offset_effects strips it
+    if ((_parms._control_variables != null && _parms._control_variables.length > 0) || _parms._remove_offset_effects)
       return _parms.interactionSpec() == null &&
-              _parms._offset_column == null &&
+              (_parms._offset_column == null || _parms._remove_offset_effects) &&
               !_parms._family.equals(Family.multinomial) &&
               !_parms._family.equals(Family.ordinal) &&
               super.havePojo();
-    if (_parms.interactionSpec() == null && _parms._offset_column == null) return super.havePojo();
-    else return false;
+    if (_parms.interactionSpec() == null && _parms._offset_column == null)
+      return super.havePojo();
+    return false;
   }
 
   @Override
   public GLMMojoWriter getMojo() {
     return new GLMMojoWriter(this);
+  }
+
+  @Override
+  public ModelDescriptor modelDescriptor() {
+    if (!_parms._remove_offset_effects)
+      return super.modelDescriptor();
+    return new H2OModelDescriptor() {
+      @Override
+      public String offsetColumn() {
+        return null;
+      }
+    };
   }
 
   private boolean isFeatureUsedInPredict(int featureIdx, double[] beta) {

--- a/h2o-algos/src/test/java/hex/glm/GLMControlVariablesAndRemoveOffsetTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMControlVariablesAndRemoveOffsetTest.java
@@ -2410,13 +2410,8 @@ public class GLMControlVariablesAndRemoveOffsetTest extends TestUtil {
             glm = new GLM(params).trainModel().get();
             Scope.track_generic(glm);
 
-            // With remove_offset_effects=true, the exported MOJO/POJO would score WITH offset
-            // but the H2O model scores WITHOUT offset. haveMojo()/havePojo() should return false.
-            // Currently haveMojo() only checks control_variables but NOT remove_offset_effects.
-            assertFalse("haveMojo() should return false when remove_offset_effects=true " +
-                    "(MOJO scoring doesn't implement offset removal)", glm.haveMojo());
-            assertFalse("havePojo() should return false when remove_offset_effects=true " +
-                    "(POJO scoring doesn't implement offset removal)", glm.havePojo());
+            assertTrue("haveMojo() should return true when remove_offset_effects=true ", glm.haveMojo());
+            assertTrue("havePojo() should return true when remove_offset_effects=true ", glm.havePojo());
         } finally {
             if (train != null) train.remove();
             if (glm != null) glm.remove();

--- a/h2o-algos/src/test/java/hex/glm/GLMMojoControlVarsOffsetTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMMojoControlVarsOffsetTest.java
@@ -1,0 +1,244 @@
+package hex.glm;
+
+import hex.generic.Generic;
+import hex.generic.GenericModel;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import water.Scope;
+import water.TestUtil;
+import water.fvec.Frame;
+import water.fvec.TestFrameBuilder;
+import water.fvec.Vec;
+import water.runner.CloudSize;
+import water.runner.H2ORunner;
+
+import java.io.File;
+import java.io.FileOutputStream;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests GLM MOJO scoring for all combinations of remove_offset_effects and control_variables
+ * across binomial, gaussian, and tweedie families.
+ */
+@RunWith(H2ORunner.class)
+@CloudSize(1)
+public class GLMMojoControlVarsOffsetTest extends TestUtil {
+
+    // -- Binomial --
+
+    @Test
+    public void testMojoBinomialBaseline() throws Exception {
+        testCombination(buildBinomialFrame(), GLMModel.GLMParameters.Family.binomial,
+                false, false, "binomial_baseline");
+    }
+
+    @Test
+    public void testMojoBinomialRemoveOffsetOnly() throws Exception {
+        testCombination(buildBinomialFrame(), GLMModel.GLMParameters.Family.binomial,
+                true, false, "binomial_roe");
+    }
+
+    @Test
+    public void testMojoBinomialControlVarsOnly() throws Exception {
+        testCombination(buildBinomialFrame(), GLMModel.GLMParameters.Family.binomial,
+                false, true, "binomial_cv");
+    }
+
+    @Test
+    public void testMojoBinomialBoth() throws Exception {
+        testCombination(buildBinomialFrame(), GLMModel.GLMParameters.Family.binomial,
+                true, true, "binomial_both");
+    }
+
+    // -- Gaussian --
+
+    @Test
+    public void testMojoGaussianBaseline() throws Exception {
+        testCombination(buildRegressionFrame(false), GLMModel.GLMParameters.Family.gaussian,
+                false, false, "gaussian_baseline");
+    }
+
+    @Test
+    public void testMojoGaussianRemoveOffsetOnly() throws Exception {
+        testCombination(buildRegressionFrame(false), GLMModel.GLMParameters.Family.gaussian,
+                true, false, "gaussian_roe");
+    }
+
+    @Test
+    public void testMojoGaussianControlVarsOnly() throws Exception {
+        testCombination(buildRegressionFrame(false), GLMModel.GLMParameters.Family.gaussian,
+                false, true, "gaussian_cv");
+    }
+
+    @Test
+    public void testMojoGaussianBoth() throws Exception {
+        testCombination(buildRegressionFrame(false), GLMModel.GLMParameters.Family.gaussian,
+                true, true, "gaussian_both");
+    }
+
+    // -- Tweedie --
+
+    @Test
+    public void testMojoTweedieBaseline() throws Exception {
+        testCombination(buildRegressionFrame(true), GLMModel.GLMParameters.Family.tweedie,
+                false, false, "tweedie_baseline");
+    }
+
+    @Test
+    public void testMojoTweedieRemoveOffsetOnly() throws Exception {
+        testCombination(buildRegressionFrame(true), GLMModel.GLMParameters.Family.tweedie,
+                true, false, "tweedie_roe");
+    }
+
+    @Test
+    public void testMojoTweedieControlVarsOnly() throws Exception {
+        testCombination(buildRegressionFrame(true), GLMModel.GLMParameters.Family.tweedie,
+                false, true, "tweedie_cv");
+    }
+
+    @Test
+    public void testMojoTweedieBoth() throws Exception {
+        testCombination(buildRegressionFrame(true), GLMModel.GLMParameters.Family.tweedie,
+                true, true, "tweedie_both");
+    }
+
+    // -- Feature-effect tests: verify all combinations produce different predictions --
+
+    @Test
+    public void testAllCombinationsDifferGaussian() throws Exception {
+        assertAllCombinationsDiffer(buildRegressionFrame(false), GLMModel.GLMParameters.Family.gaussian);
+    }
+
+    // -- Test logic --
+
+    private void assertAllCombinationsDiffer(Frame train, GLMModel.GLMParameters.Family family) throws Exception {
+        try {
+            Scope.enter();
+            Scope.track(train);
+
+            // Train all four combinations
+            Frame predsBase = trainAndScore(train, family, false, false);
+            Frame predsRO   = trainAndScore(train, family, true,  false);
+            Frame predsCV   = trainAndScore(train, family, false, true);
+            Frame predsBoth = trainAndScore(train, family, true,  true);
+
+            // Each combination should produce different predictions from every other
+            assertPredictionsDiffer(predsBase, predsRO,   "baseline vs RO");
+            assertPredictionsDiffer(predsBase, predsCV,   "baseline vs CV");
+            assertPredictionsDiffer(predsBase, predsBoth, "baseline vs RO+CV");
+            assertPredictionsDiffer(predsRO,   predsCV,   "RO vs CV");
+            assertPredictionsDiffer(predsRO,   predsBoth, "RO vs RO+CV");
+            assertPredictionsDiffer(predsCV,   predsBoth, "CV vs RO+CV");
+        } finally {
+            Scope.exit();
+        }
+    }
+
+    private Frame trainAndScore(Frame train, GLMModel.GLMParameters.Family family,
+                                boolean removeOffsetEffects, boolean useControlVars) {
+        GLMModel.GLMParameters params = makeParams(train, family, removeOffsetEffects, useControlVars);
+        GLMModel model = new GLM(params).trainModel().get();
+        Scope.track_generic(model);
+        Frame preds = model.score(train);
+        Scope.track(preds);
+        return preds;
+    }
+
+    private GLMModel.GLMParameters makeParams(Frame train, GLMModel.GLMParameters.Family family,
+                                               boolean removeOffsetEffects, boolean useControlVars) {
+        GLMModel.GLMParameters params = new GLMModel.GLMParameters();
+        params._response_column = "response";
+        params._train = train._key;
+        params._family = family;
+        params._offset_column = "offset";
+        params._lambda = new double[]{0};
+        if (removeOffsetEffects) params._remove_offset_effects = true;
+        if (useControlVars) params._control_variables = new String[]{"x3"};
+        if (family == GLMModel.GLMParameters.Family.tweedie) {
+            params._tweedie_variance_power = 1.5;
+            params._tweedie_link_power = 0;
+        }
+        return params;
+    }
+
+    private void assertPredictionsDiffer(Frame pred1, Frame pred2, String label) {
+        int colIdx = pred1.numCols() > 1 ? 1 : 0;
+        long nrows = Math.min(pred1.numRows(), 100);
+        int differ = 0;
+        for (int i = 0; i < nrows; i++) {
+            if (Math.abs(pred1.vec(colIdx).at(i) - pred2.vec(colIdx).at(i)) > 1e-10) differ++;
+        }
+        assertTrue(label + ": predictions should differ (only " + differ + "/" + nrows + " rows differed)",
+                differ > nrows / 10);
+    }
+
+    private void testCombination(Frame train, GLMModel.GLMParameters.Family family,
+                                 boolean removeOffsetEffects, boolean useControlVars, String label) throws Exception {
+        try {
+            Scope.enter();
+            Scope.track(train);
+
+            GLMModel.GLMParameters params = makeParams(train, family, removeOffsetEffects, useControlVars);
+            GLMModel model = new GLM(params).trainModel().get();
+            Scope.track_generic(model);
+            assertTrue(label + ": should support MOJO", model.haveMojo());
+
+            Frame h2oPreds = model.score(train);
+            Scope.track(h2oPreds);
+
+            // Save MOJO, reimport as GenericModel, score, and compare
+            File mojoFile = File.createTempFile("glm_mojo", ".zip");
+            mojoFile.deleteOnExit();
+            try (FileOutputStream fos = new FileOutputStream(mojoFile)) {
+                model.getMojo().writeTo(fos);
+            }
+
+            GenericModel genericModel = Generic.importMojoModel(mojoFile.getAbsolutePath(), false);
+            Scope.track_generic(genericModel);
+
+            Frame mojoPreds = genericModel.score(train);
+            Scope.track(mojoPreds);
+
+            assertFrameEquals(h2oPreds, mojoPreds, 1e-8);
+        } finally {
+            Scope.exit();
+        }
+    }
+
+    // -- Frame builders --
+
+    private Frame buildBinomialFrame() {
+        double[] x1 = {1.2, 2.3, 3.1, 0.5, 1.8, 2.7, 3.5, 0.9, 1.5, 2.1, 3.0, 0.7, 1.1, 2.5, 3.3, 0.4, 1.6, 2.9, 3.7, 0.8};
+        double[] x2 = {0.5, 1.5, 0.8, 1.2, 0.3, 1.8, 0.6, 1.1, 0.9, 1.4, 0.7, 1.6, 0.4, 1.3, 0.2, 1.7, 0.1, 1.9, 0.5, 1.0};
+        double[] x3 = {3.0, 1.0, 2.0, 4.0, 3.5, 1.5, 2.5, 3.2, 1.8, 2.8, 3.8, 1.2, 2.2, 3.6, 1.6, 2.6, 4.2, 0.8, 3.4, 1.4};
+        double[] offset = {0.1, -0.2, 0.3, -0.1, 0.2, -0.3, 0.15, -0.15, 0.25, -0.25, 0.05, -0.05, 0.12, -0.12, 0.22, -0.22, 0.08, -0.08, 0.18, -0.18};
+        String[] response = {"1", "1", "1", "0", "1", "1", "1", "0", "1", "1", "1", "0", "0", "1", "1", "0", "1", "1", "1", "0"};
+
+        Frame f = new TestFrameBuilder()
+                .withColNames("x1", "x2", "x3", "offset", "response")
+                .withVecTypes(Vec.T_NUM, Vec.T_NUM, Vec.T_NUM, Vec.T_NUM, Vec.T_CAT)
+                .withDataForCol(0, x1).withDataForCol(1, x2).withDataForCol(2, x3)
+                .withDataForCol(3, offset).withDataForCol(4, response)
+                .build();
+        return f;
+    }
+
+    private Frame buildRegressionFrame(boolean positiveResponse) {
+        double[] x1 = {1.2, 2.3, 3.1, 0.5, 1.8, 2.7, 3.5, 0.9, 1.5, 2.1, 3.0, 0.7, 1.1, 2.5, 3.3, 0.4, 1.6, 2.9, 3.7, 0.8};
+        double[] x2 = {0.5, 1.5, 0.8, 1.2, 0.3, 1.8, 0.6, 1.1, 0.9, 1.4, 0.7, 1.6, 0.4, 1.3, 0.2, 1.7, 0.1, 1.9, 0.5, 1.0};
+        double[] x3 = {3.0, 1.0, 2.0, 4.0, 3.5, 1.5, 2.5, 3.2, 1.8, 2.8, 3.8, 1.2, 2.2, 3.6, 1.6, 2.6, 4.2, 0.8, 3.4, 1.4};
+        double[] offset = {0.1, 0.2, 0.3, 0.1, 0.2, 0.3, 0.15, 0.15, 0.25, 0.25, 0.05, 0.05, 0.12, 0.12, 0.22, 0.22, 0.08, 0.08, 0.18, 0.18};
+        double[] response = positiveResponse
+                ? new double[]{2.5, 4.1, 5.8, 1.2, 3.3, 5.0, 6.5, 1.8, 2.9, 4.5, 5.6, 1.5, 2.1, 4.8, 6.2, 0.9, 3.0, 5.3, 7.0, 1.6}
+                : new double[]{2.5, 4.1, 5.8, -1.2, 3.3, 5.0, 6.5, -1.8, 2.9, 4.5, 5.6, -1.5, 2.1, 4.8, 6.2, -0.9, 3.0, 5.3, 7.0, -1.6};
+
+        Frame f = new TestFrameBuilder()
+                .withColNames("x1", "x2", "x3", "offset", "response")
+                .withVecTypes(Vec.T_NUM, Vec.T_NUM, Vec.T_NUM, Vec.T_NUM, Vec.T_NUM)
+                .withDataForCol(0, x1).withDataForCol(1, x2).withDataForCol(2, x3)
+                .withDataForCol(3, offset).withDataForCol(4, response)
+                .build();
+        return f;
+    }
+}

--- a/h2o-algos/src/test/java/hex/glm/GLMMojoControlVarsOffsetTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMMojoControlVarsOffsetTest.java
@@ -14,6 +14,7 @@ import water.runner.H2ORunner;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.nio.file.Files;
 
 import static org.junit.Assert.*;
 
@@ -188,7 +189,7 @@ public class GLMMojoControlVarsOffsetTest extends TestUtil {
             Scope.track(h2oPreds);
 
             // Save MOJO, reimport as GenericModel, score, and compare
-            File mojoFile = File.createTempFile("glm_mojo", ".zip");
+            File mojoFile = Files.createTempFile("glm_mojo", ".zip").toFile();
             mojoFile.deleteOnExit();
             try (FileOutputStream fos = new FileOutputStream(mojoFile)) {
                 model.getMojo().writeTo(fos);

--- a/h2o-algos/src/test/java/hex/glm/GLMMojoControlVarsOffsetTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMMojoControlVarsOffsetTest.java
@@ -43,7 +43,7 @@ public class GLMMojoControlVarsOffsetTest extends TestUtil {
     @Test
     public void testMojoBinomialControlVarsOnly() throws Exception {
         testCombination(buildBinomialFrame(), GLMModel.GLMParameters.Family.binomial,
-                false, true, "binomial_cv");
+                false, true, "binomial_contr_vals");
     }
 
     @Test

--- a/h2o-algos/src/test/java/hex/glm/GLMMojoControlVarsOffsetTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMMojoControlVarsOffsetTest.java
@@ -37,7 +37,7 @@ public class GLMMojoControlVarsOffsetTest extends TestUtil {
     @Test
     public void testMojoBinomialRemoveOffsetOnly() throws Exception {
         testCombination(buildBinomialFrame(), GLMModel.GLMParameters.Family.binomial,
-                true, false, "binomial_roe");
+                true, false, "binomial_rem_off_eff");
     }
 
     @Test
@@ -63,13 +63,13 @@ public class GLMMojoControlVarsOffsetTest extends TestUtil {
     @Test
     public void testMojoGaussianRemoveOffsetOnly() throws Exception {
         testCombination(buildRegressionFrame(false), GLMModel.GLMParameters.Family.gaussian,
-                true, false, "gaussian_roe");
+                true, false, "gaussian_rem_off_eff");
     }
 
     @Test
     public void testMojoGaussianControlVarsOnly() throws Exception {
         testCombination(buildRegressionFrame(false), GLMModel.GLMParameters.Family.gaussian,
-                false, true, "gaussian_cv");
+                false, true, "gaussian_contr_vals");
     }
 
     @Test
@@ -89,13 +89,13 @@ public class GLMMojoControlVarsOffsetTest extends TestUtil {
     @Test
     public void testMojoTweedieRemoveOffsetOnly() throws Exception {
         testCombination(buildRegressionFrame(true), GLMModel.GLMParameters.Family.tweedie,
-                true, false, "tweedie_roe");
+                true, false, "tweedie_rem_off_eff");
     }
 
     @Test
     public void testMojoTweedieControlVarsOnly() throws Exception {
         testCombination(buildRegressionFrame(true), GLMModel.GLMParameters.Family.tweedie,
-                false, true, "tweedie_cv");
+                false, true, "tweedie_contr_vals");
     }
 
     @Test
@@ -125,12 +125,12 @@ public class GLMMojoControlVarsOffsetTest extends TestUtil {
             Frame predsBoth = trainAndScore(train, family, true,  true);
 
             // Each combination should produce different predictions from every other
-            assertPredictionsDiffer(predsBase, predsRO,   "baseline vs RO");
-            assertPredictionsDiffer(predsBase, predsCV,   "baseline vs CV");
-            assertPredictionsDiffer(predsBase, predsBoth, "baseline vs RO+CV");
-            assertPredictionsDiffer(predsRO,   predsCV,   "RO vs CV");
-            assertPredictionsDiffer(predsRO,   predsBoth, "RO vs RO+CV");
-            assertPredictionsDiffer(predsCV,   predsBoth, "CV vs RO+CV");
+            assertPredictionsDiffer(predsBase, predsRO,   "baseline vs RemOffEff");
+            assertPredictionsDiffer(predsBase, predsCV,   "baseline vs ContrVals");
+            assertPredictionsDiffer(predsBase, predsBoth, "baseline vs RemOffEff+ContrVals");
+            assertPredictionsDiffer(predsRO,   predsCV,   "RemOffEff vs ContrVals");
+            assertPredictionsDiffer(predsRO,   predsBoth, "RemOffEff vs RemOffEff+ContrVals");
+            assertPredictionsDiffer(predsCV,   predsBoth, "ContrVals vs RemOffEff+ContrVals");
         } finally {
             Scope.exit();
         }

--- a/h2o-genmodel/src/main/java/hex/genmodel/AbstractMojoWriter.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/AbstractMojoWriter.java
@@ -16,7 +16,7 @@ import java.util.zip.ZipOutputStream;
 
 public abstract class AbstractMojoWriter {
   /**
-   * Reference to the model being written. Use this in the subclasses to retreive information from your model.
+   * Reference to the model being written. Use this in the subclasses to retrieve information from your model.
    */
   private ModelDescriptor model;
 

--- a/h2o-py/tests/testdir_algos/glm/pyunit_glm_mojo_control_vars_offset.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_glm_mojo_control_vars_offset.py
@@ -26,22 +26,22 @@ def glm_mojo_control_vars_offset():
     ]
 
     # Binomial
-    for label, roe, cv in combinations:
+    for label, roe, contr_vals in combinations:
         params = dict(family="binomial", offset_column="offset_col", lambda_=0)
         if roe:
             params["remove_offset_effects"] = True
-        if cv is not None:
-            params["control_variables"] = cv
+        if contr_vals is not None:
+            params["control_variables"] = contr_vals
         compare_mojo("binomial_" + label, "CAPSULE",
                      ["RACE", "DCAPS", "PSA", "VOL", "DPROS", "GLEASON"], train, params)
 
     # Gaussian
-    for label, roe, cv in combinations:
+    for label, roe, contr_vals in combinations:
         params = dict(family="gaussian", offset_column="offset_col", lambda_=0)
         if roe:
             params["remove_offset_effects"] = True
-        if cv is not None:
-            params["control_variables"] = cv
+        if contr_vals is not None:
+            params["control_variables"] = contr_vals
         compare_mojo("gaussian_" + label, "VOL",
                      ["RACE", "DCAPS", "PSA", "DPROS", "GLEASON"], train, params)
 
@@ -52,13 +52,13 @@ def glm_mojo_control_vars_offset():
 
     # Tweedie (response must be positive)
     train["positive_vol"] = abs(train["VOL"]) + 1
-    for label, roe, cv in combinations:
+    for label, roe, contr_vals in combinations:
         params = dict(family="tweedie", offset_column="offset_col", lambda_=0,
                       tweedie_variance_power=1.5, tweedie_link_power=0)
         if roe:
             params["remove_offset_effects"] = True
-        if cv is not None:
-            params["control_variables"] = cv
+        if contr_vals is not None:
+            params["control_variables"] = contr_vals
         compare_mojo("tweedie_" + label, "positive_vol",
                      ["RACE", "DCAPS", "PSA", "DPROS", "GLEASON"], train, params)
 
@@ -88,19 +88,19 @@ def assert_predictions_differ(pred1, pred2, label):
 
 
 def verify_features_change_predictions(family_label, y, x, data, base_params):
-    """Verify that all combinations of RO and CV produce different predictions from each other."""
+    """Verify that all combinations of RO and ContrVals produce different predictions from each other."""
     pred_base = compare_mojo(family_label + "_base_check", y, x, data, base_params)
     pred_ro   = compare_mojo(family_label + "_ro_check", y, x, data, dict(base_params, remove_offset_effects=True))
-    pred_cv   = compare_mojo(family_label + "_cv_check", y, x, data, dict(base_params, control_variables=["PSA"]))
+    pred_contr_vals   = compare_mojo(family_label + "_contr_vals_check", y, x, data, dict(base_params, control_variables=["PSA"]))
     pred_both = compare_mojo(family_label + "_both_check", y, x, data,
                              dict(base_params, remove_offset_effects=True, control_variables=["PSA"]))
 
     assert_predictions_differ(pred_base, pred_ro,   family_label + " baseline vs RO")
-    assert_predictions_differ(pred_base, pred_cv,   family_label + " baseline vs CV")
-    assert_predictions_differ(pred_base, pred_both, family_label + " baseline vs RO+CV")
-    assert_predictions_differ(pred_ro,   pred_cv,   family_label + " RO vs CV")
-    assert_predictions_differ(pred_ro,   pred_both, family_label + " RO vs RO+CV")
-    assert_predictions_differ(pred_cv,   pred_both, family_label + " CV vs RO+CV")
+    assert_predictions_differ(pred_base, pred_contr_vals,   family_label + " baseline vs ContrVals")
+    assert_predictions_differ(pred_base, pred_both, family_label + " baseline vs RO+ContrVals")
+    assert_predictions_differ(pred_ro,   pred_contr_vals,   family_label + " RO vs ContrVals")
+    assert_predictions_differ(pred_ro,   pred_both, family_label + " RO vs RO+ContrVals")
+    assert_predictions_differ(pred_contr_vals,   pred_both, family_label + " ContrVals vs RO+ContrVals")
 
 
 if __name__ == "__main__":

--- a/h2o-py/tests/testdir_algos/glm/pyunit_glm_mojo_control_vars_offset.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_glm_mojo_control_vars_offset.py
@@ -1,0 +1,109 @@
+import sys
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+import tempfile
+
+
+def glm_mojo_control_vars_offset():
+    """
+    Test GLM MOJO for all combinations of remove_offset_effects and control_variables
+    across binomial, gaussian, and tweedie families.
+    """
+    train = h2o.import_file(pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    train["CAPSULE"] = train["CAPSULE"].asfactor()
+    train["RACE"] = train["RACE"].asfactor()
+    train["DCAPS"] = train["DCAPS"].asfactor()
+    train["DPROS"] = train["DPROS"].asfactor()
+    train["offset_col"] = train["AGE"] / 100.0
+
+    combinations = [
+        ("baseline", False, None),
+        ("remove_offset_effects", True, None),
+        ("control_variables", False, ["PSA"]),
+        ("both", True, ["PSA"]),
+    ]
+
+    # Binomial
+    for label, roe, cv in combinations:
+        params = dict(family="binomial", offset_column="offset_col", lambda_=0)
+        if roe:
+            params["remove_offset_effects"] = True
+        if cv is not None:
+            params["control_variables"] = cv
+        compare_mojo("binomial_" + label, "CAPSULE",
+                     ["RACE", "DCAPS", "PSA", "VOL", "DPROS", "GLEASON"], train, params)
+
+    # Gaussian
+    for label, roe, cv in combinations:
+        params = dict(family="gaussian", offset_column="offset_col", lambda_=0)
+        if roe:
+            params["remove_offset_effects"] = True
+        if cv is not None:
+            params["control_variables"] = cv
+        compare_mojo("gaussian_" + label, "VOL",
+                     ["RACE", "DCAPS", "PSA", "DPROS", "GLEASON"], train, params)
+
+    # Verify that features actually change predictions (gaussian as representative family)
+    verify_features_change_predictions("gaussian", "VOL",
+                                       ["RACE", "DCAPS", "PSA", "DPROS", "GLEASON"], train,
+                                       dict(family="gaussian", offset_column="offset_col", lambda_=0))
+
+    # Tweedie (response must be positive)
+    train["positive_vol"] = abs(train["VOL"]) + 1
+    for label, roe, cv in combinations:
+        params = dict(family="tweedie", offset_column="offset_col", lambda_=0,
+                      tweedie_variance_power=1.5, tweedie_link_power=0)
+        if roe:
+            params["remove_offset_effects"] = True
+        if cv is not None:
+            params["control_variables"] = cv
+        compare_mojo("tweedie_" + label, "positive_vol",
+                     ["RACE", "DCAPS", "PSA", "DPROS", "GLEASON"], train, params)
+
+
+def compare_mojo(label, y, x, data, params):
+    print("=== {} ===".format(label))
+    model = H2OGeneralizedLinearEstimator(**params)
+    model.train(x=x, y=y, training_frame=data)
+
+    pred_h2o = model.predict(data)
+
+    mojo_path = model.save_mojo(path=tempfile.mkdtemp())
+    mojo_model = h2o.import_mojo(mojo_path)
+    pred_mojo = mojo_model.predict(data)
+
+    pyunit_utils.compare_frames_local(pred_h2o, pred_mojo, prob=1, tol=1e-8)
+    print("  PASSED: {}".format(label))
+    return pred_h2o
+
+
+def assert_predictions_differ(pred1, pred2, label):
+    col = "p0" if "p0" in pred1.columns else "predict"
+    max_diff = (pred1[col].asnumeric() - pred2[col].asnumeric()).abs().max()
+    assert max_diff > 1e-10, \
+        "{}: predictions should differ but max diff = {}".format(label, max_diff)
+    print("  DIFFER OK: {} (max_diff={})".format(label, max_diff))
+
+
+def verify_features_change_predictions(family_label, y, x, data, base_params):
+    """Verify that all combinations of RO and CV produce different predictions from each other."""
+    pred_base = compare_mojo(family_label + "_base_check", y, x, data, base_params)
+    pred_ro   = compare_mojo(family_label + "_ro_check", y, x, data, dict(base_params, remove_offset_effects=True))
+    pred_cv   = compare_mojo(family_label + "_cv_check", y, x, data, dict(base_params, control_variables=["PSA"]))
+    pred_both = compare_mojo(family_label + "_both_check", y, x, data,
+                             dict(base_params, remove_offset_effects=True, control_variables=["PSA"]))
+
+    assert_predictions_differ(pred_base, pred_ro,   family_label + " baseline vs RO")
+    assert_predictions_differ(pred_base, pred_cv,   family_label + " baseline vs CV")
+    assert_predictions_differ(pred_base, pred_both, family_label + " baseline vs RO+CV")
+    assert_predictions_differ(pred_ro,   pred_cv,   family_label + " RO vs CV")
+    assert_predictions_differ(pred_ro,   pred_both, family_label + " RO vs RO+CV")
+    assert_predictions_differ(pred_cv,   pred_both, family_label + " CV vs RO+CV")
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(glm_mojo_control_vars_offset)
+else:
+    glm_mojo_control_vars_offset()

--- a/h2o-r/tests/testdir_algos/glm/runit_GLM_mojo_control_vars_offset.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_GLM_mojo_control_vars_offset.R
@@ -1,0 +1,104 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues = TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+test.glm_mojo_control_vars_offset <- function() {
+  # Test GLM MOJO for all combinations of remove_offset_effects and control_variables
+  # across binomial, gaussian, and tweedie families.
+
+  h2o.data <- h2o.uploadFile(locate("smalldata/logreg/prostate.csv"))
+  h2o.data$CAPSULE <- as.factor(h2o.data$CAPSULE)
+  h2o.data$RACE <- as.factor(h2o.data$RACE)
+  h2o.data$DCAPS <- as.factor(h2o.data$DCAPS)
+  h2o.data$DPROS <- as.factor(h2o.data$DPROS)
+  h2o.data$offset_col <- h2o.data$AGE / 100.0
+  h2o.data$positive_vol <- abs(h2o.data$VOL) + 1
+
+  binomial_x <- c("RACE", "DCAPS", "PSA", "VOL", "DPROS", "GLEASON")
+  regression_x <- c("RACE", "DCAPS", "PSA", "DPROS", "GLEASON")
+
+  # Binomial
+  for (combo in list(
+    list(label = "binomial_baseline", roe = FALSE, cv = NULL),
+    list(label = "binomial_roe", roe = TRUE, cv = NULL),
+    list(label = "binomial_cv", roe = FALSE, cv = c("PSA")),
+    list(label = "binomial_both", roe = TRUE, cv = c("PSA"))
+  )) {
+    args <- list(family = "binomial", offset_column = "offset_col", lambda = 0)
+    if (combo$roe) args$remove_offset_effects <- TRUE
+    if (!is.null(combo$cv)) args$control_variables <- combo$cv
+    compare_mojo(combo$label, binomial_x, "CAPSULE", h2o.data, args)
+  }
+
+  # Gaussian
+  for (combo in list(
+    list(label = "gaussian_baseline", roe = FALSE, cv = NULL),
+    list(label = "gaussian_roe", roe = TRUE, cv = NULL),
+    list(label = "gaussian_cv", roe = FALSE, cv = c("PSA")),
+    list(label = "gaussian_both", roe = TRUE, cv = c("PSA"))
+  )) {
+    args <- list(family = "gaussian", offset_column = "offset_col", lambda = 0)
+    if (combo$roe) args$remove_offset_effects <- TRUE
+    if (!is.null(combo$cv)) args$control_variables <- combo$cv
+    compare_mojo(combo$label, regression_x, "VOL", h2o.data, args)
+  }
+
+  # Verify that features actually change predictions (gaussian as representative family)
+  verify_features_change_predictions("gaussian", regression_x, "VOL", h2o.data,
+    list(family = "gaussian", offset_column = "offset_col", lambda = 0))
+
+  # Tweedie
+  for (combo in list(
+    list(label = "tweedie_baseline", roe = FALSE, cv = NULL),
+    list(label = "tweedie_roe", roe = TRUE, cv = NULL),
+    list(label = "tweedie_cv", roe = FALSE, cv = c("PSA")),
+    list(label = "tweedie_both", roe = TRUE, cv = c("PSA"))
+  )) {
+    args <- list(family = "tweedie", offset_column = "offset_col", lambda = 0,
+                 tweedie_variance_power = 1.5, tweedie_link_power = 0)
+    if (combo$roe) args$remove_offset_effects <- TRUE
+    if (!is.null(combo$cv)) args$control_variables <- combo$cv
+    compare_mojo(combo$label, regression_x, "positive_vol", h2o.data, args)
+  }
+}
+
+compare_mojo <- function(label, x, y, data, args) {
+  Log.info(label)
+  model <- do.call(h2o.glm, c(list(x = x, y = y, training_frame = data), args))
+  pred_h2o <- h2o.predict(model, data)
+
+  mojo_path <- h2o.save_mojo(model, path = tempdir(), force = TRUE)
+  mojo_model <- h2o.import_mojo(mojo_path)
+  pred_mojo <- h2o.predict(mojo_model, data)
+
+  compareFrames(pred_h2o, pred_mojo, prob = 1, tolerance = 1e-8)
+  Log.info(paste("  PASSED:", label))
+  return(pred_h2o)
+}
+
+assert_predictions_differ <- function(pred1, pred2, label) {
+  col <- if ("p0" %in% colnames(pred1)) "p0" else "predict"
+  max_diff <- max(abs(as.data.frame(pred1[[col]]) - as.data.frame(pred2[[col]])))
+  if (max_diff <= 1e-10) {
+    stop(paste0(label, ": predictions should differ but max diff = ", max_diff))
+  }
+  Log.info(paste("  DIFFER OK:", label, "max_diff =", max_diff))
+}
+
+verify_features_change_predictions <- function(family_label, x, y, data, base_args) {
+  pred_base <- compare_mojo(paste0(family_label, "_base_check"), x, y, data, base_args)
+  pred_ro   <- compare_mojo(paste0(family_label, "_ro_check"), x, y, data,
+    c(base_args, list(remove_offset_effects = TRUE)))
+  pred_cv   <- compare_mojo(paste0(family_label, "_cv_check"), x, y, data,
+    c(base_args, list(control_variables = c("PSA"))))
+  pred_both <- compare_mojo(paste0(family_label, "_both_check"), x, y, data,
+    c(base_args, list(remove_offset_effects = TRUE, control_variables = c("PSA"))))
+
+  assert_predictions_differ(pred_base, pred_ro,   paste(family_label, "baseline vs RO"))
+  assert_predictions_differ(pred_base, pred_cv,   paste(family_label, "baseline vs CV"))
+  assert_predictions_differ(pred_base, pred_both, paste(family_label, "baseline vs RO+CV"))
+  assert_predictions_differ(pred_ro,   pred_cv,   paste(family_label, "RO vs CV"))
+  assert_predictions_differ(pred_ro,   pred_both, paste(family_label, "RO vs RO+CV"))
+  assert_predictions_differ(pred_cv,   pred_both, paste(family_label, "CV vs RO+CV"))
+}
+
+doTest("GLM MOJO with remove_offset_effects and control_variables", test.glm_mojo_control_vars_offset)

--- a/h2o-r/tests/testdir_algos/glm/runit_GLM_mojo_control_vars_offset.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_GLM_mojo_control_vars_offset.R
@@ -20,7 +20,7 @@ test.glm_mojo_control_vars_offset <- function() {
   for (combo in list(
     list(label = "binomial_baseline", roe = FALSE, cv = NULL),
     list(label = "binomial_roe", roe = TRUE, cv = NULL),
-    list(label = "binomial_cv", roe = FALSE, cv = c("PSA")),
+    list(label = "binomial_contr_vars", roe = FALSE, cv = c("PSA")),
     list(label = "binomial_both", roe = TRUE, cv = c("PSA"))
   )) {
     args <- list(family = "binomial", offset_column = "offset_col", lambda = 0)
@@ -33,7 +33,7 @@ test.glm_mojo_control_vars_offset <- function() {
   for (combo in list(
     list(label = "gaussian_baseline", roe = FALSE, cv = NULL),
     list(label = "gaussian_roe", roe = TRUE, cv = NULL),
-    list(label = "gaussian_cv", roe = FALSE, cv = c("PSA")),
+    list(label = "gaussian_contr_vars", roe = FALSE, cv = c("PSA")),
     list(label = "gaussian_both", roe = TRUE, cv = c("PSA"))
   )) {
     args <- list(family = "gaussian", offset_column = "offset_col", lambda = 0)
@@ -50,7 +50,7 @@ test.glm_mojo_control_vars_offset <- function() {
   for (combo in list(
     list(label = "tweedie_baseline", roe = FALSE, cv = NULL),
     list(label = "tweedie_roe", roe = TRUE, cv = NULL),
-    list(label = "tweedie_cv", roe = FALSE, cv = c("PSA")),
+    list(label = "tweedie_contr_vars", roe = FALSE, cv = c("PSA")),
     list(label = "tweedie_both", roe = TRUE, cv = c("PSA"))
   )) {
     args <- list(family = "tweedie", offset_column = "offset_col", lambda = 0,
@@ -88,17 +88,17 @@ verify_features_change_predictions <- function(family_label, x, y, data, base_ar
   pred_base <- compare_mojo(paste0(family_label, "_base_check"), x, y, data, base_args)
   pred_ro   <- compare_mojo(paste0(family_label, "_ro_check"), x, y, data,
     c(base_args, list(remove_offset_effects = TRUE)))
-  pred_cv   <- compare_mojo(paste0(family_label, "_cv_check"), x, y, data,
+  pred_contr_vars   <- compare_mojo(paste0(family_label, "_contr_vars_check"), x, y, data,
     c(base_args, list(control_variables = c("PSA"))))
   pred_both <- compare_mojo(paste0(family_label, "_both_check"), x, y, data,
     c(base_args, list(remove_offset_effects = TRUE, control_variables = c("PSA"))))
 
   assert_predictions_differ(pred_base, pred_ro,   paste(family_label, "baseline vs RO"))
-  assert_predictions_differ(pred_base, pred_cv,   paste(family_label, "baseline vs CV"))
-  assert_predictions_differ(pred_base, pred_both, paste(family_label, "baseline vs RO+CV"))
-  assert_predictions_differ(pred_ro,   pred_cv,   paste(family_label, "RO vs CV"))
-  assert_predictions_differ(pred_ro,   pred_both, paste(family_label, "RO vs RO+CV"))
-  assert_predictions_differ(pred_cv,   pred_both, paste(family_label, "CV vs RO+CV"))
+  assert_predictions_differ(pred_base, pred_contr_vars,   paste(family_label, "baseline vs ContrVals"))
+  assert_predictions_differ(pred_base, pred_both, paste(family_label, "baseline vs RO+ContrVals"))
+  assert_predictions_differ(pred_ro,   pred_contr_vars,   paste(family_label, "RO vs ContrVals"))
+  assert_predictions_differ(pred_ro,   pred_both, paste(family_label, "RO vs RO+ContrVals"))
+  assert_predictions_differ(pred_contr_vars,   pred_both, paste(family_label, "ContrVals vs RO+ContrVals"))
 }
 
 doTest("GLM MOJO with remove_offset_effects and control_variables", test.glm_mojo_control_vars_offset)


### PR DESCRIPTION
#16786 

This will need to be rebased once #16749 is merged. Now this is based on combinations of rel-3.46.0 and #16749 so I have control variables mojo support which is in rel-3.46.0 and remove offset effect which is in #16749 but still not in rel-3.46.0.