### PR TITLE
GH-16922: Disable obsolete s3CredentialsCheck in h2o-persist-hdfs

### DIFF
--- a/h2o-persist-hdfs/build.gradle
+++ b/h2o-persist-hdfs/build.gradle
@@ -46,7 +46,11 @@ task s3CredentialsCheck(group: "S3") {
 
 test {
     dependsOn ":h2o-core:testJar"
-    dependsOn smalldataCheck, s3CredentialsCheck, jar, testJar, testMultiNode
+    // s3CredentialsCheck is disabled: it was added for the s3n import tests, which needed AWS keys
+    // in core-site.xml because s3n had no environment-variable credential provider. s3n is no longer
+    // supported by hadoop-aws 3.0+ and the remaining s3a tests pick up AWS_ACCESS_KEY_ID /
+    // AWS_SECRET_ACCESS_KEY from the environment. Kept defined for Hadoop testing (GH-16922).
+    dependsOn smalldataCheck, /*s3CredentialsCheck,*/ jar, testJar, testMultiNode
 
     // Defeat task 'test' by running no tests.
     exclude '**'

--- a/h2o-persist-hdfs/testMultiNode.sh
+++ b/h2o-persist-hdfs/testMultiNode.sh
@@ -28,9 +28,18 @@ function cleanup () {
 
 trap cleanup SIGTERM SIGINT
 
-if [ -z "$JUNIT_CORE_SITE_PATH" ]; then
-  echo "!!! Error: environment variable JUNIT_CORE_SITE_PATH is not defined. Aborting tests !!!"
-  exit 1
+# Disabled together with :h2o-persist-hdfs:s3CredentialsCheck - the s3a tests authenticate from
+# AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY when no core-site.xml is supplied (GH-16922).
+#if [ -z "$JUNIT_CORE_SITE_PATH" ]; then
+#  echo "!!! Error: environment variable JUNIT_CORE_SITE_PATH is not defined. Aborting tests !!!"
+#  exit 1
+#fi
+
+# Only pass the config when it is actually set - an empty -Dai.h2o.hdfs_config adds the flag without
+# a value, and H2O's parser would then consume the following argument as the config path.
+HDFS_CONFIG_OPT=""
+if [ -n "$JUNIT_CORE_SITE_PATH" ]; then
+  HDFS_CONFIG_OPT="-Dai.h2o.hdfs_config=$JUNIT_CORE_SITE_PATH"
 fi
 
 # Find java command
@@ -96,7 +105,7 @@ $JVM water.H2O -name $CLUSTER_NAME -ip $H2O_NODE_IP -baseport $CLUSTER_BASEPORT 
 
 # Launch last driver JVM.  All output redir'd at the OS level to sandbox files.
 echo Running h2o-persist-hdfs junit tests...
-($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME -Dai.h2o.ip=$H2O_NODE_IP -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes -Dai.h2o.hdfs_config=$JUNIT_CORE_SITE_PATH $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt` 2>&1 ; echo $? > $OUTDIR/status.0) 1> $OUTDIR/out.0 2>&1
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME -Dai.h2o.ip=$H2O_NODE_IP -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $HDFS_CONFIG_OPT $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt` 2>&1 ; echo $? > $OUTDIR/status.0) 1> $OUTDIR/out.0 2>&1
 
 grep EXECUTION $OUTDIR/out.0 | sed -e "s/.*TEST \(.*\) EXECUTION TIME: \(.*\) (Wall.*/\2 \1/" | sort -gr | head -n 10 >> $OUTDIR/out.0
 


### PR DESCRIPTION
Closes #16922

- Comment `s3CredentialsCheck` out of `:h2o-persist-hdfs:test` and comment out the matching guard in `testMultiNode.sh`. Both are left defined rather than removed
- The check requires `JUNIT_CORE_SITE_PATH`, supplied by a Jenkins file credential lost when Jenkins was wiped, and it fails `Java 11 JUnit` and `Java 17 JUnit` before any test runs. `Java 8 JUnit` hides it by failing earlier on a different task
- It was added in 2017 (185bae2335) for the **s3n** import tests, which needed AWS keys in `core-site.xml` because s3n had no environment-variable credential provider. s3n is not supported by hadoop-aws 3.0+ and is commented out of `PersistHdfsTest`; the remaining s3a tests authenticate from `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, which are already injected into the test containers
- `-Dai.h2o.hdfs_config` is now only passed when the variable is set. An empty value adds the flag without an argument, and `H2O.incrementAndCheck` would consume the following argument as the config path
- Hadoop stages are unaffected: they read `core-site.xml` from `HADOOP_CONF_DIR` inside the Hadoop images, and never use this variable