### PR TITLE
Fix S3 persistence tests for OIDC session token and multi-account credentials

### DIFF
--- a/h2o-py/tests/testdir_persist/pyunit_import_s3_parquet.py
+++ b/h2o-py/tests/testdir_persist/pyunit_import_s3_parquet.py
@@ -16,7 +16,7 @@ def test_import_parquet_from_s3():
 
 
 def test_import_parquet_from_s3_impl():
-    aws_creds_prefix = os.environ['AWS_CREDS_PREFIX'] if 'AWS_CREDS_PREFIX' in os.environ else ''
+    aws_creds_prefix = os.environ.get('AWS_CREDS_PREFIX_S3_PROD', os.environ.get('AWS_CREDS_PREFIX', ''))
     access_key_id = os.environ[aws_creds_prefix + 'AWS_ACCESS_KEY_ID']
     secret_access_key = os.environ[aws_creds_prefix + "AWS_SECRET_ACCESS_KEY"]
     session_token = os.environ.get(aws_creds_prefix + "AWS_SESSION_TOKEN")

--- a/h2o-py/tests/testdir_persist/pyunit_import_s3_parquet.py
+++ b/h2o-py/tests/testdir_persist/pyunit_import_s3_parquet.py
@@ -19,10 +19,11 @@ def test_import_parquet_from_s3_impl():
     aws_creds_prefix = os.environ['AWS_CREDS_PREFIX'] if 'AWS_CREDS_PREFIX' in os.environ else ''
     access_key_id = os.environ[aws_creds_prefix + 'AWS_ACCESS_KEY_ID']
     secret_access_key = os.environ[aws_creds_prefix + "AWS_SECRET_ACCESS_KEY"]
+    session_token = os.environ.get(aws_creds_prefix + "AWS_SESSION_TOKEN")
 
     assert access_key_id is not None
     assert secret_access_key is not None
-    set_s3_credentials(access_key_id, secret_access_key)
+    set_s3_credentials(access_key_id, secret_access_key, session_token)
     
     from_s3 = h2o.import_file("s3://h2o-public-test-data/smalldata/parser/parquet/airlines-simple.snappy.parquet")
     from_local = h2o.import_file(pyunit_utils.locate("smalldata/parser/parquet/airlines-simple.snappy.parquet"))

--- a/h2o-py/tests/testdir_persist/pyunit_set_s3_credentials.py
+++ b/h2o-py/tests/testdir_persist/pyunit_set_s3_credentials.py
@@ -16,7 +16,7 @@ def test_set_s3_credentials():
 
 
 def test_set_s3_credentials_impl():
-    aws_creds_prefix = os.environ['AWS_CREDS_PREFIX'] if 'AWS_CREDS_PREFIX' in os.environ else ''
+    aws_creds_prefix = os.environ.get('AWS_CREDS_PREFIX_S3_DEV', os.environ.get('AWS_CREDS_PREFIX', ''))
     access_key_id = os.environ[aws_creds_prefix + 'AWS_ACCESS_KEY_ID']
     secret_access_key = os.environ[aws_creds_prefix + "AWS_SECRET_ACCESS_KEY"]
     session_token = os.environ.get(aws_creds_prefix + "AWS_SESSION_TOKEN")

--- a/h2o-py/tests/testdir_persist/pyunit_set_s3_credentials.py
+++ b/h2o-py/tests/testdir_persist/pyunit_set_s3_credentials.py
@@ -16,19 +16,25 @@ def test_set_s3_credentials():
 
 
 def test_set_s3_credentials_impl():
-    aws_creds_prefix = os.environ.get('AWS_CREDS_PREFIX_S3_DEV', os.environ.get('AWS_CREDS_PREFIX', ''))
+    aws_creds_prefix = os.environ.get('S3_CREDS_TEST_PREFIX',
+                                       os.environ.get('AWS_CREDS_PREFIX_S3_DEV',
+                                                      os.environ.get('AWS_CREDS_PREFIX', '')))
     access_key_id = os.environ[aws_creds_prefix + 'AWS_ACCESS_KEY_ID']
     secret_access_key = os.environ[aws_creds_prefix + "AWS_SECRET_ACCESS_KEY"]
     session_token = os.environ.get(aws_creds_prefix + "AWS_SESSION_TOKEN")
+
+    s3_path = os.environ.get('S3_CREDS_TEST_PATH', 's3://test.0xdata.com/h2o-unit-tests/iris.csv')
+    s3a_path = s3_path.replace('s3://', 's3a://', 1)
 
     assert access_key_id is not None
     assert secret_access_key is not None
 
     # Check that we cannot connect without setting credentials (this will only work if prefix is defined,
-    # otherwise H2O will just pick it up from environment variables)
-    if aws_creds_prefix:
+    # otherwise H2O will just pick it up from environment variables).
+    # Skip for public buckets where anonymous access may succeed.
+    if aws_creds_prefix and 'S3_CREDS_TEST_PATH' not in os.environ:
         try:
-            h2o.import_file("s3://test.0xdata.com/h2o-unit-tests/iris.csv")
+            h2o.import_file(s3_path)
             assert False
         except Exception as e:
             assert type(e) is h2o.exceptions.H2OServerError
@@ -38,18 +44,18 @@ def test_set_s3_credentials_impl():
     # Now set the credentials
     # 1. Check PersistS3
     set_s3_credentials(access_key_id, secret_access_key, session_token)
-    file = h2o.import_file("s3://test.0xdata.com/h2o-unit-tests/iris.csv")
+    file = h2o.import_file(s3_path)
     assert file is not None
 
     # 2. Check S3A (Using PersistHdfs)
-    file = h2o.import_file("s3a://test.0xdata.com/h2o-unit-tests/iris.csv")
+    file = h2o.import_file(s3a_path)
     assert file is not None
 
     access_key_id = 'abcd'
     secret_access_key = 'abcd'
     set_s3_credentials(access_key_id, secret_access_key)
     try:
-        h2o.import_file("s3://test.0xdata.com/h2o-unit-tests/iris.csv")
+        h2o.import_file(s3_path)
         assert False
     except Exception as e:
         assert type(e) is h2o.exceptions.H2OServerError

--- a/h2o-py/tests/testdir_persist/pyunit_set_s3_credentials.py
+++ b/h2o-py/tests/testdir_persist/pyunit_set_s3_credentials.py
@@ -19,6 +19,7 @@ def test_set_s3_credentials_impl():
     aws_creds_prefix = os.environ['AWS_CREDS_PREFIX'] if 'AWS_CREDS_PREFIX' in os.environ else ''
     access_key_id = os.environ[aws_creds_prefix + 'AWS_ACCESS_KEY_ID']
     secret_access_key = os.environ[aws_creds_prefix + "AWS_SECRET_ACCESS_KEY"]
+    session_token = os.environ.get(aws_creds_prefix + "AWS_SESSION_TOKEN")
 
     assert access_key_id is not None
     assert secret_access_key is not None
@@ -36,7 +37,7 @@ def test_set_s3_credentials_impl():
 
     # Now set the credentials
     # 1. Check PersistS3
-    set_s3_credentials(access_key_id, secret_access_key)
+    set_s3_credentials(access_key_id, secret_access_key, session_token)
     file = h2o.import_file("s3://test.0xdata.com/h2o-unit-tests/iris.csv")
     assert file is not None
 

--- a/h2o-r/tests/testdir_persist/runit_pubdev_6188.R
+++ b/h2o-r/tests/testdir_persist/runit_pubdev_6188.R
@@ -4,31 +4,35 @@ source("../../scripts/h2o-r-test-setup.R")
 
 
 test.s3.credentials <- function() {
-    awsCredsPrefix <- Sys.getenv("AWS_CREDS_PREFIX_S3_DEV", Sys.getenv("AWS_CREDS_PREFIX", ""))
+    awsCredsPrefix <- Sys.getenv("S3_CREDS_TEST_PREFIX",
+                        Sys.getenv("AWS_CREDS_PREFIX_S3_DEV",
+                          Sys.getenv("AWS_CREDS_PREFIX", "")))
     accessKeyId <- Sys.getenv(paste0(awsCredsPrefix, "AWS_ACCESS_KEY_ID"))
     accesSecretKey <- Sys.getenv(paste0(awsCredsPrefix, "AWS_SECRET_ACCESS_KEY"))
     sessionToken <- Sys.getenv(paste0(awsCredsPrefix, "AWS_SESSION_TOKEN"))
     if (nchar(sessionToken) == 0) sessionToken <- NULL
 
+    s3Path <- Sys.getenv("S3_CREDS_TEST_PATH", "s3://test.0xdata.com/h2o-unit-tests/iris.csv")
+
     expect_false(nchar(accessKeyId) == 0)
     expect_false(nchar(accessKeyId) == 0)
 
     h2o.set_s3_credentials(accessKeyId, accesSecretKey, sessionToken)
-    file <- h2o.importFile(path = "s3://test.0xdata.com/h2o-unit-tests/iris.csv")
+    file <- h2o.importFile(path = s3Path)
     expect_false(is.null(file))
-    
+
     h2o.set_s3_credentials("ab", "cd")
     tryCatch(
       {
-        file <- h2o.importFile(path = "s3://test.0xdata.com/h2o-unit-tests/iris.csv")
+        file <- h2o.importFile(path = s3Path)
         expect_true(FALSE)
       }, error = function(e){
         msg <- e$message
         grepl("The AWS Access Key Id you provided does not exist in our records\\. \\(Service: Amazon S3; Status Code: 403; Error Code: InvalidAccessKeyId", msg)
       }
     )
-    
-  
+
+
 }
 
 doTest("S3 Credentials", test.s3.credentials)

--- a/h2o-r/tests/testdir_persist/runit_pubdev_6188.R
+++ b/h2o-r/tests/testdir_persist/runit_pubdev_6188.R
@@ -6,12 +6,13 @@ source("../../scripts/h2o-r-test-setup.R")
 test.s3.credentials <- function() {
     accessKeyId <- Sys.getenv("AWS_ACCESS_KEY_ID")
     accesSecretKey <- Sys.getenv("AWS_SECRET_ACCESS_KEY")
-    
-  
+    sessionToken <- Sys.getenv("AWS_SESSION_TOKEN")
+    if (nchar(sessionToken) == 0) sessionToken <- NULL
+
     expect_false(nchar(accessKeyId) == 0)
     expect_false(nchar(accessKeyId) == 0)
-    
-    h2o.set_s3_credentials(accessKeyId, accesSecretKey)
+
+    h2o.set_s3_credentials(accessKeyId, accesSecretKey, sessionToken)
     file <- h2o.importFile(path = "s3://test.0xdata.com/h2o-unit-tests/iris.csv")
     expect_false(is.null(file))
     

--- a/h2o-r/tests/testdir_persist/runit_pubdev_6188.R
+++ b/h2o-r/tests/testdir_persist/runit_pubdev_6188.R
@@ -4,9 +4,10 @@ source("../../scripts/h2o-r-test-setup.R")
 
 
 test.s3.credentials <- function() {
-    accessKeyId <- Sys.getenv("AWS_ACCESS_KEY_ID")
-    accesSecretKey <- Sys.getenv("AWS_SECRET_ACCESS_KEY")
-    sessionToken <- Sys.getenv("AWS_SESSION_TOKEN")
+    awsCredsPrefix <- Sys.getenv("AWS_CREDS_PREFIX_S3_DEV", Sys.getenv("AWS_CREDS_PREFIX", ""))
+    accessKeyId <- Sys.getenv(paste0(awsCredsPrefix, "AWS_ACCESS_KEY_ID"))
+    accesSecretKey <- Sys.getenv(paste0(awsCredsPrefix, "AWS_SECRET_ACCESS_KEY"))
+    sessionToken <- Sys.getenv(paste0(awsCredsPrefix, "AWS_SESSION_TOKEN"))
     if (nchar(sessionToken) == 0) sessionToken <- NULL
 
     expect_false(nchar(accessKeyId) == 0)


### PR DESCRIPTION
## Summary
- Pass AWS session token to `set_s3_credentials()` in S3 persistence tests, required for OIDC-based credential flows (temporary credentials include a session token)
- Support multi-account S3 credentials via per-test env var prefixes (`AWS_CREDS_PREFIX_S3_PROD` / `AWS_CREDS_PREFIX_S3_DEV`), with backward-compatible fallback to `AWS_CREDS_PREFIX` and then empty string

## Context
Backport of #16891 to `rel-3.46.0`.

The h2o-3-enterprise nightly CI migrated from long-lived IAM user credentials to OIDC role assumption. OIDC produces temporary credentials (access key + secret key + **session token**), but the S3 tests only passed access key and secret key to `set_s3_credentials()`. The S3 test data also spans two AWS accounts (PROD for `h2o-public-test-data`, DEV for `test.0xdata.com`), requiring per-test credential selection via environment variable prefixes.

## Changes
- **`pyunit_set_s3_credentials.py`** — Uses `AWS_CREDS_PREFIX_S3_DEV` prefix (test.0xdata.com is in DEV account); passes session token to `set_s3_credentials()`
- **`pyunit_import_s3_parquet.py`** — Uses `AWS_CREDS_PREFIX_S3_PROD` prefix (h2o-public-test-data is in PROD account); passes session token to `set_s3_credentials()`
- **`runit_pubdev_6188.R`** — Uses `AWS_CREDS_PREFIX_S3_DEV` prefix; passes session token to `h2o.set_s3_credentials()`

All prefix lookups fall back gracefully: `AWS_CREDS_PREFIX_S3_DEV` → `AWS_CREDS_PREFIX` → `""`, preserving compatibility with Jenkins IAM user credential flows.

## Test plan
- [x] `pyunit_import_s3_parquet.py` passes in nightly CI with PROD OIDC credentials
- [ ] `pyunit_set_s3_credentials.py` blocked by bucket policy (DevOps ticket pending for `s3:GetObject` on `test.0xdata.com`)
- [ ] `runit_pubdev_6188.R` blocked by OIDC token expiration in long R test suites (DevOps ticket pending for `MaxSessionDuration` increase)