### PR TITLE
Revert "Auto-enable Nexus mirror when credentials are present" [nocheck]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
                     || (rootProject.hasProperty("doCI") && rootProject.doCI == "true"))
 
         h2oNexusEnabled = Boolean.parseBoolean(
-                (rootProject.findProperty("h2oNexusEnabled") ?: System.getenv("H2O_NEXUS_ENABLED") ?: (System.getenv("H2O_NEXUS_USERNAME") && System.getenv("H2O_NEXUS_PASSWORD") ? "true" : "false")).toString())
+                (rootProject.findProperty("h2oNexusEnabled") ?: System.getenv("H2O_NEXUS_ENABLED") ?: "false").toString())
         h2oNexusUrl = rootProject.findProperty("h2oNexusUrl") ?: ""
         h2oNexusUsername = rootProject.findProperty("h2oNexusUsername") ?: System.getenv("H2O_NEXUS_USERNAME") ?: ""
         h2oNexusPassword = rootProject.findProperty("h2oNexusPassword") ?: System.getenv("H2O_NEXUS_PASSWORD") ?: ""

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java-library'
 apply plugin: 'groovy'
 
 repositories {
-    def h2oNexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: (System.getenv('H2O_NEXUS_USERNAME') && System.getenv('H2O_NEXUS_PASSWORD') ? 'true' : 'false')).toString())
+    def h2oNexusEnabled = Boolean.parseBoolean((project.findProperty('h2oNexusEnabled') ?: System.getenv('H2O_NEXUS_ENABLED') ?: 'false').toString())
     // buildSrc is a separate build and cannot see the root project's gradle.properties,
     // so read it off disk - the mirror settings have one source of truth.
     def rootProps = new Properties()

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,9 +34,9 @@ doUBench=false
 # It needs AWS credentials to be configured in environment
 doUploadUBenchResults=false
 #
-# Internal H2O Nexus mirror. Auto-enabled when H2O_NEXUS_USERNAME and H2O_NEXUS_PASSWORD
-# are present in the environment. Can also be turned on explicitly with -Ph2oNexusEnabled=true
-# (or H2O_NEXUS_ENABLED=true). Supply h2oNexusUsername/h2oNexusPassword in
+# Internal H2O Nexus mirror, off by default - builds resolve from the public repositories, so
+# this repository builds without any H2O credentials. Turn it on with -Ph2oNexusEnabled=true
+# (or H2O_NEXUS_ENABLED=true) and supply h2oNexusUsername/h2oNexusPassword in
 # ~/.gradle/gradle.properties, or H2O_NEXUS_USERNAME/H2O_NEXUS_PASSWORD in the environment.
 # Credentials must never be committed. The url below is the single source of truth - buildSrc and
 # the gradle/ script plugins follow it.


### PR DESCRIPTION
Reverts #16948.

- Restores `h2oNexusEnabled` to the explicit `-Ph2oNexusEnabled` / `H2O_NEXUS_ENABLED` switch; the mirror no longer turns itself on from the presence of `H2O_NEXUS_USERNAME`/`H2O_NEXUS_PASSWORD`.
- The Nexus mirror plumbing from #16940 is untouched — only the implicit activation is removed.
- No effect on the Jenkins nightly: `buildConfig.groovy` always exports `H2O_NEXUS_ENABLED`, so the auto-enable fallback was never reachable there.