### PR TITLE
GH-16844 - Bump log4j to 2.25.4 to fix CVE-2026-34477/34478/34479/34480

### DIFF
--- a/h2o-logging/impl-log4j2/build.gradle
+++ b/h2o-logging/impl-log4j2/build.gradle
@@ -5,8 +5,8 @@ compileJava {
 }
 
 dependencies {
-    api("org.apache.logging.log4j:log4j-1.2-api:2.25.3")
-    api("org.apache.logging.log4j:log4j-core:2.25.3")
+    api("org.apache.logging.log4j:log4j-1.2-api:2.25.4")
+    api("org.apache.logging.log4j:log4j-core:2.25.4")
 
     testImplementation group: 'junit', name: 'junit', version: '4.12'
 }


### PR DESCRIPTION
Closes #16844

- Bump `log4j-core` and `log4j-1.2-api` from 2.25.3 to 2.25.4 in `h2o-logging/impl-log4j2/build.gradle`
- Fixes CVE-2026-34477 (MITM via incomplete hostname verification), CVE-2026-34478 (CRLF log injection), CVE-2026-34479 (DoS in 1.2 bridge), CVE-2026-34480 (DoS via invalid XML output)
- Pure dependency update, no API changes