### PR TITLE
GH-16930: Note H2O-3 Secure capabilities in the OSS docs

### DIFF
--- a/h2o-docs/src/product/cloud-integration/kubernetes.rst
+++ b/h2o-docs/src/product/cloud-integration/kubernetes.rst
@@ -1,6 +1,10 @@
 Using H2O with Kubernetes
 =========================
 
+.. note::
+
+   Kubernetes packages are part of H2O-3 Secure, the commercially supported tier of H2O-3. Contact enterprise@h2o.ai.
+
 H2O Software Stack
 ------------------
 

--- a/h2o-docs/src/product/faq/sparkling-water.rst
+++ b/h2o-docs/src/product/faq/sparkling-water.rst
@@ -1,6 +1,10 @@
 Sparkling Water
 ---------------
 
+.. note::
+
+   Sparkling Water is part of H2O-3 Secure, the commercially supported tier of H2O-3. Contact enterprise@h2o.ai.
+
 **Note**: This topic is deprecated and will be removed in a later release. Refer to the `Sparkling Water User Guide <http://docs.h2o.ai/#sparkling-water>`__ for Sparkling Water FAQs. 
 
 What is Sparkling Water?

--- a/h2o-docs/src/product/flow.rst
+++ b/h2o-docs/src/product/flow.rst
@@ -1108,7 +1108,7 @@ The following additional functions are available when viewing a model:
 
 .. note::
 
-   **Download POJO** and **Download Model Deployment Package (MOJO)** require H2O-3 Secure, the commercially supported tier of H2O-3. H2O-3 OSS blocks both at the server, so Flow returns an error. **Export** and **Download Gen Model** still work. See `Productionizing H2O <productionizing.html>`__.
+   **Download POJO** and **Download Model Deployment Package (MOJO)** require H2O-3 Secure, the commercially supported tier of H2O-3. H2O-3 OSS blocks both at the server, so Flow returns an error. See `Productionizing H2O <productionizing.html>`__.
 
 - **Refresh**: Refreshes the model.
 - **Predict**: Use this model to make predictions.  

--- a/h2o-docs/src/product/flow.rst
+++ b/h2o-docs/src/product/flow.rst
@@ -3,10 +3,6 @@
 Using Flow - H2O's Web UI
 =========================
 
-.. warning::
-
-   H2O Flow is deprecated and will be removed in a future release. Use the Python or R client instead. See `H2O-3 clients <h2o-client.html>`__.
-
 About
 ------
 

--- a/h2o-docs/src/product/flow.rst
+++ b/h2o-docs/src/product/flow.rst
@@ -1106,6 +1106,10 @@ Click on a model name to view details about the model. The information that disp
 
 The following additional functions are available when viewing a model:
 
+.. note::
+
+   **Download POJO** and **Download Model Deployment Package (MOJO)** require H2O-3 Secure, the commercially supported tier of H2O-3. H2O-3 OSS blocks both at the server, so Flow returns an error. **Export** and **Download Gen Model** still work. See `Productionizing H2O <productionizing.html>`__.
+
 - **Refresh**: Refreshes the model.
 - **Predict**: Use this model to make predictions.  
 - **Download POJO**: Generates a Plain Old Java Object (POJO) that can use the model outside of H2O. Note that a POJO can be run in standalone mode or it can be integrated into a platform, such as `Hadoop's Storm <https://github.com/h2oai/h2o-tutorials/tree/master/tutorials/streaming/storm>`__. To make the POJO work in your Java application, you will also need the ``h2o-genmodel.jar`` file (available via the **Download Generated Model** button, from the **Admin** menu, or in ``h2o-3/h2o-genmodel/build/libs/h2o-genmodel.jar``). Note that POJOs are are not supported for XGBoost models.

--- a/h2o-docs/src/product/flow.rst
+++ b/h2o-docs/src/product/flow.rst
@@ -3,6 +3,10 @@
 Using Flow - H2O's Web UI
 =========================
 
+.. warning::
+
+   H2O Flow is deprecated and will be removed in a future release. Use the Python or R client instead. See `H2O-3 clients <h2o-client.html>`__.
+
 About
 ------
 

--- a/h2o-docs/src/product/getting-started/hadoop-users.rst
+++ b/h2o-docs/src/product/getting-started/hadoop-users.rst
@@ -1,6 +1,10 @@
 Hadoop users
 ============
 
+.. note::
+
+   Hadoop packages are part of H2O-3 Secure, the commercially supported tier of H2O-3. Contact enterprise@h2o.ai.
+
 This section describes how to use H2O-3 on Hadoop.
 
 Supported Versions

--- a/h2o-docs/src/product/getting-started/kubernetes-users.rst
+++ b/h2o-docs/src/product/getting-started/kubernetes-users.rst
@@ -1,6 +1,10 @@
 Kubernetes users
 ================
 
+.. note::
+
+   Kubernetes packages are part of H2O-3 Secure, the commercially supported tier of H2O-3. Contact enterprise@h2o.ai.
+
 H2O-3 nodes must be treated as stateful by the Kubernetes environment because H2O-3 is a stateful application. H2O-3 nodes are, therefore, spawned together and deallocated together as a single unit. Subsequently, Kubernetes tooling for stateless applications is not applicable to H2O-3. In Kubernetes, a set of pods sharing a common state is named a `StatefulSet <https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/>`__.
 
 H2O-3 pods deployed on a Kubernetes cluster require a `headless service <https://kubernetes.io/docs/concepts/services-networking/service/#headless-services>`__ for H2O-3 node discovery. The headless service returns a set of addresses to all the underlying pods instead of load-balancing incoming requests to the underlying H2O-3 pods.

--- a/h2o-docs/src/product/h2o-client.rst
+++ b/h2o-docs/src/product/h2o-client.rst
@@ -6,10 +6,6 @@ These clients allow you to connect to and interact with H2O-3.
 H2O Flow
 --------
 
-.. warning::
-
-   H2O Flow is deprecated and will be removed in a future release. Use the R or Python client instead.
-
 H2O Flow is a Web based (GUI) user interface. It lets you interactively run your H2O-3 machine learning workflows and iteratively improve them. H2O Flow combines code execution, text, mathematics, plots, and rich media in a single document. See the `documentation for H2O Flow <flow.html>`__.
 
 R client

--- a/h2o-docs/src/product/h2o-client.rst
+++ b/h2o-docs/src/product/h2o-client.rst
@@ -6,6 +6,10 @@ These clients allow you to connect to and interact with H2O-3.
 H2O Flow
 --------
 
+.. warning::
+
+   H2O Flow is deprecated and will be removed in a future release. Use the R or Python client instead.
+
 H2O Flow is a Web based (GUI) user interface. It lets you interactively run your H2O-3 machine learning workflows and iteratively improve them. H2O Flow combines code execution, text, mathematics, plots, and rich media in a single document. See the `documentation for H2O Flow <flow.html>`__.
 
 R client

--- a/h2o-docs/src/product/index.rst
+++ b/h2o-docs/src/product/index.rst
@@ -10,7 +10,7 @@ Welcome to the H2O-3 documentation site! Select a learning path from the sidebar
 
 .. note::
 
-   This documentation covers H2O-3 OSS, the community edition. H2O-3 Secure is the commercially supported tier. It adds Hadoop and Kubernetes packages, model artifact extraction (MOJO and POJO), commercial CVE patching and long-term support, audit-supporting capabilities (SOC 2, ISO 27001, ISO 42001), and premium support with SLAs. Your code, APIs, and pipelines run unchanged.
+   This documentation covers H2O-3 OSS, the community edition. H2O-3 Secure is the commercially supported tier. It adds Hadoop and Kubernetes packages, model artifact extraction (MOJO and POJO), commercial CVE patching and long-term support, audit-supporting capabilities (SOC 2, ISO 27001, ISO 42001), and premium support with SLAs.
 
    For a comparison of the two, contact enterprise@h2o.ai.
 

--- a/h2o-docs/src/product/index.rst
+++ b/h2o-docs/src/product/index.rst
@@ -8,6 +8,12 @@ Overview
 
 Welcome to the H2O-3 documentation site! Select a learning path from the sidebar or browse through the full content outline below.
 
+.. note::
+
+   This documentation covers H2O-3 OSS, the community edition. H2O-3 Secure is the commercially supported tier. It adds Hadoop and Kubernetes packages, model artifact extraction (MOJO and POJO), commercial CVE patching and long-term support, audit-supporting capabilities (SOC 2, ISO 27001, ISO 42001), and premium support with SLAs. Your code, APIs, and pipelines run unchanged.
+
+   For a comparison of the two, contact enterprise@h2o.ai.
+
 We're excited you're interesting in learning more about H2O-3. If you have questions or ideas to share, please post them to the H2O community site on `Stack Overflow <http://stackoverflow.com/questions/tagged/h2o>`__.
 
 Additional resources

--- a/h2o-docs/src/product/mojo-capabilities.rst
+++ b/h2o-docs/src/product/mojo-capabilities.rst
@@ -3,6 +3,10 @@
 MOJO Capabilities
 -----------------
 
+.. note::
+
+   Downloading a model as a MOJO requires H2O-3 Secure. An H2O-3 OSS cluster blocks MOJO export, though binary model export stays available and a free MOJO license covers non-commercial use. See `Productionizing H2O <productionizing.html>`__.
+
 This section describes the basics of working with the MOJO model in H2O-3.
 
 About H2O Generated MOJO Models

--- a/h2o-docs/src/product/productionizing.rst
+++ b/h2o-docs/src/product/productionizing.rst
@@ -3,6 +3,17 @@
 Productionizing H2O
 ===================
 
+.. note::
+
+   Downloading a model as a MOJO or a POJO requires H2O-3 Secure, the commercially supported tier of H2O-3. An H2O-3 OSS cluster blocks both, including the API endpoints that produce them, so it cannot generate a deployable scoring artifact.
+
+   Two paths remain open in H2O-3 OSS:
+
+   - **Binary model export** works as usual. Save or download the model, then move it to an H2O-3 Secure cluster and produce the MOJO or POJO there. This is the intended upgrade path.
+   - **A free MOJO license** is available for non-commercial use. Request it from enterprise@h2o.ai.
+
+   H2O-3 Secure also covers Hadoop and Kubernetes packages, commercial CVE patching and long-term support, audit-supporting capabilities (SOC 2, ISO 27001, ISO 42001), and premium support with SLAs. Contact enterprise@h2o.ai.
+
 .. _about-pojo-mojo:
 
 About POJOs and MOJOs

--- a/h2o-docs/src/product/save-and-load-model.rst
+++ b/h2o-docs/src/product/save-and-load-model.rst
@@ -98,7 +98,7 @@ MOJO Models
 
 .. note::
 
-   Saving or downloading a MOJO requires H2O-3 Secure, the commercially supported tier of H2O-3. H2O-3 OSS blocks ``h2o.save_mojo()``, ``h2o.download_mojo()``, and ``h2o.download_pojo()``. A free MOJO license also covers non-commercial use. Contact enterprise@h2o.ai.
+   Saving or downloading a MOJO requires H2O-3 Secure, the commercially supported tier of H2O-3. H2O-3 OSS blocks ``h2o.save_mojo()``, ``h2o.download_mojo()``, and ``h2o.download_pojo()``. A free MOJO license covers non-commercial use. Contact enterprise@h2o.ai.
 
 Introduction
 ~~~~~~~~~~~~

--- a/h2o-docs/src/product/save-and-load-model.rst
+++ b/h2o-docs/src/product/save-and-load-model.rst
@@ -98,9 +98,7 @@ MOJO Models
 
 .. note::
 
-   Saving or downloading a MOJO requires H2O-3 Secure, the commercially supported tier of H2O-3. H2O-3 OSS blocks ``h2o.save_mojo()``, ``h2o.download_mojo()``, and ``h2o.download_pojo()``.
-
-   Importing and uploading a MOJO still work, as does everything in the preceding Binary Models section. Saving a binary model and moving it to an H2O-3 Secure cluster is the intended path to a MOJO. A free MOJO license also covers non-commercial use. Contact enterprise@h2o.ai.
+   Saving or downloading a MOJO requires H2O-3 Secure, the commercially supported tier of H2O-3. H2O-3 OSS blocks ``h2o.save_mojo()``, ``h2o.download_mojo()``, and ``h2o.download_pojo()``. A free MOJO license also covers non-commercial use. Contact enterprise@h2o.ai.
 
 Introduction
 ~~~~~~~~~~~~

--- a/h2o-docs/src/product/save-and-load-model.rst
+++ b/h2o-docs/src/product/save-and-load-model.rst
@@ -96,6 +96,12 @@ The steps for saving and loading models in Flow are described in the **Using Flo
 MOJO Models
 -----------
 
+.. note::
+
+   Saving or downloading a MOJO requires H2O-3 Secure, the commercially supported tier of H2O-3. H2O-3 OSS blocks ``h2o.save_mojo()``, ``h2o.download_mojo()``, and ``h2o.download_pojo()``.
+
+   Importing and uploading a MOJO still work, as does everything in the preceding Binary Models section. Saving a binary model and moving it to an H2O-3 Secure cluster is the intended path to a MOJO. A free MOJO license also covers non-commercial use. Contact enterprise@h2o.ai.
+
 Introduction
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
Re-adds the H2O-3 Secure notes to the OSS docs, matching what `EnterpriseGate` blocks. Replaces #16904, which #16927 reverted.


Closes #16930