### PR TITLE
GH-16844 - Bump log4j to 2.25.4 for DAI 3.46.0.10 custom build

### DIFF
--- a/h2o-logging/impl-log4j2/build.gradle
+++ b/h2o-logging/impl-log4j2/build.gradle
@@ -5,8 +5,8 @@ compileJava {
 }
 
 dependencies {
-    api("org.apache.logging.log4j:log4j-1.2-api:2.25.3")
-    api("org.apache.logging.log4j:log4j-core:2.25.3")
+    api("org.apache.logging.log4j:log4j-1.2-api:2.25.4")
+    api("org.apache.logging.log4j:log4j-core:2.25.4")
 
     testImplementation group: 'junit', name: 'junit', version: '4.12'
 }


### PR DESCRIPTION
## Summary

Cherry-pick of `79df30cb17` from `rel-3.46.0.10-sec` — bumps log4j from `2.25.3` to `2.25.4`, fixing **CVE-2026-34477**, **CVE-2026-34478**, **CVE-2026-34479**, **CVE-2026-34480**.

Part of the DAI 3.46.0.10 custom-build set; companion PR for mina-core: #16856. Same pattern as the previous DAI custom build seen in `jenkins-3.46.0.7..origin/driverlessai-3.46.0.7`.

Files changed:
- `h2o-logging/impl-log4j2/build.gradle` — `2.25.3` → `2.25.4` for both `log4j-1.2-api` and `log4j-core`.

## Test plan

- [ ] CI builds `h2o.jar` successfully
- [ ] `./gradlew :h2o-logging-impl-log4j2:dependencies | grep log4j` resolves to `2.25.4`
- [ ] Trivy/dependabot scan no longer flags CVE-2026-34477/78/79/80

🤖 Generated with [Claude Code](https://claude.com/claude-code)