### PR TITLE
GH-16875 - Reject non-boolean telemetry flags to prevent accidental opt-in

### DIFF
--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -102,6 +102,7 @@ def connect(server=None, url=None, ip=None, port=None,
 
     """
     global h2oconn
+    assert_is_type(telemetry, bool, None)
     # Programmatic telemetry on/off switch — set before any event can fire.
     # Telemetry is opt-in (off by default); telemetry=True turns it on for this
     # process, telemetry=False forces it off. None means "leave the current
@@ -232,6 +233,7 @@ def init(url=None, ip=None, port=None, name=None, https=None, cacert=None, insec
 
     """
     global h2oconn
+    assert_is_type(telemetry, bool, None)
     # Programmatic telemetry on/off switch — set early so even an exception
     # during init() doesn't leak a single ping before this line runs. Telemetry
     # is opt-in (off by default); telemetry=True turns it on, telemetry=False
@@ -365,11 +367,13 @@ def set_telemetry(enabled):
 
     Applies immediately and is remembered across sessions (stored under
     ``~/.h2oai``). The ``DO_NOT_TRACK`` environment variable still overrides it.
-    Best-effort and silent: never raises, never prints.
+    Persistence is best-effort (disk errors are swallowed); passing a
+    non-boolean raises ``H2OTypeError`` rather than silently guessing.
 
     :param enabled: ``True`` to enable telemetry, ``False`` to opt out.
     :returns: ``True`` if the preference was saved to disk, else ``False``.
     """
+    assert_is_type(enabled, bool)
     return _telemetry.set_telemetry(enabled)
 
 

--- a/h2o-py/h2o/telemetry.py
+++ b/h2o-py/h2o/telemetry.py
@@ -109,9 +109,15 @@ def set_disabled(disabled):
     Once disabled, every subsequent ``send_*`` call is a no-op until the
     next process restart. Independent of the ``DO_NOT_TRACK`` env-var opt-out,
     which always wins.
+
+    ``disabled`` must be a real bool: a loose truthiness cast here would let a
+    string such as ``"false"`` (truthy in Python) silently *enable* telemetry,
+    so a non-bool is rejected instead of guessed.
     """
     global _disabled_by_kwarg
-    _disabled_by_kwarg = bool(disabled)
+    if not isinstance(disabled, bool):
+        raise TypeError("telemetry disabled flag must be a bool, got %r" % (disabled,))
+    _disabled_by_kwarg = disabled
 
 
 def _env_truthy(name):
@@ -149,11 +155,14 @@ def set_telemetry(enabled):
     """Enable/disable client telemetry and remember the choice across sessions.
 
     Applies immediately for this process and is persisted under ``~/.h2oai`` so
-    later sessions honor it. ``DO_NOT_TRACK`` still overrides it. Best-effort and
-    silent: never raises, never prints.
+    later sessions honor it. ``DO_NOT_TRACK`` still overrides it. Persistence is
+    best-effort (disk errors are swallowed), but ``enabled`` must be a real bool:
+    a truthy string like ``"false"`` would otherwise silently enable telemetry.
 
     :returns: ``True`` if the preference was written to disk, else ``False``.
     """
+    if not isinstance(enabled, bool):
+        raise TypeError("telemetry enabled flag must be a bool, got %r" % (enabled,))
     set_disabled(not enabled)
     try:
         d = _config_dir()

--- a/h2o-py/tests/testdir_misc/pyunit_telemetry.py
+++ b/h2o-py/tests/testdir_misc/pyunit_telemetry.py
@@ -263,6 +263,52 @@ def telemetry_config_file_opt_out():
     print("OK telemetry_config_file_opt_out: ~/.h2oconfig telemetry key honored (home-only, union-off)")
 
 
+def telemetry_rejects_non_bool_flag():
+    # Regression guard for the accidental-enable footgun: telemetry is opt-in, so
+    # a value that *looks* like "off" must never turn it on. Python's bool("false")
+    # is True, so a loose cast would enable telemetry when the user passed the
+    # string "false". The setters reject non-bools instead of coercing.
+    old_home = os.environ.get("HOME")
+    old_dnt = os.environ.get("DO_NOT_TRACK")
+    tmp = tempfile.mkdtemp()
+    os.environ["HOME"] = tmp
+    os.environ.pop("DO_NOT_TRACK", None)
+    pref = os.path.join(tmp, ".h2oai", "telemetry")
+    try:
+        t.set_disabled(True)
+        for bad in ("false", "False", "0", "no", "off", "true", 1, 0):
+            try:
+                t.set_telemetry(bad)
+                raised = False
+            except TypeError:
+                raised = True
+            assert raised, "set_telemetry(%r) must raise TypeError, not coerce" % (bad,)
+            assert t.telemetry_enabled() is False, \
+                "set_telemetry(%r) left telemetry enabled" % (bad,)
+            assert not os.path.exists(pref), \
+                "set_telemetry(%r) persisted a preference" % (bad,)
+        # The low-level setter is strict too (it backs the h2o.init(telemetry=...) path).
+        for bad in ("false", "0", 0, 1):
+            try:
+                t.set_disabled(bad)
+                raised = False
+            except TypeError:
+                raised = True
+            assert raised, "set_disabled(%r) must raise TypeError" % (bad,)
+        # Real bools still work end to end.
+        assert t.set_telemetry(True) is True and t.telemetry_enabled() is True
+        assert t.set_telemetry(False) is True and t.telemetry_enabled() is False
+    finally:
+        t.set_disabled(False)
+        if old_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = old_home
+        if old_dnt is not None:
+            os.environ["DO_NOT_TRACK"] = old_dnt
+    print("OK telemetry_rejects_non_bool_flag: truthy strings rejected, never enable")
+
+
 if __name__ == "__main__":
     telemetry_wire_contract()
     telemetry_bucket_boundaries()
@@ -272,6 +318,7 @@ if __name__ == "__main__":
     telemetry_http_delivery_smoke()
     telemetry_set_persisted_pref()
     telemetry_config_file_opt_out()
+    telemetry_rejects_non_bool_flag()
     print("\nALL TELEMETRY TESTS PASSED")
 else:
     telemetry_wire_contract()
@@ -282,3 +329,4 @@ else:
     telemetry_http_delivery_smoke()
     telemetry_set_persisted_pref()
     telemetry_config_file_opt_out()
+    telemetry_rejects_non_bool_flag()

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -73,6 +73,8 @@ h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, start
                      bind_to_localhost = TRUE,
                      telemetry = NULL) {
 
+    if (!is.null(telemetry) && (!is.logical(telemetry) || length(telemetry) != 1L || is.na(telemetry)))
+      stop("`telemetry` must be TRUE, FALSE, or NULL")
     # Programmatic telemetry on/off switch — set early so even an exception
     # during h2o.init() doesn't leak a single ping before this line runs.
     # Telemetry is opt-in (off by default); telemetry = TRUE turns it on for this

--- a/h2o-r/h2o-package/R/telemetry.R
+++ b/h2o-r/h2o-package/R/telemetry.R
@@ -163,17 +163,20 @@
 #'
 #' Applies immediately for this R session and is remembered across sessions
 #' (stored under \code{~/.h2oai}). The \code{DO_NOT_TRACK} environment variable
-#' still overrides it. Best-effort and silent: never errors, never prints.
+#' still overrides it. Persistence is best-effort (disk errors are swallowed);
+#' a non-logical \code{enabled} raises an error rather than being guessed.
 #'
 #' @param enabled \code{TRUE} to enable telemetry, \code{FALSE} to opt out.
 #' @return (invisibly) \code{TRUE} if the preference was written to disk, else \code{FALSE}.
 #' @export
 h2o.set_telemetry <- function(enabled) {
-  .h2o.telemetry.set_disabled(!isTRUE(enabled))
+  if (!is.logical(enabled) || length(enabled) != 1L || is.na(enabled))
+    stop("`enabled` must be TRUE or FALSE")
+  .h2o.telemetry.set_disabled(!enabled)
   ok <- tryCatch({
     d <- .h2o.telemetry.config_dir()
     dir.create(d, showWarnings = FALSE, recursive = TRUE)
-    writeLines(if (isTRUE(enabled)) "1" else "0", file.path(d, "telemetry"))
+    writeLines(if (enabled) "1" else "0", file.path(d, "telemetry"))
     TRUE
   }, error = function(e) FALSE)
   invisible(ok)

--- a/h2o-r/tests/testdir_misc/runit_telemetry.R
+++ b/h2o-r/tests/testdir_misc/runit_telemetry.R
@@ -111,6 +111,20 @@ test.telemetry <- function() {
   Sys.unsetenv("DO_NOT_TRACK")
   expect_false(.h2o.telemetry.disabled())
 
+  # --- Input validation: telemetry is opt-in, so an ambiguous value must never
+  #     flip it on. A non-logical like "false" is rejected outright rather than
+  #     coerced, so each bad value must error while leaving telemetry off and the
+  #     persisted preference untouched. Covers both h2o.set_telemetry and the
+  #     h2o.init() guard (which stops before any connection attempt). ---
+  h2o.set_telemetry(FALSE)
+  for (bad in list("false", "FALSE", "0", "no", "true", 1, NA, c(TRUE, FALSE))) {
+    expect_error(h2o.set_telemetry(bad))
+    expect_false(h2o.telemetry_enabled())
+    expect_equal(readLines(pref, warn = FALSE), "0")
+  }
+  expect_error(h2o.init(telemetry = "false"), "must be TRUE, FALSE, or NULL")
+  expect_error(h2o.init(telemetry = 1),       "must be TRUE, FALSE, or NULL")
+
   # --- Emitters are exception-safe: bounded synchronous POST to an unreachable
   #     endpoint never raises, whether telemetry is on or off. ---
   Sys.setenv(H2O_TELEMETRY_URL = "http://127.0.0.1:1/v1/event")  # refused fast; bounded by connecttimeout


### PR DESCRIPTION
Followup #16875 (stacked on #16898 — merge that first).

Telemetry is opt-in, but the Python client coerced the flag with loose truthiness, so `h2o.init(telemetry="false")` and `h2o.set_telemetry("false")` ran `not "false"` (== False) and silently *enabled* telemetry — and `set_telemetry` persisted the opt-in to disk. This validates the flag at every entry point so an ambiguous value is rejected instead of turned on:

- Python: `assert_is_type(telemetry, bool, None)` on `h2o.init()` / `h2o.connect()`, plus strict `isinstance` guards in `set_telemetry` / `set_disabled`.
- R: `h2o.init(telemetry=)` and `h2o.set_telemetry()` stop on non-logical input.
- JVM: unchanged — it already enables only on an explicit `-Dsys.ai.h2o.telemetry.disabled=false` and fails safe to off for anything else.