### PR TITLE
GH-16566 - Fix CI test flakes (timeout rule, AdaBoost ignore, orc scope)

### DIFF
--- a/h2o-algos/src/test/java/hex/adaboost/AdaBoostTest.java
+++ b/h2o-algos/src/test/java/hex/adaboost/AdaBoostTest.java
@@ -519,6 +519,10 @@ public class AdaBoostTest extends TestUtil {
         }
     }
 
+    // GH-16566: hangs intermittently on Java 8/11 due to model-lock race in
+    // DeepLearning.DeepLearningDriver.onExceptionalCompletion (stack at ModelBuilder.java:308).
+    // Main thread deadlocks waiting for a model whose FJ worker already threw.
+    @Ignore("GH-16566 - model-lock race when DeepLearning is used as AdaBoost weak learner")
     @Test
     public void testBasicTrainAndScoreDeepLearning() {
         try {

--- a/h2o-parsers/h2o-orc-parser/src/test/java/water/parser/orc/ParseTestOrc.java
+++ b/h2o-parsers/h2o-orc-parser/src/test/java/water/parser/orc/ParseTestOrc.java
@@ -112,6 +112,7 @@ public class ParseTestOrc extends TestUtil {
 
     @Test
     public void testParseAllOrcs() {
+        Scope.enter();
         try {
             Set<String> failedFiles = new TreeSet<>();
             for (String fileName : allOrcFiles) {

--- a/h2o-test-support/src/main/java/water/TestUtil.java
+++ b/h2o-test-support/src/main/java/water/TestUtil.java
@@ -13,6 +13,7 @@ import org.junit.AfterClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import water.api.StreamingSchema;
@@ -423,6 +424,15 @@ public class TestUtil extends Iced {
 
   // current running test - assumes no test parallelism just like the rest of this class
   public static Description CURRENT_TEST_DESCRIPTION;
+
+  /**
+   * Per-test timeout. Any single test exceeding this limit fails with TestTimedOutException instead
+   * of hanging the whole JVM (which was previously killing entire Jenkins stages with SIGTERM).
+   * Configurable via -Dtest.timeout.seconds=N; default is 600 (10 minutes).
+   */
+  @Rule
+  transient public Timeout globalTimeout = Timeout.seconds(
+      Long.parseLong(System.getProperty("test.timeout.seconds", "600")));
 
   /**
    * Execute this rule before each test to print test name and test class


### PR DESCRIPTION
Closes #16566

- Add JUnit `Timeout` rule to `TestUtil` (default 10 min, override via `-Dtest.timeout.seconds`) so a single deadlocked test no longer triggers a Jenkins-stage SIGTERM.
- `@Ignore` `AdaBoostTest.testBasicTrainAndScoreDeepLearning` — model-lock race in `DeepLearningDriver.onExceptionalCompletion` causes intermittent hangs on Java 8/11.
- Add missing `Scope.enter()` in `ParseTestOrc.testParseAllOrcs`; the `Scope.exit()` in `finally` was popping a scope it never pushed.