### PR TITLE
GH-16875: First-run telemetry disclosure notice

### DIFF
--- a/h2o-core/src/main/java/water/telemetry/JvmTelemetry.java
+++ b/h2o-core/src/main/java/water/telemetry/JvmTelemetry.java
@@ -5,6 +5,8 @@ import water.H2ONode;
 import water.HeartBeat;
 import water.Paxos;
 
+import java.io.File;
+import java.io.FileWriter;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -90,7 +92,33 @@ public class JvmTelemetry {
     String os = normalizeOs(System.getProperty("os.name"));
     if (os == null) return;
 
+    maybePrintNotice();
     post(buildInit(os, H2O.CLOUD.size()));
+  }
+
+  private static final String NOTICE_TEXT =
+      "H2O-3 collects anonymous usage telemetry (H2O version, OS, and coarse cluster\n" +
+      "buckets) to help prioritize features and platforms. It never sends your code,\n" +
+      "data, file paths, or any identifiers.\n" +
+      "To opt out: set H2O_DISABLE_TELEMETRY=1 (or DO_NOT_TRACK=1), or pass\n" +
+      "-Dsys.ai.h2o.telemetry.disabled=true.\n" +
+      "Docs: https://docs.h2o.ai/h2o/latest-stable/h2o-docs/telemetry.html\n" +
+      "(This notice is shown only once.)";
+
+  /** Print the disclosure notice once per environment (per-client marker under ~/.h2o). */
+  private static void maybePrintNotice() {
+    try {
+      String home = System.getProperty("user.home");
+      if (home == null || home.isEmpty()) return;
+      File marker = new File(new File(home, ".h2o"), ".telemetry_notice_jvm");
+      if (marker.exists()) return;
+      System.out.println("\n" + NOTICE_TEXT + "\n");
+      marker.getParentFile().mkdirs();
+      FileWriter w = new FileWriter(marker);
+      try { w.write("1\n"); } finally { w.close(); }
+    } catch (Throwable ignore) {
+      // best-effort — never block or fail startup over a notice
+    }
   }
 
   // -- opt-out -----------------------------------------------------------------

--- a/h2o-py/h2o/telemetry.py
+++ b/h2o-py/h2o/telemetry.py
@@ -35,6 +35,7 @@ import queue
 import re
 import shutil
 import subprocess
+import sys
 import threading
 import time
 import urllib.request
@@ -616,6 +617,41 @@ def _strip_none(d):
     return {k: v for k, v in d.items() if v is not None}
 
 
+# -- First-run disclosure notice ----------------------------------------------
+
+_NOTICE_TEXT = (
+    "H2O-3 collects anonymous usage telemetry (H2O version, OS, algorithm names, and\n"
+    "coarse usage buckets) to help prioritize features and platforms. It never sends\n"
+    "your code, data, file paths, or any identifiers.\n"
+    "To opt out: set H2O_DISABLE_TELEMETRY=1 (or DO_NOT_TRACK=1), or pass\n"
+    "telemetry=False to h2o.init() / h2o.connect().\n"
+    "Docs: https://docs.h2o.ai/h2o/latest-stable/h2o-docs/telemetry.html\n"
+    "(This notice is shown only once.)"
+)
+
+
+def _maybe_print_notice():
+    """Print the disclosure notice once per environment, then never again.
+
+    Gated on telemetry being enabled (no point notifying an opted-out user) and
+    on a per-client marker file under ``~/.h2o``. Entirely best-effort: any
+    failure (no home dir, read-only fs) is swallowed and never blocks startup.
+    """
+    if _telemetry_disabled():
+        return
+    try:
+        marker = os.path.join(os.path.expanduser("~"), ".h2o", ".telemetry_notice_python")
+        if os.path.exists(marker):
+            return
+        sys.stderr.write("\n" + _NOTICE_TEXT + "\n\n")
+        sys.stderr.flush()
+        os.makedirs(os.path.dirname(marker), exist_ok=True)
+        with open(marker, "w") as f:
+            f.write("1\n")
+    except Exception:
+        pass
+
+
 # -- Public emitters ----------------------------------------------------------
 
 def send_init_telemetry(h2o_version, *, cluster_shape=None, attributes=None):
@@ -626,6 +662,7 @@ def send_init_telemetry(h2o_version, *, cluster_shape=None, attributes=None):
     """
     if _telemetry_disabled():
         return
+    _maybe_print_notice()
     _new_session_id()
     payload = {**_envelope(h2o_version), "event": "init"}
     payload.update(_strip_none({
@@ -649,6 +686,7 @@ def send_cluster_connect_telemetry(h2o_version, *, cluster_shape=None, attribute
     """
     if _telemetry_disabled():
         return
+    _maybe_print_notice()
     _new_session_id()
     payload = {**_envelope(h2o_version), "event": "cluster_connect"}
     payload.update(_strip_none({

--- a/h2o-py/tests/testdir_misc/pyunit_telemetry.py
+++ b/h2o-py/tests/testdir_misc/pyunit_telemetry.py
@@ -1,7 +1,9 @@
 import sys
 sys.path.insert(1, "../../")
+import io
 import json
 import os
+import tempfile
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
@@ -122,14 +124,52 @@ def telemetry_http_delivery_smoke():
     print("OK telemetry_http_delivery_smoke: worker delivered 1 event over HTTP")
 
 
+def telemetry_first_run_notice():
+    # Use a throwaway HOME so the per-environment marker doesn't touch the real one.
+    old_home = os.environ.get("HOME")
+    tmp = tempfile.mkdtemp()
+    os.environ["HOME"] = tmp
+
+    def run():
+        err = io.StringIO()
+        old = sys.stderr
+        sys.stderr = err
+        try:
+            t._maybe_print_notice()
+        finally:
+            sys.stderr = old
+        return err.getvalue()
+
+    try:
+        t.set_disabled(False)
+        first, second = run(), run()
+        assert "anonymous usage telemetry" in first, "notice not printed on first run"
+        assert second == "", "notice repeated on second run (marker not honored)"
+        assert os.path.exists(os.path.join(tmp, ".h2o", ".telemetry_notice_python"))
+
+        # Disabled telemetry never prints, even with no marker.
+        os.remove(os.path.join(tmp, ".h2o", ".telemetry_notice_python"))
+        t.set_disabled(True)
+        assert run() == "", "notice printed while telemetry disabled"
+    finally:
+        t.set_disabled(False)
+        if old_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = old_home
+    print("OK telemetry_first_run_notice: shown once, suppressed when disabled")
+
+
 if __name__ == "__main__":
     telemetry_wire_contract()
     telemetry_bucket_boundaries()
     telemetry_disabled_emits_nothing()
+    telemetry_first_run_notice()
     telemetry_http_delivery_smoke()
     print("\nALL TELEMETRY TESTS PASSED")
 else:
     telemetry_wire_contract()
     telemetry_bucket_boundaries()
     telemetry_disabled_emits_nothing()
+    telemetry_first_run_notice()
     telemetry_http_delivery_smoke()

--- a/h2o-r/h2o-package/R/telemetry.R
+++ b/h2o-r/h2o-package/R/telemetry.R
@@ -599,9 +599,34 @@ bucketize_leaderboard_size <- function(n) {
   attrs
 }
 
+# First-run disclosure notice: shown once per environment, then never again.
+# Gated on a per-client marker under ~/.h2o; entirely best-effort.
+.h2o.telemetry.notice_text <- function() paste(
+  "H2O-3 collects anonymous usage telemetry (H2O version, OS, algorithm names, and",
+  "coarse usage buckets) to help prioritize features and platforms. It never sends",
+  "your code, data, file paths, or any identifiers.",
+  "To opt out: set H2O_DISABLE_TELEMETRY=1 (or DO_NOT_TRACK=1), or pass",
+  "telemetry = FALSE to h2o.init() / h2o.connect().",
+  "Docs: https://docs.h2o.ai/h2o/latest-stable/h2o-docs/telemetry.html",
+  "(This notice is shown only once.)",
+  sep = "\n")
+
+.h2o.telemetry.maybe_print_notice <- function() {
+  if (.h2o.telemetry.disabled()) return(invisible(NULL))
+  tryCatch({
+    marker <- file.path(path.expand("~"), ".h2o", ".telemetry_notice_r")
+    if (file.exists(marker)) return(invisible(NULL))
+    message("\n", .h2o.telemetry.notice_text(), "\n")
+    dir.create(dirname(marker), showWarnings = FALSE, recursive = TRUE)
+    writeLines("1", marker)
+  }, error = function(e) invisible(NULL))
+  invisible(NULL)
+}
+
 #' @keywords internal
 .h2o.send_init_telemetry <- function(h2o_version, cluster_shape = NULL, attributes = NULL) {
   if (.h2o.telemetry.disabled()) return(invisible(NULL))
+  .h2o.telemetry.maybe_print_notice()
   .h2o.telemetry.new_session_id()
   payload <- tryCatch({
     base <- c(list(event = "init"), .h2o.telemetry.envelope(h2o_version))
@@ -616,6 +641,7 @@ bucketize_leaderboard_size <- function(n) {
 #' @keywords internal
 .h2o.send_cluster_connect_telemetry <- function(h2o_version, cluster_shape = NULL, attributes = NULL) {
   if (.h2o.telemetry.disabled()) return(invisible(NULL))
+  .h2o.telemetry.maybe_print_notice()
   .h2o.telemetry.new_session_id()
   payload <- tryCatch({
     base <- c(list(event = "cluster_connect"), .h2o.telemetry.envelope(h2o_version))

--- a/h2o-r/tests/testdir_misc/runit_telemetry.R
+++ b/h2o-r/tests/testdir_misc/runit_telemetry.R
@@ -66,6 +66,18 @@ test.telemetry <- function() {
   check(identical(h2o:::bucketize_data_size(3 * 1024^3), "1GB-5GB"),
         "files larger than 2GB bucket correctly")
 
+  # First-run disclosure notice: shown once per environment, then suppressed.
+  # Use a throwaway HOME so the marker doesn't touch the real one.
+  old_home <- Sys.getenv("HOME")
+  tmp_home <- tempfile("h2o_home"); dir.create(tmp_home)
+  Sys.setenv(HOME = tmp_home)
+  on.exit(Sys.setenv(HOME = old_home), add = TRUE)
+  h2o:::.h2o.telemetry.state$disabled_by_kwarg <- FALSE
+  first  <- capture.output(h2o:::.h2o.telemetry.maybe_print_notice(), type = "message")
+  second <- capture.output(h2o:::.h2o.telemetry.maybe_print_notice(), type = "message")
+  check(any(grepl("anonymous usage telemetry", first)), "notice printed on first run")
+  check(length(second) == 0L, "notice not repeated on second run (marker honored)")
+
   # Disabled telemetry emits nothing.
   h2o:::.h2o.telemetry.state$disabled_by_kwarg <- TRUE
   before <- length(captured$events)


### PR DESCRIPTION
Stacked on #16876 (base branch `valenad-gh-16875-telemetry`) so it sits on top of the actual telemetry code with no conflicts — retarget to `rel-3.46.0` once #16876 merges. Implements the first-run notice documented on the docs branch (#16877).

- Prints a one-time disclosure notice the first time telemetry is active in an environment, then never again (per-client marker under `~/.h2o`).
- Gated on telemetry being enabled — opted-out users never see it.
- Python, R, and JVM clients; best-effort, never blocks or raises.

Part of GH-16875.
