### PR TITLE
GH-16847 - Upgrade mina-core to 2.2.6 to fix CVE-2026-41409

### DIFF
--- a/h2o-jetty-9/build.gradle
+++ b/h2o-jetty-9/build.gradle
@@ -20,8 +20,9 @@ dependencies {
     testImplementation "org.mockito:mockito-core:2.23.0"
 
     constraints{
-        api("org.apache.mina:mina-core:2.2.4") {
+        api("org.apache.mina:mina-core:2.2.6") {
             because 'Fixes CVE-2024-52046'
+            because 'Fixes CVE-2026-41409'
         }
     }
 }


### PR DESCRIPTION
Closes #16847

- Bump `org.apache.mina:mina-core` constraint from 2.2.4 to 2.2.6 in `h2o-jetty-9/build.gradle` to fix CVE-2026-41409