### PR TITLE
GH-16914: Remove Persist Drive (GraalVM) test from Jenkins nightly

### DIFF
--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -130,28 +130,6 @@ test-py-changed:
 test-py-persist-s3: lookup-persist-s3-tests
 	export NO_GCE_CHECK=True && cd h2o-py/tests/ && ../../scripts/run.py --wipeall --geterrs --testlist .lookup.txt --numclouds 1 --jvm.xmx 3g
 
-build-h2o-persist-drive:
-	@echo "+--Building H2O Persit Drive--+"
-	@echo
-	cd h2o-persist-drive && ../gradlew clean build
-
-bootstrap-persist-drive-env:
-	mkdir -p h2o-persist-drive/build/graal && cd h2o-persist-drive/build/graal && ../../bootstrap.sh
-
-test-py-persist-drive:
-	export NO_GCE_CHECK=True \
-	 && export JAVA_HOME="$$PWD/h2o-persist-drive/build/graal/graalvm" \
-	 && cd h2o-persist-drive/tests/ \
-	 && ../../scripts/run.py --wipeall --geterrs --numclouds 1 --jvm.xmx 3g \
-	                         --jvm.cp "$(shell pwd)/$(wildcard h2o-persist-drive/build/libs/h2o-persist-drive*.jar)" \
-	                         --jvm.opt "--add-opens=java.base/java.lang=ALL-UNNAMED" \
-	                         --jvm.opt "-Dsys.ai.h2o.persist.drive.venv=../../build/graal/venv/bin/graalpython"
-
-test-py-persist-drive-jenkins:
-	@$(MAKE) -f $(THIS_FILE) build-h2o-persist-drive
-	@$(MAKE) -f $(THIS_FILE) bootstrap-persist-drive-env
-	@$(MAKE) -f $(THIS_FILE) test-py-persist-drive
-
 test-py-init:
 	export NO_GCE_CHECK=True && cd h2o-py/tests/testdir_apis/H2O_Init \
 	 && python h2o.init_test.py \
@@ -391,7 +369,6 @@ test-package-java:
 		h2o-persist-s3/build/libs/h2o-persist-s3-*.jar \
 		h2o-persist-http/src/ \
 		h2o-persist-http/build/libs/h2o-persist-http-*.jar \
-		h2o-persist-drive/ \
 		h2o-security/src/ \
 		h2o-security/build/libs/h2o-security-*.jar \
 		h2o-extensions/xgboost/src/ \

--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -544,11 +544,6 @@ def call(final pipelineContext) {
       component: pipelineContext.getBuildConfig().COMPONENT_PY, customDockerArgs: [ '--ulimit nofile=150:150' ]
     ],
     [
-      stageName: 'Persist Drive (GraalVM)', target: 'test-py-persist-drive-jenkins', javaVersion: 17, timeoutValue: 20,
-      component: pipelineContext.getBuildConfig().COMPONENT_JAVA,
-      additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY]
-    ],
-    [
       stageName: 'R4.0 Explain', target: 'test-r-explain', rVersion: '4.0.2',
       timeoutValue: 180, component: pipelineContext.getBuildConfig().COMPONENT_R
     ],


### PR DESCRIPTION
Closes #16914
Related to #16566 — one of the CI failures tracked there.

- Remove the `Persist Drive (GraalVM)` stage from `NIGHTLY_STAGES`; it failed on every run in the retained build history
- Remove the four `Makefile.jenkins` targets that only served that stage, and drop `h2o-persist-drive/` from `test-package-java`
- Root cause: GraalVM is pinned at 22.2.0 (Python 3.8) while `bootstrap.sh` installs `boto3` unpinned, so `drive_client.py` fails to import with a GraalPython `SyntaxError`
- `h2o-persist-drive` is a 2022 POC and GraalVM is no longer used elsewhere; the module itself is left in place