### PR TITLE
GH-16509: Fix unexported method identical.integer64

### DIFF
--- a/h2o-r/tests/testdir_jira/runit_pubdev_2071.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_2071.R
@@ -14,7 +14,7 @@ foo <- data.frame(c = as.integer64(as.character(lim.integer64()/10)))
 foo.hex <- as.h2o(foo)
 bar <- foo.hex[1,1]
 bari64 <- as.integer64(bar)
-res <- identical.integer64(foo[1,1],bari64)
+res <- identical(foo[1,1],bari64)
 expect_equal(res, TRUE)
 
 detach()


### PR DESCRIPTION
#16509 

This S3 method might get unexported soon so let's use R's dispatch as we should have in the first place.