### PR TITLE
GH-16875 - Add telemetry note to the PyPI package description

### DIFF
--- a/h2o-py/DESCRIPTION.rst
+++ b/h2o-py/DESCRIPTION.rst
@@ -3,3 +3,5 @@ H2O
 
 H2O scales statistics, machine learning and math over BigData. H2O is extensible and users can build blocks using simple math legos in the core. H2O keeps familiar interfaces like python, R, Excel & JSON so that BigData enthusiasts & experts can explore, munge, model and score datasets using a range of simple to advanced algorithms. Data collection is easy. Decision making is hard. H2O makes it fast and easy to derive insights from your data through faster and better predictive modeling. H2O has a vision of online scoring and modeling in a single platform.
 
+Note: H2O-3 can send anonymous usage telemetry — never your code or data. It is opt-in and off by default; enable it with ``h2o.set_telemetry(True)``. See the `Telemetry documentation <https://docs.h2o.ai/h2o/latest-stable/h2o-docs/telemetry.html>`_ for what is sent.
+


### PR DESCRIPTION
Followup #16875.

Adds a one-line telemetry note to `h2o-py/DESCRIPTION.rst` (the PyPI long description), so the opt-in disclosure is visible on the package page.