### PR TITLE
GH-16875 - Normalize telemetry client flag to an enabled sense

### DIFF
--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -108,7 +108,7 @@ def connect(server=None, url=None, ip=None, port=None,
     # process, telemetry=False forces it off. None means "leave the current
     # state" so a later bare connect() can't re-enable an earlier telemetry=False.
     if telemetry is not None:
-        _telemetry.set_disabled(not telemetry)
+        _telemetry.set_enabled(telemetry)
     svc = _strict_version_check(strict_version_check, config=config)
     if config:
         if "connect_params" in config:
@@ -240,7 +240,7 @@ def init(url=None, ip=None, port=None, name=None, https=None, cacert=None, insec
     # forces it off. None means "leave the current state", so a later bare
     # init() can't silently re-enable an earlier telemetry=False.
     if telemetry is not None:
-        _telemetry.set_disabled(not telemetry)
+        _telemetry.set_enabled(telemetry)
     assert_is_type(url, str, None)
     assert_is_type(ip, str, None)
     assert_is_type(port, int, str, None)

--- a/h2o-py/h2o/telemetry.py
+++ b/h2o-py/h2o/telemetry.py
@@ -70,16 +70,13 @@ _MAX_VERSION_FIELD_LEN = 64  # cap every *_version / *_vendor field
 _session_lock = threading.Lock()
 _session_id = None  # type: str | None
 
-# Programmatic opt-out set by h2o.init(telemetry=False). Independent of and
-# additive to the env-var opt-outs. Persists for the lifetime of the process
-# (or until set_disabled(False) is called).
-#
-# Its initial value is the client-wide default when the user never passes the
-# telemetry kwarg: True = telemetry off (opt-in model) — a bare
-# h2o.init()/h2o.connect() stays off until the user opts in (telemetry=True,
-# h2o.set_telemetry(True), or a persisted/config opt-in). Flip to False for the
-# opt-out model (on by default unless the user opts out).
-_disabled_by_kwarg = True
+# Whether telemetry is currently switched on for this process. Telemetry is
+# opt-in, so this starts False (off) and is flipped on only by an explicit
+# choice — h2o.init(telemetry=True) / h2o.connect(telemetry=True),
+# h2o.set_telemetry(True), or a persisted/config opt-in. Independent of and
+# additive to the env-var opt-outs (DO_NOT_TRACK always wins regardless).
+# Persists for the lifetime of the process (or until changed via set_enabled).
+_enabled = False
 
 # Client state persisted under the user's home config dir. The full path is
 # resolved per call (see _config_dir) so a changed HOME / test sandbox is honored.
@@ -103,21 +100,21 @@ def _normalize_os(name):
     return name
 
 
-def set_disabled(disabled):
-    """Programmatic opt-out, set by ``h2o.init(telemetry=False)``.
+def set_enabled(enabled):
+    """Programmatic on/off switch, set by ``h2o.init(telemetry=...)``.
 
-    Once disabled, every subsequent ``send_*`` call is a no-op until the
-    next process restart. Independent of the ``DO_NOT_TRACK`` env-var opt-out,
-    which always wins.
+    Once set, every subsequent ``send_*`` call honors it until the next process
+    restart. Independent of the ``DO_NOT_TRACK`` env-var opt-out, which always
+    wins.
 
-    ``disabled`` must be a real bool: a loose truthiness cast here would let a
+    ``enabled`` must be a real bool: a loose truthiness cast here would let a
     string such as ``"false"`` (truthy in Python) silently *enable* telemetry,
     so a non-bool is rejected instead of guessed.
     """
-    global _disabled_by_kwarg
-    if not isinstance(disabled, bool):
-        raise TypeError("telemetry disabled flag must be a bool, got %r" % (disabled,))
-    _disabled_by_kwarg = disabled
+    global _enabled
+    if not isinstance(enabled, bool):
+        raise TypeError("telemetry enabled flag must be a bool, got %r" % (enabled,))
+    _enabled = enabled
 
 
 def _env_truthy(name):
@@ -137,7 +134,7 @@ def _telemetry_disabled():
     # opt-out and always wins, including over a programmatic telemetry=True.
     if _env_truthy("DO_NOT_TRACK"):
         return True
-    return _disabled_by_kwarg
+    return not _enabled
 
 
 def _config_dir():
@@ -163,7 +160,7 @@ def set_telemetry(enabled):
     """
     if not isinstance(enabled, bool):
         raise TypeError("telemetry enabled flag must be a bool, got %r" % (enabled,))
-    set_disabled(not enabled)
+    set_enabled(enabled)
     try:
         d = _config_dir()
         os.makedirs(d, exist_ok=True)
@@ -231,12 +228,12 @@ def _load_persisted_pref():
     ``~/.h2oconfig`` (home) and ``~/.h2oai/telemetry``. Any explicit opt-out wins
     (union — consistent with DO_NOT_TRACK); otherwise an explicit opt-in applies;
     otherwise the default is kept. All best-effort."""
-    global _disabled_by_kwarg
+    global _enabled
     prefs = [_config_telemetry_pref(), _file_telemetry_pref()]
     if any(p is False for p in prefs):
-        _disabled_by_kwarg = True
+        _enabled = False
     elif any(p is True for p in prefs):
-        _disabled_by_kwarg = False
+        _enabled = True
 
 
 _load_persisted_pref()

--- a/h2o-py/tests/testdir_misc/pyunit_telemetry.py
+++ b/h2o-py/tests/testdir_misc/pyunit_telemetry.py
@@ -21,7 +21,7 @@ def _capture_payloads():
     captured = []
     orig = t._post_async
     t._post_async = lambda payload, enrich=None: captured.append(payload)
-    t.set_disabled(False)
+    t.set_enabled(True)
     return captured, (lambda: setattr(t, "_post_async", orig))
 
 
@@ -83,13 +83,13 @@ def telemetry_disabled_emits_nothing():
     orig = t._post_async
     t._post_async = lambda payload, enrich=None: captured.append(payload)
     try:
-        t.set_disabled(True)
+        t.set_enabled(False)
         t.send_import(VERSION, "s3", "parquet", "ok")
         t.send_init_telemetry(VERSION)
         assert captured == [], "events were emitted while telemetry is disabled: %r" % captured
     finally:
         t._post_async = orig
-        t.set_disabled(False)
+        t.set_enabled(True)
     print("OK telemetry_disabled_emits_nothing")
 
 
@@ -112,7 +112,7 @@ def telemetry_http_delivery_smoke():
     old_url = os.environ.get("H2O_TELEMETRY_URL")
     os.environ["H2O_TELEMETRY_URL"] = "http://127.0.0.1:%d/v1/event" % port
     try:
-        t.set_disabled(False)
+        t.set_enabled(True)
         t.send_import(VERSION, "local", "csv", "ok", compressed_size_bytes=1024)
         t._telemetry_queue.join()  # block until the worker drains the event
     finally:
@@ -145,7 +145,7 @@ def telemetry_first_run_notice():
         return err.getvalue()
 
     try:
-        t.set_disabled(False)
+        t.set_enabled(True)
         first, second = run(), run()
         assert "anonymous usage telemetry" in first, "notice not printed on first run"
         assert second == "", "notice repeated on second run (marker not honored)"
@@ -153,10 +153,10 @@ def telemetry_first_run_notice():
 
         # Disabled telemetry never prints, even with no marker.
         os.remove(os.path.join(tmp, ".h2oai", ".telemetry_notice_python"))
-        t.set_disabled(True)
+        t.set_enabled(False)
         assert run() == "", "notice printed while telemetry disabled"
     finally:
-        t.set_disabled(False)
+        t.set_enabled(True)
         if old_home is None:
             os.environ.pop("HOME", None)
         else:
@@ -169,7 +169,7 @@ def telemetry_do_not_track_truthiness():
     # always wins over the programmatic flag.
     old = os.environ.get("DO_NOT_TRACK")
     try:
-        t.set_disabled(False)
+        t.set_enabled(True)
         for val, disabled in [("1", True), ("true", True), ("on", True),
                               ("0", False), ("false", False), ("", False)]:
             os.environ["DO_NOT_TRACK"] = val
@@ -206,13 +206,13 @@ def telemetry_set_persisted_pref():
         assert t.telemetry_enabled() is True
 
         # A fresh process reloads the saved choice at import.
-        t.set_disabled(False)
+        t.set_enabled(True)
         with open(pref, "w") as f:
             f.write("0")
         t._load_persisted_pref()
         assert t._telemetry_disabled() is True, "persisted opt-out not reloaded"
     finally:
-        t.set_disabled(False)
+        t.set_enabled(True)
         if old_home is None:
             os.environ.pop("HOME", None)
         else:
@@ -233,13 +233,13 @@ def telemetry_config_file_opt_out():
     try:
         with open(cfg, "w") as f:
             f.write("[general]\ntelemetry = false\n")
-        t.set_disabled(False)
+        t.set_enabled(True)
         t._load_persisted_pref()
         assert t._telemetry_disabled() is True, "config telemetry=false did not opt out"
 
         with open(cfg, "w") as f:
             f.write("general.telemetry = true\n")
-        t.set_disabled(True)
+        t.set_enabled(False)
         t._load_persisted_pref()
         assert t._telemetry_disabled() is False, "config telemetry=true did not opt in"
 
@@ -249,11 +249,11 @@ def telemetry_config_file_opt_out():
             f.write("1")
         with open(cfg, "w") as f:
             f.write("[general]\ntelemetry = off\n")
-        t.set_disabled(False)
+        t.set_enabled(True)
         t._load_persisted_pref()
         assert t._telemetry_disabled() is True, "config opt-out should win (union off)"
     finally:
-        t.set_disabled(False)
+        t.set_enabled(True)
         if old_home is None:
             os.environ.pop("HOME", None)
         else:
@@ -275,7 +275,7 @@ def telemetry_rejects_non_bool_flag():
     os.environ.pop("DO_NOT_TRACK", None)
     pref = os.path.join(tmp, ".h2oai", "telemetry")
     try:
-        t.set_disabled(True)
+        t.set_enabled(False)
         for bad in ("false", "False", "0", "no", "off", "true", 1, 0):
             try:
                 t.set_telemetry(bad)
@@ -290,16 +290,16 @@ def telemetry_rejects_non_bool_flag():
         # The low-level setter is strict too (it backs the h2o.init(telemetry=...) path).
         for bad in ("false", "0", 0, 1):
             try:
-                t.set_disabled(bad)
+                t.set_enabled(bad)
                 raised = False
             except TypeError:
                 raised = True
-            assert raised, "set_disabled(%r) must raise TypeError" % (bad,)
+            assert raised, "set_enabled(%r) must raise TypeError" % (bad,)
         # Real bools still work end to end.
         assert t.set_telemetry(True) is True and t.telemetry_enabled() is True
         assert t.set_telemetry(False) is True and t.telemetry_enabled() is False
     finally:
-        t.set_disabled(False)
+        t.set_enabled(True)
         if old_home is None:
             os.environ.pop("HOME", None)
         else:

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -81,7 +81,7 @@ h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, start
     # session, telemetry = FALSE forces it off. NULL means "leave the current
     # state" so a later bare h2o.init() can't silently re-enable an earlier
     # telemetry = FALSE.
-    tryCatch(if (!is.null(telemetry)) .h2o.telemetry.set_disabled(!isTRUE(telemetry)),
+    tryCatch(if (!is.null(telemetry)) .h2o.telemetry.set_enabled(isTRUE(telemetry)),
              error = function(e) invisible(NULL))
 
     # Kick off a detached, non-blocking `java -version` probe now (unless opted

--- a/h2o-r/h2o-package/R/telemetry.R
+++ b/h2o-r/h2o-package/R/telemetry.R
@@ -38,23 +38,22 @@
 # Per-process shared session_id + caches in a private env so they persist
 # across function calls without leaking package globals.
 #
-# disabled_by_kwarg starts at the client-wide default when the user never passes
-# the telemetry arg: TRUE = telemetry off (opt-in model) — a bare h2o.init()
-# stays off until the user opts in (telemetry = TRUE, h2o.set_telemetry(TRUE),
-# or a persisted/config opt-in). Flip to FALSE for the opt-out model (default-on).
+# `enabled` tracks whether telemetry is currently switched on for this session.
+# Telemetry is opt-in, so it starts FALSE (off) and is flipped on only by an
+# explicit choice — h2o.init(telemetry = TRUE), h2o.set_telemetry(TRUE), or a
+# persisted/config opt-in. DO_NOT_TRACK always forces it off regardless.
 .h2o.telemetry.state <- new.env(parent = emptyenv())
-.h2o.telemetry.state$session_id        <- NULL
-.h2o.telemetry.state$java_info         <- NULL  # cached `java -version` parse
-.h2o.telemetry.state$disabled_by_kwarg <- TRUE  # opt-in default: off until the user opts in
+.h2o.telemetry.state$session_id <- NULL
+.h2o.telemetry.state$java_info  <- NULL   # cached `java -version` parse
+.h2o.telemetry.state$enabled    <- FALSE  # opt-in default: off until the user opts in
 
-#' Programmatic opt-out, set by `h2o.init(telemetry = FALSE)`.
+#' Programmatic on/off switch, set by `h2o.init(telemetry = ...)`.
 #'
-#' Once disabled, every subsequent `.h2o.send_*` call is a no-op until the
-#' next R session. Independent of the `DO_NOT_TRACK` env-var opt-out, which
-#' always wins.
+#' Once set, every subsequent `.h2o.send_*` call honors it until the next R
+#' session. Independent of the `DO_NOT_TRACK` env-var opt-out, which always wins.
 #' @keywords internal
-.h2o.telemetry.set_disabled <- function(disabled) {
-  .h2o.telemetry.state$disabled_by_kwarg <- isTRUE(disabled)
+.h2o.telemetry.set_enabled <- function(enabled) {
+  .h2o.telemetry.state$enabled <- isTRUE(enabled)
   invisible(NULL)
 }
 
@@ -74,7 +73,7 @@
 .h2o.telemetry.disabled <- function() {
   # DO_NOT_TRACK (cross-tool standard) is the hard opt-out and always wins.
   if (.h2o.telemetry.env_truthy("DO_NOT_TRACK")) return(TRUE)
-  isTRUE(.h2o.telemetry.state$disabled_by_kwarg)
+  !isTRUE(.h2o.telemetry.state$enabled)
 }
 
 # --- Persistent opt-out & preference sources (kept consistent with the Python client) ---
@@ -153,9 +152,9 @@
   tryCatch({
     prefs <- list(.h2o.telemetry.config_pref(), .h2o.telemetry.file_pref())
     if (any(vapply(prefs, function(p) identical(p, FALSE), logical(1L)))) {
-      .h2o.telemetry.state$disabled_by_kwarg <- TRUE
+      .h2o.telemetry.state$enabled <- FALSE
     } else if (any(vapply(prefs, function(p) identical(p, TRUE), logical(1L)))) {
-      .h2o.telemetry.state$disabled_by_kwarg <- FALSE
+      .h2o.telemetry.state$enabled <- TRUE
     }
   }, error = function(e) invisible(NULL))
   invisible(NULL)
@@ -174,7 +173,7 @@
 h2o.set_telemetry <- function(enabled) {
   if (!is.logical(enabled) || length(enabled) != 1L || is.na(enabled))
     stop("`enabled` must be TRUE or FALSE")
-  .h2o.telemetry.set_disabled(!enabled)
+  .h2o.telemetry.set_enabled(enabled)
   ok <- tryCatch({
     d <- .h2o.telemetry.config_dir()
     dir.create(d, showWarnings = FALSE, recursive = TRUE)


### PR DESCRIPTION
Followup #16875 (stacked on #16899 → #16898).

Addresses @tomasfryda's review point on #16898: the internal flag was named `_disabled_by_kwarg` (R: `disabled_by_kwarg`) but its opt-in default was `True`/`TRUE` (off), so it read as "disabled by a kwarg" even when no kwarg was passed — wrong semantics — and forced a double negative (`set_disabled(not telemetry)`) at the call sites.

Renamed to a single "enabled" sense, defaulting to off:
- Python: `_enabled` / `set_enabled()`; `_telemetry_disabled()` returns `not _enabled`.
- R: `.h2o.telemetry.state$enabled` / `.h2o.telemetry.set_enabled()`; `.h2o.telemetry.disabled()` returns `!isTRUE(...$enabled)`.
- Call sites read cleanly: `set_enabled(telemetry)` instead of `set_disabled(not telemetry)`.

No behavior change — off by default, `DO_NOT_TRACK` still wins, persisted/config opt-in still honored. Tests updated accordingly.

Shows the #16898/#16899 commits until those merge (auto-reduces to just this one after).