### PR TITLE
GH-16566: Add @TestTimeout to override per-test timeout for slow tests

### DIFF
--- a/h2o-algos/src/test/java/hex/kmeans/KmeansConstrainedTest.java
+++ b/h2o-algos/src/test/java/hex/kmeans/KmeansConstrainedTest.java
@@ -212,8 +212,6 @@ public class KmeansConstrainedTest extends TestUtil {
         }
     }
 
-    // Constrained k-means runs a min-cost-flow solve per iteration, which on this dataset legitimately
-    // needs more than the 10 minute default per-test timeout.
     @Test
     @TestTimeout(seconds = 1800)
     public void testWeatherChicagoConstrained() {

--- a/h2o-algos/src/test/java/hex/kmeans/KmeansConstrainedTest.java
+++ b/h2o-algos/src/test/java/hex/kmeans/KmeansConstrainedTest.java
@@ -6,6 +6,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.Assume;
 import water.*;
+import water.junit.TestTimeout;
 import water.fvec.Frame;
 import water.fvec.Vec;
 import water.util.ArrayUtils;
@@ -211,7 +212,10 @@ public class KmeansConstrainedTest extends TestUtil {
         }
     }
 
+    // Constrained k-means runs a min-cost-flow solve per iteration, which on this dataset legitimately
+    // needs more than the 10 minute default per-test timeout.
     @Test
+    @TestTimeout(seconds = 1800)
     public void testWeatherChicagoConstrained() {
         Assume.assumeTrue(H2O.getCloudSize() == 1); // don't test in multi-node, not worth it - this tests already takes a long time
         KMeansModel kmm = null, kmm2 = null;

--- a/h2o-test-support/src/main/java/water/TestUtil.java
+++ b/h2o-test-support/src/main/java/water/TestUtil.java
@@ -20,6 +20,7 @@ import water.api.StreamingSchema;
 import water.fvec.*;
 import water.init.NetworkInit;
 import water.junit.Priority;
+import water.junit.TestTimeout;
 import water.junit.rules.RulesPriorities;
 import water.parser.BufferedString;
 import water.parser.DefaultParserProviders;
@@ -429,10 +430,28 @@ public class TestUtil extends Iced {
    * Per-test timeout. Any single test exceeding this limit fails with TestTimedOutException instead
    * of hanging the whole JVM (which was previously killing entire Jenkins stages with SIGTERM).
    * Configurable via -Dtest.timeout.seconds=N; default is 600 (10 minutes).
+   *
+   * Individual long-running tests can opt out of the default with {@link TestTimeout}, which takes
+   * precedence over the system property.
    */
   @Rule
-  transient public Timeout globalTimeout = Timeout.seconds(
-      Long.parseLong(System.getProperty("test.timeout.seconds", "600")));
+  transient public TestRule globalTimeout = new TestRule() {
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+      return Timeout.seconds(timeoutSeconds(description)).apply(base, description);
+    }
+
+    private long timeoutSeconds(Description description) {
+      TestTimeout override = description.getAnnotation(TestTimeout.class);
+      if (override == null && description.getTestClass() != null) {
+        override = description.getTestClass().getAnnotation(TestTimeout.class);
+      }
+      return override != null
+          ? override.seconds()
+          : Long.parseLong(System.getProperty("test.timeout.seconds", "600"));
+    }
+  };
 
   /**
    * Execute this rule before each test to print test name and test class

--- a/h2o-test-support/src/main/java/water/TestUtil.java
+++ b/h2o-test-support/src/main/java/water/TestUtil.java
@@ -427,9 +427,14 @@ public class TestUtil extends Iced {
   public static Description CURRENT_TEST_DESCRIPTION;
 
   /**
+   * Default per-test timeout in seconds.
+   */
+  public static final int DEFAULT_TEST_TIMEOUT_SECONDS = 600;
+
+  /**
    * Per-test timeout. Any single test exceeding this limit fails with TestTimedOutException instead
    * of hanging the whole JVM (which was previously killing entire Jenkins stages with SIGTERM).
-   * Configurable via -Dtest.timeout.seconds=N; default is 600 (10 minutes).
+   * Configurable via -Dtest.timeout.seconds=N; defaults to {@link #DEFAULT_TEST_TIMEOUT_SECONDS}.
    *
    * Individual long-running tests can opt out of the default with {@link TestTimeout}, which takes
    * precedence over the system property.
@@ -449,7 +454,8 @@ public class TestUtil extends Iced {
       }
       return override != null
           ? override.seconds()
-          : Long.parseLong(System.getProperty("test.timeout.seconds", "600"));
+          : Long.parseLong(System.getProperty("test.timeout.seconds",
+              String.valueOf(DEFAULT_TEST_TIMEOUT_SECONDS)));
     }
   };
 

--- a/h2o-test-support/src/main/java/water/junit/TestTimeout.java
+++ b/h2o-test-support/src/main/java/water/junit/TestTimeout.java
@@ -1,0 +1,21 @@
+package water.junit;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Overrides the default per-test timeout enforced by {@code TestUtil#globalTimeout} for tests that
+ * are legitimately long-running. Applies to a single test method, or to a whole class when the
+ * annotation is placed on the type; a method-level value wins over a class-level one.
+ *
+ * Use this only for tests known to be slow - a test that hangs should be fixed or ignored instead
+ * of being given more time.
+ */
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
+public @interface TestTimeout {
+  int seconds();
+}


### PR DESCRIPTION
Follow-up to #16566 — does not close it.

- Add `water.junit.TestTimeout`, which overrides the default per-test timeout enforced by `TestUtil#globalTimeout`; applies to a method or a whole class and takes precedence over `-Dtest.timeout.seconds`
- Annotate `KmeansConstrainedTest.testWeatherChicagoConstrained` with 1800s — it needs ~5 min uncontended locally and its siblings run 3-6x slower in CI, so 600s is not enough
- The test is slow, not deadlocked: it passes locally in 263s, and the leaked keys previously reported alongside the timeout are a side effect of `Scope.exit()` never completing
- Defaults are unchanged for every other test