### PR TITLE
GH-16566: Ignore AdaBoost DeepLearning weak-learner train test

### DIFF
--- a/h2o-algos/src/test/java/hex/adaboost/AdaBoostTest.java
+++ b/h2o-algos/src/test/java/hex/adaboost/AdaBoostTest.java
@@ -108,6 +108,10 @@ public class AdaBoostTest extends TestUtil {
         }
     }
 
+    // GH-16566: same model-lock race as testBasicTrainAndScoreDeepLearning - the test hangs until
+    // the per-test timeout fires, and the leaked keys reported afterwards are a side effect of
+    // Scope.exit() never completing.
+    @Ignore("GH-16566 - model-lock race when DeepLearning is used as AdaBoost weak learner")
     @Test
     public void testBasicTrainDeepLearning() {
         try {


### PR DESCRIPTION
Follow-up to #16566 — does not close it.

- `@Ignore` `AdaBoostTest.testBasicTrainDeepLearning`, which hangs until the per-test timeout fires; the leaked keys reported afterwards are a side effect of `Scope.exit()` never completing
- Same model-lock race in `DeepLearningDriver.onExceptionalCompletion` as `testBasicTrainAndScoreDeepLearning`, ignored under the same issue in April — that change covered only one of the two entry points