### PR TITLE
GH-16932: Mark H2O Flow as deprecated in the docs

### DIFF
--- a/h2o-docs/src/product/flow.rst
+++ b/h2o-docs/src/product/flow.rst
@@ -3,6 +3,10 @@
 Using Flow - H2O's Web UI
 =========================
 
+.. warning::
+
+   H2O Flow is deprecated and will be removed in a future release. Use the Python or R client instead. See `H2O-3 clients <h2o-client.html>`__.
+
 About
 ------
 

--- a/h2o-docs/src/product/h2o-client.rst
+++ b/h2o-docs/src/product/h2o-client.rst
@@ -6,6 +6,10 @@ These clients allow you to connect to and interact with H2O-3.
 H2O Flow
 --------
 
+.. warning::
+
+   H2O Flow is deprecated and will be removed in a future release. Use the R or Python client instead.
+
 H2O Flow is a Web based (GUI) user interface. It lets you interactively run your H2O-3 machine learning workflows and iteratively improve them. H2O Flow combines code execution, text, mathematics, plots, and rich media in a single document. See the `documentation for H2O Flow <flow.html>`__.
 
 R client


### PR DESCRIPTION
Closes #16932

- Adds a deprecation warning to the top of the Flow docs page and to the Flow section of the clients page.
- Points users to the Python and R clients as the supported path.