### PR TITLE
GH-16662: Fix cartesian gridsearch subspaces tp cs ms binomial dual mode test [nocheck]

### DIFF
--- a/h2o-algos/src/main/java/hex/gam/GamSplines/ThinPlateRegressionUtils.java
+++ b/h2o-algos/src/main/java/hex/gam/GamSplines/ThinPlateRegressionUtils.java
@@ -1,5 +1,6 @@
 package hex.gam.GamSplines;
 
+import hex.genmodel.algos.gam.GamUtilsThinPlateRegression;
 import water.MRTask;
 import water.fvec.Chunk;
 import water.fvec.Frame;
@@ -211,7 +212,7 @@ public class ThinPlateRegressionUtils {
         Integer[] oneBasis = polyBasisDegree.get(polyBasisInd);
         double polyBasisVal = 1.0;
         for (int predInd = 0; predInd < d; predInd++) {
-          polyBasisVal *= Math.pow(knotsDemean[predInd][rowInd], oneBasis[predInd]);
+          polyBasisVal *= GamUtilsThinPlateRegression.intPow(knotsDemean[predInd][rowInd], oneBasis[predInd]);
         }
         starT[rowInd][polyBasisInd] = polyBasisVal;
       }

--- a/h2o-algos/src/test/java/hex/gam/GAMReproGH16662GridSearchDeterminismTest.java
+++ b/h2o-algos/src/test/java/hex/gam/GAMReproGH16662GridSearchDeterminismTest.java
@@ -1,0 +1,233 @@
+package hex.gam;
+
+import hex.Model;
+import hex.ModelMetrics;
+import hex.ModelMetricsBinomial;
+import hex.grid.Grid;
+import hex.grid.GridSearch;
+import hex.grid.HyperSpaceSearchCriteria;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import water.DKV;
+import water.Job;
+import water.Key;
+import water.Scope;
+import water.TestUtil;
+import water.fvec.Frame;
+import water.runner.CloudSize;
+import water.runner.H2ORunner;
+
+import java.util.*;
+
+import static hex.glm.GLMModel.GLMParameters.Family.binomial;
+import static org.junit.Assert.*;
+
+/**
+ * Reproduction test for GH-16662: Grid+GAM reproducible nondeterminism.
+ *
+ * Running the same cartesian grid search with GAM (using subspaces with TP, CS, MS splines)
+ * twice on the same data should produce models in the same order when sorted by metric.
+ * Due to tiny floating-point differences (~1e-17 in logloss) caused by nondeterministic
+ * distributed mean computation in thin plate spline code, the model ordering can differ
+ * between the two grid searches.
+ */
+@RunWith(H2ORunner.class)
+@CloudSize(1)
+public class GAMReproGH16662GridSearchDeterminismTest extends TestUtil {
+
+    /**
+     * Trains the same GAM model twice with thin plate splines and verifies that the
+     * resulting model metrics and coefficients are nearly identical.
+     *
+     * Due to JIT compilation warmup (FMA instruction differences between interpreted
+     * and JIT-compiled code), the logloss can differ by ~1e-17 between the first and second
+     * model training in the same JVM. This is inherent to IEEE 754 floating-point arithmetic
+     * and is not a bug — the grid search tiebreaker fix in ModelMetrics ensures that such
+     * tiny metric differences do not cause nondeterministic model ordering.
+     */
+    @Test
+    public void testGAMThinPlateDeterminism() {
+        Scope.enter();
+        try {
+            Frame train = Scope.track(parseTestFile("smalldata/gam_test/synthetic_20Cols_binomial_20KRows.csv"));
+            train.replace(train.find("response"), train.vec("response").toCategoricalVec()).remove();
+            DKV.put(train);
+
+            GAMModel gam1 = buildGAMWithTP(train);
+            Scope.track_generic(gam1);
+            GAMModel gam2 = buildGAMWithTP(train);
+            Scope.track_generic(gam2);
+
+            double logloss1 = ((ModelMetricsBinomial) gam1._output._training_metrics)._logloss;
+            double logloss2 = ((ModelMetricsBinomial) gam2._output._training_metrics)._logloss;
+
+            // GH-16662: JIT warmup can cause ~1e-17 differences in logloss between runs.
+            // Use a small tolerance to account for this.
+            assertEquals("GAM with TP splines should produce nearly identical logloss across runs",
+                    logloss1, logloss2, 1e-15);
+
+            // Verify coefficients are nearly identical
+            double[] beta1 = gam1._output._model_beta;
+            double[] beta2 = gam2._output._model_beta;
+            assertEquals("Coefficient count should match", beta1.length, beta2.length);
+            for (int i = 0; i < beta1.length; i++) {
+                assertEquals("Coefficient " + gam1._output._coefficient_names[i] +
+                                " should be nearly identical across runs",
+                        beta1[i], beta2[i], 1e-15);
+            }
+        } finally {
+            Scope.exit();
+        }
+    }
+
+    /**
+     * Runs the same cartesian grid search twice with GAM using subspaces (TP, CS, MS splines)
+     * and verifies that models sorted by logloss appear in the same order.
+     *
+     * This reproduces the exact scenario from GH-16662: the Python test
+     * pyunit_PUBDEV_7860_cartesian_gridsearch_subspaces_TP_CS_MS_binomial_dual_mode.py
+     * fails because two identical grid searches produce models in different order.
+     */
+    @Test
+    public void testCartesianGridSearchSubspacesDeterminism() {
+        Scope.enter();
+        try {
+            Frame train = Scope.track(parseTestFile("smalldata/gam_test/synthetic_20Cols_binomial_20KRows.csv"));
+            train.replace(train.find("response"), train.vec("response").toCategoricalVec()).remove();
+            String[] catCols = {"C3", "C7", "C8", "C10"};
+            for (String col : catCols) {
+                train.replace(train.find(col), train.vec(col).toCategoricalVec()).remove();
+            }
+            DKV.put(train);
+
+            // Base GAM parameters (same as the failing Python test)
+            GAMModel.GAMParameters params = new GAMModel.GAMParameters();
+            params._train = train._key;
+            params._response_column = "response";
+            params._family = binomial;
+            params._seed = 1;
+            params._keep_gam_cols = true;
+
+            // Hyperparameters with subspaces matching the Python test:
+            // Subspace 1: single-predictor smoothers (TP and CS)
+            // Subspace 2: multi-predictor smoothers (MS, TP, TP)
+            Map<String, Object[]> hyperParams = buildHyperParams();
+
+            HyperSpaceSearchCriteria.CartesianSearchCriteria searchCriteria =
+                    new HyperSpaceSearchCriteria.CartesianSearchCriteria();
+
+            // Run grid search #1
+            Job<Grid> job1 = GridSearch.startGridSearch(null, params, hyperParams,
+                    new GridSearch.SimpleParametersBuilderFactory<>(), searchCriteria, 1);
+            Scope.track_generic(job1);
+            Grid grid1 = job1.get();
+            Scope.track_generic(grid1);
+
+            // Run grid search #2 (identical parameters)
+            Map<String, Object[]> hyperParams2 = buildHyperParams();
+            Job<Grid> job2 = GridSearch.startGridSearch(null, params, hyperParams2,
+                    new GridSearch.SimpleParametersBuilderFactory<>(), searchCriteria, 1);
+            Scope.track_generic(job2);
+            Grid grid2 = job2.get();
+            Scope.track_generic(grid2);
+
+            // Sort models using the production code path (ModelMetrics.MetricsComparator)
+            // which uses reducePrecision() + lexical tiebreaker (GH-16662 fix).
+            List<Key<Model>> sorted1 = ModelMetrics.sortModelsByMetric(
+                    "logloss", false, Arrays.asList(grid1.getModelKeys()));
+            List<Key<Model>> sorted2 = ModelMetrics.sortModelsByMetric(
+                    "logloss", false, Arrays.asList(grid2.getModelKeys()));
+
+            assertEquals("Both grids should have the same number of models",
+                    sorted1.size(), sorted2.size());
+            assertTrue("Grid should have trained at least one model", sorted1.size() > 0);
+
+            // Compare models at each position - they should have the same hyperparameter
+            // configuration (same coefficient names) and similar coefficient values.
+            for (int i = 0; i < sorted1.size(); i++) {
+                GAMModel m1 = DKV.getGet(sorted1.get(i));
+                GAMModel m2 = DKV.getGet(sorted2.get(i));
+                assertNotNull("Model " + i + " from grid 1 should exist", m1);
+                assertNotNull("Model " + i + " from grid 2 should exist", m2);
+
+                // GH-16662: Same hyperparameter configuration trained in two grid searches
+                // should produce bit-for-bit identical logloss. Due to nondeterministic
+                // thin plate spline computation (JIT warmup / FMA), this currently fails.
+                double logloss1 = ((ModelMetricsBinomial) m1._output._training_metrics)._logloss;
+                double logloss2 = ((ModelMetricsBinomial) m2._output._training_metrics)._logloss;
+                assertEquals("Model at rank " + i + " should have identical logloss",
+                        logloss1, logloss2, 0.0);
+
+                assertArrayEquals("Model at rank " + i + " should have the same coefficient names",
+                        m1._output._coefficient_names, m2._output._coefficient_names);
+
+                double[] beta1 = m1._output._model_beta;
+                double[] beta2 = m2._output._model_beta;
+                for (int j = 0; j < beta1.length; j++) {
+                    assertEquals("Coefficient " + m1._output._coefficient_names[j] +
+                                    " at rank " + i + " should be identical",
+                            beta1[j], beta2[j], 0.0);
+                }
+            }
+        } finally {
+            Scope.exit();
+        }
+    }
+
+    private GAMModel buildGAMWithTP(Frame train) {
+        GAMModel.GAMParameters params = new GAMModel.GAMParameters();
+        params._train = train._key;
+        params._response_column = "response";
+        params._family = binomial;
+        params._seed = 1;
+        params._keep_gam_cols = true;
+        params._gam_columns = new String[][]{{"c_0"}, {"c_1", "c_2"}, {"c_3", "c_4", "c_5"}};
+        params._bs = new int[]{1, 1, 1}; // all thin plate
+        params._scale = new double[]{0.001, 0.001, 0.001};
+        params._lambda = new double[]{1.0};
+        // num_knots must be >= M+1 where M = choose(m+d-1, d), m = ceil((d+1)/2)+1
+        // For d=1: M=2, need >=3; for d=2: M=3, need >=4; for d=3: M=10, need >=11
+        params._num_knots = new int[]{10, 10, 12};
+        return new GAM(params).trainModel().get();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object[]> buildHyperParams() {
+        Map<String, Object[]> hyperParams = new HashMap<>();
+        hyperParams.put("_lambda", new Object[]{new double[]{1.0}, new double[]{2.0}});
+        hyperParams.put("subspaces", new Map[]{
+                // Subspace 1: single-predictor smoothers
+                new HashMap<String, Object[]>() {{
+                    put("_scale", new Object[]{
+                            new double[]{0.001},
+                            new double[]{0.0002}
+                    });
+                    put("_bs", new Object[]{
+                            new int[]{1},  // TP spline
+                            new int[]{0}   // CS spline
+                    });
+                    put("_gam_columns", new Object[]{
+                            new String[][]{{"c_0"}},
+                            new String[][]{{"c_1"}}
+                    });
+                }},
+                // Subspace 2: multi-predictor smoothers (MS + TP + TP)
+                new HashMap<String, Object[]>() {{
+                    put("_scale", new Object[]{
+                            new double[]{0.001, 0.001, 0.001},
+                            new double[]{0.0002, 0.0002, 0.0002}
+                    });
+                    put("_bs", new Object[]{
+                            new int[]{3, 1, 1},  // MS, TP, TP
+                            new int[]{0, 1, 1}   // CS, TP, TP
+                    });
+                    put("_gam_columns", new Object[]{
+                            new String[][]{{"c_0"}, {"c_1", "c_2"}, {"c_3", "c_4", "c_5"}},
+                            new String[][]{{"c_1"}, {"c_2", "c_3"}, {"c_4", "c_5", "c_6"}}
+                    });
+                }}
+        });
+        return hyperParams;
+    }
+
+}

--- a/h2o-algos/src/test/java/hex/gam/GAMReproGH16662GridSearchDeterminismTest.java
+++ b/h2o-algos/src/test/java/hex/gam/GAMReproGH16662GridSearchDeterminismTest.java
@@ -22,29 +22,10 @@ import java.util.*;
 import static hex.glm.GLMModel.GLMParameters.Family.binomial;
 import static org.junit.Assert.*;
 
-/**
- * Reproduction test for GH-16662: Grid+GAM reproducible nondeterminism.
- *
- * Running the same cartesian grid search with GAM (using subspaces with TP, CS, MS splines)
- * twice on the same data should produce models in the same order when sorted by metric.
- * Due to tiny floating-point differences (~1e-17 in logloss) caused by nondeterministic
- * distributed mean computation in thin plate spline code, the model ordering can differ
- * between the two grid searches.
- */
 @RunWith(H2ORunner.class)
 @CloudSize(1)
 public class GAMReproGH16662GridSearchDeterminismTest extends TestUtil {
 
-    /**
-     * Trains the same GAM model twice with thin plate splines and verifies that the
-     * resulting model metrics and coefficients are nearly identical.
-     *
-     * Due to JIT compilation warmup (FMA instruction differences between interpreted
-     * and JIT-compiled code), the logloss can differ by ~1e-17 between the first and second
-     * model training in the same JVM. This is inherent to IEEE 754 floating-point arithmetic
-     * and is not a bug — the grid search tiebreaker fix in ModelMetrics ensures that such
-     * tiny metric differences do not cause nondeterministic model ordering.
-     */
     @Test
     public void testGAMThinPlateDeterminism() {
         Scope.enter();
@@ -61,12 +42,9 @@ public class GAMReproGH16662GridSearchDeterminismTest extends TestUtil {
             double logloss1 = ((ModelMetricsBinomial) gam1._output._training_metrics)._logloss;
             double logloss2 = ((ModelMetricsBinomial) gam2._output._training_metrics)._logloss;
 
-            // GH-16662: JIT warmup can cause ~1e-17 differences in logloss between runs.
-            // Use a small tolerance to account for this.
             assertEquals("GAM with TP splines should produce nearly identical logloss across runs",
                     logloss1, logloss2, 1e-15);
 
-            // Verify coefficients are nearly identical
             double[] beta1 = gam1._output._model_beta;
             double[] beta2 = gam2._output._model_beta;
             assertEquals("Coefficient count should match", beta1.length, beta2.length);
@@ -80,14 +58,6 @@ public class GAMReproGH16662GridSearchDeterminismTest extends TestUtil {
         }
     }
 
-    /**
-     * Runs the same cartesian grid search twice with GAM using subspaces (TP, CS, MS splines)
-     * and verifies that models sorted by logloss appear in the same order.
-     *
-     * This reproduces the exact scenario from GH-16662: the Python test
-     * pyunit_PUBDEV_7860_cartesian_gridsearch_subspaces_TP_CS_MS_binomial_dual_mode.py
-     * fails because two identical grid searches produce models in different order.
-     */
     @Test
     public void testCartesianGridSearchSubspacesDeterminism() {
         Scope.enter();
@@ -100,7 +70,6 @@ public class GAMReproGH16662GridSearchDeterminismTest extends TestUtil {
             }
             DKV.put(train);
 
-            // Base GAM parameters (same as the failing Python test)
             GAMModel.GAMParameters params = new GAMModel.GAMParameters();
             params._train = train._key;
             params._response_column = "response";
@@ -108,22 +77,17 @@ public class GAMReproGH16662GridSearchDeterminismTest extends TestUtil {
             params._seed = 1;
             params._keep_gam_cols = true;
 
-            // Hyperparameters with subspaces matching the Python test:
-            // Subspace 1: single-predictor smoothers (TP and CS)
-            // Subspace 2: multi-predictor smoothers (MS, TP, TP)
             Map<String, Object[]> hyperParams = buildHyperParams();
 
             HyperSpaceSearchCriteria.CartesianSearchCriteria searchCriteria =
                     new HyperSpaceSearchCriteria.CartesianSearchCriteria();
 
-            // Run grid search #1
             Job<Grid> job1 = GridSearch.startGridSearch(null, params, hyperParams,
                     new GridSearch.SimpleParametersBuilderFactory<>(), searchCriteria, 1);
             Scope.track_generic(job1);
             Grid grid1 = job1.get();
             Scope.track_generic(grid1);
 
-            // Run grid search #2 (identical parameters)
             Map<String, Object[]> hyperParams2 = buildHyperParams();
             Job<Grid> job2 = GridSearch.startGridSearch(null, params, hyperParams2,
                     new GridSearch.SimpleParametersBuilderFactory<>(), searchCriteria, 1);
@@ -131,8 +95,6 @@ public class GAMReproGH16662GridSearchDeterminismTest extends TestUtil {
             Grid grid2 = job2.get();
             Scope.track_generic(grid2);
 
-            // Sort models using the production code path (ModelMetrics.MetricsComparator)
-            // which uses reducePrecision() + lexical tiebreaker (GH-16662 fix).
             List<Key<Model>> sorted1 = ModelMetrics.sortModelsByMetric(
                     "logloss", false, Arrays.asList(grid1.getModelKeys()));
             List<Key<Model>> sorted2 = ModelMetrics.sortModelsByMetric(
@@ -142,17 +104,12 @@ public class GAMReproGH16662GridSearchDeterminismTest extends TestUtil {
                     sorted1.size(), sorted2.size());
             assertTrue("Grid should have trained at least one model", sorted1.size() > 0);
 
-            // Compare models at each position - they should have the same hyperparameter
-            // configuration (same coefficient names) and similar coefficient values.
             for (int i = 0; i < sorted1.size(); i++) {
                 GAMModel m1 = DKV.getGet(sorted1.get(i));
                 GAMModel m2 = DKV.getGet(sorted2.get(i));
                 assertNotNull("Model " + i + " from grid 1 should exist", m1);
                 assertNotNull("Model " + i + " from grid 2 should exist", m2);
 
-                // GH-16662: Same hyperparameter configuration trained in two grid searches
-                // should produce bit-for-bit identical logloss. Due to nondeterministic
-                // thin plate spline computation (JIT warmup / FMA), this currently fails.
                 double logloss1 = ((ModelMetricsBinomial) m1._output._training_metrics)._logloss;
                 double logloss2 = ((ModelMetricsBinomial) m2._output._training_metrics)._logloss;
                 assertEquals("Model at rank " + i + " should have identical logloss",
@@ -182,11 +139,9 @@ public class GAMReproGH16662GridSearchDeterminismTest extends TestUtil {
         params._seed = 1;
         params._keep_gam_cols = true;
         params._gam_columns = new String[][]{{"c_0"}, {"c_1", "c_2"}, {"c_3", "c_4", "c_5"}};
-        params._bs = new int[]{1, 1, 1}; // all thin plate
+        params._bs = new int[]{1, 1, 1};
         params._scale = new double[]{0.001, 0.001, 0.001};
         params._lambda = new double[]{1.0};
-        // num_knots must be >= M+1 where M = choose(m+d-1, d), m = ceil((d+1)/2)+1
-        // For d=1: M=2, need >=3; for d=2: M=3, need >=4; for d=3: M=10, need >=11
         params._num_knots = new int[]{10, 10, 12};
         return new GAM(params).trainModel().get();
     }
@@ -196,30 +151,28 @@ public class GAMReproGH16662GridSearchDeterminismTest extends TestUtil {
         Map<String, Object[]> hyperParams = new HashMap<>();
         hyperParams.put("_lambda", new Object[]{new double[]{1.0}, new double[]{2.0}});
         hyperParams.put("subspaces", new Map[]{
-                // Subspace 1: single-predictor smoothers
                 new HashMap<String, Object[]>() {{
                     put("_scale", new Object[]{
                             new double[]{0.001},
                             new double[]{0.0002}
                     });
                     put("_bs", new Object[]{
-                            new int[]{1},  // TP spline
-                            new int[]{0}   // CS spline
+                            new int[]{1},
+                            new int[]{0}
                     });
                     put("_gam_columns", new Object[]{
                             new String[][]{{"c_0"}},
                             new String[][]{{"c_1"}}
                     });
                 }},
-                // Subspace 2: multi-predictor smoothers (MS + TP + TP)
                 new HashMap<String, Object[]>() {{
                     put("_scale", new Object[]{
                             new double[]{0.001, 0.001, 0.001},
                             new double[]{0.0002, 0.0002, 0.0002}
                     });
                     put("_bs", new Object[]{
-                            new int[]{3, 1, 1},  // MS, TP, TP
-                            new int[]{0, 1, 1}   // CS, TP, TP
+                            new int[]{3, 1, 1},
+                            new int[]{0, 1, 1}
                     });
                     put("_gam_columns", new Object[]{
                             new String[][]{{"c_0"}, {"c_1", "c_2"}, {"c_3", "c_4", "c_5"}},

--- a/h2o-core/src/main/java/hex/ModelMetrics.java
+++ b/h2o-core/src/main/java/hex/ModelMetrics.java
@@ -194,6 +194,17 @@ public class ModelMetrics extends Keyed<ModelMetrics> {
   }
 
 
+  /**
+   * Reduce metric precision for stable comparison by casting to float.
+   * This drops the least significant bits of the mantissa (29 of 52 bits),
+   * ensuring that values differing only by floating-point noise (from JIT
+   * warmup or nondeterministic parallel reduce) compare as equal.
+   * Same technique as DHistogram.reducePrecision() (GH-16662).
+   */
+  public static float reducePrecision(double val) {
+    return (float) val;
+  }
+
   private static class MetricsComparator implements Comparator<Key<Model>> {
     String _sort_by = null;
     boolean decreasing = false;
@@ -206,7 +217,14 @@ public class ModelMetrics extends Keyed<ModelMetrics> {
     public int compare(Key<Model> key1, Key<Model> key2) {
       double c1 = getMetricFromModel(key1, _sort_by);
       double c2 = getMetricFromModel(key2, _sort_by);
-      return decreasing ? Double.compare(c2, c1) : Double.compare(c1, c2);
+      // Cast to float to drop noisy low bits, same as DHistogram.reducePrecision() (GH-16662).
+      int result = decreasing ? Float.compare(reducePrecision(c2), reducePrecision(c1))
+                              : Float.compare(reducePrecision(c1), reducePrecision(c2));
+      // Tiebreaker: lexical model key order for deterministic sorting when metrics are near-equal.
+      if (result == 0) {
+        result = key1.toString().compareTo(key2.toString());
+      }
+      return result;
     }
   }
 
@@ -255,7 +273,14 @@ public class ModelMetrics extends Keyed<ModelMetrics> {
 
       double c1 = getMetricFromModelMetric(mm1, _sort_by);
       double c2 = getMetricFromModelMetric(mm2, _sort_by);
-      return decreasing ? Double.compare(c2, c1) : Double.compare(c1, c2);
+      // Cast to float to drop noisy low bits, same as DHistogram.reducePrecision() (GH-16662).
+      int result = decreasing ? Float.compare(reducePrecision(c2), reducePrecision(c1))
+                              : Float.compare(reducePrecision(c1), reducePrecision(c2));
+      // Tiebreaker: lexical model key order for deterministic sorting when metrics are near-equal.
+      if (result == 0) {
+        result = key1.toString().compareTo(key2.toString());
+      }
+      return result;
     }
   }
 

--- a/h2o-core/src/main/java/hex/ModelMetrics.java
+++ b/h2o-core/src/main/java/hex/ModelMetrics.java
@@ -194,17 +194,6 @@ public class ModelMetrics extends Keyed<ModelMetrics> {
   }
 
 
-  /**
-   * Reduce metric precision for stable comparison by casting to float.
-   * This drops the least significant bits of the mantissa (29 of 52 bits),
-   * ensuring that values differing only by floating-point noise (from JIT
-   * warmup or nondeterministic parallel reduce) compare as equal.
-   * Same technique as DHistogram.reducePrecision() (GH-16662).
-   */
-  public static float reducePrecision(double val) {
-    return (float) val;
-  }
-
   private static class MetricsComparator implements Comparator<Key<Model>> {
     String _sort_by = null;
     boolean decreasing = false;
@@ -217,14 +206,7 @@ public class ModelMetrics extends Keyed<ModelMetrics> {
     public int compare(Key<Model> key1, Key<Model> key2) {
       double c1 = getMetricFromModel(key1, _sort_by);
       double c2 = getMetricFromModel(key2, _sort_by);
-      // Cast to float to drop noisy low bits, same as DHistogram.reducePrecision() (GH-16662).
-      int result = decreasing ? Float.compare(reducePrecision(c2), reducePrecision(c1))
-                              : Float.compare(reducePrecision(c1), reducePrecision(c2));
-      // Tiebreaker: lexical model key order for deterministic sorting when metrics are near-equal.
-      if (result == 0) {
-        result = key1.toString().compareTo(key2.toString());
-      }
-      return result;
+      return decreasing ? Double.compare(c2, c1) : Double.compare(c1, c2);
     }
   }
 
@@ -273,14 +255,7 @@ public class ModelMetrics extends Keyed<ModelMetrics> {
 
       double c1 = getMetricFromModelMetric(mm1, _sort_by);
       double c2 = getMetricFromModelMetric(mm2, _sort_by);
-      // Cast to float to drop noisy low bits, same as DHistogram.reducePrecision() (GH-16662).
-      int result = decreasing ? Float.compare(reducePrecision(c2), reducePrecision(c1))
-                              : Float.compare(reducePrecision(c1), reducePrecision(c2));
-      // Tiebreaker: lexical model key order for deterministic sorting when metrics are near-equal.
-      if (result == 0) {
-        result = key1.toString().compareTo(key2.toString());
-      }
-      return result;
+      return decreasing ? Double.compare(c2, c1) : Double.compare(c1, c2);
     }
   }
 

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamUtilsThinPlateRegression.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamUtilsThinPlateRegression.java
@@ -63,6 +63,7 @@ public class GamUtilsThinPlateRegression {
    *     - https://bugs.openjdk.org/browse/JDK-8189172
    */
   public static double intPow(double base, int exp) {
+    assert exp >= 0;
     switch (exp) {
       case 0: return 1.0;
       case 1: return base;

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamUtilsThinPlateRegression.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamUtilsThinPlateRegression.java
@@ -29,7 +29,7 @@ public class GamUtilsThinPlateRegression {
                 (chk[predInd] - knots[predInd][knotInd]);  // standardized
         sumSq += temp*temp;
       }
-      double distance = Math.pow(Math.sqrt(sumSq), 2*m-d);
+      double distance = intPow(Math.sqrt(sumSq), 2 * m - d);
       rowValues[knotInd] = constantTerms*distance;
       if (dEven && (distance != 0))
         rowValues[knotInd] *= Math.log(distance);
@@ -43,11 +43,34 @@ public class GamUtilsThinPlateRegression {
       int[] oneBasis = polyBasisList[colIndex];
       double val = 1.0;
       for (int predIndex = 0; predIndex < d; predIndex++) {
-        val *= standardizeGAM?
-                Math.pow((oneDataRow[predIndex]-gamColMean[predIndex]*oneOGamStd[predIndex]), oneBasis[predIndex]):
-                Math.pow(oneDataRow[predIndex], oneBasis[predIndex]);
+        val *= intPow(standardizeGAM ? (oneDataRow[predIndex] - gamColMean[predIndex] * oneOGamStd[predIndex]) 
+                                     : oneDataRow[predIndex],
+                      oneBasis[predIndex]);
       }
       onePolyRow[colIndex] = val;
+    }
+  }
+
+  /**
+   * Deterministic integer power using explicit multiplication.
+   * Avoids Math.pow JIT intrinsification which can produce different results
+   * for Math.pow(x, 2) vs x*x (differing by 1 ULP for some values of x).
+   * For our use-case the following is faster than StrictMath.pow() since GAM typically
+   * uses low-order polynomials.
+   *
+   * For more details see:
+   *     - https://bugs.openjdk.org/browse/JDK-8063086
+   *     - https://bugs.openjdk.org/browse/JDK-8189172
+   */
+  public static double intPow(double base, int exp) {
+    switch (exp) {
+      case 0: return 1.0;
+      case 1: return base;
+      case 2: return base * base;
+      default:
+        double result = base;
+        for (int i = 1; i < exp; i++) result *= base;
+        return result;
     }
   }
 }


### PR DESCRIPTION
#16662

This works around a bug in Java - `Math.exp` is not deterministic for this use-case (differs between first and subsequent runs).

For more details see:
    - https://bugs.openjdk.org/browse/JDK-8063086
    - https://bugs.openjdk.org/browse/JDK-8189172
