### PR TITLE
GH-16906 - Revert the 3.46.0.12 release notes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,20 +2,6 @@
 
 ## H2O
 
-### 3.46.0.12 - 8/5/2026
-
-Download at: <a href='http://h2o-release.s3.amazonaws.com/h2o/rel-3.46.0/12/index.html'>http://h2o-release.s3.amazonaws.com/h2o/rel-3.46.0/12/index.html</a>
-
-#### New Feature
-- [[#16875]](https://github.com/h2oai/h2o-3/issues/16875) – Added opt-in anonymous usage telemetry to the Python, R, and JVM clients.
-- [[#16909]](https://github.com/h2oai/h2o-3/issues/16909) – Added H2O-3 OSS vs Enterprise in-product messaging.
-
-#### Task
-- [[#16910]](https://github.com/h2oai/h2o-3/issues/16910) – Blocked MOJO and POJO artifact extraction in H2O-3 OSS; it is now an enterprise-only feature.
-
-#### Docs
-- [[#16903]](https://github.com/h2oai/h2o-3/issues/16903) – Noted enterprise-only features (Hadoop, Kubernetes, Sparkling Water, and MOJO deployment) in the OSS documentation.
-
 ### 3.46.0.11 - 5/21/2026
 
 Download at: <a href='http://h2o-release.s3.amazonaws.com/h2o/rel-3.46.0/11/index.html'>http://h2o-release.s3.amazonaws.com/h2o/rel-3.46.0/11/index.html</a>


### PR DESCRIPTION
Reverts the release notes added for #16906.

- Drops the 3.46.0.12 entry from `Changes.md`.
- `SECURITY.md` is deliberately left alone: the Known Vulnerabilities table stays removed.