### PR TITLE
GH-16906 - Restore the 3.46.0.12 release notes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,7 +2,7 @@
 
 ## H2O
 
-### 3.46.0.12 - 8/5/2026
+### 3.46.0.12 - 8/12/2026
 
 Download at: <a href='http://h2o-release.s3.amazonaws.com/h2o/rel-3.46.0/12/index.html'>http://h2o-release.s3.amazonaws.com/h2o/rel-3.46.0/12/index.html</a>
 

--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,20 @@
 
 ## H2O
 
+### 3.46.0.12 - 8/5/2026
+
+Download at: <a href='http://h2o-release.s3.amazonaws.com/h2o/rel-3.46.0/12/index.html'>http://h2o-release.s3.amazonaws.com/h2o/rel-3.46.0/12/index.html</a>
+
+#### New Feature
+- [[#16875]](https://github.com/h2oai/h2o-3/issues/16875) – Added opt-in anonymous usage telemetry to the Python, R, and JVM clients.
+- [[#16909]](https://github.com/h2oai/h2o-3/issues/16909) – Added H2O-3 OSS vs Secure in-product messaging.
+
+#### Task
+- [[#16910]](https://github.com/h2oai/h2o-3/issues/16910) – Blocked MOJO and POJO artifact extraction in H2O-3 OSS; it is now an H2O-3 Secure feature.
+
+#### Docs
+- [[#16903]](https://github.com/h2oai/h2o-3/issues/16903) – Noted H2O-3 Secure features (Hadoop, Kubernetes, Sparkling Water, and MOJO deployment) in the OSS documentation.
+
 ### 3.46.0.11 - 5/21/2026
 
 Download at: <a href='http://h2o-release.s3.amazonaws.com/h2o/rel-3.46.0/11/index.html'>http://h2o-release.s3.amazonaws.com/h2o/rel-3.46.0/11/index.html</a>

--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Download at: <a href='http://h2o-release.s3.amazonaws.com/h2o/rel-3.46.0/12/inde
 
 #### Docs
 - [[#16903]](https://github.com/h2oai/h2o-3/issues/16903) – Noted H2O-3 Secure features (Hadoop, Kubernetes, Sparkling Water, and MOJO deployment) in the OSS documentation.
+- [[#16932]](https://github.com/h2oai/h2o-3/issues/16932) – Marked H2O Flow as deprecated in the documentation.
 
 ### 3.46.0.11 - 5/21/2026
 


### PR DESCRIPTION
Reinstates the release notes for #16906, reverted in eab2243b70, with H2O-3 Enterprise renamed to H2O-3 Secure.

- Restores the 3.46.0.12 entry in `Changes.md`, dated 8/12/2026.
- `SECURITY.md` is untouched, so the Known Vulnerabilities table stays removed.

One item to confirm before merge: the #16903 line describes the OSS docs notes that are currently reverted and landing in a separate PR.
