### PR TITLE
GH-16919: Raise timeouts for Small and Medium-large test stages

### DIFF
--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -200,7 +200,7 @@ def call(final pipelineContext) {
     ],
     [
       stageName: 'Py3.7 Medium-large', target: 'test-pyunit-medium-large', pythonVersion: '3.7',
-      timeoutValue: 400, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 480, component: pipelineContext.getBuildConfig().COMPONENT_PY
     ],
     [
       stageName: 'Py3.7 X-large', target: 'test-pyunit-xlarge', pythonVersion: '3.7',
@@ -208,7 +208,7 @@ def call(final pipelineContext) {
     ],
     [
       stageName: 'R3.5 Medium-large', target: 'test-r-medium-large', rVersion: '3.5.3',
-      timeoutValue: 210, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 300, component: pipelineContext.getBuildConfig().COMPONENT_R
     ],
     [
       stageName: 'R3.5 Demos Medium-large', target: 'test-r-demos-medium-large', rVersion: '3.5.3',
@@ -463,7 +463,7 @@ def call(final pipelineContext) {
     ],
     [
       stageName: 'R3.4 Medium-large', target: 'test-r-medium-large', rVersion: '3.4.1',
-      timeoutValue: 210, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 300, component: pipelineContext.getBuildConfig().COMPONENT_R
     ],
     [
       stageName: 'R3.4 Small', target: 'test-r-small', rVersion: '3.4.1',

--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -200,7 +200,7 @@ def call(final pipelineContext) {
     ],
     [
       stageName: 'Py3.7 Medium-large', target: 'test-pyunit-medium-large', pythonVersion: '3.7',
-      timeoutValue: 480, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 600, component: pipelineContext.getBuildConfig().COMPONENT_PY
     ],
     [
       stageName: 'Py3.7 X-large', target: 'test-pyunit-xlarge', pythonVersion: '3.7',
@@ -208,7 +208,7 @@ def call(final pipelineContext) {
     ],
     [
       stageName: 'R3.5 Medium-large', target: 'test-r-medium-large', rVersion: '3.5.3',
-      timeoutValue: 300, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 480, component: pipelineContext.getBuildConfig().COMPONENT_R
     ],
     [
       stageName: 'R3.5 Demos Medium-large', target: 'test-r-demos-medium-large', rVersion: '3.5.3',
@@ -459,11 +459,11 @@ def call(final pipelineContext) {
     ],
     [
       stageName: 'Py3.7 Medium-large', target: 'test-pyunit-medium-large', pythonVersion: '3.7',
-      timeoutValue: 305, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 600, component: pipelineContext.getBuildConfig().COMPONENT_PY
     ],
     [
       stageName: 'R3.4 Medium-large', target: 'test-r-medium-large', rVersion: '3.4.1',
-      timeoutValue: 300, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 480, component: pipelineContext.getBuildConfig().COMPONENT_R
     ],
     [
       stageName: 'R3.4 Small', target: 'test-r-small', rVersion: '3.4.1',
@@ -517,7 +517,7 @@ def call(final pipelineContext) {
     ],
     [
       stageName: 'Py3.7 Medium-large', target: 'test-pyunit-medium-large', pythonVersion: '3.7',
-      timeoutValue: 310, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 600, component: pipelineContext.getBuildConfig().COMPONENT_PY
     ],
     [
       stageName: 'Py3.7 Explain', target: 'test-pyunit-explain', pythonVersion: '3.7',

--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -122,7 +122,7 @@ def call(final pipelineContext) {
     ],
     [
       stageName: 'Py3.7 Small', target: 'test-pyunit-small', pythonVersion: '3.7',
-      timeoutValue: 130, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 260, component: pipelineContext.getBuildConfig().COMPONENT_PY
     ],
 //    [
 //      stageName: 'Py3.11 Small', target: 'test-pyunit-small', pythonVersion: '3.11',
@@ -156,7 +156,7 @@ def call(final pipelineContext) {
     ],
     [
       stageName: 'R3.5 Small', target: 'test-r-small', rVersion: '3.5.3',
-      timeoutValue: 180, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 300, component: pipelineContext.getBuildConfig().COMPONENT_R
     ],
     [
       stageName: 'R3.5 AutoML', target: 'test-r-automl', rVersion: '3.5.3',
@@ -172,7 +172,7 @@ def call(final pipelineContext) {
     ],
     [
       stageName: 'R4.4 Small', target: 'test-r-small', rVersion: '4.4.0',
-      timeoutValue: 190, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 300, component: pipelineContext.getBuildConfig().COMPONENT_R
     ],
     [
       stageName: 'R4.4 CMD Check as CRAN', target: 'test-r-cmd-check-as-cran', rVersion: '4.4.0',
@@ -180,7 +180,7 @@ def call(final pipelineContext) {
     ],
     [
       stageName: 'R4.5 Small', target: 'test-r-small', rVersion: '4.5.2',
-      timeoutValue: 190, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 300, component: pipelineContext.getBuildConfig().COMPONENT_R
     ],
     [
       stageName: 'R4.5 CMD Check as CRAN', target: 'test-r-cmd-check-as-cran', rVersion: '4.5.2',
@@ -447,7 +447,7 @@ def call(final pipelineContext) {
     ],
     [
       stageName: 'Py3.7 Small', target: 'test-pyunit-small', pythonVersion: '3.7',
-      timeoutValue: 210, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 260, component: pipelineContext.getBuildConfig().COMPONENT_PY
     ],
     [
       stageName: 'Py3.7 Fault Tolerance', target: 'test-pyunit-fault-tolerance', pythonVersion: '3.7',
@@ -467,7 +467,7 @@ def call(final pipelineContext) {
     ],
     [
       stageName: 'R3.4 Small', target: 'test-r-small', rVersion: '3.4.1',
-      timeoutValue: 180, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 300, component: pipelineContext.getBuildConfig().COMPONENT_R
     ],
     [
       stageName: 'R3.4 AutoML', target: 'test-r-automl', rVersion: '3.4.1',


### PR DESCRIPTION
Closes #16919

Medium-large:
- `R3.5` / `R3.4 Medium-large`: 210 -> 480 min. Both ran 214-253 min in every recent nightly, so Jenkins aborted them mid-run and produced no test results
- `Py3.7 Medium-large`: 400/305/310 -> 600 min across `PR_STAGES`, `NIGHTLY_REPEATED_STAGES` and `NIGHTLY_STAGES` — all three drive the same `test-pyunit-medium-large` target, and one was observed at 415 min

Small:
- `Py3.7 Small`: 130/210 -> 260 min (observed 85)
- `R3.5` / `R4.4` / `R4.5` / `R3.4 Small`: 180-190 -> 300 min (observed 97-110)

Headroom is deliberately generous because reverting the MOJO/POJO block restores ~148 pyunit and ~84 runit tests via `tests/pyunitEnterpriseGateExcludeList` / `tests/runitEnterpriseGateExcludeList`, and those lists are applied to both the Small and Medium-large targets. 600 min matches the existing `Py3.11 Medium-large` cap.