### PR TITLE
GH-16716: Explain in R fails when provided with ordinal family

### DIFF
--- a/h2o-algos/src/test/java/hex/pdp/PartialDependenceTest.java
+++ b/h2o-algos/src/test/java/hex/pdp/PartialDependenceTest.java
@@ -1,6 +1,8 @@
 package hex.pdp;
 
 import hex.PartialDependence;
+import hex.glm.GLM;
+import hex.glm.GLMModel;
 import hex.tree.gbm.GBM;
 import hex.tree.gbm.GBMModel;
 import org.junit.BeforeClass;
@@ -10,6 +12,8 @@ import water.fvec.Frame;
 import water.fvec.Vec;
 import water.util.Log;
 import water.util.TwoDimTable;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class PartialDependenceTest extends TestUtil {
@@ -422,6 +426,69 @@ public class PartialDependenceTest extends TestUtil {
       if (fr!=null) fr.remove();
       if (model!=null) model.remove();
       if (partialDependence !=null) partialDependence.remove();
+    }
+  }
+
+  // GH-16716: Ordinal models were blocked from partial dependence plots.
+  // This test verifies that PDP works for ordinal regression with targets specified.
+  @Test public void irisOrdinal() {
+    Scope.enter();
+    try {
+      Frame fr = parseTestFile("smalldata/iris/iris2.csv");
+      fr.replace(fr.find("response"), fr.vec("response").toCategoricalVec()).remove();
+      DKV.put(fr);
+      Scope.track(fr);
+
+      GLMModel.GLMParameters parms = new GLMModel.GLMParameters(
+              GLMModel.GLMParameters.Family.ordinal,
+              GLMModel.GLMParameters.Family.ordinal.defaultLink,
+              new double[]{0}, new double[]{0}, 0, 0);
+      parms._train = fr._key;
+      parms._response_column = "response";
+      parms._lambda = new double[]{0};
+      parms._alpha = new double[]{0.001};
+      GLMModel model = new GLM(parms).trainModel().get();
+      Scope.track_generic(model);
+
+      assertTrue("Ordinal model should have >2 classes", model._output.nclasses() > 2);
+
+      // 1D PDP + 2D PDP with multiple targets and multiple col pairs should work for ordinal.
+      // Uses 2 col pairs to exercise the column2D counter incrementing across pairs.
+      PartialDependence partialDependence = new PartialDependence(Key.<PartialDependence>make());
+      partialDependence._nbins = 10;
+      partialDependence._model_id = (Key) model._key;
+      partialDependence._frame_id = fr._key;
+      partialDependence._cols = new String[]{"Sepal.Length", "Sepal.Width"};
+      partialDependence._col_pairs_2dpdp = new String[][]{
+              {"Sepal.Length", "Sepal.Width"},
+              {"Petal.Length", "Petal.Width"}
+      };
+      partialDependence._targets = new String[]{"setosa", "versicolor"};
+      partialDependence.execImpl().get();
+      Scope.track_generic(partialDependence);
+
+      for (TwoDimTable t : partialDependence._partial_dependence_data)
+        Log.info(t);
+
+      // 2 cols * 2 targets + 2 col_pairs * 2 targets = 8
+      assertEquals("Expected 8 PDP tables", 8, partialDependence._partial_dependence_data.length);
+
+      // Verify PDP tables have correct structure and plausible values
+      for (int i = 0; i < partialDependence._partial_dependence_data.length; i++) {
+        TwoDimTable t = partialDependence._partial_dependence_data[i];
+        assertNotNull("PDP table " + i + " should not be null", t);
+        assertTrue("PDP table " + i + " should have rows", t.getRowDim() > 0);
+        // mean_response column: check values are valid probabilities for ordinal classification
+        int num1D = partialDependence._cols.length * partialDependence._targets.length;
+        int meanRespCol = (i < num1D) ? 1 : 2; // 1D tables have mean_response at col 1, 2D at col 2
+        for (int r = 0; r < t.getRowDim(); r++) {
+          double val = (double) t.get(r, meanRespCol);
+          assertTrue("mean_response should be finite in table " + i + " row " + r, Double.isFinite(val));
+          assertTrue("mean_response should be in [0,1] for ordinal, got " + val, val >= 0.0 && val <= 1.0);
+        }
+      }
+    } finally {
+      Scope.exit();
     }
   }
 

--- a/h2o-core/src/main/java/hex/PartialDependence.java
+++ b/h2o-core/src/main/java/hex/PartialDependence.java
@@ -95,7 +95,7 @@ public class PartialDependence extends Lockable<PartialDependence> {
     }
     int nclasses = m._output.nclasses();
     if(nclasses <= 2 && _targets != null){
-      throw new IllegalArgumentException("Targets parameter is available only for multinomial classification.");
+      throw new IllegalArgumentException("Targets parameter is available only for multinomial classification or ordinal regression.");
     }
     if(nclasses == 1){
       _predictor_column = 0;
@@ -105,7 +105,7 @@ public class PartialDependence extends Lockable<PartialDependence> {
       _predictor_columns = new int[]{_predictor_column};
     } else {
       if (_targets == null) {
-        throw new IllegalArgumentException("Targets parameter has to be set for multinomial classification.");
+        throw new IllegalArgumentException("Targets parameter has to be set for multinomial classification or ordinal regression.");
       } else {
         _predictor_columns = findTargetClassPredictorIndices(m, _targets);
       }
@@ -117,8 +117,8 @@ public class PartialDependence extends Lockable<PartialDependence> {
         _cols_1d_2d.addAll(Arrays.asList(_cols));
       if (_col_pairs_2dpdp != null) {
         _num_2D_pairs = _col_pairs_2dpdp.length * _predictor_columns.length;
-        for (int index=0; index < _num_2D_pairs; index++) {
-          if (!(_cols_1d_2d.contains(_col_pairs_2dpdp[index][0]))) 
+        for (int index = 0; index < _col_pairs_2dpdp.length; index++) {
+          if (!(_cols_1d_2d.contains(_col_pairs_2dpdp[index][0])))
             _cols_1d_2d.add(_col_pairs_2dpdp[index][0]);
           if (!(_cols_1d_2d.contains(_col_pairs_2dpdp[index][1])))
             _cols_1d_2d.add(_col_pairs_2dpdp[index][1]);
@@ -220,10 +220,11 @@ public class PartialDependence extends Lockable<PartialDependence> {
       _partial_dependence_data = new TwoDimTable[num_cols_1d_2d];
       
       int column = 0;
+      int column2D = 0; // separate index into _col_pairs_2dpdp
       for (int i = 0; i < num_cols_1d_2d; ++i) {  // take care of the 1d pdp first, then 2d pdp
         boolean workingOn1D = (i < _num_1D);
-        final String col = workingOn1D ? _cols[column] : _col_pairs_2dpdp[column - _num_1D][0];
-        final String col2 = workingOn1D ? null : _col_pairs_2dpdp[column - _num_1D][1];
+        final String col = workingOn1D ? _cols[column] : _col_pairs_2dpdp[column2D][0];
+        final String col2 = workingOn1D ? null : _col_pairs_2dpdp[column2D][1];
         final int whichPredictorColumn = i % _predictor_columns.length;
         Log.debug("Computing partial dependence of model on '" + col + "'"+(_targets == null ? "." : " and class "+_targets[whichPredictorColumn]+"."));
         double[] colVals = extractColValues(col, _nbins, fr.vec(col));
@@ -314,9 +315,9 @@ public class PartialDependence extends Lockable<PartialDependence> {
           _partial_dependence_data[i].set(j, colIndex++, stdErrorOfTheMeanResponse[j]);
         }
         if(_targets == null){
-          column++;
+          if (workingOn1D) column++; else column2D++;
         } else if((i+1) % _targets.length == 0){
-          column++;
+          if (workingOn1D) column++; else column2D++;
         }
         _job.update(1);
         update(_job);

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -3149,7 +3149,7 @@ def _process_models_input(
 
     :param models: H2OAutoML/List of models/H2O Model
     :param frame: H2O Frame
-    :returns: tuple (is_aml, models_to_show, classification, multinomial_classification,
+    :returns: tuple (is_aml, models_to_show, classification, multinomial_or_ordinal,
                     multiple_models, targets, tree_models_to_show)
     """
     is_aml = False
@@ -3179,11 +3179,11 @@ def _process_models_input(
     if any(_get_treatment(x) is not None for x in models_to_show):
         raise ValueError("Uplift models currently cannot be used with explain function.")
     classification = frame[y].isfactor()[0]
-    multinomial_classification = classification and frame[y].nlevels()[0] > 2
+    multinomial_or_ordinal = classification and frame[y].nlevels()[0] > 2
     targets = [None]
-    if multinomial_classification:
+    if multinomial_or_ordinal:
         targets = [[t] for t in frame[y].levels()[0]]
-    return is_aml, models_to_show, classification, multinomial_classification, \
+    return is_aml, models_to_show, classification, multinomial_or_ordinal, \
            multiple_models, targets, tree_models_to_show, models_with_varimp
 
 
@@ -3274,7 +3274,7 @@ def explain(
     >>> aml.leader.explain(test)
     """
     plt = get_matplotlib_pyplot(False, raise_if_not_available=True)
-    (is_aml, models_to_show, classification, multinomial_classification, multiple_models, targets,
+    (is_aml, models_to_show, classification, multinomial_or_ordinal, multiple_models, targets,
      tree_models_to_show, models_with_varimp) = _process_models_input(models, frame)
 
     if top_n_features < 0:
@@ -3402,8 +3402,9 @@ def explain(
                                        colormap=sequential_colormap,
                                        figsize=figsize)))
 
-    # SHAP Summary
-    if "shap_summary" in explanations and not multinomial_classification:
+    # SHAP Summary -- skipped for multinomial (multi-output visualization not supported)
+    # and ordinal (no ordinal-capable model currently supports TreeSHAP contributions)
+    if "shap_summary" in explanations and not multinomial_or_ordinal:
         shap_models = tree_models_to_show
         if background_frame is not None:
             shap_models = [m for m in models_to_show if has_extension(m, "Contributions")]
@@ -3556,7 +3557,7 @@ def explain_row(
     >>> # Create the leader model explanation
     >>> aml.leader.explain_row(test, row_index=0)
     """
-    (is_aml, models_to_show, _, multinomial_classification, multiple_models,
+    (is_aml, models_to_show, _, multinomial_or_ordinal, multiple_models,
      targets, tree_models_to_show, models_with_varimp) = _process_models_input(models, frame)
 
     if columns is not None and isinstance(columns, list):
@@ -3602,7 +3603,8 @@ def explain_row(
                                                                      plot_overrides.get("leaderboard"),
                                                                      frame=frame)))
 
-    if "shap_explain_row" in explanations and not multinomial_classification:
+    # SHAP -- skipped for multinomial/ordinal (see explain() for rationale)
+    if "shap_explain_row" in explanations and not multinomial_or_ordinal:
         shap_models = tree_models_to_show
         if background_frame is not None:
             shap_models = [m for m in models_to_show if has_extension(m, "Contributions")]

--- a/h2o-py/tests/testdir_misc/explain/pyunit_explain.py
+++ b/h2o-py/tests/testdir_misc/explain/pyunit_explain.py
@@ -467,6 +467,50 @@ def test_explanation_single_model_multinomial_classification():
     assert isinstance(gbm.explain_row(train, 1, render=False), H2OExplanation)
 
 
+def test_explanation_single_model_ordinal_classification():
+    train = h2o.upload_file(pyunit_utils.locate("smalldata/iris/iris2.csv"))
+    y = "response"
+    train[y] = train[y].asfactor()
+
+    # get at most one column from each type
+    cols_to_test = []
+    for col, typ in train.types.items():
+        for ctt in cols_to_test:
+            if typ == train.types[ctt] or col == y:
+                break
+        else:
+            cols_to_test.append(col)
+
+    glm = H2OGeneralizedLinearEstimator(family="ordinal",
+                                        generate_scoring_history=True,
+                                        score_each_iteration=True,
+                                        seed=42)
+    glm.train(y=y, training_frame=train)
+
+    # test pd_plot
+    for col in cols_to_test:
+        assert isinstance(glm.pd_plot(train, col, target="setosa").figure(), matplotlib.pyplot.Figure)
+
+    # test ICE plot
+    for col in cols_to_test:
+        assert isinstance(glm.ice_plot(train, col, target="setosa").figure(), matplotlib.pyplot.Figure)
+    matplotlib.pyplot.close("all")
+
+    # test learning curve
+    assert isinstance(glm.learning_curve_plot().figure(), matplotlib.pyplot.Figure)
+    matplotlib.pyplot.close("all")
+
+    # test explain and verify SHAP is skipped for ordinal
+    explanation = glm.explain(train, render=False)
+    assert isinstance(explanation, H2OExplanation)
+    assert "shap_summary" not in explanation, "SHAP should be skipped for ordinal models"
+
+    # test explain row and verify SHAP is skipped for ordinal
+    explanation_row = glm.explain_row(train, 1, render=False)
+    assert isinstance(explanation_row, H2OExplanation)
+    assert "shap_explain_row" not in explanation_row, "SHAP should be skipped for ordinal models"
+
+
 def test_explanation_automl_multinomial_classification():
     train = h2o.upload_file(pyunit_utils.locate("smalldata/iris/iris2.csv"))
     y = "response"
@@ -963,6 +1007,7 @@ pyunit_utils.run_tests([
     test_explanation_single_model_binomial_classification,
     test_explanation_automl_binomial_classification,
     test_explanation_list_of_models_binomial_classification,
+    test_explanation_single_model_ordinal_classification,
     test_explanation_single_model_multinomial_classification,
     test_explanation_automl_multinomial_classification,
     test_explanation_list_of_models_multinomial_classification,

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -219,7 +219,7 @@ case_insensitive_match_arg <- function(arg, choices) {
              "leaderboard",
              "model_ids",
              "is_classification",
-             "is_multinomial_classification",
+             "is_multinomial_or_ordinal",
              "x",
              "y",
              "model",
@@ -244,11 +244,11 @@ case_insensitive_match_arg <- function(arg, choices) {
         y <<- single_model@allparameters$y
         if (is.null(newdata)) {
           is_classification <<- NA
-          is_multinomial_classification <<- NA
+          is_multinomial_or_ordinal <<- NA
         } else {
           y_col <- newdata[[.self$y]]
           is_classification <<- is.factor(y_col)
-          is_multinomial_classification <<- is.factor(y_col) && h2o.nlevels(y_col) > 2
+          is_multinomial_or_ordinal <<- is.factor(y_col) && h2o.nlevels(y_col) > 2
         }
       }
       .self
@@ -274,10 +274,10 @@ case_insensitive_match_arg <- function(arg, choices) {
 #' @param only_with_varimp If TRUE, return only models that have variable importance
 #' @param best_of_family If TRUE, return only the best of family models; if FALSE return all models in \code{object}
 #' @param require_newdata If TRUE, require newdata to be specified; otherwise allow NULL instead, this can be used when
-#'                        there is no need to know if the problem is (multinomial) classification.
+#'                        there is no need to know if the problem is (multinomial) classification or ordinal regression.
 #' @param check_x_y_consistency If TRUE, make sure that when given a list of models all models have the same X and y. Defaults to TRUE.
 #' @return a list with the following names \code{leader}, \code{is_automl}, \code{models},
-#'   \code{is_classification}, \code{is_multinomial_classification}, \code{x}, \code{y}, \code{model}
+#'   \code{is_classification}, \code{is_multinomial_or_ordinal}, \code{x}, \code{y}, \code{model}
 #' @noRd
 .process_models_or_automl <- function(object, newdata,
                                       require_single_model = FALSE,
@@ -1551,7 +1551,7 @@ handle_pdp <- function(newdata, column, target, show_logodds, row_index, models_
     margin <- ggplot2::margin(5.5, 5.5, 5.5, max(5.5, max(nchar(h2o.levels(newdata[[column]])))))
 
   targets <- NULL
-  if (models_info$is_multinomial_classification) {
+  if (models_info$is_multinomial_or_ordinal) {
     targets <- h2o.levels(newdata[[models_info$y]])
   }
 
@@ -2707,7 +2707,7 @@ h2o.pd_multi_plot <- function(object,
 
   if (length(models_info$model_ids) == 1) {
     targets <- NULL
-    if (models_info$is_multinomial_classification) {
+    if (models_info$is_multinomial_or_ordinal) {
       targets <- h2o.levels(newdata[[models_info$y]])
     }
     h2o.no_progress({
@@ -3969,8 +3969,9 @@ h2o.explain <- function(object,
     }
   }
 
-  # SHAP summary
-  if (!"shap_summary" %in% skip_explanations && !models_info$is_multinomial_classification) {
+  # SHAP summary -- skipped for multinomial (multi-output visualization not supported)
+  # and ordinal (no ordinal-capable model currently supports TreeSHAP contributions)
+  if (!"shap_summary" %in% skip_explanations && !models_info$is_multinomial_or_ordinal) {
     shap_models <- if (is.H2OFrame(background_frame)) models_info$model_ids else Filter(.is_h2o_tree_model, models_info$model_ids)
     num_of_shap_models <- length(shap_models)
     if (num_of_shap_models > 0) {
@@ -3999,7 +4000,7 @@ h2o.explain <- function(object,
       description = .describe("pdp"),
       plots = list())
     for (col in columns_of_interest) {
-      if (models_info$is_multinomial_classification) {
+      if (models_info$is_multinomial_or_ordinal) {
         targets <- h2o.levels(newdata[[models_info$y]])
         if (!is.null(plot_overrides$pdp[["target"]])) {
           targets <- plot_overrides$pdp[["target"]]
@@ -4059,7 +4060,7 @@ h2o.explain <- function(object,
     for (col in columns_of_interest) {
       for (m in models_info$model_ids) {
         m <- models_info$get_model(m)
-        if (models_info$is_multinomial_classification) {
+        if (models_info$is_multinomial_or_ordinal) {
           targets <- h2o.levels(newdata[[models_info$y]])
           if (!is.null(plot_overrides$ice[["target"]])) {
             targets <- plot_overrides$ice[["target"]]
@@ -4262,7 +4263,8 @@ h2o.explain_row <- function(object,
       data = .leaderboard_for_row(models_info, newdata, row_index))
   }
 
-  if (!"shap_explain_row" %in% skip_explanations && !models_info$is_multinomial_classification) {
+  # SHAP -- skipped for multinomial/ordinal (see h2o.explain for rationale)
+  if (!"shap_explain_row" %in% skip_explanations && !models_info$is_multinomial_or_ordinal) {
     shap_models <- if(is.H2OFrame(background_frame)) models_info$model_ids else Filter(.is_h2o_tree_model, models_info$model_ids)
     num_of_shap_models <- length(shap_models)
     if (num_of_shap_models > 0) {
@@ -4293,7 +4295,7 @@ h2o.explain_row <- function(object,
       plots = list()
     )
     for (col in columns_of_interest) {
-      if (models_info$is_multinomial_classification) {
+      if (models_info$is_multinomial_or_ordinal) {
         targets <- h2o.levels(newdata[[models_info$y]])
         if (!is.null(plot_overrides$ice[["target"]])) {
           targets <- plot_overrides$ice[["target"]]

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -5866,14 +5866,13 @@ h2o.partialPlot <- function(object, newdata, cols, destination_key, nbins=20, pl
       }
   }
   if(!is(object, "H2OModel")) stop("object must be an H2Omodel")
-  if( is(object, "H2OOrdinalModel")) stop("object must be a regression model or binary and multinomial classfier")
   if(!is(newdata, "H2OFrame")) stop("newdata must be H2OFrame")
   if(!is.numeric(nbins) | !(nbins > 0) ) stop("nbins must be a positive numeric")
   if(!is.logical(plot)) stop("plot must be a logical value")
   if(!is.logical(plot_stddev)) stop("plot must be a logical value")
   if(!is.logical(include_na)) stop("add_missing_NA must be a logical value")
-  if((is(object, "H2OMultinomialModel"))){
-    if(is.null(targets)) stop("targets parameter has to be set for multinomial classification")
+  if((is(object, "H2OMultinomialModel") || is(object, "H2OOrdinalModel"))){
+    if(is.null(targets)) stop("targets parameter has to be set for multinomial classification or ordinal regression")
     for(i in 1:length(targets)){
         if(!is.character(targets[i])) stop("targets parameter must be a list of string values")
     }

--- a/h2o-r/tests/testdir_misc/explain/runit_explain.R
+++ b/h2o-r/tests/testdir_misc/explain/runit_explain.R
@@ -398,6 +398,46 @@ explanation_test_single_model_multinomial_classification <- function() {
   expect_true("H2OExplanation" %in% class(h2o.explain_row(gbm, train, 1)))
 }
 
+explanation_test_single_model_ordinal_classification <- function() {
+  train <- h2o.uploadFile(locate("smalldata/iris/iris2.csv"))
+  y <- "response"
+  train[, y] <- as.factor(train[, y])
+
+  col_types <- setNames(unlist(h2o.getTypes(train)), names(train))
+  col_types <- col_types[names(col_types) != y]
+  cols_to_test <- names(col_types[!duplicated(col_types)])
+
+  glm <- h2o.glm(family = "ordinal",
+                  y = y,
+                  training_frame = train,
+                  generate_scoring_history = TRUE,
+                  score_each_iteration = TRUE,
+                  seed = 42)
+
+  # test partial dependences
+  for (col in cols_to_test) {
+    expect_ggplot(h2o.pd_plot(glm, train, col, target = "setosa"))
+  }
+
+  # test ice plot
+  for (col in cols_to_test) {
+    expect_ggplot(h2o.ice_plot(glm, train, col, target = "setosa"))
+  }
+
+  # test learning curve plot
+  expect_ggplot(h2o.learning_curve_plot(glm))
+
+  # test explanation and verify SHAP is skipped for ordinal
+  explanation <- h2o.explain(glm, train)
+  expect_true("H2OExplanation" %in% class(explanation))
+  expect_false("shap_summary" %in% names(explanation), info = "SHAP should be skipped for ordinal models")
+
+  # test explanation row and verify SHAP is skipped for ordinal
+  explanation_row <- h2o.explain_row(glm, train, 1)
+  expect_true("H2OExplanation" %in% class(explanation_row))
+  expect_false("shap_explain_row" %in% names(explanation_row), info = "SHAP should be skipped for ordinal models")
+}
+
 explanation_test_automl_multinomial_classification <- function() {
   train <- h2o.uploadFile(locate("smalldata/iris/iris2.csv"))
   y <- "response"
@@ -804,6 +844,7 @@ doSuite("Explanation Tests", makeSuite(
    , explanation_test_single_model_binomial_classification
    , explanation_test_automl_binomial_classification
    , explanation_test_list_of_models_binomial_classification
+   , explanation_test_single_model_ordinal_classification
    , explanation_test_single_model_multinomial_classification
    , explanation_test_automl_multinomial_classification
    , explanation_test_list_of_models_multinomial_classification


### PR DESCRIPTION
#16716 

Python works with ordinal family so I enabled it in R.

This PR also fixes a bug that occurs when user specifies multiple targets and columns:
```java
        _num_2D_pairs = _col_pairs_2dpdp.length * _predictor_columns.length;
       for (int index=0; index < _num_2D_pairs; index++) {
          if (!(_cols_1d_2d.contains(_col_pairs_2dpdp[index][0]))) 
```
when multiple `_predictor_columns` => `ArrayOutOfBoundsError`