### PR TITLE
GH-16930: Route free MOJO license requests to enterprise@h2o.ai

### DIFF
--- a/h2o-core/src/main/java/water/EnterpriseGate.java
+++ b/h2o-core/src/main/java/water/EnterpriseGate.java
@@ -104,7 +104,7 @@ public class EnterpriseGate {
         "You must upgrade to H2O-3 Secure for Hadoop and Kubernetes enterprise packages, " +
         "audit-supporting capabilities (SOC 2, ISO 27001, ISO 42001), commercial CVE patching " +
         "and long-term support, and premium support with SLAs. If you need MOJO, we provide a " +
-        "free license for non-commercial use - request it at " + LEARN_MORE + ". " +
-        "Contact: " + ENTERPRISE_EMAIL);
+        "free license for non-commercial use. See " + LEARN_MORE + " to compare the two tiers. " +
+        "Request a license or upgrade at " + ENTERPRISE_EMAIL);
   }
 }

--- a/h2o-py/h2o/enterprise.py
+++ b/h2o-py/h2o/enterprise.py
@@ -61,9 +61,9 @@ def block(operation):
         u"  - Premium support with SLAs",
         u"",
         u"If you need MOJO, we provide a free license for non-commercial",
-        u"use. Request it at h2o.ai/h2o-3/oss-vs-secure",
+        u"use. See h2o.ai/h2o-3/oss-vs-secure to compare the two tiers.",
         u"",
-        u"Contact:    " + ENTERPRISE_EMAIL,
+        u"Request a license or upgrade:  " + ENTERPRISE_EMAIL,
     ]) + u"\n")
     sys.stdout.flush()
     raise H2OValueError(operation + " requires H2O-3 Secure. Contact " + ENTERPRISE_EMAIL)

--- a/h2o-r/h2o-package/R/enterprise.R
+++ b/h2o-r/h2o-package/R/enterprise.R
@@ -52,9 +52,9 @@
     "  - Premium support with SLAs",
     "",
     "If you need MOJO, we provide a free license for non-commercial",
-    "use. Request it at h2o.ai/h2o-3/oss-vs-secure",
+    "use. See h2o.ai/h2o-3/oss-vs-secure to compare the two tiers.",
     "",
-    paste0("Contact:    ", .h2o.enterprise.email)
+    paste0("Request a license or upgrade:  ", .h2o.enterprise.email)
   ))
   message("\n", msg, "\n")
   stop(paste0(operation, " requires H2O-3 Secure. Contact ", .h2o.enterprise.email),


### PR DESCRIPTION
Relates to #16930

The blocked-capability notice told users to request the free non-commercial MOJO license at `h2o.ai/h2o-3/oss-vs-secure`, while the docs point them at `enterprise@h2o.ai`. Requests come in by email, so the notice now says so and keeps the URL as the tier comparison.

- Updated in all three surfaces: `EnterpriseGate.block()`, the Python client notice, and the R client notice.