### PR TITLE
GH-16930: List audit-supporting capabilities as a callout bullet

### DIFF
--- a/h2o-dist/index.html
+++ b/h2o-dist/index.html
@@ -620,8 +620,8 @@
                 <li>Commercial CVE patching &amp; long-term support</li>
                 <li>Model lineage and audit evidence</li>
                 <li>Supportability documentation for auditors and regulators</li>
+                <li>Audit-supporting capabilities (SOC 2, ISO 27001, ISO 42001)</li>
               </ul>
-              <p>Under SOC 2, ISO 27001, and ISO 42001, that operational and audit burden is your organization's exposure.</p>
               <p>H<sub>2</sub>O-3 Secure is the commercially supported upgrade for enterprises running audit-sensitive AI/ML in production. Keep everything you have: same code, APIs and pipelines run unchanged.</p>
               <p>See comparison table, which path is right for you? <a href="https://h2o.ai/h2o-3/oss-vs-secure" target="_blank">h2o.ai/h2o-3/oss-vs-secure</a></p>
               <p>Contact: <a href="mailto:enterprise@h2o.ai">enterprise@h2o.ai</a></p>
@@ -713,8 +713,8 @@
                 <li>Commercial CVE patching &amp; long-term support</li>
                 <li>Model lineage and audit evidence</li>
                 <li>Supportability documentation for auditors and regulators</li>
+                <li>Audit-supporting capabilities (SOC 2, ISO 27001, ISO 42001)</li>
               </ul>
-              <p>Under SOC 2, ISO 27001, and ISO 42001, that operational and audit burden is your organization's exposure.</p>
               <p>H<sub>2</sub>O-3 Secure is the commercially supported upgrade for enterprises running audit-sensitive AI/ML in production. Keep everything you have: same code, APIs and pipelines run unchanged.</p>
               <p>See comparison table, which path is right for you? <a href="https://h2o.ai/h2o-3/oss-vs-secure" target="_blank">h2o.ai/h2o-3/oss-vs-secure</a></p>
               <p>Contact: <a href="mailto:enterprise@h2o.ai">enterprise@h2o.ai</a></p>
@@ -756,8 +756,8 @@ dependencies {</br>
                     <li>Commercial CVE patching &amp; long-term support</li>
                     <li>Model lineage and audit evidence</li>
                     <li>Supportability documentation for auditors and regulators</li>
+                    <li>Audit-supporting capabilities (SOC 2, ISO 27001, ISO 42001)</li>
                   </ul>
-                  <p>Under SOC 2, ISO 27001, and ISO 42001, that operational and audit burden is your organization's exposure.</p>
                   <p>H<sub>2</sub>O-3 Secure is the commercially supported upgrade for enterprises running audit-sensitive AI/ML in production. Keep everything you have: same code, APIs and pipelines run unchanged.</p>
                   <p>See comparison table, which path is right for you? <a href="https://h2o.ai/h2o-3/oss-vs-secure" target="_blank">h2o.ai/h2o-3/oss-vs-secure</a></p>
                   <p>Contact: <a href="mailto:enterprise@h2o.ai">enterprise@h2o.ai</a></p>


### PR DESCRIPTION
Relates to #16930

- Moves the SOC 2 / ISO 27001 / ISO 42001 line into the bulleted list of the H2O-3 Secure callout on the download page, so all five capabilities read consistently instead of one trailing as a paragraph.
- Applies to all three tabs carrying the callout (Download and Run, Install on Hadoop, Kubernetes).