### PR TITLE
GH-16852 - Upgrade mina-core to 2.2.7 to fix CVE-2026-42778 and CVE-2026-42779

### DIFF
--- a/h2o-jetty-9/build.gradle
+++ b/h2o-jetty-9/build.gradle
@@ -20,9 +20,11 @@ dependencies {
     testImplementation "org.mockito:mockito-core:2.23.0"
 
     constraints{
-        api("org.apache.mina:mina-core:2.2.6") {
+        api("org.apache.mina:mina-core:2.2.7") {
             because 'Fixes CVE-2024-52046'
             because 'Fixes CVE-2026-41409'
+            because 'Fixes CVE-2026-42778'
+            because 'Fixes CVE-2026-42779'
         }
     }
 }


### PR DESCRIPTION
Closes #16852

- Bump `org.apache.mina:mina-core` constraint from 2.2.6 to 2.2.7 in `h2o-jetty-9/build.gradle` to fix CVE-2026-42778 and CVE-2026-42779