### PR TITLE
GH-16939: Route Gradle dependency resolution through the internal Nexus mirror

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,14 +8,9 @@ buildscript {
                     || System.getenv("CI") != null
                     || (rootProject.hasProperty("doCI") && rootProject.doCI == "true"))
 
-        // Ordered first so every artifact is cached in our mirror; it rejects anonymous reads,
-        // so without credentials it is skipped rather than failing every resolution.
-        // -P is read before the environment so the opt-out still works on agents exporting H2O_NEXUS_*.
         h2oNexusEnabled = Boolean.parseBoolean(
                 (rootProject.findProperty("h2oNexusEnabled") ?: System.getenv("H2O_NEXUS_ENABLED") ?: "true").toString())
         h2oNexusUrl = rootProject.findProperty("h2oNexusUrl") ?: System.getenv("H2O_NEXUS_URL") ?: ""
-        // Credentials stay behind a closure instead of becoming project properties, which are
-        // printed verbatim by `gradlew properties` and by build scans.
         h2oNexusCredentials = {
             [rootProject.findProperty("h2oNexusUsername") ?: System.getenv("H2O_NEXUS_USERNAME") ?: "",
              rootProject.findProperty("h2oNexusPassword") ?: System.getenv("H2O_NEXUS_PASSWORD") ?: ""]
@@ -69,9 +64,6 @@ apply from: 'gradle/java.gradle'
 // Print out time taken for each task so we find things that are slow.
 apply from: 'gradle/timing.gradle'
 
-// State the mirror decision explicitly. Misconfiguration is otherwise invisible: the build stays
-// green while resolving from the public repositories, so nothing is actually being mirrored.
-// Incomplete configuration warns rather than failing, so forks and public builds still work.
 if (useNexusMirror) {
     logger.lifecycle("Nexus mirror: resolving through ${h2oNexusUrl}/maven-public")
 } else if (!h2oNexusEnabled) {

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
         if (useNexusMirror) {
             maven {
                 name "NexusMirror"
-                url h2oNexusUrl
+                url "${h2oNexusUrl}/maven-public"
                 credentials {
                     username = h2oNexusCredentials()[0]
                     password = h2oNexusCredentials()[1]
@@ -73,7 +73,7 @@ apply from: 'gradle/timing.gradle'
 // green while resolving from the public repositories, so nothing is actually being mirrored.
 // Incomplete configuration warns rather than failing, so forks and public builds still work.
 if (useNexusMirror) {
-    logger.lifecycle("Nexus mirror: resolving through ${h2oNexusUrl}")
+    logger.lifecycle("Nexus mirror: resolving through ${h2oNexusUrl}/maven-public")
 } else if (!h2oNexusEnabled) {
     logger.lifecycle("Nexus mirror: disabled, resolving from the public repositories")
 } else {
@@ -273,7 +273,7 @@ subprojects {
         if (rootProject.useNexusMirror) {
             maven {
                 name "NexusMirror"
-                url rootProject.h2oNexusUrl
+                url "${rootProject.h2oNexusUrl}/maven-public"
                 credentials {
                     username = rootProject.h2oNexusCredentials()[0]
                     password = rootProject.h2oNexusCredentials()[1]

--- a/build.gradle
+++ b/build.gradle
@@ -8,9 +8,8 @@ buildscript {
                     || System.getenv("CI") != null
                     || (rootProject.hasProperty("doCI") && rootProject.doCI == "true"))
 
-        // Internal Nexus mirror - a pull-through proxy of our upstreams, declared ahead of the
-        // public repositories so artifacts get cached there. The mirror rejects anonymous reads,
-        // so it is skipped without credentials. Configuration is documented in gradle.properties.
+        // Ordered first so every artifact is cached in our mirror; it rejects anonymous reads,
+        // so without credentials it is skipped rather than failing every resolution.
         nexusUrl = System.getenv("NEXUS_URL") ?: rootProject.findProperty("nexusUrl") ?: ""
         nexusUsername = System.getenv("NEXUS_USERNAME") ?: rootProject.findProperty("nexusUsername") ?: ""
         nexusPassword = System.getenv("NEXUS_PASSWORD") ?: rootProject.findProperty("nexusPassword") ?: ""

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 
         h2oNexusEnabled = Boolean.parseBoolean(
                 (rootProject.findProperty("h2oNexusEnabled") ?: System.getenv("H2O_NEXUS_ENABLED") ?: "false").toString())
-        h2oNexusUrl = rootProject.findProperty("h2oNexusUrl") ?: System.getenv("H2O_NEXUS_URL") ?: ""
+        h2oNexusUrl = rootProject.findProperty("h2oNexusUrl") ?: ""
         h2oNexusUsername = rootProject.findProperty("h2oNexusUsername") ?: System.getenv("H2O_NEXUS_USERNAME") ?: ""
         h2oNexusPassword = rootProject.findProperty("h2oNexusPassword") ?: System.getenv("H2O_NEXUS_PASSWORD") ?: ""
         useNexusMirror = h2oNexusEnabled && h2oNexusUrl && h2oNexusUsername && h2oNexusPassword
@@ -71,11 +71,7 @@ apply from: 'gradle/timing.gradle'
 if (useNexusMirror) {
     logger.lifecycle("Nexus mirror: resolving through ${h2oNexusUrl}/maven-public")
 } else if (h2oNexusEnabled) {
-    def missing = []
-    if (!h2oNexusUrl) missing << "h2oNexusUrl (or H2O_NEXUS_URL)"
-    if (!h2oNexusUsername) missing << "h2oNexusUsername (or H2O_NEXUS_USERNAME)"
-    if (!h2oNexusPassword) missing << "h2oNexusPassword (or H2O_NEXUS_PASSWORD)"
-    logger.warn("Nexus mirror: enabled but not configured - missing ${missing.join(', ')}. " +
+    logger.warn("Nexus mirror: enabled but h2oNexusUsername/h2oNexusPassword are not set. " +
                 "Falling back to the public repositories; nothing will be cached in the mirror.")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
                     || (rootProject.hasProperty("doCI") && rootProject.doCI == "true"))
 
         h2oNexusEnabled = Boolean.parseBoolean(
-                (rootProject.findProperty("h2oNexusEnabled") ?: System.getenv("H2O_NEXUS_ENABLED") ?: "true").toString())
+                (rootProject.findProperty("h2oNexusEnabled") ?: System.getenv("H2O_NEXUS_ENABLED") ?: "false").toString())
         h2oNexusUrl = rootProject.findProperty("h2oNexusUrl") ?: System.getenv("H2O_NEXUS_URL") ?: ""
         h2oNexusUsername = rootProject.findProperty("h2oNexusUsername") ?: System.getenv("H2O_NEXUS_USERNAME") ?: ""
         h2oNexusPassword = rootProject.findProperty("h2oNexusPassword") ?: System.getenv("H2O_NEXUS_PASSWORD") ?: ""
@@ -67,11 +67,10 @@ apply from: 'gradle/java.gradle'
 // Print out time taken for each task so we find things that are slow.
 apply from: 'gradle/timing.gradle'
 
+// Silent unless the mirror was asked for - a plain build resolves from the public repositories.
 if (useNexusMirror) {
     logger.lifecycle("Nexus mirror: resolving through ${h2oNexusUrl}/maven-public")
-} else if (!h2oNexusEnabled) {
-    logger.lifecycle("Nexus mirror: disabled, resolving from the public repositories")
-} else {
+} else if (h2oNexusEnabled) {
     def missing = []
     if (!h2oNexusUrl) missing << "h2oNexusUrl (or H2O_NEXUS_URL)"
     if (!h2oNexusUsername) missing << "h2oNexusUsername (or H2O_NEXUS_USERNAME)"

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,11 @@ buildscript {
                     username = h2oNexusUsername
                     password = h2oNexusPassword
                 }
+                // Send credentials on the first request. Without this Gradle waits for a 401
+                // challenge and retries, doubling the round trips for every artifact.
+                authentication {
+                    basic(BasicAuthentication)
+                }
             }
         }
         maven { url 'https://plugins.gradle.org/m2/' }
@@ -267,6 +272,9 @@ subprojects {
                 credentials {
                     username = rootProject.h2oNexusUsername
                     password = rootProject.h2oNexusPassword
+                }
+                authentication {
+                    basic(BasicAuthentication)
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -10,20 +10,27 @@ buildscript {
 
         // Ordered first so every artifact is cached in our mirror; it rejects anonymous reads,
         // so without credentials it is skipped rather than failing every resolution.
-        nexusUrl = System.getenv("NEXUS_URL") ?: rootProject.findProperty("nexusUrl") ?: ""
-        nexusUsername = System.getenv("NEXUS_USERNAME") ?: rootProject.findProperty("nexusUsername") ?: ""
-        nexusPassword = System.getenv("NEXUS_PASSWORD") ?: rootProject.findProperty("nexusPassword") ?: ""
-        useNexusMirror = nexusUrl && nexusUrl != "NO_NEXUS" && nexusUsername && nexusPassword
+        // -P is read before the environment so the opt-out still works on agents exporting NEXUS_*.
+        h2oNexusEnabled = Boolean.parseBoolean(
+                (rootProject.findProperty("h2oNexusEnabled") ?: System.getenv("NEXUS_ENABLED") ?: "true").toString())
+        h2oNexusUrl = rootProject.findProperty("h2oNexusUrl") ?: System.getenv("NEXUS_URL") ?: ""
+        // Credentials stay behind a closure instead of becoming project properties, which are
+        // printed verbatim by `gradlew properties` and by build scans.
+        h2oNexusCredentials = {
+            [rootProject.findProperty("h2oNexusUsername") ?: System.getenv("NEXUS_USERNAME") ?: "",
+             rootProject.findProperty("h2oNexusPassword") ?: System.getenv("NEXUS_PASSWORD") ?: ""]
+        }
+        useNexusMirror = h2oNexusEnabled && h2oNexusUrl && h2oNexusCredentials().every { it }
     }
 
     repositories {
         if (useNexusMirror) {
             maven {
                 name "NexusMirror"
-                url "${nexusUrl}/maven-public"
+                url h2oNexusUrl
                 credentials {
-                    username = nexusUsername
-                    password = nexusPassword
+                    username = h2oNexusCredentials()[0]
+                    password = h2oNexusCredentials()[1]
                 }
             }
         }
@@ -61,6 +68,22 @@ apply from: 'gradle/java.gradle'
 
 // Print out time taken for each task so we find things that are slow.
 apply from: 'gradle/timing.gradle'
+
+// State the mirror decision explicitly. Misconfiguration is otherwise invisible: the build stays
+// green while resolving from the public repositories, so nothing is actually being mirrored.
+// Incomplete configuration warns rather than failing, so forks and public builds still work.
+if (useNexusMirror) {
+    logger.lifecycle("Nexus mirror: resolving through ${h2oNexusUrl}")
+} else if (!h2oNexusEnabled) {
+    logger.lifecycle("Nexus mirror: disabled, resolving from the public repositories")
+} else {
+    def missing = []
+    if (!h2oNexusUrl) missing << "h2oNexusUrl (or NEXUS_URL)"
+    if (!h2oNexusCredentials()[0]) missing << "h2oNexusUsername (or NEXUS_USERNAME)"
+    if (!h2oNexusCredentials()[1]) missing << "h2oNexusPassword (or NEXUS_PASSWORD)"
+    logger.warn("Nexus mirror: enabled but not configured - missing ${missing.join(', ')}. " +
+                "Falling back to the public repositories; nothing will be cached in the mirror.")
+}
 
 //
 // Common configuration
@@ -250,10 +273,10 @@ subprojects {
         if (rootProject.useNexusMirror) {
             maven {
                 name "NexusMirror"
-                url "${rootProject.nexusUrl}/maven-public"
+                url rootProject.h2oNexusUrl
                 credentials {
-                    username = rootProject.nexusUsername
-                    password = rootProject.nexusPassword
+                    username = rootProject.h2oNexusCredentials()[0]
+                    password = rootProject.h2oNexusCredentials()[1]
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -10,15 +10,15 @@ buildscript {
 
         // Ordered first so every artifact is cached in our mirror; it rejects anonymous reads,
         // so without credentials it is skipped rather than failing every resolution.
-        // -P is read before the environment so the opt-out still works on agents exporting NEXUS_*.
+        // -P is read before the environment so the opt-out still works on agents exporting H2O_NEXUS_*.
         h2oNexusEnabled = Boolean.parseBoolean(
-                (rootProject.findProperty("h2oNexusEnabled") ?: System.getenv("NEXUS_ENABLED") ?: "true").toString())
-        h2oNexusUrl = rootProject.findProperty("h2oNexusUrl") ?: System.getenv("NEXUS_URL") ?: ""
+                (rootProject.findProperty("h2oNexusEnabled") ?: System.getenv("H2O_NEXUS_ENABLED") ?: "true").toString())
+        h2oNexusUrl = rootProject.findProperty("h2oNexusUrl") ?: System.getenv("H2O_NEXUS_URL") ?: ""
         // Credentials stay behind a closure instead of becoming project properties, which are
         // printed verbatim by `gradlew properties` and by build scans.
         h2oNexusCredentials = {
-            [rootProject.findProperty("h2oNexusUsername") ?: System.getenv("NEXUS_USERNAME") ?: "",
-             rootProject.findProperty("h2oNexusPassword") ?: System.getenv("NEXUS_PASSWORD") ?: ""]
+            [rootProject.findProperty("h2oNexusUsername") ?: System.getenv("H2O_NEXUS_USERNAME") ?: "",
+             rootProject.findProperty("h2oNexusPassword") ?: System.getenv("H2O_NEXUS_PASSWORD") ?: ""]
         }
         useNexusMirror = h2oNexusEnabled && h2oNexusUrl && h2oNexusCredentials().every { it }
     }
@@ -78,9 +78,9 @@ if (useNexusMirror) {
     logger.lifecycle("Nexus mirror: disabled, resolving from the public repositories")
 } else {
     def missing = []
-    if (!h2oNexusUrl) missing << "h2oNexusUrl (or NEXUS_URL)"
-    if (!h2oNexusCredentials()[0]) missing << "h2oNexusUsername (or NEXUS_USERNAME)"
-    if (!h2oNexusCredentials()[1]) missing << "h2oNexusPassword (or NEXUS_PASSWORD)"
+    if (!h2oNexusUrl) missing << "h2oNexusUrl (or H2O_NEXUS_URL)"
+    if (!h2oNexusCredentials()[0]) missing << "h2oNexusUsername (or H2O_NEXUS_USERNAME)"
+    if (!h2oNexusCredentials()[1]) missing << "h2oNexusPassword (or H2O_NEXUS_PASSWORD)"
     logger.warn("Nexus mirror: enabled but not configured - missing ${missing.join(', ')}. " +
                 "Falling back to the public repositories; nothing will be cached in the mirror.")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,18 +7,29 @@ buildscript {
         isCi = (!rootProject.hasProperty("forcePublic")) && (System.getProperty("user.name").equals("jenkins")
                     || System.getenv("CI") != null
                     || (rootProject.hasProperty("doCI") && rootProject.doCI == "true"))
+
+        // Internal Nexus mirror - a pull-through proxy of our upstreams, declared ahead of the
+        // public repositories so artifacts get cached there. The mirror rejects anonymous reads,
+        // so it is skipped without credentials. Configuration is documented in gradle.properties.
+        nexusUrl = System.getenv("NEXUS_URL") ?: rootProject.findProperty("nexusUrl") ?: ""
+        nexusUsername = System.getenv("NEXUS_USERNAME") ?: rootProject.findProperty("nexusUsername") ?: ""
+        nexusPassword = System.getenv("NEXUS_PASSWORD") ?: rootProject.findProperty("nexusPassword") ?: ""
+        useNexusMirror = nexusUrl && nexusUrl != "NO_NEXUS" && nexusUsername && nexusPassword
     }
 
     repositories {
-        if (false) {
-//            maven {
-//                allowInsecureProtocol = true
-//                url "${localNexusLocation}/public"
-//            }
-        } else {
-            maven { url 'https://plugins.gradle.org/m2/' }
-            mavenCentral()
+        if (useNexusMirror) {
+            maven {
+                name "NexusMirror"
+                url "${nexusUrl}/maven-public"
+                credentials {
+                    username = nexusUsername
+                    password = nexusPassword
+                }
+            }
         }
+        maven { url 'https://plugins.gradle.org/m2/' }
+        mavenCentral()
     }
 
     //noinspection GroovyAssignabilityCheck
@@ -237,29 +248,29 @@ subprojects {
         if (project.hasProperty("enableMavenLocal")) { // useful for development
             mavenLocal()
         }
-        if (false) {
-//            maven {
-//                allowInsecureProtocol = true
-//                url "${localNexusLocation}/public"
-//            }
+        if (rootProject.useNexusMirror) {
             maven {
-                url "https://oss.sonatype.org/content/groups/staging/"
+                name "NexusMirror"
+                url "${rootProject.nexusUrl}/maven-public"
+                credentials {
+                    username = rootProject.nexusUsername
+                    password = rootProject.nexusPassword
+                }
             }
-        } else {
-            mavenCentral()
-            maven {
-                url "https://repository.cloudera.com/artifactory/cloudera-repos/"
-            }
-            maven {
-                allowInsecureProtocol = true
-                url "http://nexus-private.hortonworks.com:8081/nexus/"
-            }
-            maven {
-                url "https://repository.mapr.com/maven/"
-            }
-            maven {
-                url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/"
-            }
+        }
+        mavenCentral()
+        maven {
+            url "https://repository.cloudera.com/artifactory/cloudera-repos/"
+        }
+        maven {
+            allowInsecureProtocol = true
+            url "http://nexus-private.hortonworks.com:8081/nexus/"
+        }
+        maven {
+            url "https://repository.mapr.com/maven/"
+        }
+        maven {
+            url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/"
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,11 +11,9 @@ buildscript {
         h2oNexusEnabled = Boolean.parseBoolean(
                 (rootProject.findProperty("h2oNexusEnabled") ?: System.getenv("H2O_NEXUS_ENABLED") ?: "true").toString())
         h2oNexusUrl = rootProject.findProperty("h2oNexusUrl") ?: System.getenv("H2O_NEXUS_URL") ?: ""
-        h2oNexusCredentials = {
-            [rootProject.findProperty("h2oNexusUsername") ?: System.getenv("H2O_NEXUS_USERNAME") ?: "",
-             rootProject.findProperty("h2oNexusPassword") ?: System.getenv("H2O_NEXUS_PASSWORD") ?: ""]
-        }
-        useNexusMirror = h2oNexusEnabled && h2oNexusUrl && h2oNexusCredentials().every { it }
+        h2oNexusUsername = rootProject.findProperty("h2oNexusUsername") ?: System.getenv("H2O_NEXUS_USERNAME") ?: ""
+        h2oNexusPassword = rootProject.findProperty("h2oNexusPassword") ?: System.getenv("H2O_NEXUS_PASSWORD") ?: ""
+        useNexusMirror = h2oNexusEnabled && h2oNexusUrl && h2oNexusUsername && h2oNexusPassword
     }
 
     repositories {
@@ -24,8 +22,8 @@ buildscript {
                 name "NexusMirror"
                 url "${h2oNexusUrl}/maven-public"
                 credentials {
-                    username = h2oNexusCredentials()[0]
-                    password = h2oNexusCredentials()[1]
+                    username = h2oNexusUsername
+                    password = h2oNexusPassword
                 }
             }
         }
@@ -71,8 +69,8 @@ if (useNexusMirror) {
 } else {
     def missing = []
     if (!h2oNexusUrl) missing << "h2oNexusUrl (or H2O_NEXUS_URL)"
-    if (!h2oNexusCredentials()[0]) missing << "h2oNexusUsername (or H2O_NEXUS_USERNAME)"
-    if (!h2oNexusCredentials()[1]) missing << "h2oNexusPassword (or H2O_NEXUS_PASSWORD)"
+    if (!h2oNexusUsername) missing << "h2oNexusUsername (or H2O_NEXUS_USERNAME)"
+    if (!h2oNexusPassword) missing << "h2oNexusPassword (or H2O_NEXUS_PASSWORD)"
     logger.warn("Nexus mirror: enabled but not configured - missing ${missing.join(', ')}. " +
                 "Falling back to the public repositories; nothing will be cached in the mirror.")
 }
@@ -267,8 +265,8 @@ subprojects {
                 name "NexusMirror"
                 url "${rootProject.h2oNexusUrl}/maven-public"
                 credentials {
-                    username = rootProject.h2oNexusCredentials()[0]
-                    password = rootProject.h2oNexusCredentials()[1]
+                    username = rootProject.h2oNexusUsername
+                    password = rootProject.h2oNexusPassword
                 }
             }
         }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -2,6 +2,22 @@ apply plugin: 'java-library'
 apply plugin: 'groovy'
 
 repositories {
+    // buildSrc is a separate build and cannot see the root gradle.properties, so the mirror is
+    // configured from the environment or ~/.gradle - keep the default URL in step with
+    // nexusUrl in the root gradle.properties.
+    def nexusUrl = System.getenv('NEXUS_URL') ?: project.findProperty('nexusUrl') ?: 'https://nexus.h2o.dev/repository'
+    def nexusUser = System.getenv('NEXUS_USERNAME') ?: project.findProperty('nexusUsername')
+    def nexusPass = System.getenv('NEXUS_PASSWORD') ?: project.findProperty('nexusPassword')
+    if (nexusUrl && nexusUrl != 'NO_NEXUS' && nexusUser && nexusPass) {
+        maven {
+            name 'NexusMirror'
+            url "${nexusUrl}/maven-public"
+            credentials {
+                username = nexusUser
+                password = nexusPass
+            }
+        }
+    }
     mavenCentral()
 }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -14,6 +14,9 @@ repositories {
                 username = h2oNexusUsername
                 password = h2oNexusPassword
             }
+            authentication {
+                basic(BasicAuthentication)
+            }
         }
     }
     mavenCentral()

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -3,7 +3,11 @@ apply plugin: 'groovy'
 
 repositories {
     def h2oNexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: 'false').toString())
-    def h2oNexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('H2O_NEXUS_URL') ?: 'https://nexus.h2o.dev/repository'
+    // buildSrc is a separate build and cannot see the root project's gradle.properties,
+    // so read it off disk - the mirror settings have one source of truth.
+    def rootProps = new Properties()
+    file('../gradle.properties').withInputStream { rootProps.load(it) }
+    def h2oNexusUrl = project.findProperty('h2oNexusUrl') ?: rootProps.getProperty('h2oNexusUrl') ?: ''
     def h2oNexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('H2O_NEXUS_USERNAME')
     def h2oNexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('H2O_NEXUS_PASSWORD')
     if (h2oNexusEnabled && h2oNexusUrl && h2oNexusUsername && h2oNexusPassword) {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java-library'
 apply plugin: 'groovy'
 
 repositories {
-    def h2oNexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: 'true').toString())
+    def h2oNexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: 'false').toString())
     def h2oNexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('H2O_NEXUS_URL') ?: 'https://nexus.h2o.dev/repository'
     def h2oNexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('H2O_NEXUS_USERNAME')
     def h2oNexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('H2O_NEXUS_PASSWORD')

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -2,19 +2,18 @@ apply plugin: 'java-library'
 apply plugin: 'groovy'
 
 repositories {
-    // buildSrc is a separate build and cannot see the root gradle.properties, so the mirror is
-    // configured from the environment or ~/.gradle - keep the default URL in step with
-    // nexusUrl in the root gradle.properties.
+    // buildSrc is a separate build and cannot read the root gradle.properties, so the URL is
+    // defaulted here - keep it in step with nexusUrl there.
     def nexusUrl = System.getenv('NEXUS_URL') ?: project.findProperty('nexusUrl') ?: 'https://nexus.h2o.dev/repository'
-    def nexusUser = System.getenv('NEXUS_USERNAME') ?: project.findProperty('nexusUsername')
-    def nexusPass = System.getenv('NEXUS_PASSWORD') ?: project.findProperty('nexusPassword')
-    if (nexusUrl && nexusUrl != 'NO_NEXUS' && nexusUser && nexusPass) {
+    def nexusUsername = System.getenv('NEXUS_USERNAME') ?: project.findProperty('nexusUsername')
+    def nexusPassword = System.getenv('NEXUS_PASSWORD') ?: project.findProperty('nexusPassword')
+    if (nexusUrl && nexusUrl != 'NO_NEXUS' && nexusUsername && nexusPassword) {
         maven {
             name 'NexusMirror'
             url "${nexusUrl}/maven-public"
             credentials {
-                username = nexusUser
-                password = nexusPass
+                username = nexusUsername
+                password = nexusPassword
             }
         }
     }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -5,13 +5,13 @@ repositories {
     // buildSrc is a separate build and cannot read the root gradle.properties, so the URL is
     // defaulted here - keep it in step with h2oNexusUrl there.
     def nexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('NEXUS_ENABLED') ?: 'true').toString())
-    def nexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('NEXUS_URL') ?: 'https://nexus.h2o.dev/repository/maven-public'
+    def nexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('NEXUS_URL') ?: 'https://nexus.h2o.dev/repository'
     def nexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('NEXUS_USERNAME')
     def nexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('NEXUS_PASSWORD')
     if (nexusEnabled && nexusUrl && nexusUsername && nexusPassword) {
         maven {
             name 'NexusMirror'
-            url nexusUrl
+            url "${nexusUrl}/maven-public"
             credentials {
                 username = nexusUsername
                 password = nexusPassword

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -3,14 +3,15 @@ apply plugin: 'groovy'
 
 repositories {
     // buildSrc is a separate build and cannot read the root gradle.properties, so the URL is
-    // defaulted here - keep it in step with nexusUrl there.
-    def nexusUrl = System.getenv('NEXUS_URL') ?: project.findProperty('nexusUrl') ?: 'https://nexus.h2o.dev/repository'
-    def nexusUsername = System.getenv('NEXUS_USERNAME') ?: project.findProperty('nexusUsername')
-    def nexusPassword = System.getenv('NEXUS_PASSWORD') ?: project.findProperty('nexusPassword')
-    if (nexusUrl && nexusUrl != 'NO_NEXUS' && nexusUsername && nexusPassword) {
+    // defaulted here - keep it in step with h2oNexusUrl there.
+    def nexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('NEXUS_ENABLED') ?: 'true').toString())
+    def nexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('NEXUS_URL') ?: 'https://nexus.h2o.dev/repository/maven-public'
+    def nexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('NEXUS_USERNAME')
+    def nexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('NEXUS_PASSWORD')
+    if (nexusEnabled && nexusUrl && nexusUsername && nexusPassword) {
         maven {
             name 'NexusMirror'
-            url "${nexusUrl}/maven-public"
+            url nexusUrl
             credentials {
                 username = nexusUsername
                 password = nexusPassword

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -2,8 +2,6 @@ apply plugin: 'java-library'
 apply plugin: 'groovy'
 
 repositories {
-    // buildSrc is a separate build and cannot read the root gradle.properties, so the URL is
-    // defaulted here - keep it in step with h2oNexusUrl there.
     def h2oNexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: 'true').toString())
     def h2oNexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('H2O_NEXUS_URL') ?: 'https://nexus.h2o.dev/repository'
     def h2oNexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('H2O_NEXUS_USERNAME')

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -4,10 +4,10 @@ apply plugin: 'groovy'
 repositories {
     // buildSrc is a separate build and cannot read the root gradle.properties, so the URL is
     // defaulted here - keep it in step with h2oNexusUrl there.
-    def nexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('NEXUS_ENABLED') ?: 'true').toString())
-    def nexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('NEXUS_URL') ?: 'https://nexus.h2o.dev/repository'
-    def nexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('NEXUS_USERNAME')
-    def nexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('NEXUS_PASSWORD')
+    def nexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: 'true').toString())
+    def nexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('H2O_NEXUS_URL') ?: 'https://nexus.h2o.dev/repository'
+    def nexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('H2O_NEXUS_USERNAME')
+    def nexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('H2O_NEXUS_PASSWORD')
     if (nexusEnabled && nexusUrl && nexusUsername && nexusPassword) {
         maven {
             name 'NexusMirror'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -4,17 +4,17 @@ apply plugin: 'groovy'
 repositories {
     // buildSrc is a separate build and cannot read the root gradle.properties, so the URL is
     // defaulted here - keep it in step with h2oNexusUrl there.
-    def nexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: 'true').toString())
-    def nexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('H2O_NEXUS_URL') ?: 'https://nexus.h2o.dev/repository'
-    def nexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('H2O_NEXUS_USERNAME')
-    def nexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('H2O_NEXUS_PASSWORD')
-    if (nexusEnabled && nexusUrl && nexusUsername && nexusPassword) {
+    def h2oNexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: 'true').toString())
+    def h2oNexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('H2O_NEXUS_URL') ?: 'https://nexus.h2o.dev/repository'
+    def h2oNexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('H2O_NEXUS_USERNAME')
+    def h2oNexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('H2O_NEXUS_PASSWORD')
+    if (h2oNexusEnabled && h2oNexusUrl && h2oNexusUsername && h2oNexusPassword) {
         maven {
             name 'NexusMirror'
-            url "${nexusUrl}/maven-public"
+            url "${h2oNexusUrl}/maven-public"
             credentials {
-                username = nexusUsername
-                password = nexusPassword
+                username = h2oNexusUsername
+                password = h2oNexusPassword
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,11 +35,11 @@ doUBench=false
 doUploadUBenchResults=false
 #
 # Internal Nexus mirror. Searched ahead of the public repositories, which stay as a failsafe.
-# Credentials are required and must not be committed - set nexusUsername/nexusPassword
+# Credentials are required and must not be committed - set h2oNexusUsername/h2oNexusPassword
 # in ~/.gradle/gradle.properties, or NEXUS_USERNAME/NEXUS_PASSWORD (and NEXUS_URL) in the
-# environment. Use -PnexusUrl=NO_NEXUS to build against the public repositories only.
+# environment. Use -Ph2oNexusEnabled=false to build against the public repositories only.
 #
-nexusUrl=https://nexus.h2o.dev/repository
+h2oNexusUrl=https://nexus.h2o.dev/repository/maven-public
 #
 # Public Nexus location
 #

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,11 +39,7 @@ doUploadUBenchResults=false
 # in ~/.gradle/gradle.properties, or NEXUS_USERNAME/NEXUS_PASSWORD (and NEXUS_URL) in the
 # environment. Use -Ph2oNexusEnabled=false to build against the public repositories only.
 #
-h2oNexusUrl=https://nexus.h2o.dev/repository/maven-public
-#
-# Public Nexus location
-#
-#publicNexusLocation="http://nexus.h2o.ai:8081/repository"
+h2oNexusUrl=https://nexus.h2o.dev/repository
 
 ##
 # Version of libraries used inside H2O

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,9 +34,12 @@ doUBench=false
 # It needs AWS credentials to be configured in environment
 doUploadUBenchResults=false
 #
-# Internal Nexus location
+# Internal Nexus mirror. Searched ahead of the public repositories, which stay as a failsafe.
+# Credentials are required and must not be committed - set nexusUsername/nexusPassword
+# in ~/.gradle/gradle.properties, or NEXUS_USERNAME/NEXUS_PASSWORD (and NEXUS_URL) in the
+# environment. Use -PnexusUrl=NO_NEXUS to build against the public repositories only.
 #
-#localNexusLocation="http://nexus.h2o.ai:8081/repository"
+nexusUrl=https://nexus.h2o.dev/repository
 #
 # Public Nexus location
 #

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,8 +36,8 @@ doUploadUBenchResults=false
 #
 # Internal Nexus mirror. Searched ahead of the public repositories, which stay as a failsafe.
 # Credentials are required and must not be committed - set h2oNexusUsername/h2oNexusPassword
-# in ~/.gradle/gradle.properties, or NEXUS_USERNAME/NEXUS_PASSWORD (and NEXUS_URL) in the
-# environment. Use -Ph2oNexusEnabled=false to build against the public repositories only.
+# in ~/.gradle/gradle.properties, or H2O_NEXUS_USERNAME/H2O_NEXUS_PASSWORD (and H2O_NEXUS_URL)
+# in the environment. Use -Ph2oNexusEnabled=false to build against the public repositories only.
 #
 h2oNexusUrl=https://nexus.h2o.dev/repository
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,8 +38,8 @@ doUploadUBenchResults=false
 # this repository builds without any H2O credentials. Turn it on with -Ph2oNexusEnabled=true
 # (or H2O_NEXUS_ENABLED=true) and supply h2oNexusUsername/h2oNexusPassword in
 # ~/.gradle/gradle.properties, or H2O_NEXUS_USERNAME/H2O_NEXUS_PASSWORD in the environment.
-# Credentials must never be committed. When enabled the mirror is searched ahead of the public
-# repositories, which stay as a failsafe.
+# Credentials must never be committed. The url below is the single source of truth - buildSrc and
+# the gradle/ script plugins follow it.
 #
 h2oNexusUrl=https://nexus.h2o.dev/repository
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,10 +34,12 @@ doUBench=false
 # It needs AWS credentials to be configured in environment
 doUploadUBenchResults=false
 #
-# Internal Nexus mirror. Searched ahead of the public repositories, which stay as a failsafe.
-# Credentials are required and must not be committed - set h2oNexusUsername/h2oNexusPassword
-# in ~/.gradle/gradle.properties, or H2O_NEXUS_USERNAME/H2O_NEXUS_PASSWORD (and H2O_NEXUS_URL)
-# in the environment. Use -Ph2oNexusEnabled=false to build against the public repositories only.
+# Internal H2O Nexus mirror, off by default - builds resolve from the public repositories, so
+# this repository builds without any H2O credentials. Turn it on with -Ph2oNexusEnabled=true
+# (or H2O_NEXUS_ENABLED=true) and supply h2oNexusUsername/h2oNexusPassword in
+# ~/.gradle/gradle.properties, or H2O_NEXUS_USERNAME/H2O_NEXUS_PASSWORD in the environment.
+# Credentials must never be committed. When enabled the mirror is searched ahead of the public
+# repositories, which stay as a failsafe.
 #
 h2oNexusUrl=https://nexus.h2o.dev/repository
 

--- a/gradle/prCheck.gradle
+++ b/gradle/prCheck.gradle
@@ -16,6 +16,9 @@ buildscript {
                     username = h2oNexusUsername
                     password = h2oNexusPassword
                 }
+                authentication {
+                    basic(BasicAuthentication)
+                }
             }
         }
         mavenCentral()

--- a/gradle/prCheck.gradle
+++ b/gradle/prCheck.gradle
@@ -4,17 +4,17 @@
 
 buildscript {
     repositories {
-        def nexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: 'true').toString())
-        def nexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('H2O_NEXUS_URL') ?: ''
-        def nexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('H2O_NEXUS_USERNAME') ?: ''
-        def nexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('H2O_NEXUS_PASSWORD') ?: ''
-        if (nexusEnabled && nexusUrl && nexusUsername && nexusPassword) {
+        def h2oNexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: 'true').toString())
+        def h2oNexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('H2O_NEXUS_URL') ?: ''
+        def h2oNexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('H2O_NEXUS_USERNAME') ?: ''
+        def h2oNexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('H2O_NEXUS_PASSWORD') ?: ''
+        if (h2oNexusEnabled && h2oNexusUrl && h2oNexusUsername && h2oNexusPassword) {
             maven {
                 name 'NexusMirror'
-                url "${nexusUrl}/maven-public"
+                url "${h2oNexusUrl}/maven-public"
                 credentials {
-                    username = nexusUsername
-                    password = nexusPassword
+                    username = h2oNexusUsername
+                    password = h2oNexusPassword
                 }
             }
         }

--- a/gradle/prCheck.gradle
+++ b/gradle/prCheck.gradle
@@ -4,9 +4,9 @@
 
 buildscript {
     repositories {
-        def nexusUrl = System.getenv('NEXUS_URL') ?: project.findProperty('nexusMirrorUrl') ?: ''
-        def nexusUser = System.getenv('NEXUS_USERNAME') ?: project.findProperty('nexusMirrorUsername') ?: ''
-        def nexusPass = System.getenv('NEXUS_PASSWORD') ?: project.findProperty('nexusMirrorPassword') ?: ''
+        def nexusUrl = System.getenv('NEXUS_URL') ?: project.findProperty('nexusUrl') ?: ''
+        def nexusUser = System.getenv('NEXUS_USERNAME') ?: project.findProperty('nexusUsername') ?: ''
+        def nexusPass = System.getenv('NEXUS_PASSWORD') ?: project.findProperty('nexusPassword') ?: ''
         if (nexusUrl && nexusUrl != 'NO_NEXUS' && nexusUser && nexusPass) {
             maven {
                 name 'NexusMirror'

--- a/gradle/prCheck.gradle
+++ b/gradle/prCheck.gradle
@@ -11,7 +11,7 @@ buildscript {
         if (nexusEnabled && nexusUrl && nexusUsername && nexusPassword) {
             maven {
                 name 'NexusMirror'
-                url nexusUrl
+                url "${nexusUrl}/maven-public"
                 credentials {
                     username = nexusUsername
                     password = nexusPassword

--- a/gradle/prCheck.gradle
+++ b/gradle/prCheck.gradle
@@ -4,10 +4,10 @@
 
 buildscript {
     repositories {
-        def nexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('NEXUS_ENABLED') ?: 'true').toString())
-        def nexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('NEXUS_URL') ?: ''
-        def nexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('NEXUS_USERNAME') ?: ''
-        def nexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('NEXUS_PASSWORD') ?: ''
+        def nexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: 'true').toString())
+        def nexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('H2O_NEXUS_URL') ?: ''
+        def nexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('H2O_NEXUS_USERNAME') ?: ''
+        def nexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('H2O_NEXUS_PASSWORD') ?: ''
         if (nexusEnabled && nexusUrl && nexusUsername && nexusPassword) {
             maven {
                 name 'NexusMirror'

--- a/gradle/prCheck.gradle
+++ b/gradle/prCheck.gradle
@@ -5,15 +5,15 @@
 buildscript {
     repositories {
         def nexusUrl = System.getenv('NEXUS_URL') ?: project.findProperty('nexusUrl') ?: ''
-        def nexusUser = System.getenv('NEXUS_USERNAME') ?: project.findProperty('nexusUsername') ?: ''
-        def nexusPass = System.getenv('NEXUS_PASSWORD') ?: project.findProperty('nexusPassword') ?: ''
-        if (nexusUrl && nexusUrl != 'NO_NEXUS' && nexusUser && nexusPass) {
+        def nexusUsername = System.getenv('NEXUS_USERNAME') ?: project.findProperty('nexusUsername') ?: ''
+        def nexusPassword = System.getenv('NEXUS_PASSWORD') ?: project.findProperty('nexusPassword') ?: ''
+        if (nexusUrl && nexusUrl != 'NO_NEXUS' && nexusUsername && nexusPassword) {
             maven {
                 name 'NexusMirror'
                 url "${nexusUrl}/maven-public"
                 credentials {
-                    username = nexusUser
-                    password = nexusPass
+                    username = nexusUsername
+                    password = nexusPassword
                 }
             }
         }

--- a/gradle/prCheck.gradle
+++ b/gradle/prCheck.gradle
@@ -4,17 +4,13 @@
 
 buildscript {
     repositories {
-        def h2oNexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: 'false').toString())
-        def h2oNexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('H2O_NEXUS_URL') ?: ''
-        def h2oNexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('H2O_NEXUS_USERNAME') ?: ''
-        def h2oNexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('H2O_NEXUS_PASSWORD') ?: ''
-        if (h2oNexusEnabled && h2oNexusUrl && h2oNexusUsername && h2oNexusPassword) {
+        if (rootProject.useNexusMirror) {
             maven {
                 name 'NexusMirror'
-                url "${h2oNexusUrl}/maven-public"
+                url "${rootProject.h2oNexusUrl}/maven-public"
                 credentials {
-                    username = h2oNexusUsername
-                    password = h2oNexusPassword
+                    username = rootProject.h2oNexusUsername
+                    password = rootProject.h2oNexusPassword
                 }
                 authentication {
                     basic(BasicAuthentication)

--- a/gradle/prCheck.gradle
+++ b/gradle/prCheck.gradle
@@ -4,7 +4,7 @@
 
 buildscript {
     repositories {
-        def h2oNexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: 'true').toString())
+        def h2oNexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: 'false').toString())
         def h2oNexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('H2O_NEXUS_URL') ?: ''
         def h2oNexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('H2O_NEXUS_USERNAME') ?: ''
         def h2oNexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('H2O_NEXUS_PASSWORD') ?: ''

--- a/gradle/prCheck.gradle
+++ b/gradle/prCheck.gradle
@@ -4,13 +4,14 @@
 
 buildscript {
     repositories {
-        def nexusUrl = System.getenv('NEXUS_URL') ?: project.findProperty('nexusUrl') ?: ''
-        def nexusUsername = System.getenv('NEXUS_USERNAME') ?: project.findProperty('nexusUsername') ?: ''
-        def nexusPassword = System.getenv('NEXUS_PASSWORD') ?: project.findProperty('nexusPassword') ?: ''
-        if (nexusUrl && nexusUrl != 'NO_NEXUS' && nexusUsername && nexusPassword) {
+        def nexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('NEXUS_ENABLED') ?: 'true').toString())
+        def nexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('NEXUS_URL') ?: ''
+        def nexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('NEXUS_USERNAME') ?: ''
+        def nexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('NEXUS_PASSWORD') ?: ''
+        if (nexusEnabled && nexusUrl && nexusUsername && nexusPassword) {
             maven {
                 name 'NexusMirror'
-                url "${nexusUrl}/maven-public"
+                url nexusUrl
                 credentials {
                     username = nexusUsername
                     password = nexusPassword

--- a/gradle/prCheck.gradle
+++ b/gradle/prCheck.gradle
@@ -4,6 +4,19 @@
 
 buildscript {
     repositories {
+        def nexusUrl = System.getenv('NEXUS_URL') ?: project.findProperty('nexusMirrorUrl') ?: ''
+        def nexusUser = System.getenv('NEXUS_USERNAME') ?: project.findProperty('nexusMirrorUsername') ?: ''
+        def nexusPass = System.getenv('NEXUS_PASSWORD') ?: project.findProperty('nexusMirrorPassword') ?: ''
+        if (nexusUrl && nexusUrl != 'NO_NEXUS' && nexusUser && nexusPass) {
+            maven {
+                name 'NexusMirror'
+                url "${nexusUrl}/maven-public"
+                credentials {
+                    username = nexusUser
+                    password = nexusPass
+                }
+            }
+        }
         mavenCentral()
     }
     dependencies {

--- a/gradle/s3sync.gradle
+++ b/gradle/s3sync.gradle
@@ -5,17 +5,13 @@
 
 buildscript {
     repositories {
-        def h2oNexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: 'false').toString())
-        def h2oNexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('H2O_NEXUS_URL') ?: ''
-        def h2oNexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('H2O_NEXUS_USERNAME') ?: ''
-        def h2oNexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('H2O_NEXUS_PASSWORD') ?: ''
-        if (h2oNexusEnabled && h2oNexusUrl && h2oNexusUsername && h2oNexusPassword) {
+        if (rootProject.useNexusMirror) {
             maven {
                 name 'NexusMirror'
-                url "${h2oNexusUrl}/maven-public"
+                url "${rootProject.h2oNexusUrl}/maven-public"
                 credentials {
-                    username = h2oNexusUsername
-                    password = h2oNexusPassword
+                    username = rootProject.h2oNexusUsername
+                    password = rootProject.h2oNexusPassword
                 }
                 authentication {
                     basic(BasicAuthentication)

--- a/gradle/s3sync.gradle
+++ b/gradle/s3sync.gradle
@@ -5,9 +5,9 @@
 
 buildscript {
     repositories {
-        def nexusUrl = System.getenv('NEXUS_URL') ?: project.findProperty('nexusMirrorUrl') ?: ''
-        def nexusUser = System.getenv('NEXUS_USERNAME') ?: project.findProperty('nexusMirrorUsername') ?: ''
-        def nexusPass = System.getenv('NEXUS_PASSWORD') ?: project.findProperty('nexusMirrorPassword') ?: ''
+        def nexusUrl = System.getenv('NEXUS_URL') ?: project.findProperty('nexusUrl') ?: ''
+        def nexusUser = System.getenv('NEXUS_USERNAME') ?: project.findProperty('nexusUsername') ?: ''
+        def nexusPass = System.getenv('NEXUS_PASSWORD') ?: project.findProperty('nexusPassword') ?: ''
         if (nexusUrl && nexusUrl != 'NO_NEXUS' && nexusUser && nexusPass) {
             maven {
                 name 'NexusMirror'

--- a/gradle/s3sync.gradle
+++ b/gradle/s3sync.gradle
@@ -5,6 +5,19 @@
 
 buildscript {
     repositories {
+        def nexusUrl = System.getenv('NEXUS_URL') ?: project.findProperty('nexusMirrorUrl') ?: ''
+        def nexusUser = System.getenv('NEXUS_USERNAME') ?: project.findProperty('nexusMirrorUsername') ?: ''
+        def nexusPass = System.getenv('NEXUS_PASSWORD') ?: project.findProperty('nexusMirrorPassword') ?: ''
+        if (nexusUrl && nexusUrl != 'NO_NEXUS' && nexusUser && nexusPass) {
+            maven {
+                name 'NexusMirror'
+                url "${nexusUrl}/maven-public"
+                credentials {
+                    username = nexusUser
+                    password = nexusPass
+                }
+            }
+        }
         mavenCentral()
     }
     dependencies {

--- a/gradle/s3sync.gradle
+++ b/gradle/s3sync.gradle
@@ -5,17 +5,17 @@
 
 buildscript {
     repositories {
-        def nexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: 'true').toString())
-        def nexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('H2O_NEXUS_URL') ?: ''
-        def nexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('H2O_NEXUS_USERNAME') ?: ''
-        def nexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('H2O_NEXUS_PASSWORD') ?: ''
-        if (nexusEnabled && nexusUrl && nexusUsername && nexusPassword) {
+        def h2oNexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: 'true').toString())
+        def h2oNexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('H2O_NEXUS_URL') ?: ''
+        def h2oNexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('H2O_NEXUS_USERNAME') ?: ''
+        def h2oNexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('H2O_NEXUS_PASSWORD') ?: ''
+        if (h2oNexusEnabled && h2oNexusUrl && h2oNexusUsername && h2oNexusPassword) {
             maven {
                 name 'NexusMirror'
-                url "${nexusUrl}/maven-public"
+                url "${h2oNexusUrl}/maven-public"
                 credentials {
-                    username = nexusUsername
-                    password = nexusPassword
+                    username = h2oNexusUsername
+                    password = h2oNexusPassword
                 }
             }
         }

--- a/gradle/s3sync.gradle
+++ b/gradle/s3sync.gradle
@@ -12,7 +12,7 @@ buildscript {
         if (nexusEnabled && nexusUrl && nexusUsername && nexusPassword) {
             maven {
                 name 'NexusMirror'
-                url nexusUrl
+                url "${nexusUrl}/maven-public"
                 credentials {
                     username = nexusUsername
                     password = nexusPassword

--- a/gradle/s3sync.gradle
+++ b/gradle/s3sync.gradle
@@ -5,7 +5,7 @@
 
 buildscript {
     repositories {
-        def h2oNexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: 'true').toString())
+        def h2oNexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: 'false').toString())
         def h2oNexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('H2O_NEXUS_URL') ?: ''
         def h2oNexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('H2O_NEXUS_USERNAME') ?: ''
         def h2oNexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('H2O_NEXUS_PASSWORD') ?: ''

--- a/gradle/s3sync.gradle
+++ b/gradle/s3sync.gradle
@@ -17,6 +17,9 @@ buildscript {
                     username = h2oNexusUsername
                     password = h2oNexusPassword
                 }
+                authentication {
+                    basic(BasicAuthentication)
+                }
             }
         }
         mavenCentral()

--- a/gradle/s3sync.gradle
+++ b/gradle/s3sync.gradle
@@ -6,15 +6,15 @@
 buildscript {
     repositories {
         def nexusUrl = System.getenv('NEXUS_URL') ?: project.findProperty('nexusUrl') ?: ''
-        def nexusUser = System.getenv('NEXUS_USERNAME') ?: project.findProperty('nexusUsername') ?: ''
-        def nexusPass = System.getenv('NEXUS_PASSWORD') ?: project.findProperty('nexusPassword') ?: ''
-        if (nexusUrl && nexusUrl != 'NO_NEXUS' && nexusUser && nexusPass) {
+        def nexusUsername = System.getenv('NEXUS_USERNAME') ?: project.findProperty('nexusUsername') ?: ''
+        def nexusPassword = System.getenv('NEXUS_PASSWORD') ?: project.findProperty('nexusPassword') ?: ''
+        if (nexusUrl && nexusUrl != 'NO_NEXUS' && nexusUsername && nexusPassword) {
             maven {
                 name 'NexusMirror'
                 url "${nexusUrl}/maven-public"
                 credentials {
-                    username = nexusUser
-                    password = nexusPass
+                    username = nexusUsername
+                    password = nexusPassword
                 }
             }
         }

--- a/gradle/s3sync.gradle
+++ b/gradle/s3sync.gradle
@@ -5,10 +5,10 @@
 
 buildscript {
     repositories {
-        def nexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('NEXUS_ENABLED') ?: 'true').toString())
-        def nexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('NEXUS_URL') ?: ''
-        def nexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('NEXUS_USERNAME') ?: ''
-        def nexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('NEXUS_PASSWORD') ?: ''
+        def nexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: 'true').toString())
+        def nexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('H2O_NEXUS_URL') ?: ''
+        def nexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('H2O_NEXUS_USERNAME') ?: ''
+        def nexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('H2O_NEXUS_PASSWORD') ?: ''
         if (nexusEnabled && nexusUrl && nexusUsername && nexusPassword) {
             maven {
                 name 'NexusMirror'

--- a/gradle/s3sync.gradle
+++ b/gradle/s3sync.gradle
@@ -5,13 +5,14 @@
 
 buildscript {
     repositories {
-        def nexusUrl = System.getenv('NEXUS_URL') ?: project.findProperty('nexusUrl') ?: ''
-        def nexusUsername = System.getenv('NEXUS_USERNAME') ?: project.findProperty('nexusUsername') ?: ''
-        def nexusPassword = System.getenv('NEXUS_PASSWORD') ?: project.findProperty('nexusPassword') ?: ''
-        if (nexusUrl && nexusUrl != 'NO_NEXUS' && nexusUsername && nexusPassword) {
+        def nexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('NEXUS_ENABLED') ?: 'true').toString())
+        def nexusUrl = project.findProperty('h2oNexusUrl') ?: System.getenv('NEXUS_URL') ?: ''
+        def nexusUsername = project.findProperty('h2oNexusUsername') ?: System.getenv('NEXUS_USERNAME') ?: ''
+        def nexusPassword = project.findProperty('h2oNexusPassword') ?: System.getenv('NEXUS_PASSWORD') ?: ''
+        if (nexusEnabled && nexusUrl && nexusUsername && nexusPassword) {
             maven {
                 name 'NexusMirror'
-                url "${nexusUrl}/maven-public"
+                url nexusUrl
                 credentials {
                     username = nexusUsername
                     password = nexusPassword

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -32,7 +32,7 @@ warmup-caches:
 
 test-build-h2o-public:
 	git config --global --add safe.directory '*' # TODO github Find better solution
-	BUILD_HADOOP="true" ./gradlew --gradle-user-home $$HOME/.gradle_public clean build -x test -PforcePublic=true -PlocalNexusLocation=NO_NEXUS $$ADDITIONAL_GRADLE_OPTS
+	BUILD_HADOOP="true" ./gradlew --gradle-user-home $$HOME/.gradle_public clean build -x test -PforcePublic=true -Ph2oNexusEnabled=false $$ADDITIONAL_GRADLE_OPTS
 
 compress-huge-logfiles:
 	find * -type f -name 'java*.out.txt' -exec gzip {} \;

--- a/scripts/jenkins/groovy/buildConfig.groovy
+++ b/scripts/jenkins/groovy/buildConfig.groovy
@@ -28,6 +28,9 @@ class BuildConfig {
   public static final String XGB_TARGET_GPU = 'gpu'
   public static final String XGB_BUILD_TAG = '-b1'
   private Map supportedXGBEnvironments
+  // The mirror is slower than the public repositories on a cold cache, and every build starts on
+  // a fresh agent, so keep it off unless a build explicitly asks for it.
+  private boolean nexusMirrorEnabled = false
 
   public static final String COMPONENT_PY = 'py'
   public static final String COMPONENT_R = 'r'
@@ -86,6 +89,7 @@ class BuildConfig {
                   final String xgbVersion, final String gradleVersion) {
     this.mode = mode
     this.nodeLabel = nodeLabel
+    this.nexusMirrorEnabled = context.params.useNexusMirror ?: false
     this.commitMessage = commitMessage
     this.buildHadoop = (mode == 'MODE_HADOOP' || mode == 'MODE_KERBEROS')
     this.additionalGradleOpts = gradleOpts
@@ -161,7 +165,8 @@ class BuildConfig {
   List<String> getBuildEnv() {
     return [
       'JAVA_VERSION=8',
-      "BUILD_HADOOP=false"
+      "BUILD_HADOOP=false",
+      "H2O_NEXUS_ENABLED=${nexusMirrorEnabled}"
     ]
   }
 
@@ -179,7 +184,8 @@ class BuildConfig {
     ]
 
     jobProperties += context.parameters([
-      context.booleanParam(name: 'executeFailedOnly', defaultValue: false, description: 'If checked, execute only failed stages')
+      context.booleanParam(name: 'executeFailedOnly', defaultValue: false, description: 'If checked, execute only failed stages'),
+      context.booleanParam(name: 'useNexusMirror', defaultValue: false, description: 'If checked, resolve dependencies through the internal Nexus mirror instead of the public repositories')
     ])
     
     if (customProperties != null) {

--- a/scripts/jenkins/groovy/buildConfig.groovy
+++ b/scripts/jenkins/groovy/buildConfig.groovy
@@ -30,7 +30,7 @@ class BuildConfig {
   private Map supportedXGBEnvironments
   // The mirror is slower than the public repositories on a cold cache, and every build starts on
   // a fresh agent, so keep it off unless a build explicitly asks for it.
-  private boolean nexusMirrorEnabled = false
+  private boolean h2oNexusEnabled = false
 
   public static final String COMPONENT_PY = 'py'
   public static final String COMPONENT_R = 'r'
@@ -89,7 +89,7 @@ class BuildConfig {
                   final String xgbVersion, final String gradleVersion) {
     this.mode = mode
     this.nodeLabel = nodeLabel
-    this.nexusMirrorEnabled = context.params.useNexusMirror ?: false
+    this.h2oNexusEnabled = context.params.h2oNexusEnabled ?: false
     this.commitMessage = commitMessage
     this.buildHadoop = (mode == 'MODE_HADOOP' || mode == 'MODE_KERBEROS')
     this.additionalGradleOpts = gradleOpts
@@ -166,7 +166,7 @@ class BuildConfig {
     return [
       'JAVA_VERSION=8',
       "BUILD_HADOOP=false",
-      "H2O_NEXUS_ENABLED=${nexusMirrorEnabled}"
+      "H2O_NEXUS_ENABLED=${h2oNexusEnabled}"
     ]
   }
 
@@ -185,7 +185,7 @@ class BuildConfig {
 
     jobProperties += context.parameters([
       context.booleanParam(name: 'executeFailedOnly', defaultValue: false, description: 'If checked, execute only failed stages'),
-      context.booleanParam(name: 'useNexusMirror', defaultValue: false, description: 'If checked, resolve dependencies through the internal Nexus mirror instead of the public repositories')
+      context.booleanParam(name: 'h2oNexusEnabled', defaultValue: false, description: 'If checked, resolve dependencies through the internal Nexus mirror instead of the public repositories')
     ])
     
     if (customProperties != null) {

--- a/scripts/jenkins/groovy/buildConfig.groovy
+++ b/scripts/jenkins/groovy/buildConfig.groovy
@@ -89,7 +89,7 @@ class BuildConfig {
                   final String xgbVersion, final String gradleVersion) {
     this.mode = mode
     this.nodeLabel = nodeLabel
-    this.h2oNexusEnabled = context.params.h2oNexusEnabled ?: false
+    this.h2oNexusEnabled = Boolean.parseBoolean(String.valueOf(context.params.h2oNexusEnabled))
     this.commitMessage = commitMessage
     this.buildHadoop = (mode == 'MODE_HADOOP' || mode == 'MODE_KERBEROS')
     this.additionalGradleOpts = gradleOpts

--- a/scripts/jenkins/groovy/buildH2O3.groovy
+++ b/scripts/jenkins/groovy/buildH2O3.groovy
@@ -15,7 +15,7 @@ def call(final pipelineContext) {
         try {
             // Launch docker container, build h2o-3, create test packages and archive artifacts
             def buildEnv = pipelineContext.getBuildConfig().getBuildEnv() + "PYTHON_VERSION=${PYTHON_VERSION}" + "R_VERSION=${R_VERSION}" + "JAVA_VERSION=${JAVA_VERSION}"
-            def timeoutMinutes = pipelineContext.getBuildConfig().getBuildHadoop() ? 50 : 15
+            def timeoutMinutes = pipelineContext.getBuildConfig().getBuildHadoop() ? 50 : 30
             stage(stageName) {
 //                pipelineContext.getUtils().stashXGBoostWheels(this, pipelineContext)
                 insideDocker(buildEnv, pipelineContext.getBuildConfig().getDefaultImage(), pipelineContext.getBuildConfig().DOCKER_REGISTRY, pipelineContext.getBuildConfig(), timeoutMinutes, 'MINUTES') {

--- a/scripts/jenkins/groovy/buildH2O3.groovy
+++ b/scripts/jenkins/groovy/buildH2O3.groovy
@@ -15,7 +15,7 @@ def call(final pipelineContext) {
         try {
             // Launch docker container, build h2o-3, create test packages and archive artifacts
             def buildEnv = pipelineContext.getBuildConfig().getBuildEnv() + "PYTHON_VERSION=${PYTHON_VERSION}" + "R_VERSION=${R_VERSION}" + "JAVA_VERSION=${JAVA_VERSION}"
-            def timeoutMinutes = pipelineContext.getBuildConfig().getBuildHadoop() ? 50 : 30
+            def timeoutMinutes = pipelineContext.getBuildConfig().getBuildHadoop() ? 50 : 15
             stage(stageName) {
 //                pipelineContext.getUtils().stashXGBoostWheels(this, pipelineContext)
                 insideDocker(buildEnv, pipelineContext.getBuildConfig().getDefaultImage(), pipelineContext.getBuildConfig().DOCKER_REGISTRY, pipelineContext.getBuildConfig(), timeoutMinutes, 'MINUTES') {

--- a/scripts/jenkins/groovy/insideDocker.groovy
+++ b/scripts/jenkins/groovy/insideDocker.groovy
@@ -24,7 +24,7 @@ def call(customEnv, image, registry, buildConfig, timeoutValue, timeoutUnit, cus
           withCredentials([string(credentialsId: 'DRIVERLESS_AI_LICENSE_KEY', variable: 'DRIVERLESS_AI_LICENSE_KEY'), string(credentialsId: "H2O3_GET_PROJECT_TOKEN", variable:  "H2O3_GET_PROJECT_TOKEN")]) {
             // Bound to the environment, not -P arguments: buildSrc runs as a separate build and
             // would not see a project property.
-            withCredentials([usernamePassword(credentialsId: 'PUBLIC_NEXUS_DEV', usernameVariable: 'NEXUS_USERNAME', passwordVariable: 'NEXUS_PASSWORD')]) {
+            withCredentials([usernamePassword(credentialsId: 'PUBLIC_NEXUS_DEV', usernameVariable: 'H2O_NEXUS_USERNAME', passwordVariable: 'H2O_NEXUS_PASSWORD')]) {
             dockerGroupIdAdd = ""
             if (addToDockerGroup) {
               dockerGroupName = "docker"
@@ -36,9 +36,9 @@ def call(customEnv, image, registry, buildConfig, timeoutValue, timeoutUnit, cus
               }
             }
 //            // TODO add -e H2O3_GET_PROJECT_TOKEN=${H2O3_GET_PROJECT_TOKEN}
-           // NEXUS_* use the value-less "-e NAME" form to keep the password out of the command
+           // H2O_NEXUS_* use the value-less "-e NAME" form to keep the password out of the command
            // line Jenkins echoes.
-           docker.image(image).inside("--user=root:root --entrypoint='' --init ${dockerGroupIdAdd} -e AWS_CREDS_PREFIX='${awsCredsPrefix}' -e ${awsCredsPrefix}AWS_ACCESS_KEY_ID=${awsCredsPrefix}\${AWS_ACCESS_KEY_ID} -e ${awsCredsPrefix}AWS_SECRET_ACCESS_KEY=${awsCredsPrefix}\${AWS_SECRET_ACCESS_KEY} -e DRIVERLESS_AI_LICENSE_KEY=${DRIVERLESS_AI_LICENSE_KEY} -e NEXUS_USERNAME -e NEXUS_PASSWORD -v /home/jenkins:/home/jenkins/repos  -v /mnt/h2o-shared-data:/mnt/h2o-shared-data ${customArgs}") {
+           docker.image(image).inside("--user=root:root --entrypoint='' --init ${dockerGroupIdAdd} -e AWS_CREDS_PREFIX='${awsCredsPrefix}' -e ${awsCredsPrefix}AWS_ACCESS_KEY_ID=${awsCredsPrefix}\${AWS_ACCESS_KEY_ID} -e ${awsCredsPrefix}AWS_SECRET_ACCESS_KEY=${awsCredsPrefix}\${AWS_SECRET_ACCESS_KEY} -e DRIVERLESS_AI_LICENSE_KEY=${DRIVERLESS_AI_LICENSE_KEY} -e H2O_NEXUS_USERNAME -e H2O_NEXUS_PASSWORD -v /home/jenkins:/home/jenkins/repos  -v /mnt/h2o-shared-data:/mnt/h2o-shared-data ${customArgs}") {
               sh """
               id
               printenv | sort

--- a/scripts/jenkins/groovy/insideDocker.groovy
+++ b/scripts/jenkins/groovy/insideDocker.groovy
@@ -34,7 +34,7 @@ def call(customEnv, image, registry, buildConfig, timeoutValue, timeoutUnit, cus
               }
             }
 //            // TODO add -e H2O3_GET_PROJECT_TOKEN=${H2O3_GET_PROJECT_TOKEN}
-           docker.image(image).inside("--user=root:root --entrypoint='' --init ${dockerGroupIdAdd} -e AWS_CREDS_PREFIX='${awsCredsPrefix}' -e ${awsCredsPrefix}AWS_ACCESS_KEY_ID=${awsCredsPrefix}\${AWS_ACCESS_KEY_ID} -e ${awsCredsPrefix}AWS_SECRET_ACCESS_KEY=${awsCredsPrefix}\${AWS_SECRET_ACCESS_KEY} -e DRIVERLESS_AI_LICENSE_KEY=${DRIVERLESS_AI_LICENSE_KEY} -e H2O_NEXUS_USERNAME -e H2O_NEXUS_PASSWORD -e H2O_NEXUS_ENABLED -e GRADLE_USER_HOME=/home/jenkins/.gradle -v /home/jenkins:/home/jenkins/repos -v /mnt/h2o-shared-data:/mnt/h2o-shared-data ${customArgs}") {
+           docker.image(image).inside("--user=root:root --entrypoint='' --init ${dockerGroupIdAdd} -e AWS_CREDS_PREFIX='${awsCredsPrefix}' -e ${awsCredsPrefix}AWS_ACCESS_KEY_ID=${awsCredsPrefix}\${AWS_ACCESS_KEY_ID} -e ${awsCredsPrefix}AWS_SECRET_ACCESS_KEY=${awsCredsPrefix}\${AWS_SECRET_ACCESS_KEY} -e DRIVERLESS_AI_LICENSE_KEY=${DRIVERLESS_AI_LICENSE_KEY} -e H2O_NEXUS_USERNAME -e H2O_NEXUS_PASSWORD -e H2O_NEXUS_ENABLED -v /home/jenkins:/home/jenkins/repos -v /mnt/h2o-shared-data:/mnt/h2o-shared-data ${customArgs}") {
               sh """
               id
               printenv | sort

--- a/scripts/jenkins/groovy/insideDocker.groovy
+++ b/scripts/jenkins/groovy/insideDocker.groovy
@@ -34,7 +34,7 @@ def call(customEnv, image, registry, buildConfig, timeoutValue, timeoutUnit, cus
               }
             }
 //            // TODO add -e H2O3_GET_PROJECT_TOKEN=${H2O3_GET_PROJECT_TOKEN}
-           docker.image(image).inside("--user=root:root --entrypoint='' --init ${dockerGroupIdAdd} -e AWS_CREDS_PREFIX='${awsCredsPrefix}' -e ${awsCredsPrefix}AWS_ACCESS_KEY_ID=${awsCredsPrefix}\${AWS_ACCESS_KEY_ID} -e ${awsCredsPrefix}AWS_SECRET_ACCESS_KEY=${awsCredsPrefix}\${AWS_SECRET_ACCESS_KEY} -e DRIVERLESS_AI_LICENSE_KEY=${DRIVERLESS_AI_LICENSE_KEY} -e H2O_NEXUS_USERNAME -e H2O_NEXUS_PASSWORD -v /home/jenkins:/home/jenkins/repos  -v /mnt/h2o-shared-data:/mnt/h2o-shared-data ${customArgs}") {
+           docker.image(image).inside("--user=root:root --entrypoint='' --init ${dockerGroupIdAdd} -e AWS_CREDS_PREFIX='${awsCredsPrefix}' -e ${awsCredsPrefix}AWS_ACCESS_KEY_ID=${awsCredsPrefix}\${AWS_ACCESS_KEY_ID} -e ${awsCredsPrefix}AWS_SECRET_ACCESS_KEY=${awsCredsPrefix}\${AWS_SECRET_ACCESS_KEY} -e DRIVERLESS_AI_LICENSE_KEY=${DRIVERLESS_AI_LICENSE_KEY} -e H2O_NEXUS_USERNAME -e H2O_NEXUS_PASSWORD -e GRADLE_USER_HOME=/home/jenkins/.gradle -v /home/jenkins:/home/jenkins/repos -v /mnt/h2o-shared-data:/mnt/h2o-shared-data ${customArgs}") {
               sh """
               id
               printenv | sort

--- a/scripts/jenkins/groovy/insideDocker.groovy
+++ b/scripts/jenkins/groovy/insideDocker.groovy
@@ -34,18 +34,10 @@ def call(customEnv, image, registry, buildConfig, timeoutValue, timeoutUnit, cus
               }
             }
 //            // TODO add -e H2O3_GET_PROJECT_TOKEN=${H2O3_GET_PROJECT_TOKEN}
-           docker.image(image).inside("--user=root:root --entrypoint='' --init ${dockerGroupIdAdd} -e AWS_CREDS_PREFIX='${awsCredsPrefix}' -e ${awsCredsPrefix}AWS_ACCESS_KEY_ID=${awsCredsPrefix}\${AWS_ACCESS_KEY_ID} -e ${awsCredsPrefix}AWS_SECRET_ACCESS_KEY=${awsCredsPrefix}\${AWS_SECRET_ACCESS_KEY} -e DRIVERLESS_AI_LICENSE_KEY=${DRIVERLESS_AI_LICENSE_KEY} -e H2O_NEXUS_USERNAME -e H2O_NEXUS_PASSWORD -e GRADLE_USER_HOME=/home/jenkins/repos/.gradle-ci -v /home/jenkins:/home/jenkins/repos -v /mnt/h2o-shared-data:/mnt/h2o-shared-data ${customArgs}") {
-              // The Gradle cache lives on the agent so it survives between builds - the container
-              // itself is thrown away. Seed it from the copy the image warmed up, otherwise the
-              // first build on a fresh agent has to download every dependency through the mirror.
+           docker.image(image).inside("--user=root:root --entrypoint='' --init ${dockerGroupIdAdd} -e AWS_CREDS_PREFIX='${awsCredsPrefix}' -e ${awsCredsPrefix}AWS_ACCESS_KEY_ID=${awsCredsPrefix}\${AWS_ACCESS_KEY_ID} -e ${awsCredsPrefix}AWS_SECRET_ACCESS_KEY=${awsCredsPrefix}\${AWS_SECRET_ACCESS_KEY} -e DRIVERLESS_AI_LICENSE_KEY=${DRIVERLESS_AI_LICENSE_KEY} -e H2O_NEXUS_USERNAME -e H2O_NEXUS_PASSWORD -e H2O_NEXUS_ENABLED -e GRADLE_USER_HOME=/home/jenkins/.gradle -v /home/jenkins:/home/jenkins/repos -v /mnt/h2o-shared-data:/mnt/h2o-shared-data ${customArgs}") {
               sh """
               id
               printenv | sort
-              if [ ! -d "\$GRADLE_USER_HOME/caches" ] && [ -d /home/jenkins/.gradle/caches ]; then
-                mkdir -p "\$GRADLE_USER_HOME"
-                cp -a /home/jenkins/.gradle/. "\$GRADLE_USER_HOME"/ || true
-              fi
-              du -sh "\$GRADLE_USER_HOME" 2>/dev/null || true
             """
               block()
             }

--- a/scripts/jenkins/groovy/insideDocker.groovy
+++ b/scripts/jenkins/groovy/insideDocker.groovy
@@ -22,6 +22,9 @@ def call(customEnv, image, registry, buildConfig, timeoutValue, timeoutUnit, cus
       docker.withRegistry("https://${registry}") {
         withCredentials([/**file(credentialsId: 'c096a055-bb45-4dac-ba5e-10e6e470f37e', variable: 'JUNIT_CORE_SITE_PATH'),**/ [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: "${awsCredsPrefix}AWS_ACCESS_KEY_ID", credentialsId: 'H2O-AWS_CT-JENKINS-SHARED-SERVICE-PROD', secretKeyVariable: "${awsCredsPrefix}AWS_SECRET_ACCESS_KEY"]]) {
           withCredentials([string(credentialsId: 'DRIVERLESS_AI_LICENSE_KEY', variable: 'DRIVERLESS_AI_LICENSE_KEY'), string(credentialsId: "H2O3_GET_PROJECT_TOKEN", variable:  "H2O3_GET_PROJECT_TOKEN")]) {
+            // Nexus mirror credentials, bound to the environment rather than -P arguments so the
+            // password never reaches a command line and buildSrc picks them up as well.
+            withCredentials([usernamePassword(credentialsId: 'PUBLIC_NEXUS_DEV', usernameVariable: 'NEXUS_USERNAME', passwordVariable: 'NEXUS_PASSWORD')]) {
             dockerGroupIdAdd = ""
             if (addToDockerGroup) {
               dockerGroupName = "docker"
@@ -33,12 +36,15 @@ def call(customEnv, image, registry, buildConfig, timeoutValue, timeoutUnit, cus
               }
             }
 //            // TODO add -e H2O3_GET_PROJECT_TOKEN=${H2O3_GET_PROJECT_TOKEN}
-           docker.image(image).inside("--user=root:root --entrypoint='' --init ${dockerGroupIdAdd} -e AWS_CREDS_PREFIX='${awsCredsPrefix}' -e ${awsCredsPrefix}AWS_ACCESS_KEY_ID=${awsCredsPrefix}\${AWS_ACCESS_KEY_ID} -e ${awsCredsPrefix}AWS_SECRET_ACCESS_KEY=${awsCredsPrefix}\${AWS_SECRET_ACCESS_KEY} -e DRIVERLESS_AI_LICENSE_KEY=${DRIVERLESS_AI_LICENSE_KEY} -v /home/jenkins:/home/jenkins/repos  -v /mnt/h2o-shared-data:/mnt/h2o-shared-data ${customArgs}") {
+           // NEXUS_* use the value-less "-e NAME" form so the password is read from the agent
+           // environment instead of being embedded in the command line Jenkins echoes.
+           docker.image(image).inside("--user=root:root --entrypoint='' --init ${dockerGroupIdAdd} -e AWS_CREDS_PREFIX='${awsCredsPrefix}' -e ${awsCredsPrefix}AWS_ACCESS_KEY_ID=${awsCredsPrefix}\${AWS_ACCESS_KEY_ID} -e ${awsCredsPrefix}AWS_SECRET_ACCESS_KEY=${awsCredsPrefix}\${AWS_SECRET_ACCESS_KEY} -e DRIVERLESS_AI_LICENSE_KEY=${DRIVERLESS_AI_LICENSE_KEY} -e NEXUS_USERNAME -e NEXUS_PASSWORD -v /home/jenkins:/home/jenkins/repos  -v /mnt/h2o-shared-data:/mnt/h2o-shared-data ${customArgs}") {
               sh """
               id
               printenv | sort
             """
               block()
+            }
             }
           }
         }

--- a/scripts/jenkins/groovy/insideDocker.groovy
+++ b/scripts/jenkins/groovy/insideDocker.groovy
@@ -22,8 +22,6 @@ def call(customEnv, image, registry, buildConfig, timeoutValue, timeoutUnit, cus
       docker.withRegistry("https://${registry}") {
         withCredentials([/**file(credentialsId: 'c096a055-bb45-4dac-ba5e-10e6e470f37e', variable: 'JUNIT_CORE_SITE_PATH'),**/ [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: "${awsCredsPrefix}AWS_ACCESS_KEY_ID", credentialsId: 'H2O-AWS_CT-JENKINS-SHARED-SERVICE-PROD', secretKeyVariable: "${awsCredsPrefix}AWS_SECRET_ACCESS_KEY"]]) {
           withCredentials([string(credentialsId: 'DRIVERLESS_AI_LICENSE_KEY', variable: 'DRIVERLESS_AI_LICENSE_KEY'), string(credentialsId: "H2O3_GET_PROJECT_TOKEN", variable:  "H2O3_GET_PROJECT_TOKEN")]) {
-            // Bound to the environment, not -P arguments: buildSrc runs as a separate build and
-            // would not see a project property.
             withCredentials([usernamePassword(credentialsId: 'PUBLIC_NEXUS_DEV', usernameVariable: 'H2O_NEXUS_USERNAME', passwordVariable: 'H2O_NEXUS_PASSWORD')]) {
             dockerGroupIdAdd = ""
             if (addToDockerGroup) {
@@ -36,8 +34,6 @@ def call(customEnv, image, registry, buildConfig, timeoutValue, timeoutUnit, cus
               }
             }
 //            // TODO add -e H2O3_GET_PROJECT_TOKEN=${H2O3_GET_PROJECT_TOKEN}
-           // H2O_NEXUS_* use the value-less "-e NAME" form to keep the password out of the command
-           // line Jenkins echoes.
            docker.image(image).inside("--user=root:root --entrypoint='' --init ${dockerGroupIdAdd} -e AWS_CREDS_PREFIX='${awsCredsPrefix}' -e ${awsCredsPrefix}AWS_ACCESS_KEY_ID=${awsCredsPrefix}\${AWS_ACCESS_KEY_ID} -e ${awsCredsPrefix}AWS_SECRET_ACCESS_KEY=${awsCredsPrefix}\${AWS_SECRET_ACCESS_KEY} -e DRIVERLESS_AI_LICENSE_KEY=${DRIVERLESS_AI_LICENSE_KEY} -e H2O_NEXUS_USERNAME -e H2O_NEXUS_PASSWORD -v /home/jenkins:/home/jenkins/repos  -v /mnt/h2o-shared-data:/mnt/h2o-shared-data ${customArgs}") {
               sh """
               id

--- a/scripts/jenkins/groovy/insideDocker.groovy
+++ b/scripts/jenkins/groovy/insideDocker.groovy
@@ -22,8 +22,8 @@ def call(customEnv, image, registry, buildConfig, timeoutValue, timeoutUnit, cus
       docker.withRegistry("https://${registry}") {
         withCredentials([/**file(credentialsId: 'c096a055-bb45-4dac-ba5e-10e6e470f37e', variable: 'JUNIT_CORE_SITE_PATH'),**/ [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: "${awsCredsPrefix}AWS_ACCESS_KEY_ID", credentialsId: 'H2O-AWS_CT-JENKINS-SHARED-SERVICE-PROD', secretKeyVariable: "${awsCredsPrefix}AWS_SECRET_ACCESS_KEY"]]) {
           withCredentials([string(credentialsId: 'DRIVERLESS_AI_LICENSE_KEY', variable: 'DRIVERLESS_AI_LICENSE_KEY'), string(credentialsId: "H2O3_GET_PROJECT_TOKEN", variable:  "H2O3_GET_PROJECT_TOKEN")]) {
-            // Nexus mirror credentials, bound to the environment rather than -P arguments so the
-            // password never reaches a command line and buildSrc picks them up as well.
+            // Bound to the environment, not -P arguments: buildSrc runs as a separate build and
+            // would not see a project property.
             withCredentials([usernamePassword(credentialsId: 'PUBLIC_NEXUS_DEV', usernameVariable: 'NEXUS_USERNAME', passwordVariable: 'NEXUS_PASSWORD')]) {
             dockerGroupIdAdd = ""
             if (addToDockerGroup) {
@@ -36,8 +36,8 @@ def call(customEnv, image, registry, buildConfig, timeoutValue, timeoutUnit, cus
               }
             }
 //            // TODO add -e H2O3_GET_PROJECT_TOKEN=${H2O3_GET_PROJECT_TOKEN}
-           // NEXUS_* use the value-less "-e NAME" form so the password is read from the agent
-           // environment instead of being embedded in the command line Jenkins echoes.
+           // NEXUS_* use the value-less "-e NAME" form to keep the password out of the command
+           // line Jenkins echoes.
            docker.image(image).inside("--user=root:root --entrypoint='' --init ${dockerGroupIdAdd} -e AWS_CREDS_PREFIX='${awsCredsPrefix}' -e ${awsCredsPrefix}AWS_ACCESS_KEY_ID=${awsCredsPrefix}\${AWS_ACCESS_KEY_ID} -e ${awsCredsPrefix}AWS_SECRET_ACCESS_KEY=${awsCredsPrefix}\${AWS_SECRET_ACCESS_KEY} -e DRIVERLESS_AI_LICENSE_KEY=${DRIVERLESS_AI_LICENSE_KEY} -e NEXUS_USERNAME -e NEXUS_PASSWORD -v /home/jenkins:/home/jenkins/repos  -v /mnt/h2o-shared-data:/mnt/h2o-shared-data ${customArgs}") {
               sh """
               id

--- a/scripts/jenkins/groovy/insideDocker.groovy
+++ b/scripts/jenkins/groovy/insideDocker.groovy
@@ -34,10 +34,18 @@ def call(customEnv, image, registry, buildConfig, timeoutValue, timeoutUnit, cus
               }
             }
 //            // TODO add -e H2O3_GET_PROJECT_TOKEN=${H2O3_GET_PROJECT_TOKEN}
-           docker.image(image).inside("--user=root:root --entrypoint='' --init ${dockerGroupIdAdd} -e AWS_CREDS_PREFIX='${awsCredsPrefix}' -e ${awsCredsPrefix}AWS_ACCESS_KEY_ID=${awsCredsPrefix}\${AWS_ACCESS_KEY_ID} -e ${awsCredsPrefix}AWS_SECRET_ACCESS_KEY=${awsCredsPrefix}\${AWS_SECRET_ACCESS_KEY} -e DRIVERLESS_AI_LICENSE_KEY=${DRIVERLESS_AI_LICENSE_KEY} -e H2O_NEXUS_USERNAME -e H2O_NEXUS_PASSWORD -e GRADLE_USER_HOME=/home/jenkins/.gradle -v /home/jenkins:/home/jenkins/repos -v /mnt/h2o-shared-data:/mnt/h2o-shared-data ${customArgs}") {
+           docker.image(image).inside("--user=root:root --entrypoint='' --init ${dockerGroupIdAdd} -e AWS_CREDS_PREFIX='${awsCredsPrefix}' -e ${awsCredsPrefix}AWS_ACCESS_KEY_ID=${awsCredsPrefix}\${AWS_ACCESS_KEY_ID} -e ${awsCredsPrefix}AWS_SECRET_ACCESS_KEY=${awsCredsPrefix}\${AWS_SECRET_ACCESS_KEY} -e DRIVERLESS_AI_LICENSE_KEY=${DRIVERLESS_AI_LICENSE_KEY} -e H2O_NEXUS_USERNAME -e H2O_NEXUS_PASSWORD -e GRADLE_USER_HOME=/home/jenkins/repos/.gradle-ci -v /home/jenkins:/home/jenkins/repos -v /mnt/h2o-shared-data:/mnt/h2o-shared-data ${customArgs}") {
+              // The Gradle cache lives on the agent so it survives between builds - the container
+              // itself is thrown away. Seed it from the copy the image warmed up, otherwise the
+              // first build on a fresh agent has to download every dependency through the mirror.
               sh """
               id
               printenv | sort
+              if [ ! -d "\$GRADLE_USER_HOME/caches" ] && [ -d /home/jenkins/.gradle/caches ]; then
+                mkdir -p "\$GRADLE_USER_HOME"
+                cp -a /home/jenkins/.gradle/. "\$GRADLE_USER_HOME"/ || true
+              fi
+              du -sh "\$GRADLE_USER_HOME" 2>/dev/null || true
             """
               block()
             }


### PR DESCRIPTION
Closes #16939

Adds support for resolving Gradle dependencies through the internal Nexus mirror (`nexus.h2o.dev`), a pull-through proxy of our upstreams, so downloaded artifacts get cached in our own infrastructure.

- Off by default everywhere: a plain clone builds from the public repositories, needs no H2O credentials, and says nothing about the mirror
- Opt in with `-Ph2oNexusEnabled=true` (or `H2O_NEXUS_ENABLED=true`); Jenkins jobs get an `h2oNexusEnabled` checkbox next to `executeFailedOnly`
- When enabled the mirror is searched ahead of the public repositories, which stay in the list
- Covers `buildSrc` and the `gradle/` script plugins, which resolve independently of the root repository configuration and would otherwise bypass the mirror
- `h2oNexusUrl` in `gradle.properties` is the single source of truth; credentials belong in `~/.gradle/gradle.properties` or `H2O_NEXUS_USERNAME`/`H2O_NEXUS_PASSWORD`, never in the repo
- Enabled but without credentials warns and falls back rather than failing, so a missing credential cannot quietly turn the mirror into a no-op

Default is off because Jenkins agents are ephemeral and start with a cold cache. Resolving the full dependency set through the mirror takes roughly five times longer than the public repositories and overruns the build stage timeout. Turning it on for CI needs the build image warmed through the mirror first, which is DevOps-side work.

Scope is local development and the Jenkins pipeline; publishing is untouched. The GitHub Actions side is h2oai/h2o-3-enterprise#241 and #252, which still export `NEXUS_*` and need renaming to `H2O_NEXUS_*`.
