### PR TITLE
GH-16903 - Revert the enterprise-only notes in the OSS docs

### DIFF
--- a/h2o-docs/src/product/cloud-integration/kubernetes.rst
+++ b/h2o-docs/src/product/cloud-integration/kubernetes.rst
@@ -1,10 +1,6 @@
 Using H2O with Kubernetes
 =========================
 
-.. note::
-
-   Running H2O-3 on Kubernetes is part of H2O-3 Enterprise, the supported, production-grade path for production deployments. Contact enterprise@h2o.ai for access.
-
 H2O Software Stack
 ------------------
 

--- a/h2o-docs/src/product/faq/sparkling-water.rst
+++ b/h2o-docs/src/product/faq/sparkling-water.rst
@@ -1,10 +1,6 @@
 Sparkling Water
 ---------------
 
-.. note::
-
-   Running H2O-3 on Spark through Sparkling Water is part of H2O-3 Enterprise, the supported, production-grade path for production deployments. Contact enterprise@h2o.ai for access.
-
 **Note**: This topic is deprecated and will be removed in a later release. Refer to the `Sparkling Water User Guide <http://docs.h2o.ai/#sparkling-water>`__ for Sparkling Water FAQs. 
 
 What is Sparkling Water?

--- a/h2o-docs/src/product/getting-started/hadoop-users.rst
+++ b/h2o-docs/src/product/getting-started/hadoop-users.rst
@@ -1,10 +1,6 @@
 Hadoop users
 ============
 
-.. note::
-
-   Running H2O-3 on Hadoop is part of H2O-3 Enterprise, the supported, production-grade path for production deployments. Contact enterprise@h2o.ai for access.
-
 This section describes how to use H2O-3 on Hadoop.
 
 Supported Versions
@@ -71,7 +67,7 @@ Walkthrough
 
 The following steps show you how to download or build H2O-3 with Hadoop and the parameters involved in launching H2O-3 from the command line.
 
-1. Obtain the H2O-3 release for your version of Hadoop. See the note at the top of this page for how to get Hadoop builds.
+1. Download the latest H2O-3 release for your version of Hadoop from the `Downloads page <http://h2o-release.s3.amazonaws.com/h2o/latest_stable.html>`__. Refer to the H2O-3 on Hadoop tab of the H2O-3 download page for the latest stable release or the nightly bleeding edge release.
 2. Prepare the job input on the Hadoop node by unzipping the build file and changing to the directory with the Hadoop and H2O-3's driver jar files:
 
 ::

--- a/h2o-docs/src/product/getting-started/kubernetes-users.rst
+++ b/h2o-docs/src/product/getting-started/kubernetes-users.rst
@@ -1,10 +1,6 @@
 Kubernetes users
 ================
 
-.. note::
-
-   Running H2O-3 on Kubernetes is part of H2O-3 Enterprise, the supported, production-grade path for production deployments. Contact enterprise@h2o.ai for access.
-
 H2O-3 nodes must be treated as stateful by the Kubernetes environment because H2O-3 is a stateful application. H2O-3 nodes are, therefore, spawned together and deallocated together as a single unit. Subsequently, Kubernetes tooling for stateless applications is not applicable to H2O-3. In Kubernetes, a set of pods sharing a common state is named a `StatefulSet <https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/>`__.
 
 H2O-3 pods deployed on a Kubernetes cluster require a `headless service <https://kubernetes.io/docs/concepts/services-networking/service/#headless-services>`__ for H2O-3 node discovery. The headless service returns a set of addresses to all the underlying pods instead of load-balancing incoming requests to the underlying H2O-3 pods.

--- a/h2o-docs/src/product/hadoop.rst
+++ b/h2o-docs/src/product/hadoop.rst
@@ -3,10 +3,6 @@
 Using H2O on Hadoop
 ===================
 
-.. note::
-
-   Running H2O-3 on Hadoop is part of H2O-3 Enterprise, the supported, production-grade path for production deployments. Contact enterprise@h2o.ai for access.
-
 Currently supported versions:
 
 -  CDH 5.2
@@ -81,7 +77,7 @@ Walkthrough
 The following steps show you how to download or build H2O with Hadoop
 and the parameters involved in launching H2O from the command line.
 
-1. Obtain the H2O-3 release for your version of Hadoop. See the note at the top of this page for how to get Hadoop builds.
+1. Download the latest H2O release for your version of Hadoop. Refer to the `H2O on Hadoop <http://www.h2o.ai/download>`__ tab of the download page for either the latest stable release or the nightly bleeding edge release.
 
 2. Prepare the job input on the Hadoop Node by unzipping the build file
    and changing to the directory with the Hadoop and H2O's driver jar

--- a/h2o-docs/src/product/index.rst
+++ b/h2o-docs/src/product/index.rst
@@ -8,10 +8,6 @@ Overview
 
 Welcome to the H2O-3 documentation site! Select a learning path from the sidebar or browse through the full content outline below.
 
-.. note::
-
-   H2O-3 OSS is for experimentation and prototyping, not production. H2O-3 Enterprise is the supported, production-grade path for production deployments. Contact enterprise@h2o.ai for access.
-
 We're excited you're interesting in learning more about H2O-3. If you have questions or ideas to share, please post them to the H2O community site on `Stack Overflow <http://stackoverflow.com/questions/tagged/h2o>`__.
 
 Additional resources

--- a/h2o-docs/src/product/mojo-capabilities.rst
+++ b/h2o-docs/src/product/mojo-capabilities.rst
@@ -3,10 +3,6 @@
 MOJO Capabilities
 -----------------
 
-.. note::
-
-   H2O-3 Enterprise provides the supported, production-grade path for scoring and inspecting models with the MOJO API. Contact enterprise@h2o.ai for access.
-
 This section describes the basics of working with the MOJO model in H2O-3.
 
 About H2O Generated MOJO Models

--- a/h2o-docs/src/product/productionizing.rst
+++ b/h2o-docs/src/product/productionizing.rst
@@ -3,10 +3,6 @@
 Productionizing H2O
 ===================
 
-.. note::
-
-   H2O-3 Enterprise provides the supported, production-grade path for deploying models. Contact enterprise@h2o.ai for access.
-
 .. _about-pojo-mojo:
 
 About POJOs and MOJOs


### PR DESCRIPTION
Reverts the documentation notes added for #16903.

- Removes the H2O-3 Enterprise notes from the Hadoop, Kubernetes, Sparkling Water, MOJO capabilities, productionizing and docs overview pages.
- Restores the Hadoop download links on both Hadoop pages.