### PR TITLE
GH-16944: Fix DeepLearningTest exporting MOJO to a stray file

### DIFF
--- a/h2o-algos/src/test/java/hex/deeplearning/DeepLearningTest.java
+++ b/h2o-algos/src/test/java/hex/deeplearning/DeepLearningTest.java
@@ -1107,10 +1107,10 @@ public class DeepLearningTest {
       // Build a first model; all remaining models should be equal
       dl = new DeepLearning(parms).trainModel().get();
 
-      URI uri = dl.exportMojo("prcak", true);
-      
+      URI uri = dl.exportMojo(tmp.newFile("dl_autoencoder_mojo").getAbsolutePath(), true);
+
       MojoModel aeMojo = MojoModel.load(uri.getPath(), true);
-      
+
 
       assertTrue(dl.testJavaScoring(tfr, fr2=dl.score(tfr), 1e-5));
 


### PR DESCRIPTION
Issue: https://github.com/h2oai/h2o-3/issues/16944

testAutoEncoder exported its MOJO to a bare relative path ("prcak") with no cleanup, leaving a leftover file in h2o-algos/ after every test run. Use the test's existing TemporaryFolder rule instead.