### PR TITLE
GH-16940: Add Nexus mirror to s3sync.gradle and prCheck.gradle

### DIFF
--- a/gradle/prCheck.gradle
+++ b/gradle/prCheck.gradle
@@ -4,6 +4,19 @@
 
 buildscript {
     repositories {
+        def nexusUrl = System.getenv('NEXUS_URL') ?: project.findProperty('nexusMirrorUrl') ?: ''
+        def nexusUser = System.getenv('NEXUS_USERNAME') ?: project.findProperty('nexusMirrorUsername') ?: ''
+        def nexusPass = System.getenv('NEXUS_PASSWORD') ?: project.findProperty('nexusMirrorPassword') ?: ''
+        if (nexusUrl && nexusUrl != 'NO_NEXUS' && nexusUser && nexusPass) {
+            maven {
+                name 'NexusMirror'
+                url "${nexusUrl}/maven-public"
+                credentials {
+                    username = nexusUser
+                    password = nexusPass
+                }
+            }
+        }
         mavenCentral()
     }
     dependencies {

--- a/gradle/s3sync.gradle
+++ b/gradle/s3sync.gradle
@@ -5,6 +5,19 @@
 
 buildscript {
     repositories {
+        def nexusUrl = System.getenv('NEXUS_URL') ?: project.findProperty('nexusMirrorUrl') ?: ''
+        def nexusUser = System.getenv('NEXUS_USERNAME') ?: project.findProperty('nexusMirrorUsername') ?: ''
+        def nexusPass = System.getenv('NEXUS_PASSWORD') ?: project.findProperty('nexusMirrorPassword') ?: ''
+        if (nexusUrl && nexusUrl != 'NO_NEXUS' && nexusUser && nexusPass) {
+            maven {
+                name 'NexusMirror'
+                url "${nexusUrl}/maven-public"
+                credentials {
+                    username = nexusUser
+                    password = nexusPass
+                }
+            }
+        }
         mavenCentral()
     }
     dependencies {


### PR DESCRIPTION
## Summary

- Adds Nexus mirror support to `gradle/s3sync.gradle` and `gradle/prCheck.gradle`
- These `apply from:` scripts have independent `buildscript` blocks that resolve dependencies directly from Maven Central, bypassing the Nexus mirror configured in `build.gradle`
- Uses the same env-var pattern (`NEXUS_URL`, `NEXUS_USERNAME`, `NEXUS_PASSWORD`) as `build.gradle` and `buildSrc/build.gradle` from PR #16940
- Nexus is added ahead of `mavenCentral()` so it acts as a mirror with Maven Central fallback

## Context

Without this change, `gradle-download-task`, `joda-time`, and `cowsay` are fetched directly from Maven Central even when the Nexus mirror is configured, causing 429 rate limits in CI.

## Test plan

- [x] Verify build resolves `s3sync.gradle` and `prCheck.gradle` buildscript dependencies through Nexus
- [x] Verify build still works without Nexus credentials (falls back to Maven Central)