### PR TITLE
GH-16875 - Correct telemetry opt-in wording in client docstrings

### DIFF
--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -102,9 +102,10 @@ def connect(server=None, url=None, ip=None, port=None,
 
     """
     global h2oconn
-    # Programmatic telemetry opt-out — set before any event can fire. None means
-    # "leave the current state" so a later bare connect() can't re-enable an
-    # earlier telemetry=False.
+    # Programmatic telemetry on/off switch — set before any event can fire.
+    # Telemetry is opt-in (off by default); telemetry=True turns it on for this
+    # process, telemetry=False forces it off. None means "leave the current
+    # state" so a later bare connect() can't re-enable an earlier telemetry=False.
     if telemetry is not None:
         _telemetry.set_disabled(not telemetry)
     svc = _strict_version_check(strict_version_check, config=config)
@@ -219,8 +220,9 @@ def init(url=None, ip=None, port=None, name=None, https=None, cacert=None, insec
     :param telemetry: ``True``/``False`` explicitly enables/disables all anonymous usage telemetry for this process;
         ``False`` is equivalent to setting the ``DO_NOT_TRACK=1`` environment variable. The default ``None`` leaves the
         current state unchanged, so an earlier ``telemetry=False`` is not silently re-enabled by a later bare
-        ``h2o.init()``. On a fresh process the state is the package default (currently enabled). See the
-        "Privacy & Telemetry" section of the project README for what is collected and how to opt out persistently.
+        ``h2o.init()``. Telemetry is opt-in: on a fresh process the package default is disabled (nothing is sent
+        until you turn it on). See the "Privacy & Telemetry" section of the project README for what is collected
+        and how to enable it persistently.
 
 
     :examples:
@@ -230,10 +232,11 @@ def init(url=None, ip=None, port=None, name=None, https=None, cacert=None, insec
 
     """
     global h2oconn
-    # Programmatic telemetry opt-out — set early so even an exception during
-    # init() doesn't leak a single ping before this line runs. None means "leave
-    # the current state", so a later bare init() can't silently re-enable an
-    # earlier telemetry=False.
+    # Programmatic telemetry on/off switch — set early so even an exception
+    # during init() doesn't leak a single ping before this line runs. Telemetry
+    # is opt-in (off by default); telemetry=True turns it on, telemetry=False
+    # forces it off. None means "leave the current state", so a later bare
+    # init() can't silently re-enable an earlier telemetry=False.
     if telemetry is not None:
         _telemetry.set_disabled(not telemetry)
     assert_is_type(url, str, None)

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -36,7 +36,7 @@
 #' @param extra_classpath (Optional) A vector of paths to libraries to be added to the Java classpath when H2O is started from R.
 #' @param jvm_custom_args (Optional) A \code{character} list of custom arguments for the JVM where new H2O instance is going to run, if started. Ignored when connecting to an existing instance.
 #' @param bind_to_localhost (Optional) A \code{logical} flag indicating whether access to the H2O instance should be restricted to the local machine (default) or if it can be reached from other computers on the network. Only applicable when H2O is started from R.
-#' @param telemetry (Optional) \code{TRUE}/\code{FALSE} explicitly enables/disables all anonymous usage telemetry for this R session (\code{FALSE} is equivalent to setting \code{DO_NOT_TRACK=1}). The default \code{NULL} leaves the current state unchanged, so an earlier \code{telemetry = FALSE} is not silently re-enabled by a later bare \code{h2o.init()}. On a fresh session the state is the package default (currently enabled). See the "Privacy & Telemetry" section of the project README for what is collected and how to opt out persistently.
+#' @param telemetry (Optional) \code{TRUE}/\code{FALSE} explicitly enables/disables all anonymous usage telemetry for this R session (\code{FALSE} is equivalent to setting \code{DO_NOT_TRACK=1}). The default \code{NULL} leaves the current state unchanged, so an earlier \code{telemetry = FALSE} is not silently re-enabled by a later bare \code{h2o.init()}. Telemetry is opt-in: on a fresh session the package default is disabled (nothing is sent until you turn it on). See the "Privacy & Telemetry" section of the project README for what is collected and how to enable it persistently.
 #' @return this method will load it and return a \code{H2OConnection} object containing the IP address and port number of the H2O server.
 #' @note Users may wish to manually upgrade their package (rather than waiting until being prompted), which requires
 #' that they fully uninstall and reinstall the H2O package, and the H2O client package. You must unload packages running
@@ -73,10 +73,12 @@ h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, start
                      bind_to_localhost = TRUE,
                      telemetry = NULL) {
 
-    # Programmatic telemetry opt-out — set early so even an exception during
-    # h2o.init() doesn't leak a single ping before this line runs. NULL means
-    # "leave the current state" so a later bare h2o.init() can't silently
-    # re-enable an earlier telemetry = FALSE.
+    # Programmatic telemetry on/off switch — set early so even an exception
+    # during h2o.init() doesn't leak a single ping before this line runs.
+    # Telemetry is opt-in (off by default); telemetry = TRUE turns it on for this
+    # session, telemetry = FALSE forces it off. NULL means "leave the current
+    # state" so a later bare h2o.init() can't silently re-enable an earlier
+    # telemetry = FALSE.
     tryCatch(if (!is.null(telemetry)) .h2o.telemetry.set_disabled(!isTRUE(telemetry)),
              error = function(e) invisible(NULL))
 


### PR DESCRIPTION
Followup #16875 

The h2o.init()/h2o.connect() telemetry parameter docs (Python and R) and the surrounding code comments described an opt-out default ("currently enabled"). Telemetry is opt-in (off by default); align the wording with the behavior.