### PR TITLE
GH-16875 - Register R telemetry topics in pkgdown reference index

### DIFF
--- a/h2o-r/h2o-package/R/telemetry.R
+++ b/h2o-r/h2o-package/R/telemetry.R
@@ -22,6 +22,8 @@
 #' which always wins. Reacts to 1/0/true/false; 0/false/empty do not opt out.
 #'
 #' URL override: H2O_TELEMETRY_URL.
+#'
+#' @keywords internal
 
 # Production endpoint. Override via the H2O_TELEMETRY_URL environment variable.
 .h2o.telemetry.url <- "https://telemetry.h2o.ai/v1/event"

--- a/h2o-r/h2o-package/pkgdown/_pkgdown.yml
+++ b/h2o-r/h2o-package/pkgdown/_pkgdown.yml
@@ -358,6 +358,7 @@ reference:
       - h2o.sd 
       - h2o.sdev
       - h2o.set_s3_credentials
+      - h2o.set_telemetry
       - h2o.setLevels
       - h2o.setTimezone
       - h2o.shap_explain_row_plot
@@ -388,6 +389,7 @@ reference:
       - h2o.target_encode_apply
       - h2o.target_encode_create
       - h2o.targetencoder
+      - h2o.telemetry_enabled
       - h2o.tf_idf
       - h2o.toFrame
       - h2o.tokenize


### PR DESCRIPTION
Followup #16875.

The telemetry merge (#16876) added three R doc topics that pkgdown rejects because they are neither in the reference index nor marked internal, so `r-generate-docs` (`pkgdown::build_site`) aborts during the dist build:

> In pkgdown/_pkgdown.yml, 3 topics missing from index: ".h2o.telemetry.url", "h2o.set_telemetry", and "h2o.telemetry_enabled".

- `.h2o.telemetry.url` — internal endpoint constant; the file-header roxygen block attaches to it and generated a public topic. Marked `@keywords internal` to drop it from the index, matching the other internal telemetry helpers.
- `h2o.set_telemetry` / `h2o.telemetry_enabled` — public exported API; added to the pkgdown reference index.

Independent of #16898 / #16899 (different files/regions).