### PR TITLE
GH-16186: Update Cloud Integration user guide to Makersaurus guidelines

### DIFF
--- a/h2o-docs/src/product/cloud-integration.rst
+++ b/h2o-docs/src/product/cloud-integration.rst
@@ -1,17 +1,18 @@
-Cloud Integration
------------------
+Cloud integration
+=================
 
-H2O is supported on a number of cloud environments, including
+H2O-3 is supported on a number of cloud environments, including:
 
-- EC2 Instances and S3 Storage (RedHat AMI, Amazon Linux AMI, and Ubuntu AMI)
+- EC2 instances and S3 storage (Red Hat AMI, Amazon Linux AMI, and Ubuntu AMI)
 - Amazon AWS
 - Microsoft Azure
-- Databricks
 - IBM DSX
 - Nimbix Cloud
+- Google Cloud Storage
+- Google Cloud Platform
 - Kubernetes
 
-Refer to the following topics:
+See the following topics:
 
 .. toctree::
    :maxdepth: 1
@@ -24,4 +25,3 @@ Refer to the following topics:
    cloud-integration/gcs
    cloud-integration/kubernetes
    cloud-integration/google-compute
-

--- a/h2o-docs/src/product/cloud-integration/aws.rst
+++ b/h2o-docs/src/product/cloud-integration/aws.rst
@@ -1,6 +1,6 @@
-Using H2O with Amazon AWS
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Using H2O-3 with Amazon AWS
+===========================
 
-The old `H2O Artificial Intelligence instance <https://aws.amazon.com/marketplace/pp/prodview-76ewxkmzkvr3m>`_ is no longer available.
+The old `H2O Artificial Intelligence instance <https://aws.amazon.com/marketplace/pp/prodview-76ewxkmzkvr3m>`__ is no longer available.
 
-Please see `Training and serving H2O models using Amazon SageMaker <https://aws.amazon.com/blogs/machine-learning/training-and-serving-h2o-models-using-amazon-sagemaker/>`_.
+For an alternative, see `Training and serving H2O models using Amazon SageMaker <https://aws.amazon.com/blogs/machine-learning/training-and-serving-h2o-models-using-amazon-sagemaker/>`__.

--- a/h2o-docs/src/product/cloud-integration/azure-dsvm.rst
+++ b/h2o-docs/src/product/cloud-integration/azure-dsvm.rst
@@ -1,64 +1,64 @@
-Using H2O with Microsoft Azure Linux Data Science VM
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Using H2O-3 with Microsoft Azure Linux Data Science VM
+======================================================
 
-The Data Science Virtual Machine (DSVM) for Linux is an Ubuntu-based virtual machine image that makes it easy to get started with deep learning on Azure. CNTK, TensorFlow, MXNet, Caffe, Caffe2, DIGITS, H2O, Keras, Theano, and Torch are built, installed, and configured, so they are ready to run immediately. The NVIDIA driver, CUDA, and cuDNN are also included. All frameworks are the GPU versions but work on the CPU as well. Many sample Jupyter notebooks are included.
+The Data Science Virtual Machine (DSVM) for Linux is an Ubuntu-based virtual machine image that simplifies getting started with deep learning on Azure. CNTK, TensorFlow, MXNet, Caffe, Caffe2, DIGITS, H2O-3, Keras, Theano, and Torch are preconfigured and ready to run. The NVIDIA driver, CUDA, and cuDNN are also included. All frameworks are the GPU versions, but they also work on the CPU. Many sample Jupyter notebooks are included.
 
-You can view a full list of installed tools for the Linux edition `here <https://docs.microsoft.com/en-us/azure/machine-learning/machine-learning-data-science-virtual-machine-overview>`__.
+For a `full list of installed tools for the Linux edition <https://docs.microsoft.com/en-us/azure/machine-learning/machine-learning-data-science-virtual-machine-overview>`__, see the Microsoft documentation site.
 
-Follow the steps below to create the H2O Artificial Intelligence VM.
+To create the H2O Artificial Intelligence VM:
 
-1. Log in to your Azure portal at `https://portal.azure.com <https://portal.azure.com>`__, and click the **New** button.  
+1. Log in to your `Azure portal <https://portal.azure.com>`__, then click the **New** button.
 
   .. figure:: ../images/azurelin_new.png
      :alt: Create a new VM
 
-2. Search in the Marketplace for “H2O”. The result will show all of the H2O offering in the Azure Marketplace. Select the Data Science Virtual Machine for Linux (Ubuntu), and click the **Create** button.
+2. Search the Marketplace for "H2O". The result shows all of the H2O offerings in the Azure Marketplace. Select the **Data Science Virtual Machine for Linux (Ubuntu)**, then click the **Create** button.
 
   .. figure:: ../images/azurelin_h2o_dsvm.png
      :alt: Data Science VM for Linux
 
-3. Follow the UI instructions and fill the Basic settings: 
-   
-   - Username and Password that you will be using to connect to the VM
-   - Subscriptions where you want to create the VM
-   - The new resource group name
-   - The location where the VM is going to be created
-   - Size of the VM. 
+3. Follow the UI instructions and fill in the basic settings:
 
-   Optional: For VMs with GPU, select the HDD disk option, and search for the N-Series VM. For more information, click `here <http://gpu.azure.com/>`__. 
+   - Username and password that you will use to connect to the VM.
+   - Subscription where you want to create the VM.
+   - The new resource group name.
+   - The location where the VM will be created.
+   - Size of the VM.
 
-4. Wait for the VM Solution to be created. The expected creation time is around 10 minutes.
+   For VMs with GPU, select the HDD disk option, then search for the N-Series VM. For more information, see the `GPU on Azure documentation <http://gpu.azure.com/>`__.
 
-5. After your deployment is created, locate your network security group. Your Network Security Group is named by the default as **<your VM name>-nsg**. After you locate the security group, look at the inbound security rules.  
+4. Wait for the VM solution to be created. The expected creation time is around 10 minutes.
+
+5. After your deployment is created, locate your network security group. By default, your network security group is named **<your VM name>-nsg**. After you locate the security group, look at the inbound security rules.
 
   .. figure:: ../images/azurelin_inbound_secrules.png
      :alt: Inbound security rules
 
-6. Click **Add** to add a new Inbound Security Rule, and create a TCP Rule with Port Range 54321. Click **OK** when you are done.
+6. Click **Add** to add a new inbound security rule, then create a TCP rule with port range ``54321``. Click **OK** when you are done.
 
   .. figure:: ../images/azurelin_add_inbound_secrule.png
      :alt: Add inbound security rule
 
-7. After the new Inbound Security Rule is added, then you are ready to start using your Linux DSVM with H2O. Simply connect to your Jupyter notebooks and look at the examples in the **h2o > python** folder to create your first H2O Model on Azure. 
+7. After the new inbound security rule is added, you are ready to start using your Linux DSVM with H2O-3. Connect to your Jupyter Notebooks and look at the examples in the **h2o > python** folder to create your first H2O-3 model on Azure.
 
-   1. Connect to Jupyter Notebook by going to **https://<<VM DNS Name or IP Address>>:8000/**.
-   2. Connect to H2O Flow by going to **http://<<VM DNS Name or IP Address>>:54321/**.
+   - Connect to Jupyter Notebook by going to ``https://<<VM DNS Name or IP Address>>:8000/``.
+   - Connect to H2O Flow by going to ``http://<<VM DNS Name or IP Address>>:54321/``.
 
-Troubleshooting Tips
-'''''''''''''''''''' 
+Troubleshooting tips
+--------------------
 
-- Be aware that Azure subscriptions by default allow only 20 cores. If you get a Validation error on template deployment, this might be the cause. To increase the cores limit, follow these steps: `https://blogs.msdn.microsoft.com/girishp/2015/09/20/increasing-core-quota-limits-in-azure/ <https://blogs.msdn.microsoft.com/girishp/2015/09/20/increasing-core-quota-limits-in-azure/>`__
-- OS Disk by default is small (approx 30GB). In this case, you will have approximately 16GB of free space to start with. This is the same for all VM sizes. It is recommended that you add an SSD data disk by following these instructions: `https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-classic-attach-disk/ <https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-classic-attach-disk/>`__
-- Pick a VM size that provides RAM of at least 4x the size of your dataset. More information on Azure VM sizes is available here: `https://azure.microsoft.com/en-us/pricing/details/virtual-machines/ <https://azure.microsoft.com/en-us/pricing/details/virtual-machines/>`__
-- The included examples use a ``locate`` function for importing data. This function is not available to end users. For example:
+- Azure subscriptions by default allow only 20 cores. If you get a validation error on template deployment, this might be the cause. To increase the cores limit, see `Increasing core quota limits in Azure <https://blogs.msdn.microsoft.com/girishp/2015/09/20/increasing-core-quota-limits-in-azure/>`__.
+- The OS disk by default is small (approximately 30 GB). In this case, you have approximately 16 GB of free space to start with. This is the same for all VM sizes. We recommend that you add an SSD data disk by following the `Azure documentation for attaching a disk to a Linux VM <https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-classic-attach-disk/>`__.
+- Pick a VM size that provides RAM of at least four times the size of your dataset. For more information on Azure VM sizes, see the `Azure virtual machine pricing page <https://azure.microsoft.com/en-us/pricing/details/virtual-machines/>`__.
+- The included examples use a ``locate`` function for importing data. This function is not available outside the DSVM environment. For example:
 
-  :: 
+  ::
 
     air_path = [_locate("smalldata/airlines/allyears2k_headers.zip")]
 
- To retrieve the datasets, use one of the following methods instead:
+  To retrieve the datasets, use one of the following methods instead:
 
-  - Replace this path with a pointer to a raw github file at **https://raw.github.com/h2o.ai/h2o/master/..**. For example, ``air_path="https://raw.github.com/h2oai/h2o/master/smalldata/airlines/allyears2k_headers.zip"``
+  - Replace this path with a pointer to a raw GitHub file at ``https://raw.github.com/h2oai/h2o/master/...``. For example: ``air_path="https://raw.github.com/h2oai/h2o/master/smalldata/airlines/allyears2k_headers.zip"``.
   - Use ``wget`` to retrieve the files.
 
- A list of the datasets used in the examples along with their locate path is available in the **h2o > python > README** file.
+  A list of the datasets used in the examples — along with their ``locate`` paths — is available in the **h2o > python > README** file.

--- a/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
+++ b/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
@@ -1,29 +1,27 @@
-EC2 Instances & S3 Storage
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+EC2 instances and S3 storage
+============================
 
-*Tested on Redhat AMI, Amazon Linux AMI, and Ubuntu AMI*
+*Tested on Red Hat AMI, Amazon Linux AMI, and Ubuntu AMI.*
 
-To use the Amazon Web Services (AWS) S3 storage solution, you will need to pass your S3 access credentials to H2O. This will allow you to access your data on S3 when importing data frames with path prefixes ``s3://...``.
+To use the Amazon Web Services (AWS) S3 storage solution, you must pass your S3 access credentials to H2O-3. This lets you access your data on S3 when importing data frames with path prefixes ``s3://...``.
 
-To use the `Minio Cloud Storage <https://minio.io/>`__, you will need to pass an endpoint in addition to access credentials.
+To use `Minio Cloud Storage <https://minio.io/>`__, you must pass an endpoint in addition to access credentials.
 
-For security reasons, we recommend writing a script to read the access credentials that are stored in a separate file. This will not only keep your credentials from propagating to other locations, but it will also make it easier to change the credential information later.
+For security, write a script to read the access credentials that are stored in a separate file. This not only keeps your credentials from propagating to other locations, but it also makes it easier to change the credential information later.
 
-**Notes**: 
+.. note::
 
- - You can only specify one S3 endpoint. This means you can either read data from AWS S3 or Minio S3, not from both.
- - We recommend using S3 for data ingestion and S3N for data export. 
+    - You can specify only one S3 endpoint. This means you can read data from either AWS S3 or Minio S3, but not from both.
+    - Use S3 for data ingestion and S3N for data export.
 
-AWS Standalone Instance
-'''''''''''''''''''''''
+AWS standalone instance
+-----------------------
 
-When running H2O in standalone mode using the simple Java launch command, we can pass in the S3 credentials in three ways.
-H2O supports both AWS Credentials (pair consisting of AWS SECRET KEY and AWS SECRET ACCESS KEY) and temporary authentication using Session token
-(a triplet consisting of AWS SECRET KEY, AWS SECRET ACCESS KEY and AWS SESSION TOKEN).
+When running H2O-3 in standalone mode using the simple Java launch command, you can pass in the S3 credentials in three ways. H2O-3 supports both AWS credentials (a pair consisting of AWS SECRET KEY and AWS SECRET ACCESS KEY) and temporary authentication using a session token (a triplet consisting of AWS SECRET KEY, AWS SECRET ACCESS KEY, and AWS SESSION TOKEN).
 
--  You can pass in AWS Credentials in standalone mode by creating a ``core-site.xml`` file and passing it in with the flag ``-hdfs_config``. For an example ``core-site.xml`` file, refer to `Core-site.xml`_.
+- You can pass in AWS credentials in standalone mode by creating a ``core-site.xml`` file and passing it in with the ``-hdfs_config`` flag. For an example ``core-site.xml`` file, see the `Core-site.xml example`_ section.
 
-   1. Edit the properties in the core-site.xml file to include your Access Key ID, Access Key, and Session Token as shown in the following example:
+   1. Edit the properties in the ``core-site.xml`` file to include your access key ID, access key, and session token as shown in the following example:
 
      ::
 
@@ -38,33 +36,33 @@ H2O supports both AWS Credentials (pair consisting of AWS SECRET KEY and AWS SEC
        </property>
 
 
-   2. Launch with the configuration file ``core-site.xml`` by entering the following in the command line:
+   2. Launch H2O-3 with the configuration file ``core-site.xml`` by running the following command:
 
      ::
 
        java -jar h2o.jar -hdfs_config core-site.xml
 
-   3. Set the credentials dynamically before accessing the bucket (where ``AWS_ACCESS_KEY`` represents your user name, and ``AWS_SECRET_KEY`` represents your password).
+   3. Set the credentials dynamically before accessing the bucket (where ``AWS_ACCESS_KEY`` represents your username and ``AWS_SECRET_KEY`` represents your password).
 
-    -  To set the credentials dynamically using the R API:
+      - To set the credentials dynamically using the R API:
 
-      ::
+        ::
 
-        h2o.set_s3_credentials("AWS_ACCESS_KEY", "AWS_SECRET_KEY")
-        h2o.importFile(path = "s3://bucket/path/to/file.csv")
+          h2o.set_s3_credentials("AWS_ACCESS_KEY", "AWS_SECRET_KEY")
+          h2o.importFile(path = "s3://bucket/path/to/file.csv")
 
-    -  To set the credentials dynamically using the Python API:
+      - To set the credentials dynamically using the Python API:
 
-      ::
+        ::
 
-        from h2o.persist import set_s3_credentials
-        set_s3_credentials("AWS_ACCESS_KEY", "AWS_SECRET_KEY")
-        h2o.import_file(path = "s3://bucket/path/to/file.csv")
+          from h2o.persist import set_s3_credentials
+          set_s3_credentials("AWS_ACCESS_KEY", "AWS_SECRET_KEY")
+          h2o.import_file(path = "s3://bucket/path/to/file.csv")
 
-        
--  Just like regular AWS credentials, temporary credentials using AWS SESSION TOKEN can be passed in standalone mode by creating a ``core-site.xml`` file and passing it in with the flag ``-hdfs_config``. For an example ``core-site.xml`` file, refer to `Core-site.xml`_. The only difference lies in specifying a triplet of (AWS SECRET KEY, AWS SECRET ACCESS KEY and AWS SESSION TOKEN) and defining a credentials provider capable of resolving temporary credentials.
 
-   1. Edit the properties in the core-site.xml file to include your Access Key ID, Access Key, and Session Token as shown in the following example:
+- Just like regular AWS credentials, temporary credentials using AWS SESSION TOKEN can be passed in standalone mode by creating a ``core-site.xml`` file and passing it in with the ``-hdfs_config`` flag. For an example ``core-site.xml`` file, see the `Core-site.xml example`_ section. The only difference is specifying a triplet of (AWS SECRET KEY, AWS SECRET ACCESS KEY, and AWS SESSION TOKEN) and defining a credentials provider capable of resolving temporary credentials.
+
+   1. Edit the properties in the ``core-site.xml`` file to include your access key ID, access key, and session token as shown in the following example:
 
      ::
 
@@ -89,37 +87,39 @@ H2O supports both AWS Credentials (pair consisting of AWS SECRET KEY and AWS SEC
        <property>
 
 
-   2. Launch with the configuration file ``core-site.xml`` by entering the following in the command line:
+   2. Launch H2O-3 with the configuration file ``core-site.xml`` by running the following command:
 
      ::
 
        java -jar h2o.jar -hdfs_config core-site.xml
 
-   3. Set the credentials dynamically before accessing the bucket (where ``AWS_ACCESS_KEY`` represents your user name, ``AWS_SECRET_KEY`` represents your password and ``AWS_SESSION_TOKEN`` represents temporary session token).
+   3. Set the credentials dynamically before accessing the bucket (where ``AWS_ACCESS_KEY`` represents your username, ``AWS_SECRET_KEY`` represents your password, and ``AWS_SESSION_TOKEN`` represents the temporary session token).
 
-    -  To set the credentials dynamically using the R API:
+      - To set the credentials dynamically using the R API:
 
-      ::
+        ::
 
-        h2o.set_s3_credentials("AWS_ACCESS_KEY", "AWS_SECRET_KEY", "AWS_SESSION_TOKEN")
-        h2o.importFile(path = "s3://bucket/path/to/file.csv")
+          h2o.set_s3_credentials("AWS_ACCESS_KEY", "AWS_SECRET_KEY", "AWS_SESSION_TOKEN")
+          h2o.importFile(path = "s3://bucket/path/to/file.csv")
 
-    -  To set the credentials dynamically using the Python API:
+      - To set the credentials dynamically using the Python API:
 
-      ::
+        ::
 
-        from h2o.persist import set_s3_credentials
-        set_s3_credentials("AWS_ACCESS_KEY", "AWS_SECRET_KEY", "AWS_SESSION_TOKEN")
-        h2o.import_file(path = "s3://bucket/path/to/file.csv")
+          from h2o.persist import set_s3_credentials
+          set_s3_credentials("AWS_ACCESS_KEY", "AWS_SECRET_KEY", "AWS_SESSION_TOKEN")
+          h2o.import_file(path = "s3://bucket/path/to/file.csv")
 
-**Note**: Passing credentials in the URL, e.g. ``h2o.importFile(path = "s3://<AWS_ACCESS_KEY>:<AWS_SECRET_KEY>:<AWS_SESSION_TOKEN>@bucket/path/to/file.csv")``, is considered a security risk and is deprecated. 
+.. note::
+
+    Passing credentials in the URL — for example, ``h2o.importFile(path = "s3://<AWS_ACCESS_KEY>:<AWS_SECRET_KEY>:<AWS_SESSION_TOKEN>@bucket/path/to/file.csv")`` — is considered a security risk and is deprecated.
 
 .. _Core-site.xml:
 
-Core-site.xml Example
-'''''''''''''''''''''
+Core-site.xml example
+---------------------
 
-The following is an example core-site.xml file:
+The following is an example ``core-site.xml`` file:
 
 ::
 
@@ -153,65 +153,72 @@ The following is an example core-site.xml file:
         </property>
     </configuration>
 
-AWS Multi-Node Instance
-'''''''''''''''''''''''
+AWS multi-node instance
+-----------------------
 
-`Python <http://www.amazon.com/Python-and-AWS-Cookbook-ebook/dp/B005ZTO0UW/ref=sr_1_1?ie=UTF8&qid=1379879111&sr=8-1&keywords=python+aws>`_ and the `boto <http://boto.readthedocs.org/en/latest/>`_ Python library are required to launch a multi-node instance of H2O on EC2. Confirm these dependencies are installed before proceeding.
+`Python <http://www.amazon.com/Python-and-AWS-Cookbook-ebook/dp/B005ZTO0UW/ref=sr_1_1?ie=UTF8&qid=1379879111&sr=8-1&keywords=python+aws>`__ and the `boto <http://boto.readthedocs.org/en/latest/>`__ Python library are required to launch a multi-node instance of H2O-3 on EC2. Confirm these dependencies are installed before proceeding.
 
-For more information, refer to the `H2O EC2 repo <https://github.com/h2oai/h2o-3/tree/master/ec2>`_.
+For more information, see the `H2O EC2 repo <https://github.com/h2oai/h2o-3/tree/master/ec2>`__.
 
-Build a cluster of EC2 instances by running the following commands on the host that can access the nodes using a public DNS name.
+To build a cluster of EC2 instances, run the following commands on the host that can access the nodes using a public DNS name.
 
-1. Edit `h2o-cluster-launch-instances.py` to include your SSH key name and security group name, as well as any other environment-specific variables.
+1. Edit ``h2o-cluster-launch-instances.py`` to include your SSH key name and security group name, as well as any other environment-specific variables.
 
- ::
+   ::
 
-    ./h2o-cluster-launch-instances.py
-    ./h2o-cluster-distribute-h2o.sh
+      ./h2o-cluster-launch-instances.py
+      ./h2o-cluster-distribute-h2o.sh
 
- --OR--
+   --OR--
 
- ::
+   ::
 
-    ./h2o-cluster-launch-instances.py
-    ./h2o-cluster-download-h2o.sh
+      ./h2o-cluster-launch-instances.py
+      ./h2o-cluster-download-h2o.sh
 
- **Note**: The second method may be faster than the first because download pulls from S3.
+   .. note::
+
+       The second method may be faster than the first because download pulls from S3.
 
 2. Distribute the credentials using ``./h2o-cluster-distribute-aws-credentials.sh``.
 
-  **Note**: If you are running H2O using an IAM role, it is not necessary to distribute the AWS credentials to all the nodes in the cluster. The latest version of H2O can access the temporary access key.
+   .. note::
 
-  **Caution**: Distributing both regular AWS credentials and temporary AWS credentials using session token copies the Amazon AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and optionally (if temporary credentials are used) AWS_SESSION_TOKEN to the instances to enable S3 and S3N access. Use caution when adding your security keys to the cloud.
+       If you are running H2O-3 using an IAM role, it is not necessary to distribute the AWS credentials to all the nodes in the cluster. The latest version of H2O-3 can access the temporary access key.
 
-3. Start H2O by launching one H2O node per EC2 instance:
+   .. warning::
 
- ::
+       Distributing both regular AWS credentials and temporary AWS credentials using a session token copies the Amazon AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and (optionally, if temporary credentials are used) AWS_SESSION_TOKEN to the instances to enable S3 and S3N access. Use caution when adding your security keys to the cloud.
 
-    ./h2o-cluster-start-h2o.sh
+3. Start H2O-3 by launching one H2O-3 node per EC2 instance:
 
- Wait 60 seconds after entering the command before entering it on the next node.
+   ::
 
-4. In your internet browser, substitute any of the public DNS node addresses for *IP_ADDRESS* in the following example: ``http://IP_ADDRESS:54321``
+      ./h2o-cluster-start-h2o.sh
 
-  - To start H2O: ``./h2o-cluster-start-h2o.sh``
-  - To stop H2O: ``./h2o-cluster-stop-h2o.sh``
-  - To shut down the cluster, use your `Amazon AWS console <http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/UsingEMR_TerminateJobFlow.html>`_ to shut down the cluster manually.
+   Wait 60 seconds before repeating this command on the next node.
 
-  **Note**: To successfully import data, the data must reside in the same location on all nodes.
+4. In your internet browser, substitute any of the public DNS node addresses for ``IP_ADDRESS`` in the following example: ``http://IP_ADDRESS:54321``.
+
+   - To start H2O-3: ``./h2o-cluster-start-h2o.sh``
+   - To stop H2O-3: ``./h2o-cluster-stop-h2o.sh``
+   - To shut down the cluster, use the `Amazon AWS console <http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/UsingEMR_TerminateJobFlow.html>`__ to shut down the cluster manually.
+
+   .. note::
+
+       To successfully import data, the data must reside in the same location on all nodes.
 
 .. _minio:
 
-Minio Instance
-''''''''''''''
+Minio instance
+--------------
 
 Minio Cloud Storage is an alternative to Amazon AWS S3. When connecting to a Minio server, the following additional parameters are specified in the Java launch command:
 
-- ``endpoint``: Specifies a Minio server instance (including address and port). This overrides the existing endpoint, which is currently hardcoded to be AWS S3.
+- ``endpoint``: Specifies a Minio server instance (including address and port). This overrides the existing endpoint, which is currently hardcoded to AWS S3.
+- ``enable.path.style``: Overrides the default S3 behavior to expose every bucket as a full DNS-enabled path. This is a Minio recommendation.
 
-- ``enable.path.style``: Specifies to override the default S3 behavior to expose every bucket as a full DNS enabled path. Note that this is a Minio recommendation.
-
-To pass in credentials, create a ``core-site.xml`` file that contains your Access Key ID and Secret Access Key and use the flag ``-hdfs_config`` flag when launching:
+To pass in credentials, create a ``core-site.xml`` file that contains your access key ID and secret access key, then use the ``-hdfs_config`` flag when launching:
 
 ::
 
@@ -225,64 +232,69 @@ To pass in credentials, create a ``core-site.xml`` file that contains your Acces
          <value>[AWS SECRET ACCESS KEY]</value>
        </property>
 
-1. Launch H2O by entering the following in the command line:
+1. Launch H2O-3 by running the following command:
 
-  ::
+   ::
 
       java -Dsys.ai.h2o.persist.s3.endPoint=https://play.min.io:9000 -Dsys.ai.h2o.persist.s3.enable.path.style=true -jar h2o.jar -hdfs_config core-site.xml
 
-  **Note**: https://play.min.io:9000 is an example Minio server URL.
+   .. note::
 
-2. Import the data using ``importFile`` with the Minio S3 url path: **s3://bucket/path/to/file.csv**.
+       ``https://play.min.io:9000`` is an example Minio server URL.
 
- - To import the data from the Flow API:
+2. Import the data using ``importFile`` with the Minio S3 URL path: ``s3://bucket/path/to/file.csv``.
 
-  ::
+   - To import the data from the Flow API:
 
-   importFiles [ "s3://bucket/path/to/file.csv" ]
+     ::
 
- - To import the data from the R API:
+        importFiles [ "s3://bucket/path/to/file.csv" ]
 
-  ::
+   - To import the data from the R API:
 
-   h2o.importFile(path = "s3://bucket/path/to/file.csv")
+     ::
 
- - To import the data from the Python API:
+        h2o.importFile(path = "s3://bucket/path/to/file.csv")
 
-  ::
+   - To import the data from the Python API:
 
-   h2o.import_file(path = "s3://bucket/path/to/file.csv")
+     ::
 
-Launching H2O
-'''''''''''''
+        h2o.import_file(path = "s3://bucket/path/to/file.csv")
 
-**Note**: Before launching H2O on an EC2 cluster, verify that ports ``54321`` and ``54322`` are both accessible by TCP.
+Launching H2O-3
+---------------
 
-**Selecting the Operating System and Virtualization Type**
+.. note::
 
-Select your operating system and the virtualization type of the prebuilt AMI on Amazon. If you are using Windows, you will need to use a hardware-assisted virtual machine (HVM). If you are using Linux, you can choose between para-virtualization (PV) and HVM. These selections determine the type of instances you can launch.
+    Before launching H2O-3 on an EC2 cluster, verify that ports ``54321`` and ``54322`` are both accessible by TCP.
+
+Selecting the operating system and virtualization type
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Select your operating system and the virtualization type of the prebuilt AMI on Amazon. If you are using Windows, you must use a hardware-assisted virtual machine (HVM). If you are using Linux, you can choose between para-virtualization (PV) and HVM. These selections determine the type of instances you can launch.
 
 .. figure:: ../EC2_images/ec2_system.png
-   :alt: EC2 Systems
+   :alt: EC2 systems
 
 
-For more information about virtualization types, refer to `Amazon <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html>`__.
+For more information about virtualization types, see the `Amazon virtualization types documentation <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html>`__.
 
+Configuring the instance
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Configuring the Instance**
+1. Select the IAM role and policy to use to launch the instance. H2O-3 detects the temporary access keys associated with the instance, so you don't need to copy your AWS credentials to the instances.
 
-1. Select the IAM role and policy to use to launch the instance. H2O detects the temporary access keys associated with the instance, so you don't need to copy your AWS credentials to the instances.
-
-  .. figure:: ../EC2_images/ec2_config.png
-     :alt: EC2 Configuration
+   .. figure:: ../EC2_images/ec2_config.png
+      :alt: EC2 configuration
 
 2. When launching the instance, select an accessible key pair.
 
-  .. figure:: ../EC2_images/ec2_key_pair.png
-     :alt: EC2 Key Pair
+   .. figure:: ../EC2_images/ec2_key_pair.png
+      :alt: EC2 key pair
 
-
-**(Windows Users) Tunneling into the Instance**
+(Windows users) Tunneling into the instance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For Windows users who do not have the ability to use ``ssh`` from the terminal, either download Cygwin or a Git Bash that has the capability to run ``ssh``:
 
@@ -295,34 +307,36 @@ Otherwise, download PuTTY and follow these instructions:
 1. Launch the PuTTY Key Generator.
 2. Load your downloaded AWS pem key file.
 
- **Note:** To see the file, change the browser file type to "All".
+   .. note::
 
-3. Save the private key as a .ppk file.
+       To see the file, change the browser file type to **All**.
 
- .. figure:: ../EC2_images/ec2_putty_key.png
-    :alt: Private Key
+3. Save the private key as a ``.ppk`` file.
+
+   .. figure:: ../EC2_images/ec2_putty_key.png
+      :alt: Private key
 
 4. Launch the PuTTY client.
-5. In the *Session* section, enter the host name or IP address. For Ubuntu users, the default host name is ``ubuntu@<ip-address>``. For Linux users, the default host name is ``ec2-user@<ip-address>``.
+5. In the **Session** section, enter the host name or IP address. For Ubuntu users, the default host name is ``ubuntu@<ip-address>``. For Linux users, the default host name is ``ec2-user@<ip-address>``.
 
- .. figure:: ../EC2_images/ec2_putty_connect_1.png
-    :alt: Configuring Session
+   .. figure:: ../EC2_images/ec2_putty_connect_1.png
+      :alt: Configuring session
 
-6. Select *SSH*, then *Auth* in the sidebar, and click the **Browse** button to select the private key file for authentication.
+6. Select **SSH**, then **Auth** in the sidebar, then click the **Browse** button to select the private key file for authentication.
 
- .. figure:: ../EC2_images/ec2_putty_connect_2.png
+   .. figure:: ../EC2_images/ec2_putty_connect_2.png
 
 7. Start a new session and click the **Yes** button to confirm caching of the server's rsa2 key fingerprint and continue connecting.
 
- .. figure:: ../EC2_images/ec2_putty_alert.png
-    :alt: PuTTY Alert
+   .. figure:: ../EC2_images/ec2_putty_alert.png
+      :alt: PuTTY alert
 
 
-Downloading Java and H2O
-''''''''''''''''''''''''
+Downloading Java and H2O-3
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Download `Java <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#java-requirements>`__ (JDK 1.8 or later) if it is not already available on the instance.
-2. To download H2O, run the ``wget`` command with the link to the zip file available on our `website <http://h2o.ai/download/>`__ by copying the link associated with the **Download** button for the selected H2O build.
+2. To download H2O-3, run the ``wget`` command with the link to the ZIP file available on our `website <http://h2o.ai/download/>`__ by copying the link associated with the **Download** button for the selected H2O-3 build:
 
    ::
 
@@ -331,5 +345,4 @@ Downloading Java and H2O
        cd h2o-{{project_version}}
        java -Xmx4g -jar h2o.jar
 
-3. From your browser, navigate to ``<Private_IP_Address>:54321`` or ``<Public_DNS>:54321`` to use H2O's web interface.
-
+3. From your browser, navigate to ``<Private_IP_Address>:54321`` or ``<Public_DNS>:54321`` to use H2O-3's web interface.

--- a/h2o-docs/src/product/cloud-integration/gcs.rst
+++ b/h2o-docs/src/product/cloud-integration/gcs.rst
@@ -1,14 +1,14 @@
-Using H2O with Google Cloud Storage
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Using H2O-3 with Google Cloud Storage
+=====================================
 
-To use the Google Cloud Storage solution, you will have to ensure your GCS credentials are provided to H2O. This will allow you to access your data on GCS when importing data frames with path prefixes ``gs://...``.
+To use the Google Cloud Storage solution, you must provide your GCS credentials to H2O-3. This lets you access your data on GCS when importing data frames with path prefixes ``gs://...``.
 
-Under the hood **https://github.com/google/google-auth-library-java** is used to authenticate requests. It supports a wide range of authentication types.
+H2O-3 uses `google-auth-library-java <https://github.com/google/google-auth-library-java>`__ to authenticate requests. It supports a wide range of authentication types.
 
 The following are searched (in order) to find the Application Default Credentials:
 
-  * Credentials file pointed to by the ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable
-  * Credentials provided by the Google Cloud SDK ``gcloud auth application-default login`` command
-  * Google App Engine built-in credentials
-  * Google Cloud Shell built-in credentials
-  * Google Compute Engine built-in credentials
+- Credentials file pointed to by the ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable.
+- Credentials provided by the Google Cloud SDK ``gcloud auth application-default login`` command.
+- Google App Engine built-in credentials.
+- Google Cloud Shell built-in credentials.
+- Google Compute Engine built-in credentials.

--- a/h2o-docs/src/product/cloud-integration/google-compute.rst
+++ b/h2o-docs/src/product/cloud-integration/google-compute.rst
@@ -1,19 +1,19 @@
 .. _install-on-google-cloud:
 
-Install H2O on the Google Cloud Platform Offering
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Using H2O-3 with Google Cloud Platform
+======================================
 
-This section describes how to install and start H2O Flow (H2O-3 web offering) in a Google Compute environment using the available Cloud Launcher offering.
+This section describes how to install and start H2O Flow (the H2O-3 web offering) in a Google Compute environment using the available Cloud Launcher offering.
 
-Before You Begin
-''''''''''''''''
+Before you begin
+----------------
 
-If you are trying GCP for the first time and have just created an account, please check your Google Compute Engine (GCE) resource quota limits. Our default recommendation for launching H2O-3 is 4 CPUs, 15 GB RAM, and 3 nodes. By default, GCP allocates a maximum of 8 CPUs, so most H2O-3 users can easily run without reaching a quota limit. Some users of H2O, however, may require more resources. If necessary, you can change these settings to match your quota limit, or you can request more resources from GCP. Refer to https://cloud.google.com/compute/quotas for more information, including information on how to check your quota and request additional quota.
+If you are trying GCP for the first time and have just created an account, check your Google Compute Engine (GCE) resource quota limits. The recommended configuration for H2O-3 is 4 CPUs, 15 GB RAM, and 3 nodes. By default, GCP allocates a maximum of 8 CPUs, so most H2O-3 users can run without reaching a quota limit. Some users, however, may require more resources. If necessary, you can change these settings to match your quota limit, or you can request more resources from GCP. See the `GCE resource quotas page <https://cloud.google.com/compute/quotas>`__ for more information, including how to check your quota and request additional quota.
 
-Installation Procedure
-''''''''''''''''''''''
+Installation procedure
+----------------------
 
-1. In your browser, log in to the Google Compute Engine Console at https://console.cloud.google.com/. 
+1. In your browser, log in to the `Google Compute Engine Console <https://console.cloud.google.com/>`__.
 
 2. In the left navigation panel, select **Marketplace**.
 
@@ -21,31 +21,31 @@ Installation Procedure
      :align: center
      :scale: 70%
 
-3. On the Cloud Launcher page, search for **H2O** and select the H2O-3 offering. 
+3. On the Cloud Launcher page, search for **H2O** and select the H2O-3 offering.
 
   .. image:: ../images/google_h2o_offering.png
      :align: center
 
 4. Click **Launch on Compute Engine**.
 
- - Specify a name for this deployment.
- - Select a zone for the deployment.
- - Select or customize a machine type and memory amount.
- - Specify the number of nodes for the virtual machine.
- - Specify the boot disk type and size (in GB).
- - Specify the network and subnetwork names. 
+   - Specify a name for this deployment.
+   - Select a zone for the deployment.
+   - Select or customize a machine type and memory amount.
+   - Specify the number of nodes for the virtual machine.
+   - Specify the boot disk type and size (in GB).
+   - Specify the network and subnetwork names.
 
- Click **Deploy** when you are done. H2O-3 will begin deploying. Note that this can take several minutes. 
+   Click **Deploy**. H2O-3 begins deploying. This can take several minutes.
 
- .. image:: ../images/google_deploy_compute_engine.png
-  :align: center
+   .. image:: ../images/google_deploy_compute_engine.png
+      :align: center
 
-5. A summary page displays when the compute engine is successfully deployed. This page includes the instance ID and the username (always **h2oai**) and password that will be required when starting H2O-3. Click on the Instance link to retrieve the external IP address for starting H2O-3.
+5. A summary page appears when the compute engine is successfully deployed. This page includes the instance ID and the username (always ``h2oai``) and password that are required when starting H2O-3. Click the **Instance** link to retrieve the external IP address for starting H2O-3.
 
   .. image:: ../images/google_deploy_summary.png
      :align: center
 
-6. Connecto to the H2O-3 Cluster using one of the following methods:
+6. Connect to the H2O-3 cluster using one of the following methods:
 
 .. tabs::
   .. group-tab:: R
@@ -62,6 +62,8 @@ Installation Procedure
 
   .. group-tab:: Flow
 
-    In your browser, go to https://[External_IP]:54321 to start Flow. Enter your username and password when prompted. 
+    In your browser, go to ``https://[External_IP]:54321`` to start Flow. Enter your username and password when prompted.
 
-    **Note**: When starting H2O Flow, you may receive a message indicating that the connection is not private. Note that the connection is secure and encrypted, but H2O uses a self-signed certificate to handle Nginx encryption, which prompts the warning. You can avoid this message by using your own self-signed certificate. 
+    .. note::
+
+        When starting H2O Flow, you may receive a message indicating that the connection is not private. The connection is secure and encrypted, but H2O-3 uses a self-signed certificate to handle Nginx encryption, which prompts the warning. You can avoid this message by using your own self-signed certificate.

--- a/h2o-docs/src/product/cloud-integration/ibm-dsx.rst
+++ b/h2o-docs/src/product/cloud-integration/ibm-dsx.rst
@@ -1,9 +1,9 @@
-Using H2O with IBM Data Science Experience
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Using H2O-3 with IBM Data Science Experience
+============================================
 
-The IBM Data Science Experience (DSX) provides an interactive, collaborative, cloud-based environment where data scientists can use multiple tools to activate their insights. With DSX, Data scientists can use the best of open source tools such as R and Python, tap into IBMs unique features, grow their capabilities, and share their successes.
+The IBM Data Science Experience (DSX) provides an interactive, collaborative, cloud-based environment where data scientists can use multiple tools to activate their insights. With DSX, you can use open source tools like R and Python, use IBM's tools, grow your capabilities, and share your successes.
 
-This section shows how simple it is to use H2O R with IBM DSX.
+This section shows how to use H2O-3 with IBM DSX in R.
 
 1. Sign in to `datascience.ibm.com <http://datascience.ibm.com>`__. (Or select **Sign Up** if you do not yet have an account.)
 
@@ -15,18 +15,18 @@ This section shows how simple it is to use H2O R with IBM DSX.
   .. figure:: ../images/ibm-select-r-studio.png
       :alt: Start RStudio
 
-3. Install and start H2O R using the instructions included on the `H2O Download site <http://h2o-release.s3.amazonaws.com/h2o/latest_stable.html>`__. Note that this page opens by default to the **Download and Run** tab. Be sure to select the **Install in R** tab for R installation instructions. |install|
+3. Install and start H2O-3 R using the instructions on the `H2O-3 download site <http://h2o-release.s3.amazonaws.com/h2o/latest_stable.html>`__. This page opens by default to the **Download and Run** tab. Be sure to select the **Install in R** tab for R installation instructions. |install|
 
-  You can also view a quick start video of installing and starting H2O in R by clicking `here <https://www.youtube.com/embed/zzV1kTCnmR0?list=PLNtMya54qvOHbBdA1x8FNRSpMBEHmhxr0>`__.
+  You can also `watch a quick start video for installing and starting H2O-3 in R <https://www.youtube.com/embed/zzV1kTCnmR0?list=PLNtMya54qvOHbBdA1x8FNRSpMBEHmhxr0>`__.
 
   .. |install| image:: ../images/ibm_install_in_r.png
      :height: 24
      :width: 204
 
   .. figure:: ../images/ibm-start-h2o.png
-      :alt: Install and start H2O
+      :alt: Install and start H2O-3
 
-After H2O is installed and running, you are ready to use H2O in DSX! Refer to any of the following references for more information about using H2O with R:
+After H2O-3 is installed and running, you are ready to use H2O-3 in DSX. See the following references for more information about using H2O-3 with R:
 
 - `New User Quick Start <https://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#new-user-quick-start>`__
 - `R Booklet <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/booklets/RBooklet.pdf>`__

--- a/h2o-docs/src/product/cloud-integration/kubernetes.rst
+++ b/h2o-docs/src/product/cloud-integration/kubernetes.rst
@@ -1,39 +1,41 @@
-Using H2O with Kubernetes
-=========================
+Using H2O-3 with Kubernetes
+===========================
 
-H2O Software Stack
-------------------
+H2O-3 software stack
+--------------------
 
-In order to understand the behavior and limitations of a H2O distributed cluster, it is mandatory to understand the basics of H2O's design. The H2O cluster is stateful. If one H2O node is terminated, the cluster is immediately recognized as unhealthy and has to be restarted as a whole.
+To understand the behavior and limitations of an H2O-3 distributed cluster, you need to understand the basics of H2O-3's design. The H2O-3 cluster is stateful: if one H2O-3 node is terminated, the cluster is immediately recognized as unhealthy and must be restarted as a whole.
 
-This implies that H2O nodes must be treated as stateful by Kubernetes. In Kubernetes, a set of pods sharing a common state is handled by a `StatefulSet <https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/>`__. Kubernetes tooling for stateless applications in not applicable to H2O. The proper way to deploy H2O is to set ``kind: StatefulSet``. A StatefulSet ensures:
+This means H2O-3 nodes must be treated as stateful by Kubernetes. In Kubernetes, a set of pods sharing a common state is handled by a `StatefulSet <https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/>`__. Kubernetes tooling for stateless applications is not applicable to H2O-3. The proper way to deploy H2O-3 is to set ``kind: StatefulSet``. A StatefulSet ensures that:
 
-- H2O Nodes are treated as a single unit, being brought up and down gracefully and together.
-- No attempts will be made by K8S healthcheck (if defined) to restart individual H2O nodes in case of an error.
-- Persistent storages and volumes associated with the StatefulSet of H2O Nodes will not be deleted once the cluster is brought down.
+- H2O-3 nodes are treated as a single unit, being brought up and down gracefully and together.
+- The Kubernetes healthcheck (if defined) does not attempt to restart individual H2O-3 nodes in case of an error.
+- Persistent storage and volumes associated with the StatefulSet of H2O-3 nodes are not deleted once the cluster is brought down.
 
 
-H2O Kubernetes Deployment
--------------------------
+H2O-3 Kubernetes deployment
+---------------------------
 
-In order to spawn a H2O cluster inside a Kubernetes cluster, the following list of requirements must be met:
+To spawn an H2O-3 cluster inside a Kubernetes cluster, the following requirements must be met:
 
-1. A Kubernetes cluster. For local development, k3s is a great choice. For easy start, OpenShift by RedHat is a great choice with their 30 day free trial.
-2. Docker image with H2O inside.
-3. A Kubernetes deployment definition with a StatefulSet of H2O pods and a headless service.
+1. A Kubernetes cluster. For local development, k3s works well. OpenShift by Red Hat offers a 30-day free trial.
+2. A Docker image with H2O-3 inside.
+3. A Kubernetes deployment definition with a StatefulSet of H2O-3 pods and a headless service.
 
-After H2O is started, there must be a way for H2O nodes to "find" themselves and form a cluster. This is the role of the `headless service <https://kubernetes.io/docs/concepts/services-networking/service/#headless-services>`__. This approach works on all major Kubernetes clusters without any additional permissions required.
+After H2O-3 is started, there must be a way for H2O-3 nodes to "find" themselves and form a cluster. This is the role of the `headless service <https://kubernetes.io/docs/concepts/services-networking/service/#headless-services>`__. This approach works on all major Kubernetes clusters without any additional permissions required.
 
 For reproducibility, resource limits and requests should always be set to equal values.
 
-**Note**: Official K8s images don’t apply any `security settings <../security.html>`__. The default user is ``root``. If you require a secure interface with H2O running the image, you need to change the user and execution command to add security parameters before running the image. The following is the default command used in Docker images:
+.. note::
 
-::
-  
-  java -Djava.library.path=/opt/h2oai/h2o-3/xgb_lib_dir -XX:+UseContainerSupport -XX:MaxRAMPercentage=50 -jar /opt/h2oai/h2o-3/h2o.jar
+    Official Kubernetes images don't apply any `security settings <../security.html>`__. The default user is ``root``. If you require a secure interface with the H2O-3 image, you must change the user and execution command to add security parameters before running the image. The following is the default command used in Docker images:
+
+    ::
+
+      java -Djava.library.path=/opt/h2oai/h2o-3/xgb_lib_dir -XX:+UseContainerSupport -XX:MaxRAMPercentage=50 -jar /opt/h2oai/h2o-3/h2o.jar
 
 
-Headless Service
+Headless service
 ~~~~~~~~~~~~~~~~
 
 .. code:: yaml
@@ -52,9 +54,9 @@ Headless Service
     - protocol: TCP
       port: 54321
 
-The ``clusterIP: None`` defines the service as headless, and ``port: 54321`` is the default H2O port. Users and client libraries use this port to talk to the H2O cluster.
+The ``clusterIP: None`` defines the service as headless, and ``port: 54321`` is the default H2O-3 port. You and your client libraries use this port to talk to the H2O-3 cluster.
 
-The ``app: h2o-k8s`` setting is the name of the application with H2O pods inside. Be sure this setting corresponds to the name of the chosen H2O deployment name.
+The ``app: h2o-k8s`` setting is the name of the application with H2O-3 pods inside. Make sure this setting matches the name of your chosen H2O-3 deployment.
 
 StatefulSet
 ~~~~~~~~~~~
@@ -105,41 +107,40 @@ StatefulSet
             value: '8081'
 
 
-Besides the standardized Kubernetes settings (e.g. replicas: 3 defining the number of pods with H2O instantiated), there are several settings to pay attention to:
+Besides the standardized Kubernetes settings (for example, ``replicas: 3``, which defines the number of pods with H2O-3 instantiated), pay attention to the following settings:
 
-- The **application name** (``app: h2o-k8s``) must correspond to the name expected by the above-defined headless service in order for the H2O node discovery to work. 
-- H2O communicates on port 54321, therefore ``containerPort: 54321`` must be exposed to make it possible for the clients to connect.
-- The **pod management policy** must be set to parallel: ``podManagementPolicy: "Parallel"``. This makes Kubernetes spawn all H2O nodes at once. If not specified, Kubernetes will spawn the pods with H2O nodes sequentially, one after another, significantly prolonging the startup process.
+- The **application name** (``app: h2o-k8s``) must match the name expected by the headless service defined above for H2O-3 node discovery to work.
+- H2O-3 communicates on port ``54321``, so ``containerPort: 54321`` must be exposed to make it possible for clients to connect.
+- The **pod management policy** must be set to parallel: ``podManagementPolicy: "Parallel"``. This makes Kubernetes spawn all H2O-3 nodes at once. If not specified, Kubernetes spawns the pods with H2O-3 nodes sequentially, one after another, significantly prolonging the startup process.
 
-Native Kubernetes Resources
+Native Kubernetes resources
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-H2O is able to discover other pods with H2O under the same service automatically by using the resources native to Kubernetes: services and environment variables.
+H2O-3 can discover other pods with H2O-3 under the same service automatically by using resources native to Kubernetes: services and environment variables.
 
 Services
 ''''''''
 
-In order to ensure reproducibility, all requests should be directed towards the H2O Leader node. Leader node election is done after the node discovery process is completed. Therefore, after the clustering is formed and the leader node is known, only the pod with the H2O leader node should be made available (ready). This makes the service(s) on top of the deployment route all requests only to the leader node. 
+To ensure reproducibility, all requests should be directed toward the H2O-3 leader node. Leader node election happens after the node discovery process completes. Therefore, after the cluster is formed and the leader node is known, only the pod with the H2O-3 leader node should be made available (ready). This makes the service(s) on top of the deployment route all requests only to the leader node.
 
-Once the clustering is done, all nodes but the leader node mark themselves as "not ready", leaving only the leader node exposed. The ``readinessProbe`` residing on ``/kubernetes/isLeaderNode`` makes sure only the leader node is exposed once the cluster is formed by making all nodes but the leader node "not available". 
+Once the cluster is formed, all nodes except the leader node mark themselves as "not ready", leaving only the leader node exposed. The ``readinessProbe`` residing on ``/kubernetes/isLeaderNode`` ensures that only the leader node is exposed once the cluster is formed by making all nodes except the leader node "not available".
 
-The default port for H2O Kubernetes API is 8080. However, in the example, an optional environment variable changes the port to 8081 to demonstrate the functionality.
+The default port for the H2O-3 Kubernetes API is 8080. However, in the example, an optional environment variable changes the port to 8081 to demonstrate the functionality.
 
-Environment Variables
+Environment variables
 '''''''''''''''''''''
 
-If none of the optional lookup constraints are specified, a sensible default node lookup timeout will be set (defaults to 3 minutes). If any of the lookup constraints are defined, the H2O node lookup is terminated on whichever condition is met first.
+If none of the optional lookup constraints are specified, a sensible default node lookup timeout is set (defaults to 3 minutes). If any of the lookup constraints are defined, the H2O-3 node lookup terminates on whichever condition is met first.
 
-1. ``H2O_KUBERNETES_SERVICE_DNS`` - **[MANDATORY]** Crucial for the clustering to work. The format usually follows the ``<service-name>.<project-name>.svc.cluster.local`` pattern. This setting enables H2O node discovery via DNS. It must be modified to match the name of the headless service created. Also, pay attention to the rest of the address to match the specifics of your Kubernetes implementation.
-2. ``H2O_NODE_LOOKUP_TIMEOUT`` - **[OPTIONAL]** Node lookup constraint. Specify the time before the node lookup times out.
-3. ``H2O_NODE_EXPECTED_COUNT`` - **[OPTIONAL]** Node lookup constraint. This is the expected number of H2O pods to be discovered (should be equal to the number of replicas).
-4. ``H2O_KUBERNETES_API_PORT`` - **[OPTIONAL]** Port for Kubernetes API checks and probes to listen on. Defaults to 8080.
+1. ``H2O_KUBERNETES_SERVICE_DNS`` — **[MANDATORY]** Crucial for clustering to work. The format usually follows the ``<service-name>.<project-name>.svc.cluster.local`` pattern. This setting enables H2O-3 node discovery via DNS. It must be modified to match the name of the headless service created. Also, pay attention to the rest of the address to match the specifics of your Kubernetes implementation.
+2. ``H2O_NODE_LOOKUP_TIMEOUT`` — **[OPTIONAL]** Node lookup constraint. Specifies the time before the node lookup times out.
+3. ``H2O_NODE_EXPECTED_COUNT`` — **[OPTIONAL]** Node lookup constraint. The expected number of H2O-3 pods to be discovered (should be equal to the number of replicas).
+4. ``H2O_KUBERNETES_API_PORT`` — **[OPTIONAL]** Port for Kubernetes API checks and probes to listen on. Defaults to 8080.
 
-Exposing H2O
-~~~~~~~~~~~~
+Exposing H2O-3
+~~~~~~~~~~~~~~
 
-In order to expose H2O and make it available from the outside of the Kubernetes cluster, an Ingress is required. Some vendors provide custom resources to achieve the same goal (e.g.
-`OpenShift and Routes <https://docs.openshift.com/container-platform/4.5/networking/ingress-operator.html#nw-ingress-sharding_configuring-ingress>`__). An example of an ingress is found below. Path configuration, namespace and other Ingress attributes are always specific to user's cluster specification.
+To expose H2O-3 and make it available from outside the Kubernetes cluster, an Ingress is required. Some vendors provide custom resources to achieve the same goal (for example, `OpenShift and Routes <https://docs.openshift.com/container-platform/4.5/networking/ingress-operator.html#nw-ingress-sharding_configuring-ingress>`__). The following is an example Ingress definition. Path configuration, namespace, and other Ingress attributes are always specific to your cluster specification.
 
 .. code:: yaml
 
@@ -158,27 +159,27 @@ In order to expose H2O and make it available from the outside of the Kubernetes 
             servicePort: 80
 
 Reproducibility notes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
-There are three key requirements to make sure actions invoked on H2O are reproducible:
+There are three key requirements for ensuring that actions invoked on H2O-3 are reproducible:
 
-1. Same amount of memory,
-2. Same number of CPUs,
-3. Client sends requests only to the H2O leader node.
+1. The same amount of memory.
+2. The same number of CPUs.
+3. The client sends requests only to the H2O-3 leader node.
 
-In a Kubernetes environment, one common mistake is to set different resource quotas for ``requests`` and ``limits`` for a pod. If the underlying JVM running inside the docker image inside a pod uses certain percentage of memory available, that amount of memory might be different each time H2O starts, as Kubernetes might actually allocate different amount of memory every time. These same rules apply to CPU ``limits`` and ``requests``.
+In a Kubernetes environment, one common mistake is to set different resource quotas for ``requests`` and ``limits`` for a pod. If the underlying JVM running inside the Docker image inside a pod uses a certain percentage of available memory, that amount of memory might be different each time H2O-3 starts, because Kubernetes might allocate a different amount of memory every time. The same rules apply to CPU ``limits`` and ``requests``.
 
-The ``readinessProbe`` residing on ``/kubernetes/isLeaderNode`` makes sure only the leader node is exposed once the cluster is formed by making all nodes but the leader node "not available". Without the readiness probe, reproducibility is not guaranteed.
+The ``readinessProbe`` residing on ``/kubernetes/isLeaderNode`` ensures that only the leader node is exposed once the cluster is formed by making all nodes except the leader node "not available". Without the readiness probe, reproducibility is not guaranteed.
 
 
-Installing H2O with Helm
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Installing H2O-3 with Helm
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-`Helm <https://helm.sh/>`__ can be used to deploy H2O into a kubernetes cluster. Helm requires setting up the KUBECONFIG environment variable properly or stating the KUBECONFIG destination explicitly. There are three steps required in order to use the official H2O Helm chart:
+`Helm <https://helm.sh/>`__ can be used to deploy H2O-3 into a Kubernetes cluster. Helm requires that you set up the ``KUBECONFIG`` environment variable properly or that you state the ``KUBECONFIG`` destination explicitly. There are three steps required to use the official H2O-3 Helm chart:
 
-1. Add H2O Helm chart repository,
-2. Use ``helm install`` to install H2O Open source to Kubernetes,
-3. (Optional) test the installation.
+1. Add the H2O-3 Helm chart repository.
+2. Use ``helm install`` to install H2O-3 open source to Kubernetes.
+3. (Optional) Test the installation.
 
 .. code:: bash
 
@@ -187,9 +188,9 @@ Installing H2O with Helm
   helm test basic-h2o
 
 
-The basic command ``helm install basic-h2o h2o/h2o`` only installs a minimal H2O cluster with few resources. There are various settings and modifications available. To inspect a complete list of the configuration options available, use the  ``helm inspect values h2o/h2o --version |version|`` command.
+The basic command ``helm install basic-h2o h2o/h2o`` only installs a minimal H2O-3 cluster with few resources. There are various settings and modifications available. To inspect a complete list of the configuration options available, use the ``helm inspect values h2o/h2o --version |version|`` command.
 
-Among the most common settings are number of H2O nodes (there is one pod per each H2O node) spawned, memory and CPU resources for each H2O node, and an ingress. Below is an example on how to configure these basic options.
+Among the most common settings are the number of H2O-3 nodes (there is one pod per H2O-3 node) spawned, memory and CPU resources for each H2O-3 node, and an ingress. The following example configures node count, memory, CPU, and ingress.
 
 .. code:: yaml
 
@@ -205,4 +206,3 @@ Among the most common settings are number of H2O nodes (there is one pod per eac
       - host: ""
         paths: ["/"]
     tls: []
-

--- a/h2o-docs/src/product/cloud-integration/nimbix.rst
+++ b/h2o-docs/src/product/cloud-integration/nimbix.rst
@@ -1,108 +1,115 @@
-Using H2O with Nimbix
-~~~~~~~~~~~~~~~~~~~~~
+Using H2O-3 with Nimbix
+=======================
 
 The Nimbix Cloud is a high performance computing (HPC) platform. Through either a portal or a processing API, the Nimbix Cloud runs compute-intensive applications on bare-metal machines. These applications can include CPU, GPU, FPGA systems, or a supercomputing cluster.
 
-This section shows to run H2O on the Nimbix Cloud and walks you through the following steps:
+This section shows how to run H2O-3 on the Nimbix Cloud and walks you through the following steps:
 
 - Initial setup
 - Creating applications
 - Pulling applications
 - Running applications
 
-This assumes that you have a Nimbix account. If you do not, then contact your administrator or sign up for one at `http://www.nimbix.net <https://www.nimbix.net/>`__.
+This section assumes that you have a Nimbix account. If you do not, contact your administrator or `sign up for a Nimbix account <https://www.nimbix.net/>`__.
 
-Initial Setup
-'''''''''''''
+Initial setup
+-------------
 
-1. Log in to your Nimbix account at `https://mc.jarvice.com/ <https://mc.jarvice.com/>`__.
+1. Log in to your Nimbix account at `mc.jarvice.com <https://mc.jarvice.com/>`__.
 
-2. Click the **Nimbix** logo in the upper right corner to expand the Nimbix sidebar.
+2. Click the **Nimbix** logo in the upper-right corner to expand the Nimbix sidebar.
 
    .. figure:: ../images/nimbix_menu_bar.png
       :alt: Nimbix menu
       :height: 337
       :width: 153
 
-3. Click **Account** in this right-hand menu. The Profile page should open by default. If it is not open, then on the left menu, click **Profile** to open the Profile page. This page shows your API key.
+3. Click **Account** in the right-hand menu. The Profile page opens by default. If it is not open, click **Profile** in the left menu to open the Profile page. This page shows your API key.
 
-  Your API key is important for SFTP file transfer. Every account has a specific file storage that is distributed among all of your applications. To access this, you can use SFTP on the command-line or another SFTP client such as Cyberduck or Filezilla.
+  Your API key is required for SFTP file transfer. Every account has a specific file storage that is distributed among all of your applications. To access this file storage, you can use SFTP on the command line or another SFTP client (such as Cyberduck or Filezilla).
 
-  Example: 
+  For example:
 
   ::
 
     sftp <username>@drop.jarvice.com
     password: <API KEY>
 
-  **Warning**: To avoid issues with Jupyter Notebooks opening to an empty folder, we suggest placing at least 1 file into your file storage before continuing.
+  .. warning::
 
-  Alternatively, you can launch the Nimbix File Manager, which is a GUI based application that runs inside of Nimbix. 
+      To avoid issues with Jupyter Notebooks opening to an empty folder, place at least one file into your file storage before continuing.
 
-Initial Application Creation
-''''''''''''''''''''''''''''
+  Alternatively, you can launch the Nimbix File Manager — a GUI application that runs inside Nimbix.
 
-This section describes how to create the following applications. Note that when specifying the Docker repository, H2O.ai principal repo is "opsh2oai", and all h2o images have "nae" appended. 
+Initial application creation
+----------------------------
 
-- H2o3 Core: Docker repository opsh2oai/h2o3-nae
-- H2oAI: Docker repository opsh2oai/h2oai_nae
+This section describes how to create the following applications. When specifying the Docker repository, the H2O.ai principal repo is ``opsh2oai``, and all H2O-3 images have ``nae`` appended.
 
-1. In the right-side menu, select the **PushToCompute™** menu option, then click the **New** icon. 
+- H2O-3 Core: Docker repository ``opsh2oai/h2o3-nae``
+- H2OAI: Docker repository ``opsh2oai/h2oai_nae``
+
+1. In the right-side menu, select the **PushToCompute™** menu option, then click the **New** icon.
 
    .. figure:: ../images/nimbix_new.png
       :alt: New application
       :height: 159
       :width: 200
 
-2. Specify a name for your application, for example "h2o3".
-3. Enter the docker repository. For example "opsh2oai/h2o3_nae".
-4. Select "Intel x86 64-bit (x86_64)" from the **System Architecture** drop down.
+2. Specify a name for your application (for example, ``h2o3``).
+3. Enter the Docker repository (for example, ``opsh2oai/h2o3_nae``).
+4. Select **Intel x86 64-bit (x86_64)** from the **System Architecture** dropdown.
 
    .. figure:: ../images/nimbix_create_app.png
       :alt: Create application
       :height: 307
       :width: 458
 
-5. Click **OK** when you are done. 
+5. Click **OK** when you are done.
 6. Repeat steps 1 through 5 for the following applications:
 
- - H2oAI: Docker repository opsh2oai/h2oai_nae
- - H2o3 for Power8: Docker repository opsh2oai/h2o3_power_nae. **Note**: For H2o3 for Power8, DO NOT use "Intel x86 64-bit (x86_64)". Instead, select "IBM Power 64-bit, Little Endian (ppc64le)" from the **System Architecture** drop-down menu.
+   - H2OAI: Docker repository ``opsh2oai/h2oai_nae``
+   - H2O-3 for Power8: Docker repository ``opsh2oai/h2o3_power_nae``.
 
-Pull Applications
-'''''''''''''''''
+   .. note::
 
-After applications are created, the next step is to pull each application. For each application, click the menu icon (three lines) in the upper-left corner of the application, then click **Pull**. 
+       For H2O-3 for Power8, do not use **Intel x86 64-bit (x86_64)**. Instead, select **IBM Power 64-bit, Little Endian (ppc64le)** from the **System Architecture** dropdown.
+
+Pull applications
+-----------------
+
+After applications are created, the next step is to pull each application. For each application, click the menu icon (three lines) in the upper-left corner of the application, then click **Pull**.
 
 .. figure:: ../images/nimbix_pull.png
    :alt: Pull application
    :height: 347
    :width: 374
 
-Once you start a pull, you will receive an email from Nimbix stating that a Pull has been scheduled followed by another when the Pull is completed. After you receive the final email stating that the Pull has completed, your application is ready to use.
+Once you start a pull, you receive an email from Nimbix stating that a pull has been scheduled, followed by another when the pull completes. After you receive the final email stating that the pull has completed, your application is ready to use.
 
-**Note**: To avoid UI issues with Nimbix, we recommend logging out and then logging back in to ensure that the template and UI for the Application has been properly loaded into the NAE framework.
+.. note::
 
-Running Applications
-''''''''''''''''''''
+    To avoid UI issues with Nimbix, log out and then log back in to ensure that the template and UI for the application have been properly loaded into the NAE framework.
 
-This section shows how easy it is to run applications after they are built and pulled.
+Running applications
+--------------------
 
-1. Select the Application and the desired launch type (for example Batch, H2O-3 Cluster, Jupyter Notebook, or SSH).
+This section shows how to run applications after they are built and pulled.
 
+1. Select the application and the desired launch type (for example, **Batch**, **H2O-3 Cluster**, **Jupyter Notebook**, or **SSH**).
 
   .. figure:: ../images/nimbix_start_app.png
      :alt: Start application
      :height: 312
      :width: 551
 
-2. Select the Machine Type and the number of cores, then click **Submit**.
+2. Select the machine type and the number of cores, then click **Submit**.
 
   .. figure:: ../images/nimbix_machine_type.png
      :alt: Select machine type and number of cores
      :height: 194
      :width: 416
 
-That's it! At this point, you are now running your H2O applications in Nimbix.
+.. warning::
 
-**Warning**: Be sure to shut off your instances when you are done. 
+    Shut off your instances when you are done.


### PR DESCRIPTION
Closes #16186. Part of #16839.

Brings the *Cloud Integration* user-guide page and its eight sub-pages in line with the Makersaurus style conventions established by the prior `GH-1618x` / `GH-1620x` / `GH-1621x` conversions: sentence-case headings, top-level `===` page titles, `.. note::` / `.. warning::` directives in place of inline `**Note**:` paragraphs, second-person voice, and descriptive link text. Content is preserved — only prose, headings, and directive style change.

Index page (`cloud-integration.rst`) was also resynced with the actual toctree: removed the dangling Databricks bullet (no Databricks page exists) and added Google Cloud Storage and Google Cloud Platform to match what's actually linked.

**Suggested follow-up:** Several of these pages document deployment paths that have been retired or rebranded (AWS H2O AMI, Azure DSVM with H2O preinstalled, Nimbix Cloud, GCP Cloud Launcher offering). Worth opening a separate content-currency issue to decide whether to deprecate, rewrite, or remove them.