### PR TITLE
GH-16875 - Use dedicated recovery dir in R grid recovery test

### DIFF
--- a/h2o-r/tests/testdir_algos/grid/runit_grid_recovery_dir.R
+++ b/h2o-r/tests/testdir_algos/grid/runit_grid_recovery_dir.R
@@ -6,7 +6,11 @@ test.grid.resume <- function() {
 
   ntrees_opts <- c(100, 200)
   learn_rate_opts <- c(0.01, 0.02)
-  export_dir <- tempdir()
+  # Dedicated directory, not tempdir() itself: the emptiness check below must
+  # assert that H2O cleaned up its own recovery files, not that nothing else in
+  # the R session ever wrote to the shared session temp dir.
+  export_dir <- tempfile("grid_recovery")
+  dir.create(export_dir)
 
   hyper_parameters <- list(ntrees = ntrees_opts, learn_rate = learn_rate_opts)
   baseline_grid <- h2o.grid(

--- a/h2o-r/tests/testdir_algos/grid/runit_grid_recovery_dir.R
+++ b/h2o-r/tests/testdir_algos/grid/runit_grid_recovery_dir.R
@@ -6,9 +6,6 @@ test.grid.resume <- function() {
 
   ntrees_opts <- c(100, 200)
   learn_rate_opts <- c(0.01, 0.02)
-  # Dedicated directory, not tempdir() itself: the emptiness check below must
-  # assert that H2O cleaned up its own recovery files, not that nothing else in
-  # the R session ever wrote to the shared session temp dir.
   export_dir <- tempfile("grid_recovery")
   dir.create(export_dir)
 


### PR DESCRIPTION
Follow-up to #16875.

- The test used `tempdir()` itself as the grid `recovery_dir` and then asserted that directory was empty, so any unrelated entry in the shared R session temp dir failed it. The telemetry code calls `.h2o.startedH2O()` from `h2o.init()` to pick the init vs cluster_connect event, and that helper creates an empty directory under `tempdir()` on every call — which broke the R nightlies.
- The test now creates its own `tempfile("grid_recovery")` directory, so the assertion verifies H2O cleaned up its recovery files rather than that nothing else in the session wrote to `tempdir()`.
- Test-only change per code freeze; the `h2o.init()` side effect itself is unchanged.