### PR TITLE
GH-7836: Round numeric leaderboard metrics to 5 decimal places in explain()

### DIFF
--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -3092,6 +3092,13 @@ def _get_leaderboard(
     leaderboard = models if isinstance(models, h2o.H2OFrame) else h2o.make_leaderboard(models, frame,
                                                                                        extra_columns="ALL" if frame is not None else None)
     leaderboard = leaderboard.head(rows=min(leaderboard.nrow, top_n))
+
+    # Round numeric metric columns to 5 decimal places for cleaner display
+    # (addresses visual improvement sub-task from GH-7836)
+    for col, col_type in leaderboard.types.items():
+        if col_type in ("real", "double", "float"):
+            leaderboard[col] = leaderboard[col].round(5)
+
     if row_index is not None:
         model_ids = [m[0] for m in
                      leaderboard["model_id"].as_data_frame(use_pandas=False, header=False)]
@@ -3740,5 +3747,3 @@ def disparate_analysis(models, frame, protected_columns, reference, favorable_cl
         additional_columns["p.value_median"].append(np.median(pvalue))
         additional_columns["p.value_max"].append(np.max(pvalue))
     return leaderboard.cbind(h2o.H2OFrame(additional_columns))
-
-


### PR DESCRIPTION
## Summary
This PR addresses a visual improvement sub-task from #7836: the leaderboard printed by `h2o.explain()` now rounds numeric metric columns to 5 decimal places.

## Before vs After
**Before:** `0.82345678901234` (cluttered, hard to scan)
**After:** `0.82346` (clean, readable)

## Changes
- Added rounding logic in `_get_leaderboard()` inside `h2o-py/h2o/explanation/_explain.py`
- Only affects `real`/`double`/`float` columns; `model_id`, `algo`, and integer columns are untouched
- Works for both `explain()` and `explain_row()` since both use `_get_leaderboard()`

## Testing
- Logic verified for correct column type filtering
- Full integration test relies on existing h2o-py test suite / CI

Relates to #7836