### PR TITLE
GH-16909 - Restore in-product messaging as H2O-3 Secure

### DIFF
--- a/h2o-core/src/main/java/water/EnterpriseGate.java
+++ b/h2o-core/src/main/java/water/EnterpriseGate.java
@@ -1,9 +1,10 @@
 package water;
 
 import water.exceptions.H2OIllegalArgumentException;
+import water.util.Log;
 
 /**
- * Server-side H2O-3 Enterprise gate for production-only capabilities.
+ * Server-side H2O-3 Secure gate for production-only capabilities.
  *
  * The OSS build enforces the paywall where the artifacts are actually produced, so it holds
  * regardless of how the caller got there - REST, Flow, a patched client, an embedded H2O
@@ -30,14 +31,14 @@ import water.exceptions.H2OIllegalArgumentException;
  * rather than by a {@code StreamWriter}. The client-side notices in the Python/R packages are
  * only the friendly message.
  *
- * Binary model export stays open by design: a model can still be moved to an Enterprise
+ * Binary model export stays open by design: a model can still be moved to an H2O-3 Secure
  * cluster, which is the intended upgrade path. What OSS will not do is convert one into a
  * deployable scoring artifact.
  */
 public class EnterpriseGate {
 
   public static final String ENTERPRISE_EMAIL = "enterprise@h2o.ai";
-  public static final String LEARN_MORE = "h2o.ai/h2o-3/oss-vs-enterprise";
+  public static final String LEARN_MORE = "h2o.ai/h2o-3/oss-vs-secure";
 
   /**
    * True when this JVM is running the H2O test harness. The multi-node JUnit suites
@@ -68,6 +69,19 @@ public class EnterpriseGate {
   }
 
   /**
+   * Log the OSS-vs-Secure notice at cluster startup. Emitted via {@link Log#info}
+   * (not System.out) so it flows through the standard logging pipeline.
+   */
+  public static void logStartupBanner() {
+    Log.info("You are running the community edition of H2O-3 OSS.");
+    Log.info("For commercial use, H2O-3 Secure is now recommended.");
+    Log.info("This includes production support, CVE fixes, multi-node scaling, " +
+             "model artifact extraction, and more.");
+    Log.info("See " + LEARN_MORE + " for additional details.");
+    Log.info("Contact " + ENTERPRISE_EMAIL + " to upgrade.");
+  }
+
+  /**
    * Enforcement point for the {@code hex.Model} artifact-producing methods, which the
    * test harness itself relies on. Identical to {@link #block(String)} for every shipped
    * cluster; a no-op under the JUnit suites. The REST layer deliberately does not use
@@ -84,13 +98,13 @@ public class EnterpriseGate {
    */
   public static void block(String operation) {
     throw new H2OIllegalArgumentException(
-        "H2O-3 ENTERPRISE REQUIRED - " + operation + " is blocked. " +
-        operation + " is a production capability available only in H2O-3 Enterprise, " +
-        "the commercially supported tier of H2O-3. You are running H2O-3 OSS, built for " +
-        "experimentation and research, not production. Upgrade to H2O-3 Enterprise for " +
-        "multi-node production deployment (Hadoop, Spark, Kubernetes), audit-ready governance " +
-        "(SOC 2, ISO 27001, ISO 42001), prioritized CVE patching, and premium support with SLAs. " +
-        "H2O-3 Enterprise is a drop-in replacement - your existing code, APIs, and pipelines run " +
-        "unchanged. Learn more: " + LEARN_MORE + ". Contact: " + ENTERPRISE_EMAIL);
+        "H2O-3 SECURE REQUIRED - " + operation + " is blocked. " +
+        operation + " is a production capability available only in H2O-3 Secure, " +
+        "the commercially supported tier of H2O-3. You are running self-managed H2O-3 OSS. " +
+        "You must upgrade to H2O-3 Secure for Hadoop and Kubernetes enterprise packages, " +
+        "audit-supporting capabilities (SOC 2, ISO 27001, ISO 42001), commercial CVE patching " +
+        "and long-term support, and premium support with SLAs. If you need MOJO, we provide a " +
+        "free license for non-commercial use - request it at " + LEARN_MORE + ". " +
+        "Contact: " + ENTERPRISE_EMAIL);
   }
 }

--- a/h2o-core/src/main/java/water/H2OStarter.java
+++ b/h2o-core/src/main/java/water/H2OStarter.java
@@ -51,6 +51,7 @@ public class H2OStarter {
       Log.info(message);
       Log.info("");
     }
+    EnterpriseGate.logStartupBanner();
   }
 
   public static void start(String[] args, String relativeResourcePath) {

--- a/h2o-core/src/test/java/water/EnterpriseGateTest.java
+++ b/h2o-core/src/test/java/water/EnterpriseGateTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import water.exceptions.H2OIllegalArgumentException;
 
 /**
- * Unit tests for the server-side H2O-3 Enterprise gate. Pure (no cloud needed):
+ * Unit tests for the server-side H2O-3 Secure gate. Pure (no cloud needed):
  * {@link EnterpriseGate#block(String)} only builds and throws.
  */
 public class EnterpriseGateTest {
@@ -18,7 +18,7 @@ public class EnterpriseGateTest {
     } catch (H2OIllegalArgumentException e) {
       String msg = e.getMessage();
       assertTrue("names the operation", msg.contains("MOJO export"));
-      assertTrue("marked as blocked/enterprise", msg.contains("H2O-3 ENTERPRISE REQUIRED"));
+      assertTrue("marked as blocked/secure", msg.contains("H2O-3 SECURE REQUIRED"));
       assertTrue("routes to contact", msg.contains(EnterpriseGate.ENTERPRISE_EMAIL));
       assertTrue("links the comparison page", msg.contains(EnterpriseGate.LEARN_MORE));
     }
@@ -56,7 +56,7 @@ public class EnterpriseGateTest {
       EnterpriseGate.block("MOJO export");
       fail("block must throw even under the test harness - it is what the REST layer uses");
     } catch (H2OIllegalArgumentException expected) {
-      assertTrue(expected.getMessage().contains("H2O-3 ENTERPRISE REQUIRED"));
+      assertTrue(expected.getMessage().contains("H2O-3 SECURE REQUIRED"));
     }
   }
 

--- a/h2o-dist/index.html
+++ b/h2o-dist/index.html
@@ -54,7 +54,7 @@
       }
       #title {
         height: 200px;
-        background: #fbe93a;
+        background: #FFDD00;
       }
       #title h1 {
         background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGMAAABDCAYAAACIl7ujAAAI/UlEQVR4Ae2de2wVRRTG29InLdCW0pbSqlECREU0KCCIBoUGQsQXSpCEiEAEAY0YwERjAkSMBCQq4aEhPiJiBIIYNAqEaOThH6gBEsLDF7SU0gctUAptKfV3mt6ybHfvnpbeMjd7N9ns7plvzsx838zszOzcNjoqcgRlICMjo098fHx+TEzMgIaGhv6Ac6Kjo7txn8z1Itdz2Iq4P3T16tUDtbW128vKyo4FdeoSGJ2Xl9fgEtZsrq+vX1lUVDSn2aC8ycnJ+ahTp06zveAFBQXRXpiODE9JSenRrVu3GaQ5CRH6tjZtRDlCnPXnz59fc+HChTJt/Bgt0A84EaFXr16rU1NTTyLCorYIITwRrx/nYgQtwN+qLl26ZGj4i4jRxFJ2dvbMtLS0o5A4gy4nUUOeF0b84G8mohzt2bPnS174iBhRUSnU3k1xcXGrICvNi7C2hCNKemxs7BrS+Zr4yW4+fC0G3VJmbm7uPmrvM24EtaeddCYgyB63bsu3YnTt2jWd7mMHtfbu9iTcyxeCDCDtHeBS7Vi/ihFL7dwKMffYCemIZ9K9lxbyLWl1sqbnSzEgYiGEPGQloqPvSf8Rhv5vW9P1nRhZWVlDIOANKwmae+YOe5lvzbt06dLAs2fPZjM3iperPIud8H0aP1YMXeRbjOIeCNhiAzd+uTKqWUatVFdCZtiH6urq5p45c2annaOLFy+ekRP7H5zLEHoko7L3IVlm6p6H5APscoAPC1idKU/PYQCArMcp/zBtVqnxGwoLC4c4CeHkQ3CCl3hO4U42xBhO6xgrYb4Sg1bhOfEKEEa38wVLQM/zXB2wKa/VEk/iK/FRLBnJ0ot/xEhOTs6ivKM1BEHknlOnTk3TYN0wEl/8uIXb7KMlf75pGQxlx9BFXTeUtBHS+AiB9VeuXJnJQ51TeCtsvGrqXhZ/XnHIlwy1R6te4PRr4xiG9fZyag8n3p122816pisYpEx7C33/ISU2KKykpOQgw+gtgMYHBRKIIINUYgC8BbycYXtQMQZqMk+r2KTBaTHij+8hGjHu9003xRA1W0Pg5cuX92twWozWn+TPN2JAnmpF9ty5c0VaojW4VvhL840YdFMJGvLAqLpupS+BxWmwkj/fiAEh5RpSWMnN1OC0GPz1UGLLfSMGfXKphpSkpKS+GpwWg79+Giz5K1E1SYBncXha49SG6UnzS7fZbtZjiSZhhsD54H7QYDUYRqLiT3OUqsRg4vJVKHeHaHLaDphipY+nwc3nrFXig8HiqYziT3MU+6abokLt1jBCTc5j88AUDdYLwwLgVPzleuEknPz96hsxqqurt2tIEQwELurevXsvLd4Jl56enkuXt9ApzMnGd5HtvhGD8f6/1L7jTkTYbYiRmZiYKDPxRHuY8jmpc+fOm/GjGkmRr2OVlZX/qd4ZygyEGpbAOs84BhOjKOQQrpkyOOCsojAyUvqT6y5awEaIr3DJzDbsr7mEXWeWNEhvJ7sCn2BXoGpYLA6adiNuJV/atTBpiZKv8FhCZ5FyGsQcJ9Pf0PSnU9D+3GdxlQlVGvd9OCfwvWItZJxg+8172FvsT6IrWIGINVJwzYHPYezk2I8/1UuYd8R45hX7ifegxr9gJD98LVwh96a3jCSEWIcAEyWzmgMiuoCbL62IRbrnrCuwfLMuoPv4mPA5Gl+Cwd9tXDYjyO+0vE2Qt4PWUgiBFXyDSGcekcunVmmtz3LeJ3Fac+BzLfkqlDgmixEDoRspYOMnydYUULDE6wdJP/MiHU5hDwfiV1RULGEb5zRaVVLAprmCH0ilkJXfd/EZJeeNHghRTZe6JODH2Be4bGNpqxCBwkGg1NyfeO4asFGjiyFB5hE3/aCVzSM/sqGh8TBSDBkWIkSrt9MECmW94oceJvdNq40J7Eo2Dayz2jr6nvQ/IR+rrOkaKQb9+nxqtesqKzW7gcJ8ynUmtWspBXIbPQXKKu+IzoEHuUKEfBLda7V11D3p7ib92fb0jBQDIYJuRKYwkynMi3z0X8PWmAV8wBmMzXX4ib8ktumMshW+lv76SeLts9lD+kh6exgAPEUiLZZbjBMjMzNT9r/muDFCYQ6cPn36S2t4aWnpceyLrTb7PcPewXZbVVVVKYKOIO5n9rBQPEvXSHqPuv2ayTgxZBQUjAi6Jdm91+KQ39K1MFoMxJOtOk5HDQRNYRg8F8xlJ8CN2vB7CSFepTVPw1eLFhHwb5wYDB/zAplzutLlOOaZAl9wwlts170zLPbGW1rbCiaFvWkla/FVZw9vy7P4QYRVDK3vQIgPvXwY9cPGpsymMJlKccs4Q0GpvZX2cLq3oQkJCa6bxiB5BS1grj2e0zOz6NvJw+sIP5aWeqsTJpgNEWQd7HuWZpbLmlMwrDXMxElfFYRXWTOpuWeC95gH7pRHeHMwL/Z/OGdhmMXqbT+22oxGlCE8yxJMD8iWdbFUrpVcS7jKKfOFfXSXP7b1p8cmitFMSitupOuaFAxfU1PzS7Bwt7Dy8vIjhMkZ8sOx/w15qu2cALP1F6i5rt+uqbWHqa3tuh+qnYvQ6C7sxZANw3QVzes7TiQxUpKJofFHuHdTcSz6bUQMt2GrfM78rri4+HPjlSCDYd0y6J5WI8RwN6Lpnv7iRTzdLdw0e9i2DJbX3+E9MdWNUFrECYaWjzHLLnHDmGY3cZ7hyREt4hUmhx+4ARGiABFG0Cr+dsOYaA87MRBiIl3TelqFY94R4jgtYiQfkU6aSHiwPDkWKFiEmxnGLDufCdg2xIhzygdCHGTGm2/9YOOEM9UWNmLwsX8QXdMuWkSLjQZCLkL8xnLHGG5bLJWYSr49X2EhBn8NrS/rTrsRIsNegKbnCuYSC2gxQZdRWKzb4BLfCLPxYsjOPjaU7UWIG/4Zm2l/8c1eA4we2rJ6miYbCqjxNyyEveAmPps86UtiQ5q8rO8ykbhQ5MlUMWKb9kwNDUWhTfVpohjRCLGOd0SbNq+ZSrQmX8aJwaRuKUJM1mQ+gokwEGEgwkCEgQgDEQYiDEQYiDBwjQHVfwm4Bo/chZIB4+YZoSys6b4jYhikUEQMg8T4H+LNJUd1pdXbAAAAAElFTkSuQmCC);
@@ -140,6 +140,7 @@
       #downloads {
         text-align: center;
         margin-top: 20px;
+        margin-bottom: 25px;
       }
       a.download-button {
         display: inline-block;
@@ -294,6 +295,39 @@
       .callout--telemetry a {
           color: #3b4a58;
           font-weight: bold;
+      }
+
+      .callout--enterprise {
+          padding-left: 55px;
+          border-left-color: #FFDD00;
+          background-color: rgb(255 221 0 / 0.18);
+      }
+
+      /* Star uses a darkened Sunshine Yellow; the brand hue itself is too light
+         to read against the pale tint behind it. */
+      .callout--enterprise::before {
+          content: '\2605';
+          font-size: 28px;
+          color: #D6BA00;
+          position: absolute;
+          top: 8px;
+          left: 12px;
+      }
+
+      .callout--enterprise a {
+          color: #1c1c1d;
+          font-weight: bold;
+      }
+
+      .callout--enterprise ul {
+          list-style: disc;
+          margin: 8px 0;
+          padding-left: 22px;
+      }
+
+      .callout--enterprise strong {
+          display: block;
+          margin-bottom: 14px;
       }
 
     </style>
@@ -523,35 +557,6 @@
 
         tmp = document.getElementById("booklets")
         tmp.innerHTML = out;
-
-        out = "";
-        out += "<ul>\n";
-        hadoop_distributions = obj.hadoop_distributions;
-        for (i = 0; i < hadoop_distributions.length; i++) {
-          dist = hadoop_distributions[i];
-          var url = location.href;
-          var url2 = url.substring(0, url.lastIndexOf("/"));
-          out += "wget ";
-          out += url2;
-          out += "/";
-          out += dist.zip_file_path;
-          out += "<br/>";
-          out += "\n";
-        }
-        out += "</ul>\n";
-
-        tmp = document.getElementById("to_copy4")
-        tmp.innerHTML = out;
-      }
-
-      replaceDockerImageTag = function () {
-          const versionRegexp = /(\d+\.\d+\.\d+\.\d{4,})/g; // Nightly builds have at least 4 digits at the end
-          var dockerTag = "SUBST_PROJECT_VERSION";
-          if (dockerTag.match(versionRegexp) != null) {
-              dockerTag = "nightly" // If the last number is not 4 or more digits, substitute the version for "nightly"
-          }
-          docker_sample = document.getElementById("to_copy10");
-          docker_sample.innerHTML = docker_sample.innerHTML.replace("docker-image-version", dockerTag);
       }
 
       readBuildInfoJsonFile = function() {
@@ -562,7 +567,6 @@
           if (xmlhttp.readyState == 4 && xmlhttp.status == 200) {
             var myObj = JSON.parse(xmlhttp.responseText);
             populatePageWithBuildInfoJson(myObj);
-            replaceDockerImageTag();
 
             // Must be after populating the page or id's won't be found.
             initializeTabs();
@@ -607,6 +611,20 @@
           <div id="quickstart-zip">
             <div id="downloads">
               <a id="download-zip" class="download-button" href="h2o-SUBST_PROJECT_VERSION.zip">Download H<sub>2</sub>O</a>
+            </div>
+            <div class="callout callout--enterprise">
+              <strong>NOW AVAILABLE: H<sub>2</sub>O-3 Secure FOR PRODUCTION AI/ML</strong>
+              <p>H<sub>2</sub>O-3 OSS is designed for self-managed production and therefore places every operational responsibility on your internal teams:</p>
+              <ul>
+                <li>SLAs, incident response, and remediation timelines</li>
+                <li>Commercial CVE patching &amp; long-term support</li>
+                <li>Model lineage and audit evidence</li>
+                <li>Supportability documentation for auditors and regulators</li>
+              </ul>
+              <p>Under SOC 2, ISO 27001, and ISO 42001, that operational and audit burden is your organization's exposure.</p>
+              <p>H<sub>2</sub>O-3 Secure is the commercially supported upgrade for enterprises running audit-sensitive AI/ML in production. Keep everything you have: same code, APIs and pipelines run unchanged.</p>
+              <p>See comparison table, which path is right for you? <a href="https://h2o.ai/h2o-3/oss-vs-secure" target="_blank">h2o.ai/h2o-3/oss-vs-secure</a></p>
+              <p>Contact: <a href="mailto:enterprise@h2o.ai">enterprise@h2o.ai</a></p>
             </div>
             <h2>Get started with H<sub>2</sub>O in 3 easy steps</h2>
             <p>1. Download H<sub>2</sub>O. This is a zip file that contains everything you need to get started.</p>
@@ -685,38 +703,22 @@
             </div>
 
           <div id="quickstart-hadoop" style="display:none">
-            <h2>Run H<sub>2</sub>O on Hadoop in just 3 steps</h2>
+            <h2>Run H<sub>2</sub>O on Hadoop</h2>
             <p class="callout callout--telemetry">H<sub>2</sub>O-3 can send anonymous usage telemetry to help prioritize features and platforms &mdash; never your code or data. It is off by default; to enable or learn more, see the <a href="https://docs.h2o.ai/h2o/latest-stable/h2o-docs/telemetry.html" target="_blank">Telemetry documentation</a>.</p>
-            <p>1. Download H<sub>2</sub>O for your version of Hadoop. This is a zip file that contains everything you need to get started.</p>
-            <button class="btn copy_button" id="btnCopy4" data-clipboard-target='#to_copy4'></button>
-            <p class="terminal" id="to_copy4"></p>
-            <p>2. Unpack the zip file and launch a 6g instance of H<sub>2</sub>O: </p>
-             <button class="btn copy_button" id="btnCopy7" data-clipboard-target='#to_copy7'></button>
-            <p class="terminal" id="to_copy7">
-                unzip h2o-SUBST_PROJECT_VERSION-*.zip<br/>
-                cd h2o-SUBST_PROJECT_VERSION-*<br/>
-                hadoop jar h2odriver.jar -nodes 1 -mapperXmx 6g<br/>
-            </p>
-            <p>3. Point your browser to H2O (see "Open H2O Flow in your web browser" in the output below):</p>
-            <button class="btn copy_button" id="btnCopy5" data-clipboard-target='#to_copy5'></button>
-            <p class="terminal" id="to_copy5">
-                Determining driver host interface for mapper->driver callback...<br/>
-                [Possible callback IP address: 172.16.2.181]<br/>
-                [Possible callback IP address: 127.0.0.1]<br/>
-                ...<br/>
-                Waiting for H2O cluster to come up...<br/>
-                H2O node 172.16.2.188:54321 requested flatfile<br/>
-                Sending flatfiles to nodes...<br/>
-                    [Sending flatfile to node 172.16.2.188:54321]<br/>
-                H2O node 172.16.2.188:54321 reports H2O cluster size 1<br/>
-                H2O cluster (1 nodes) is up<br/>
-                (Note: Use the -disown option to exit the driver after cluster formation)<br/>
-                <br/>
-                <em>Open H2O Flow in your web browser: http://172.16.2.188:54321</em><br/>
-                <br/>
-                (Press Ctrl-C to kill the cluster)<br/>
-                Blocking until the H2O cluster shuts down...<br/>
-            </p>
+            <div class="callout callout--enterprise">
+              <strong>NOW AVAILABLE: H<sub>2</sub>O-3 Secure FOR PRODUCTION AI/ML</strong>
+              <p>H<sub>2</sub>O-3 OSS is designed for self-managed production and therefore places every operational responsibility on your internal teams:</p>
+              <ul>
+                <li>SLAs, incident response, and remediation timelines</li>
+                <li>Commercial CVE patching &amp; long-term support</li>
+                <li>Model lineage and audit evidence</li>
+                <li>Supportability documentation for auditors and regulators</li>
+              </ul>
+              <p>Under SOC 2, ISO 27001, and ISO 42001, that operational and audit burden is your organization's exposure.</p>
+              <p>H<sub>2</sub>O-3 Secure is the commercially supported upgrade for enterprises running audit-sensitive AI/ML in production. Keep everything you have: same code, APIs and pipelines run unchanged.</p>
+              <p>See comparison table, which path is right for you? <a href="https://h2o.ai/h2o-3/oss-vs-secure" target="_blank">h2o.ai/h2o-3/oss-vs-secure</a></p>
+              <p>Contact: <a href="mailto:enterprise@h2o.ai">enterprise@h2o.ai</a></p>
+            </div>
           </div>
 
           <div id="quickstart-maven" style="display:none">
@@ -744,103 +746,22 @@ dependencies {</br>
 }</br>
           </div>
             <div id="quickstart-kubernetes" style="display:none">
-                <p class="callout callout--telemetry" style="margin-top: 25px;">H<sub>2</sub>O-3 can send anonymous usage telemetry to help prioritize features and platforms &mdash; never your code or data. It is off by default; to enable or learn more, see the <a href="https://docs.h2o.ai/h2o/latest-stable/h2o-docs/telemetry.html" target="_blank">Telemetry documentation</a>.</p>
-
-                <h2>Setup H<sub>2</sub>O on Kubernetes using Helm</h2>
-                    <p><a href="https://helm.sh/" target="_blank">Helm</a> can be used to deploy H2O into a kubernetes cluster. Helm requires the KUBECONFIG environment variable to be set up properly, or stating the kubeconfig destination explicitly. Please refer to Helm's documentation
-                    for further information.</p>
-                <button class="btn copy_button" id="btnCopy11" data-clipboard-target='#to_copy11'></button>
-                
-                    <p class="terminal" id="to_copy11">
-                        helm repo add h2o https://charts.h2o.ai<br/>
-                        helm install basic-h2o h2o/h2o<br/>
-                        helm test basic-h2o
-                    </p>
-                
-
-                <p>There are various settings and modifications available. To inspect the configuration options available, use the  "helm inspect values h2o/h2o --version SUBST_PROJECT_VERSION" command.</p>
-                
-                <h2>Setup H<sub>2</sub>O on Kubernetes with kubectl</h2>
-                <p>1. Set-up kubernetes cluster and kubectl.</p>
-                <p>2. (Optional) Adjust the 'default' namespace in the following YAML, if required.</p>
-    
-                <button class="btn copy_button" id="btnCopy10" data-clipboard-target='#to_copy10'></button>
-                <p class="terminal pre" id="to_copy10">
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: h2o-cluster-stateful-set
-  namespace: default
-spec:
-  serviceName: h2o-service
-  podManagementPolicy: "Parallel"
-  replicas: 1
-  selector:
-    matchLabels:
-      app: h2o-cluster
-  template:
-    metadata:
-      labels:
-        app: h2o-cluster
-    spec:
-      containers:
-        - name: h2o-cluster
-          image: 'h2oai/h2o-open-source-k8s:docker-image-version'
-          command: ["/bin/bash", "-c", "java -XX:+UseContainerSupport -XX:MaxRAMPercentage=50 -jar /opt/h2oai/h2o-3/h2o.jar"]
-          ports:
-            - containerPort: 54321
-              protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /kubernetes/isLeaderNode
-              port: 8081
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            failureThreshold: 1
-          resources:
-            limits:
-              cpu: '1'
-              memory: 1Gi
-            requests:
-              cpu: '1'
-              memory: 1Gi
-          env:
-          - name: H2O_KUBERNETES_SERVICE_DNS
-            value: h2o-cluster-service.default.svc.cluster.local
-          - name: H2O_NODE_LOOKUP_TIMEOUT
-            value: '180'
-          - name: H2O_NODE_EXPECTED_COUNT
-            value: '1'
-          - name: H2O_KUBERNETES_API_PORT
-            value: '8081'
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: h2o-cluster-service
-  namespace: default
-spec:
-  type: ClusterIP
-  clusterIP: None
-  selector:
-    app: h2o-cluster
-  ports:
-  - protocol: TCP
-    port: 80
-    targetPort: 54321
-                </p>
-                
-                <p>
-                    Environment variables:<br/><br/>
-                    H2O_KUBERNETES_SERVICE_DNS - [MANDATORY] Crucial for the clustering to work. The format usually follows the {service-name}.{project-name}.svc.cluster.local pattern. This setting enables H2O node discovery via DNS. It must be modified to match the name of the headless service created. Also, pay attention to the rest of the address to match the specifics of your Kubernetes implementation.<br/><br/>
-                    H2O_NODE_LOOKUP_TIMEOUT - [OPTIONAL] Node lookup constraint. Time before the node lookup is ended.<br/><br/>
-                    H2O_NODE_EXPECTED_COUNT - [OPTIONAL] Node lookup constraint. Expected number of H2O pods to be discovered.<br/><br/>
-                    H2O_KUBERNETES_API_PORT - [OPTIONAL] Port for Kubernetes API checks and probes to listen on. Defaults to 8080.<br/><br/>
-                </p>
-                
-                <p>3. Issue "kubectl apply -f filename.yaml" to deploy H2O into Kubernetes.</p>
-                <p>4. (Optional) Adjust the YAML file to spawn more nodes or allocate more resources for the H2O cluster.</p>
-                
+                <h2>Run H<sub>2</sub>O on Kubernetes</h2>
+                <p class="callout callout--telemetry">H<sub>2</sub>O-3 can send anonymous usage telemetry to help prioritize features and platforms &mdash; never your code or data. It is off by default; to enable or learn more, see the <a href="https://docs.h2o.ai/h2o/latest-stable/h2o-docs/telemetry.html" target="_blank">Telemetry documentation</a>.</p>
+                <div class="callout callout--enterprise">
+                  <strong>NOW AVAILABLE: H<sub>2</sub>O-3 Secure FOR PRODUCTION AI/ML</strong>
+                  <p>H<sub>2</sub>O-3 OSS is designed for self-managed production and therefore places every operational responsibility on your internal teams:</p>
+                  <ul>
+                    <li>SLAs, incident response, and remediation timelines</li>
+                    <li>Commercial CVE patching &amp; long-term support</li>
+                    <li>Model lineage and audit evidence</li>
+                    <li>Supportability documentation for auditors and regulators</li>
+                  </ul>
+                  <p>Under SOC 2, ISO 27001, and ISO 42001, that operational and audit burden is your organization's exposure.</p>
+                  <p>H<sub>2</sub>O-3 Secure is the commercially supported upgrade for enterprises running audit-sensitive AI/ML in production. Keep everything you have: same code, APIs and pipelines run unchanged.</p>
+                  <p>See comparison table, which path is right for you? <a href="https://h2o.ai/h2o-3/oss-vs-secure" target="_blank">h2o.ai/h2o-3/oss-vs-secure</a></p>
+                  <p>Contact: <a href="mailto:enterprise@h2o.ai">enterprise@h2o.ai</a></p>
+                </div>
             </div>
             <div id="quickstart-other-artifacts" style="display:none">
               <p class="callout callout--telemetry" style="margin-top: 25px;">H<sub>2</sub>O-3 can send anonymous usage telemetry to help prioritize features and platforms &mdash; never your code or data. It is off by default; to enable or learn more, see the <a href="https://docs.h2o.ai/h2o/latest-stable/h2o-docs/telemetry.html" target="_blank">Telemetry documentation</a>.</p>

--- a/h2o-py/h2o/enterprise.py
+++ b/h2o-py/h2o/enterprise.py
@@ -1,10 +1,11 @@
 # -*- encoding: utf-8 -*-
 """
-H2O-3 Enterprise messaging shown by the open-source Python client.
+H2O-3 Secure messaging shown by the open-source Python client.
 
-Single source for the OSS-vs-Enterprise notice so the wording and the box style
-stay consistent across the MOJO entry points. Kept dependency-free (only ``sys``
-+ ``h2o.exceptions``) to avoid import cycles.
+Single source for the "two paths, one product" notice (H2O-3 OSS vs. H2O-3
+Secure) so the wording and the box style stay consistent across
+``h2o.init()``, ``h2o.connect()`` and the MOJO entry points. Kept dependency-free
+(only ``sys`` + ``h2o.exceptions``) to avoid import cycles.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
@@ -18,10 +19,10 @@ ENTERPRISE_EMAIL = "enterprise@h2o.ai"
 def _box(lines):
     """Render the given lines inside an ASCII frame.
 
-    Deliberately ASCII-only: box-drawing characters raise UnicodeEncodeError when stdout
-    cannot represent them (Windows with a redirected or piped stdout uses the ANSI code
-    page). In block() the write happens before the raise, so that would mask the
-    H2OValueError we actually want to surface.
+    Deliberately ASCII-only: this banner prints on every h2o.init(), and box-drawing
+    characters raise UnicodeEncodeError when stdout cannot represent them (Windows with
+    a redirected or piped stdout uses the ANSI code page). In block() the write happens
+    before the raise, so that would mask the H2OValueError we actually want to surface.
     """
     width = max(len(s) for s in lines)
     rule = u"+" + u"-" * (width + 2) + u"+"
@@ -29,28 +30,40 @@ def _box(lines):
     return u"\n".join([rule] + body + [rule])
 
 
-def block(operation):
-    """Print the Enterprise 'blocked' notice, then raise: MOJO is Enterprise-only."""
+def show_cluster_banner():
+    """Print the OSS-vs-Secure notice shown by h2o.init() / h2o.connect()."""
     sys.stdout.write(u"\n" + _box([
-        u"H2O-3 ENTERPRISE REQUIRED  -  THIS ACTION IS BLOCKED",
+        u"You are running the community edition of H2O-3 OSS.",
+        u"",
+        u"For commercial use, H2O-3 Secure is now recommended.",
+        u"This includes production support, CVE fixes, multi-node scaling,",
+        u"model artifact extraction, and more.",
+        u"See h2o.ai/h2o-3/oss-vs-secure for additional details.",
+        u"Contact " + ENTERPRISE_EMAIL + u" to upgrade.",
+    ]) + u"\n")
+    sys.stdout.flush()
+
+
+def block(operation):
+    """Print the H2O-3 Secure 'blocked' notice, then raise: MOJO is Secure-only."""
+    sys.stdout.write(u"\n" + _box([
+        u"H2O-3 SECURE REQUIRED  -  THIS ACTION IS BLOCKED",
         u"",
         operation + u" is a production capability available only in",
-        u"H2O-3 Enterprise, the commercially supported tier of H2O-3.",
+        u"H2O-3 Secure, the commercially supported tier of H2O-3.",
         u"",
-        u"You are running H2O-3 OSS: built for experimentation and",
-        u"research, not production.",
+        u"You are running self-managed H2O-3 OSS.",
         u"",
-        u"You must upgrade to H2O-3 Enterprise for:",
-        u"  - Multi-node production deployment (Hadoop, Spark, Kubernetes)",
-        u"  - Audit-ready governance (SOC 2, ISO 27001, ISO 42001)",
-        u"  - Prioritized CVE patching and long-term security maintenance",
+        u"You must upgrade to H2O-3 Secure for:",
+        u"  - Hadoop and Kubernetes enterprise packages",
+        u"  - Audit-supporting capabilities (SOC 2, ISO 27001, ISO 42001)",
+        u"  - Commercial CVE patching & long-term support",
         u"  - Premium support with SLAs",
         u"",
-        u"H2O-3 Enterprise is a drop-in replacement for H2O-3 OSS -",
-        u"your existing code, APIs, and pipelines run unchanged.",
+        u"If you need MOJO, we provide a free license for non-commercial",
+        u"use. Request it at h2o.ai/h2o-3/oss-vs-secure",
         u"",
-        u"Learn more: h2o.ai/h2o-3/oss-vs-enterprise",
         u"Contact:    " + ENTERPRISE_EMAIL,
     ]) + u"\n")
     sys.stdout.flush()
-    raise H2OValueError(operation + " requires H2O-3 Enterprise. Contact " + ENTERPRISE_EMAIL)
+    raise H2OValueError(operation + " requires H2O-3 Secure. Contact " + ENTERPRISE_EMAIL)

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -123,6 +123,7 @@ def connect(server=None, url=None, ip=None, port=None,
                                      verbose=verbose, strict_version_check=svc)
         if verbose:
             h2oconn.cluster.show_status()
+            _enterprise.show_cluster_banner()
     # Fire-and-forget telemetry; never blocks, never raises. h2o.connect()
     # by definition attaches to an existing cluster (no local JVM spawn),
     # so we always emit `cluster_connect`. Honors the DO_NOT_TRACK env var
@@ -349,6 +350,7 @@ def init(url=None, ip=None, port=None, name=None, https=None, cacert=None, insec
     h2oconn.cluster.timezone = "UTC"
     if verbose:
         h2oconn.cluster.show_status()
+        _enterprise.show_cluster_banner()
     # Fire-and-forget telemetry; never blocks, never raises. Honors the
     # DO_NOT_TRACK env var internally.
     # Pick the event type based on whether we actually spawned a local JVM:

--- a/h2o-py/tests/testdir_misc/pyunit_enterprise_mojo_block.py
+++ b/h2o-py/tests/testdir_misc/pyunit_enterprise_mojo_block.py
@@ -3,7 +3,7 @@ sys.path.insert(1, "../../")
 from h2o import enterprise as e
 from h2o.exceptions import H2OValueError
 
-# The H2O-3 Enterprise paywall (marketing demo) blocks getting a model *out* of
+# The H2O-3 Secure paywall (marketing demo) blocks getting a model *out* of
 # OSS: MOJO download/export (model.download_mojo / model.save_mojo) and POJO
 # download (model.download_pojo). MOJO import/upload are intentionally left
 # unblocked. No cluster needed: block is the first statement of the blocked entry
@@ -19,13 +19,13 @@ def enterprise_block_raises():
         except H2OValueError as ex:
             msg = str(ex)
             assert op in msg, msg
-            assert "requires H2O-3 Enterprise" in msg, msg
+            assert "requires H2O-3 Secure" in msg, msg
             assert "enterprise@h2o.ai" in msg, msg
     print("OK enterprise_block_raises")
 
 
 if __name__ == "__main__":
     enterprise_block_raises()
-    print("\nALL ENTERPRISE MOJO BLOCK TESTS PASSED")
+    print("\nALL SECURE MOJO BLOCK TESTS PASSED")
 else:
     enterprise_block_raises()

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -310,6 +310,8 @@ h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, start
   }
   .attach.new.session(conn)
 
+  .h2o.enterprise.show_cluster_banner()
+
   # Fire-and-forget telemetry; never blocks h2o.init(), never raises.
   # Honors the DO_NOT_TRACK env var internally.
   # Pick init vs cluster_connect based on whether we actually spawned a JVM.

--- a/h2o-r/h2o-package/R/enterprise.R
+++ b/h2o-r/h2o-package/R/enterprise.R
@@ -1,9 +1,10 @@
-# H2O-3 Enterprise messaging shown by the open-source R client.
+# H2O-3 Secure messaging shown by the open-source R client.
 #
-# Mirrors h2o-py/h2o/enterprise.py: a single place for the "blocked" notice so
-# the wording and box style stay consistent across the MOJO entry points. This
-# is the friendly client-side message; the actual paywall is enforced
-# server-side (water.EnterpriseGate) so the REST API cannot be bypassed.
+# Mirrors h2o-py/h2o/enterprise.py: a single place for the OSS-vs-Secure and
+# "blocked" notices so the wording and box style stay consistent across the
+# cluster banner and the MOJO entry points. These are the friendly client-side
+# messages; the actual paywall is enforced server-side (water.EnterpriseGate)
+# so the REST API cannot be bypassed.
 
 .h2o.enterprise.email <- "enterprise@h2o.ai"
 
@@ -20,30 +21,42 @@
   paste(c(rule, body, rule), collapse = "\n")
 }
 
-# Print the Enterprise "blocked" notice, then stop(): MOJO is Enterprise-only.
+# Print the OSS-vs-Secure notice shown by h2o.init() / h2o.connect().
+.h2o.enterprise.show_cluster_banner <- function() {
+  msg <- .h2o.enterprise.box(c(
+    "You are running the community edition of H2O-3 OSS.",
+    "",
+    "For commercial use, H2O-3 Secure is now recommended.",
+    "This includes production support, CVE fixes, multi-node scaling,",
+    "model artifact extraction, and more.",
+    "See h2o.ai/h2o-3/oss-vs-secure for additional details.",
+    paste0("Contact ", .h2o.enterprise.email, " to upgrade.")
+  ))
+  cat("\n", msg, "\n\n", sep = "")
+}
+
+# Print the H2O-3 Secure "blocked" notice, then stop(): MOJO is Secure-only.
 .h2o.enterprise.block <- function(operation) {
   msg <- .h2o.enterprise.box(c(
-    "H2O-3 ENTERPRISE REQUIRED  -  THIS ACTION IS BLOCKED",
+    "H2O-3 SECURE REQUIRED  -  THIS ACTION IS BLOCKED",
     "",
     paste0(operation, " is a production capability available only in"),
-    "H2O-3 Enterprise, the commercially supported tier of H2O-3.",
+    "H2O-3 Secure, the commercially supported tier of H2O-3.",
     "",
-    "You are running H2O-3 OSS: built for experimentation and",
-    "research, not production.",
+    "You are running self-managed H2O-3 OSS.",
     "",
-    "You must upgrade to H2O-3 Enterprise for:",
-    "  - Multi-node production deployment (Hadoop, Spark, Kubernetes)",
-    "  - Audit-ready governance (SOC 2, ISO 27001, ISO 42001)",
-    "  - Prioritized CVE patching and long-term security maintenance",
+    "You must upgrade to H2O-3 Secure for:",
+    "  - Hadoop and Kubernetes enterprise packages",
+    "  - Audit-supporting capabilities (SOC 2, ISO 27001, ISO 42001)",
+    "  - Commercial CVE patching & long-term support",
     "  - Premium support with SLAs",
     "",
-    "H2O-3 Enterprise is a drop-in replacement for H2O-3 OSS -",
-    "your existing code, APIs, and pipelines run unchanged.",
+    "If you need MOJO, we provide a free license for non-commercial",
+    "use. Request it at h2o.ai/h2o-3/oss-vs-secure",
     "",
-    "Learn more: h2o.ai/h2o-3/oss-vs-enterprise",
     paste0("Contact:    ", .h2o.enterprise.email)
   ))
   message("\n", msg, "\n")
-  stop(paste0(operation, " requires H2O-3 Enterprise. Contact ", .h2o.enterprise.email),
+  stop(paste0(operation, " requires H2O-3 Secure. Contact ", .h2o.enterprise.email),
        call. = FALSE)
 }

--- a/h2o-r/tests/testdir_misc/runit_enterprise_mojo_block.R
+++ b/h2o-r/tests/testdir_misc/runit_enterprise_mojo_block.R
@@ -3,7 +3,7 @@ setwd(normalizePath(dirname(
 )))
 source("../../scripts/h2o-r-test-setup.R")
 
-# The H2O-3 Enterprise paywall (marketing demo) blocks getting a model *out* of
+# The H2O-3 Secure paywall (marketing demo) blocks getting a model *out* of
 # OSS: MOJO download/export (h2o.download_mojo / h2o.save_mojo) and POJO download
 # (h2o.download_pojo). MOJO import/upload are intentionally left unblocked. No
 # cluster needed: the block is the first statement of the blocked functions, so
@@ -16,7 +16,7 @@ test.enterprise_mojo_block <- function() {
     msg <- tryCatch({ force(expr); NULL }, error = function(err) conditionMessage(err))
     expect_false(is.null(msg))                              # it must raise
     expect_true(grepl(op_text, msg, fixed = TRUE))          # names the operation
-    expect_true(grepl("requires H2O-3 Enterprise", msg, fixed = TRUE))
+    expect_true(grepl("requires H2O-3 Secure", msg, fixed = TRUE))
     expect_true(grepl("enterprise@h2o.ai", msg, fixed = TRUE))
   }
 
@@ -25,5 +25,5 @@ test.enterprise_mojo_block <- function() {
   expect_blocked(h2o.download_pojo("dummy_model"), "POJO download")
 }
 
-doTest("Enterprise: MOJO export/import/upload blocked in the OSS R client",
+doTest("Secure: MOJO export/import/upload blocked in the OSS R client",
        test.enterprise_mojo_block)


### PR DESCRIPTION
Reinstates the in-product messaging for #16909, reverted in 53c10d1a49, rebranded from H2O-3 Enterprise to H2O-3 Secure with the new copy.

- Download page callout on the Download, Hadoop and Kubernetes tabs. The Hadoop and Kubernetes download instructions stay removed, as before.
- JVM startup banner plus the `h2o.init()` / `h2o.connect()` notices in the Python and R clients.
- GH-16910 MOJO/POJO block message updated in the Java, Python and R paths, including the new non-commercial MOJO licence line.
- `LEARN_MORE` now points at `h2o.ai/h2o-3/oss-vs-secure`.

Class, function and CSS names are deliberately unchanged - only user-visible strings move. Two things worth knowing: the messages stay ASCII (the em-dash in the source copy became `-`) because `R CMD check` rejects non-ASCII in R code and the box prints to consoles that cannot encode it; and the `.rst` docs are out of scope here, landing separately.