### PR TITLE
GH-16847/GH-16852 - Upgrade mina-core to 2.2.7 for DAI 3.46.0.10 custom build

### DIFF
--- a/h2o-jetty-9/build.gradle
+++ b/h2o-jetty-9/build.gradle
@@ -20,8 +20,9 @@ dependencies {
     testImplementation "org.mockito:mockito-core:2.23.0"
 
     constraints{
-        api("org.apache.mina:mina-core:2.2.4") {
+        api("org.apache.mina:mina-core:2.2.6") {
             because 'Fixes CVE-2024-52046'
+            because 'Fixes CVE-2026-41409'
         }
     }
 }

--- a/h2o-jetty-9/build.gradle
+++ b/h2o-jetty-9/build.gradle
@@ -20,9 +20,11 @@ dependencies {
     testImplementation "org.mockito:mockito-core:2.23.0"
 
     constraints{
-        api("org.apache.mina:mina-core:2.2.6") {
+        api("org.apache.mina:mina-core:2.2.7") {
             because 'Fixes CVE-2024-52046'
             because 'Fixes CVE-2026-41409'
+            because 'Fixes CVE-2026-42778'
+            because 'Fixes CVE-2026-42779'
         }
     }
 }

--- a/h2o-jetty-9/build.gradle
+++ b/h2o-jetty-9/build.gradle
@@ -23,6 +23,7 @@ dependencies {
         api("org.apache.mina:mina-core:2.2.7") {
             because 'Fixes CVE-2024-52046'
             because 'Fixes CVE-2026-41409'
+            because 'Fixes CVE-2026-41635'
             because 'Fixes CVE-2026-42778'
             because 'Fixes CVE-2026-42779'
         }


### PR DESCRIPTION
## Summary

Cherry-picks the mina-core CVE fixes from `rel-3.46.0.10-sec` onto the DAI custom-build branch `driverlessai-3.46.0.10` so that the `h2o.jar` hot-patched into the DAI Docker image no longer carries the vulnerable mina-core versions.

Commits in this PR:

- Cherry-pick of `251d31de5d` — mina-core 2.2.4 → 2.2.6, fixes **CVE-2026-41409** (GH-16847 / upstream PR #16849)
- Cherry-pick of `a01bd8b28b` — mina-core 2.2.6 → 2.2.7, fixes **CVE-2026-42778**, **CVE-2026-42779** (GH-16852 / upstream PR #16854)
- Follow-up: add `because 'Fixes CVE-2026-41635'` to the `mina-core:2.2.7` constraint — the 2.2.7 release covers this CVE; the `because` line is needed so the vulnerability scanner attributes the fix.

3.46.0.10 is the latest released H2O version and no upstream tag exists with these fixes — same pattern as the previous DAI custom build seen in `jenkins-3.46.0.7..origin/driverlessai-3.46.0.7`.

## Test plan

- [ ] CI builds `h2o.jar` successfully
- [ ] `./gradlew :h2o-jetty-9:dependencies | grep mina-core` resolves to `2.2.7`
- [ ] Trivy/dependabot scan no longer flags CVE-2026-41409, CVE-2026-41635, CVE-2026-42778, CVE-2026-42779

🤖 Generated with [Claude Code](https://claude.com/claude-code)