### PR TITLE
GH-16885: Upgrade jackson-databind to 2.18.9

### DIFF
--- a/h2o-assemblies/main/build.gradle
+++ b/h2o-assemblies/main/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     api "com.google.protobuf:protobuf-java:3.25.5"
 
     constraints {
-        api('com.fasterxml.jackson.core:jackson-databind:2.18.8') {
+        api('com.fasterxml.jackson.core:jackson-databind:2.18.9') {
             because 'Fixes CVE-2022-42003'
             because 'Fixes PRISMA-2023-0067'
             because 'Fixes CVE-2023-35116'

--- a/h2o-assemblies/steam/build.gradle
+++ b/h2o-assemblies/steam/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     api "com.google.oauth-client:google-oauth-client:1.33.3"
 
     constraints {
-        api('com.fasterxml.jackson.core:jackson-databind:2.18.8') {
+        api('com.fasterxml.jackson.core:jackson-databind:2.18.9') {
             because 'Fixes CVE-2022-42003'
             because 'Fixes PRISMA-2023-0067'
             because 'Fixes CVE-2023-35116'


### PR DESCRIPTION
Closes #16885

- Follow-up to #16888. The bump to 2.18.8 did not clear CVE-2026-54515, which trivy keeps flagging.
- Upgrades the jackson-databind version constraint to 2.18.9 in both the main and steam assemblies.