### PR TITLE
Auto-enable Nexus mirror when credentials are present [master]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
                     || (rootProject.hasProperty("doCI") && rootProject.doCI == "true"))
 
         h2oNexusEnabled = Boolean.parseBoolean(
-                (rootProject.findProperty("h2oNexusEnabled") ?: System.getenv("H2O_NEXUS_ENABLED") ?: "false").toString())
+                (rootProject.findProperty("h2oNexusEnabled") ?: System.getenv("H2O_NEXUS_ENABLED") ?: (System.getenv("H2O_NEXUS_USERNAME") && System.getenv("H2O_NEXUS_PASSWORD") ? "true" : "false")).toString())
         h2oNexusUrl = rootProject.findProperty("h2oNexusUrl") ?: ""
         h2oNexusUsername = rootProject.findProperty("h2oNexusUsername") ?: System.getenv("H2O_NEXUS_USERNAME") ?: ""
         h2oNexusPassword = rootProject.findProperty("h2oNexusPassword") ?: System.getenv("H2O_NEXUS_PASSWORD") ?: ""

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java-library'
 apply plugin: 'groovy'
 
 repositories {
-    def h2oNexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: 'false').toString())
+    def h2oNexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: (System.getenv('H2O_NEXUS_USERNAME') && System.getenv('H2O_NEXUS_PASSWORD') ? 'true' : 'false')).toString())
     // buildSrc is a separate build and cannot see the root project's gradle.properties,
     // so read it off disk - the mirror settings have one source of truth.
     def rootProps = new Properties()

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,9 +34,9 @@ doUBench=false
 # It needs AWS credentials to be configured in environment
 doUploadUBenchResults=false
 #
-# Internal H2O Nexus mirror, off by default - builds resolve from the public repositories, so
-# this repository builds without any H2O credentials. Turn it on with -Ph2oNexusEnabled=true
-# (or H2O_NEXUS_ENABLED=true) and supply h2oNexusUsername/h2oNexusPassword in
+# Internal H2O Nexus mirror. Auto-enabled when H2O_NEXUS_USERNAME and H2O_NEXUS_PASSWORD
+# are present in the environment. Can also be turned on explicitly with -Ph2oNexusEnabled=true
+# (or H2O_NEXUS_ENABLED=true). Supply h2oNexusUsername/h2oNexusPassword in
 # ~/.gradle/gradle.properties, or H2O_NEXUS_USERNAME/H2O_NEXUS_PASSWORD in the environment.
 # Credentials must never be committed. The url below is the single source of truth - buildSrc and
 # the gradle/ script plugins follow it.


### PR DESCRIPTION
## Summary
- Auto-enable the Nexus mirror in `buildSrc/build.gradle` and `build.gradle` when `H2O_NEXUS_USERNAME` and `H2O_NEXUS_PASSWORD` are set in the environment
- Removes the need for the explicit `H2O_NEXUS_ENABLED=true` flag in CI
- OSS builds without credentials remain unaffected (no behavioral change)

## Problem
Nightly CI runs 40+ parallel EC2 test runners that all hit Maven Central simultaneously to resolve `buildSrc` dependencies (`io.minio:minio:3.0.3`), triggering **HTTP 429 (Too Many Requests)** rate limiting. This causes all Java JUnit tests and Smoke tests to fail with `:buildSrc:compileJava FAILED`.

The Nexus mirror credentials (`H2O_NEXUS_USERNAME`/`H2O_NEXUS_PASSWORD`) are already present in the CI environment, but the mirror was never activated because `H2O_NEXUS_ENABLED` was not set.

## Fix
Instead of requiring an explicit `H2O_NEXUS_ENABLED=true`, the build now auto-detects when Nexus credentials are available and enables the mirror automatically.

## Test plan
- [x] Verify OSS builds without credentials still resolve from Maven Central
- [x] Verify CI builds with credentials now resolve from Nexus mirror
- [x] Confirm nightly Java/Smoke test failures are resolved